### PR TITLE
fix(make): fix clean target for docs/cli

### DIFF
--- a/src/mako/deps.mako
+++ b/src/mako/deps.mako
@@ -132,7 +132,12 @@ ${api_clean}:
 % endfor
 % endfor
 
+% if agsuffix not in ["-api", "-cli"]:
 clean-all${agsuffix}: ${space_join(1)} docs-clean${agsuffix}
+% else:
+clean-all${agsuffix}: ${space_join(1)}
+% endif
+
 cargo${agsuffix}: ${space_join(2)}
 publish${agsuffix}: | gen-all${agsuffix} ${space_join(4)}
 gen-all${agsuffix}: ${space_join(0)}


### PR DESCRIPTION
clean-all-docs and clean-all-cli aren't valid targets. The current mako
template causes `make clean` to abend reporting that it can't make these
targets.