### PR TITLE
fix(Makefile): force python2.7 in virtualenv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ $(VENV):
 	chmod +x $@
 
 $(PYTHON): $(VENV)
-	$(VENV) $(VENV_DIR)
+	$(VENV) -p python2.7 $(VENV_DIR)
 	$(PIP) install mako pyyaml
 
 $(MAKO_RENDER): $(PYTHON)


### PR DESCRIPTION
force the usage of python2.7 on systems where /usr/bin/python points to python3.x

fixes issue #12