### PR TITLE
fix(api types): Add an unused field to empty API types.

### DIFF
--- a/gen/appengine1/src/lib.rs.in
+++ b/gen/appengine1/src/lib.rs.in
@@ -230,7 +230,7 @@ impl ResponseResult for Service {}
 /// * [repair apps](struct.AppRepairCall.html) (request)
 /// 
 #[derive(Default, Clone, Debug, Serialize, Deserialize)]
-pub struct RepairApplicationRequest;
+pub struct RepairApplicationRequest { _never_set: Option<bool> }
 
 impl RequestValue for RepairApplicationRequest {}
 
@@ -424,7 +424,7 @@ impl ResponseResult for Location {}
 /// * [services versions instances debug apps](struct.AppServiceVersionInstanceDebugCall.html) (request)
 /// 
 #[derive(Default, Clone, Debug, Serialize, Deserialize)]
-pub struct DebugInstanceRequest;
+pub struct DebugInstanceRequest { _never_set: Option<bool> }
 
 impl RequestValue for DebugInstanceRequest {}
 

--- a/gen/appengine1_beta4/src/lib.rs.in
+++ b/gen/appengine1_beta4/src/lib.rs.in
@@ -371,7 +371,7 @@ impl Part for Library {}
 /// * [modules versions instances debug apps](struct.AppModuleVersionInstanceDebugCall.html) (request)
 /// 
 #[derive(Default, Clone, Debug, Serialize, Deserialize)]
-pub struct DebugInstanceRequest;
+pub struct DebugInstanceRequest { _never_set: Option<bool> }
 
 impl RequestValue for DebugInstanceRequest {}
 

--- a/gen/appengine1_beta5/src/lib.rs.in
+++ b/gen/appengine1_beta5/src/lib.rs.in
@@ -406,7 +406,7 @@ impl ResponseResult for Location {}
 /// * [services versions instances debug apps](struct.AppServiceVersionInstanceDebugCall.html) (request)
 /// 
 #[derive(Default, Clone, Debug, Serialize, Deserialize)]
-pub struct DebugInstanceRequest;
+pub struct DebugInstanceRequest { _never_set: Option<bool> }
 
 impl RequestValue for DebugInstanceRequest {}
 

--- a/gen/classroom1/src/lib.rs.in
+++ b/gen/classroom1/src/lib.rs.in
@@ -319,7 +319,7 @@ impl Part for AssignmentSubmission {}
 /// * [course work student submissions return courses](struct.CourseCourseWorkStudentSubmissionReturnCall.html) (request)
 /// 
 #[derive(Default, Clone, Debug, Serialize, Deserialize)]
-pub struct ReturnStudentSubmissionRequest;
+pub struct ReturnStudentSubmissionRequest { _never_set: Option<bool> }
 
 impl RequestValue for ReturnStudentSubmissionRequest {}
 
@@ -343,7 +343,7 @@ impl RequestValue for ReturnStudentSubmissionRequest {}
 /// * [accept invitations](struct.InvitationAcceptCall.html) (response)
 /// 
 #[derive(Default, Clone, Debug, Serialize, Deserialize)]
-pub struct Empty;
+pub struct Empty { _never_set: Option<bool> }
 
 impl ResponseResult for Empty {}
 
@@ -478,7 +478,7 @@ impl ResponseResult for Guardian {}
 /// * [course work student submissions turn in courses](struct.CourseCourseWorkStudentSubmissionTurnInCall.html) (request)
 /// 
 #[derive(Default, Clone, Debug, Serialize, Deserialize)]
-pub struct TurnInStudentSubmissionRequest;
+pub struct TurnInStudentSubmissionRequest { _never_set: Option<bool> }
 
 impl RequestValue for TurnInStudentSubmissionRequest {}
 
@@ -894,7 +894,7 @@ impl ResponseResult for ListCourseAliasesResponse {}
 /// * [course work student submissions reclaim courses](struct.CourseCourseWorkStudentSubmissionReclaimCall.html) (request)
 /// 
 #[derive(Default, Clone, Debug, Serialize, Deserialize)]
