### PR TITLE
chore(deps): Update hyper for generated crates to ^0.10

### DIFF
--- a/src/mako/Cargo.toml.mako
+++ b/src/mako/Cargo.toml.mako
@@ -26,7 +26,7 @@ name = "${util.program_name()}"
 % endif
 
 [dependencies]
-hyper = "^ 0.9"
+hyper = "^ 0.10"
 ## Must match the one hyper uses, otherwise there are duplicate similarly named `Mime` structs
 mime = "^ 0.2.0"
 serde = "^ 0.8"


### PR DESCRIPTION
You guessed it, again related to the openssl upgrade in dermesser/yup-oauth2#51. As long as the API crates depend on openssl 0.7 via hyper 0.9, any client using the APIs won't build, because yup-oauth2 pulls in openssl 0.9 (...because openssl 0.7 doesn't build on Mac). It's one big yak to shave, and I'm sorry for all the trouble :(

Please regenerate and publish afterwards, if possible.