### PR TITLE
chore(dependencies): bump hyper dep to 0.5.0

### DIFF
--- a/src/mako/Cargo.toml.mako
+++ b/src/mako/Cargo.toml.mako
@@ -23,7 +23,7 @@ name = "${util.program_name()}"
 % endif
 
 [dependencies]
-hyper = ">= 0.4.0"
+hyper = ">= 0.5.0"
 mime = "*"
 yup-oauth2 = "*"
 % for dep in cargo.get('dependencies', list()):


### PR DESCRIPTION
google-apis-rs no longer builds with hyper 0.4.0, due to the use of a
now-undefined macro