-pub struct ReclaimStudentSubmissionRequest;
+pub struct ReclaimStudentSubmissionRequest { _never_set: Option<bool> }
 
 impl RequestValue for ReclaimStudentSubmissionRequest {}
 

--- a/gen/clouddebugger2/src/lib.rs.in
+++ b/gen/clouddebugger2/src/lib.rs.in
@@ -282,7 +282,7 @@ impl RequestValue for RegisterDebuggeeRequest {}
 /// * [debuggees breakpoints update controller](struct.ControllerDebuggeeBreakpointUpdateCall.html) (response)
 /// 
 #[derive(Default, Clone, Debug, Serialize, Deserialize)]
-pub struct UpdateActiveBreakpointResponse;
+pub struct UpdateActiveBreakpointResponse { _never_set: Option<bool> }
 
 impl ResponseResult for UpdateActiveBreakpointResponse {}
 
@@ -392,7 +392,7 @@ impl Part for RepoId {}
 /// * [debuggees breakpoints delete debugger](struct.DebuggerDebuggeeBreakpointDeleteCall.html) (response)
 /// 
 #[derive(Default, Clone, Debug, Serialize, Deserialize)]
-pub struct Empty;
+pub struct Empty { _never_set: Option<bool> }
 
 impl ResponseResult for Empty {}
 

--- a/gen/cloudresourcemanager1/src/lib.rs.in
+++ b/gen/cloudresourcemanager1/src/lib.rs.in
@@ -170,7 +170,7 @@ impl<'a, C, A> CloudResourceManager<C, A>
 /// * [undelete projects](struct.ProjectUndeleteCall.html) (request)
 /// 
 #[derive(Default, Clone, Debug, Serialize, Deserialize)]
-pub struct UndeleteProjectRequest;
+pub struct UndeleteProjectRequest { _never_set: Option<bool> }
 
 impl RequestValue for UndeleteProjectRequest {}
 
@@ -220,7 +220,7 @@ impl ResponseResult for TestIamPermissionsResponse {}
 /// * [get iam policy projects](struct.ProjectGetIamPolicyCall.html) (request)
 /// 
 #[derive(Default, Clone, Debug, Serialize, Deserialize)]
-pub struct GetIamPolicyRequest;
+pub struct GetIamPolicyRequest { _never_set: Option<bool> }
 
 impl RequestValue for GetIamPolicyRequest {}
 
@@ -417,7 +417,7 @@ impl ResponseResult for ListProjectsResponse {}
 /// * [undelete projects](struct.ProjectUndeleteCall.html) (response)
 /// 
 #[derive(Default, Clone, Debug, Serialize, Deserialize)]
-pub struct Empty;
+pub struct Empty { _never_set: Option<bool> }
 
 impl ResponseResult for Empty {}
 

--- a/gen/cloudresourcemanager1_beta1/src/lib.rs.in
+++ b/gen/cloudresourcemanager1_beta1/src/lib.rs.in
@@ -171,7 +171,7 @@ impl<'a, C, A> CloudResourceManager<C, A>
 /// * [get iam policy organizations](struct.OrganizationGetIamPolicyCall.html) (request)
 /// 
 #[derive(Default, Clone, Debug, Serialize, Deserialize)]
-pub struct GetIamPolicyRequest;
+pub struct GetIamPolicyRequest { _never_set: Option<bool> }
 
 impl RequestValue for GetIamPolicyRequest {}
 
@@ -287,7 +287,7 @@ impl ResponseResult for Project {}
 /// * [get ancestry projects](struct.ProjectGetAncestryCall.html) (request)
 /// 
 #[derive(Default, Clone, Debug, Serialize, Deserialize)]
-pub struct GetAncestryRequest;
+pub struct GetAncestryRequest { _never_set: Option<bool> }
 
 impl RequestValue for GetAncestryRequest {}
 
@@ -388,7 +388,7 @@ impl ResponseResult for ListProjectsResponse {}
 /// * [undelete projects](struct.ProjectUndeleteCall.html) (response)
 /// 
 #[derive(Default, Clone, Debug, Serialize, Deserialize)]
-pub struct Empty;
+pub struct Empty { _never_set: Option<bool> }
 
 impl ResponseResult for Empty {}
 
@@ -403,7 +403,7 @@ impl ResponseResult for Empty {}
 /// * [undelete projects](struct.ProjectUndeleteCall.html) (request)
 /// 
 #[derive(Default, Clone, Debug, Serialize, Deserialize)]
-pub struct UndeleteProjectRequest;
+pub struct UndeleteProjectRequest { _never_set: Option<bool> }
 
 impl RequestValue for UndeleteProjectRequest {}
 

--- a/gen/cloudtrace1/src/lib.rs.in
+++ b/gen/cloudtrace1/src/lib.rs.in
@@ -236,7 +236,7 @@ impl Part for TraceSpan {}
 /// * [patch traces projects](struct.ProjectPatchTraceCall.html) (response)
 /// 
 #[derive(Default, Clone, Debug, Serialize, Deserialize)]
-pub struct Empty;
+pub struct Empty { _never_set: Option<bool> }
 
 impl ResponseResult for Empty {}
 

--- a/gen/dataproc1/src/lib.rs.in
+++ b/gen/dataproc1/src/lib.rs.in
@@ -229,7 +229,7 @@ impl Part for InstanceGroupConfig {}
 /// * [regions operations delete projects](struct.ProjectRegionOperationDeleteCall.html) (response)
 /// 
 #[derive(Default, Clone, Debug, Serialize, Deserialize)]
-pub struct Empty;
+pub struct Empty { _never_set: Option<bool> }
 
 impl ResponseResult for Empty {}
 
@@ -503,7 +503,7 @@ impl Part for NodeInitializationAction {}
 /// * [regions clusters diagnose projects](struct.ProjectRegionClusterDiagnoseCall.html) (request)
 /// 
 #[derive(Default, Clone, Debug, Serialize, Deserialize)]
-pub struct DiagnoseClusterRequest;
+pub struct DiagnoseClusterRequest { _never_set: Option<bool> }
 
 impl RequestValue for DiagnoseClusterRequest {}
 
@@ -854,7 +854,7 @@ impl ResponseResult for Operation {}
 /// * [regions jobs cancel projects](struct.ProjectRegionJobCancelCall.html) (request)
 /// 
 #[derive(Default, Clone, Debug, Serialize, Deserialize)]
-pub struct CancelJobRequest;
+pub struct CancelJobRequest { _never_set: Option<bool> }
 
 impl RequestValue for CancelJobRequest {}
 

--- a/gen/genomics1/src/lib.rs.in
+++ b/gen/genomics1/src/lib.rs.in
@@ -436,7 +436,7 @@ impl RequestValue for ImportVariantsRequest {}
 /// * [delete annotationsets](struct.AnnotationsetDeleteCall.html) (response)
 /// 
 #[derive(Default, Clone, Debug, Serialize, Deserialize)]
-pub struct Empty;
+pub struct Empty { _never_set: Option<bool> }
 
 impl ResponseResult for Empty {}
 
@@ -603,7 +603,7 @@ impl ResponseResult for Annotation {}
 /// * [get iam policy datasets](struct.DatasetGetIamPolicyCall.html) (request)
 /// 
 #[derive(Default, Clone, Debug, Serialize, Deserialize)]
-pub struct GetIamPolicyRequest;
+pub struct GetIamPolicyRequest { _never_set: Option<bool> }
 
 impl RequestValue for GetIamPolicyRequest {}
 
@@ -1653,7 +1653,7 @@ impl RequestValue for SearchAnnotationSetsRequest {}
 /// * [undelete datasets](struct.DatasetUndeleteCall.html) (request)
 /// 
 #[derive(Default, Clone, Debug, Serialize, Deserialize)]
-pub struct UndeleteDatasetRequest;
+pub struct UndeleteDatasetRequest { _never_set: Option<bool> }
 
 impl RequestValue for UndeleteDatasetRequest {}
 
@@ -1941,7 +1941,7 @@ impl ResponseResult for Dataset {}
 /// * [cancel operations](struct.OperationCancelCall.html) (request)
 /// 
 #[derive(Default, Clone, Debug, Serialize, Deserialize)]
-pub struct CancelOperationRequest;
+pub struct CancelOperationRequest { _never_set: Option<bool> }
 
 impl RequestValue for CancelOperationRequest {}
 

--- a/gen/iam1/src/lib.rs.in
+++ b/gen/iam1/src/lib.rs.in
@@ -351,7 +351,7 @@ impl ResponseResult for Policy {}
 /// * [service accounts keys delete projects](struct.ProjectServiceAccountKeyDeleteCall.html) (response)
 /// 
 #[derive(Default, Clone, Debug, Serialize, Deserialize)]
-pub struct Empty;
+pub struct Empty { _never_set: Option<bool> }
 
 impl ResponseResult for Empty {}
 
@@ -361,7 +361,7 @@ impl ResponseResult for Empty {}
 /// This type is not used in any activity, and only used as *part* of another schema.
 /// 
 #[derive(Default, Clone, Debug, Serialize, Deserialize)]
-pub struct CloudAuditOptions;
+pub struct CloudAuditOptions { _never_set: Option<bool> }
 
 impl Part for CloudAuditOptions {}
 
@@ -419,7 +419,7 @@ impl Part for Binding {}
 /// This type is not used in any activity, and only used as *part* of another schema.
 /// 
 #[derive(Default, Clone, Debug, Serialize, Deserialize)]
-pub struct DataAccessOptions;
+pub struct DataAccessOptions { _never_set: Option<bool> }
 
 impl Part for DataAccessOptions {}
 

--- a/gen/logging2_beta1/src/lib.rs.in
+++ b/gen/logging2_beta1/src/lib.rs.in
@@ -376,7 +376,7 @@ impl RequestValue for ListLogEntriesRequest {}
 /// * [sinks delete projects](struct.ProjectSinkDeleteCall.html) (response)
 /// 
 #[derive(Default, Clone, Debug, Serialize, Deserialize)]
-pub struct Empty;
+pub struct Empty { _never_set: Option<bool> }
 
 impl ResponseResult for Empty {}
 
@@ -451,7 +451,7 @@ impl ResponseResult for ListSinksResponse {}
 /// * [write entries](struct.EntryWriteCall.html) (response)
 /// 
 #[derive(Default, Clone, Debug, Serialize, Deserialize)]
-pub struct WriteLogEntriesResponse;
+pub struct WriteLogEntriesResponse { _never_set: Option<bool> }
 
 impl ResponseResult for WriteLogEntriesResponse {}
 

--- a/gen/monitoring3/src/lib.rs.in
+++ b/gen/monitoring3/src/lib.rs.in
@@ -465,7 +465,7 @@ impl Part for Distribution {}
 /// * [groups delete projects](struct.ProjectGroupDeleteCall.html) (response)
 /// 
 #[derive(Default, Clone, Debug, Serialize, Deserialize)]
-pub struct Empty;
+pub struct Empty { _never_set: Option<bool> }
 
 impl ResponseResult for Empty {}
 

--- a/gen/proximitybeacon1_beta1/src/lib.rs.in
+++ b/gen/proximitybeacon1_beta1/src/lib.rs.in
@@ -402,7 +402,7 @@ impl Part for BeaconInfo {}
 /// * [activate beacons](struct.BeaconActivateCall.html) (response)
 /// 
 #[derive(Default, Clone, Debug, Serialize, Deserialize)]
-pub struct Empty;
+pub struct Empty { _never_set: Option<bool> }
 
 impl ResponseResult for Empty {}
 

--- a/gen/pubsub1/src/lib.rs.in
+++ b/gen/pubsub1/src/lib.rs.in
@@ -394,7 +394,7 @@ impl RequestValue for ModifyPushConfigRequest {}
 /// * [subscriptions modify ack deadline projects](struct.ProjectSubscriptionModifyAckDeadlineCall.html) (response)
 /// 
 #[derive(Default, Clone, Debug, Serialize, Deserialize)]
-pub struct Empty;
+pub struct Empty { _never_set: Option<bool> }
 
 impl ResponseResult for Empty {}
 

--- a/gen/pubsub1_beta2/src/lib.rs.in
+++ b/gen/pubsub1_beta2/src/lib.rs.in
@@ -397,7 +397,7 @@ impl RequestValue for ModifyPushConfigRequest {}
 /// * [subscriptions modify ack deadline projects](struct.ProjectSubscriptionModifyAckDeadlineCall.html) (response)
 /// 
 #[derive(Default, Clone, Debug, Serialize, Deserialize)]
-pub struct Empty;
+pub struct Empty { _never_set: Option<bool> }
 
 impl ResponseResult for Empty {}
 

--- a/gen/storagetransfer1/src/lib.rs.in
+++ b/gen/storagetransfer1/src/lib.rs.in
@@ -201,7 +201,7 @@ impl Part for TransferSpec {}
 /// * [pause transfer operations](struct.TransferOperationPauseCall.html) (request)
 /// 
 #[derive(Default, Clone, Debug, Serialize, Deserialize)]
-pub struct PauseTransferOperationRequest;
+pub struct PauseTransferOperationRequest { _never_set: Option<bool> }
 
 impl RequestValue for PauseTransferOperationRequest {}
 
@@ -443,7 +443,7 @@ impl Part for TimeOfDay {}
 /// * [resume transfer operations](struct.TransferOperationResumeCall.html) (response)
 /// 
 #[derive(Default, Clone, Debug, Serialize, Deserialize)]
-pub struct Empty;
+pub struct Empty { _never_set: Option<bool> }
 
 impl ResponseResult for Empty {}
 
@@ -557,7 +557,7 @@ impl Part for ErrorSummary {}
 /// * [resume transfer operations](struct.TransferOperationResumeCall.html) (request)
 /// 
 #[derive(Default, Clone, Debug, Serialize, Deserialize)]
-pub struct ResumeTransferOperationRequest;
+pub struct ResumeTransferOperationRequest { _never_set: Option<bool> }
 
 impl RequestValue for ResumeTransferOperationRequest {}
 

--- a/gen/youtube3/src/lib.rs.in
+++ b/gen/youtube3/src/lib.rs.in
@@ -3835,7 +3835,7 @@ impl Part for ChannelContentDetails {}
 /// This type is not used in any activity, and only used as *part* of another schema.
 /// 
 #[derive(Default, Clone, Debug, Serialize, Deserialize)]
-pub struct TokenPagination;
+pub struct TokenPagination { _never_set: Option<bool> }
 
 impl Part for TokenPagination {}
 

--- a/gen/youtubereporting1/src/lib.rs.in
+++ b/gen/youtubereporting1/src/lib.rs.in
@@ -360,7 +360,7 @@ impl ResponseResult for Report {}
 /// * [delete jobs](struct.JobDeleteCall.html) (response)
 /// 
 #[derive(Default, Clone, Debug, Serialize, Deserialize)]
-pub struct Empty;
+pub struct Empty { _never_set: Option<bool> }
 
 impl ResponseResult for Empty {}
 

--- a/src/mako/api/lib/schema.mako
+++ b/src/mako/api/lib/schema.mako
@@ -42,7 +42,8 @@ impl Default for ${et} {
     }
 }
 % else: ## it's an empty struct, i.e. struct Foo;
-${struct};
+        ## However, to enable the empty JSON object to be parsed, we set one unused optional parameter.
+${struct} { _never_set: Option<bool> }
 % endif ## 'properties' in s
 </%def>
 


### PR DESCRIPTION
Null structs (`struct Foo;`) cause the following error when trying to
deserialize an empty JSON object `{}` into them:

```
JsonDecodeError("{}\n", Syntax(InvalidType(Map), 1, 1))`
```
string representation:

```
invalid type: map at line 1 column 1: {}
```
The optional struct member prevents this error.