### PR TITLE
Updated index.html documentation template

### DIFF
--- a/src/mako/index.html.mako
+++ b/src/mako/index.html.mako
@@ -69,79 +69,75 @@ function onCopy(e) {
 	<title>${title}</title>
 </head>
 <body>
-    <div class="container">
-<h1>${title}</h1>
-<table class="table table-hover">
+  <div class="container">
+  <h1>${title}</h1>
+  <table class="table table-hover">
     <thead>
-        <tr>
-            <th>API Name</th>
-            <th>API Docs</th>
-            <th>CLI Docs</th>
-            <th>Install</th>
-        </tr>
+      <tr>
+        <th>API Name</th>
+        <th>API Docs</th>
+        <th>CLI Docs</th>
+        <th>Install</th>
+      </tr>
     </thead>
     <tbody>
     % for name in sorted(api.list.keys()):
-        % if name in api.blacklist:
-            <% continue %>\
-        % endif
-        % for version in api.list[name]:
-        <tr>
-            <% 
-                # We know type_names is just ["api", "cli"]
-                #type_names = tc.keys()
-                type_names = ["api", "cli"]
-                with open(api_json_path(directories.api_base, name, version)) as fp:
-                    metadata = json.load(fp)
+      % if name in api.blacklist:
+        <% continue %>\
+      % endif
+    % for version in api.list[name]:
+      <tr>
+        <% 
+            # We know type_names is just ["api", "cli"]
+            #type_names = tc.keys()
+            type_names = ["api", "cli"]
+            with open(api_json_path(directories.api_base, name, version)) as fp:
+                metadata = json.load(fp)
 
-                if metadata is None:
-                    continue
+            if metadata is None:
+                continue
 
-                api_data = tc["api"]
-                api_revision = api_data.get('revision', None)
+            api_data = tc["api"]
+            api_revision = api_data.get('revision', None)
 
-                # TODO: Find out why the api link always ends in +00000 instead of +20161020
-                api_link = api_index(DOC_ROOT, name, version, api_data['make'], 
-                    api_data['cargo'], api_revision)
+            # TODO: Find out why the api link always ends in +00000 instead of +20161020
+            api_link = api_index(DOC_ROOT, name, version, api_data['make'], 
+                api_data['cargo'], api_revision)
 
-                crates_link = crates_io_url(name, version) + "/" + crate_version(api_data.cargo.build_version, api_revision)
+            crates_link = crates_io_url(name, version)
+            crates_link += "/"
+            crates_link += crate_version(api_data.cargo.build_version, api_revision)
 
-                cli_data = tc["cli"]
-                cli_revision = cli_data.get('revision', None)
-                cli_link = api_index(DOC_ROOT, 
-                                     name, 
-                                     version, 
-                                     cli_data['make'], 
-                                     cli_data['cargo'], 
-                                     cli_revision)
-            %>\
-            <td>${name} (${version})</td> 
-            <td>
-                <a href="${api_link}" title="API docs for the ${name} ${version}">
-                    API
-                </a>
-                <a href="${crates_link}">
-                    <img src="${url_info.asset_urls.crates_img}" 
-                    title="This API on crates.io" height="16" width="16"/>
-                </a>
-            </td>
-            <td>
-                <a href="${cli_link}" title="CLI docs for the ${name} ${version}">
-                    CLI
-                </a>
-            </td>
-            <td>
-                <button class="mono" onclick="onClick(this)" 
-                    oncopy="onCopy(event)" 
-                    title="Copy complete installation script to clipboard">
-                    cargo install ${library_to_crate_name(library_name(name, version))}-cli
-                </button>
-            </td>
+            cli_data = tc["cli"]
+            cli_revision = cli_data.get('revision', None)
+            cli_link = api_index(DOC_ROOT, name, version, cli_data['make'], 
+                                 cli_data['cargo'], cli_revision)
+        %>\
+        <td>${name} (${version})</td> 
+          <td>
+            <a href="${api_link}" title="API docs for the ${name} ${version}">API</a>
+            <a href="${crates_link}">
+              <img src="${url_info.asset_urls.crates_img}" 
+                title="This API on crates.io" height="16" width="16"/>
+            </a>
+          </td>
+          <td>
+            <a href="${cli_link}" title="CLI docs for the ${name} ${version}">
+              CLI
+            </a>
+          </td>
+          <td>
+            <button class="mono" onclick="onClick(this)" 
+              oncopy="onCopy(event)" 
+              title="Copy complete installation script to clipboard">
+              cargo install ${library_to_crate_name(library_name(name, version))}-cli
+            </button>
+          </td>
         </tr>
-        % endfor # each version
-    % endfor # each API
-</tbody>
-</table>
-</div>
+      % endfor # each version
+      % endfor # each API
+      </tbody>
+    </table>
+  </div>
 </body>
 </html>

--- a/src/mako/index.html.mako
+++ b/src/mako/index.html.mako
@@ -91,9 +91,9 @@ function onCopy(e) {
     % for version in api.list[name]:
       <tr>
         <% 
-            # We know type_names is just ["api", "cli"]
-            #type_names = tc.keys()
             type_names = ["api", "cli"]
+            assert set(type_names) == set(tc.keys()), "The type cache has changed, make sure to update the documentation accordingly"
+
             with open(api_json_path(directories.api_base, name, version)) as fp:
                 metadata = json.load(fp)
 

--- a/src/mako/index.html.mako
+++ b/src/mako/index.html.mako
@@ -29,19 +29,19 @@ DO NOT EDIT !
 <head>
 <link rel="stylesheet" href="main.css">
 <style type="text/css">
-.lib {
-  color: #000000;
-  font-size: 20px;
-  float: left;
-  width: 300px;
-}
-.mod {
-  color: #4d76ae;
-  font-size: 20px;
-}
-.mono {
-  font-family: monospace;
-}
+## .lib {
+##   color: #000000;
+##   font-size: 20px;
+##   float: left;
+##   width: 300px;
+## }
+## .mod {
+##   color: #4d76ae;
+##   font-size: 20px;
+## }
+## .mono {
+##   font-family: monospace;
+## }
 </style>
 <script type="text/javascript">
 alertShown = false
@@ -84,32 +84,33 @@ function onCopy(e) {
 	<title>${title}</title>
 </head>
 <body>
-<H1>${title}</H1>
+<h1>${title}</h1>
 <ul>
-% for an in sorted(api.list.keys()):
-    % if an in api.blacklist:
+% for name in sorted(api.list.keys()):
+    % if name in api.blacklist:
         <% continue %>\
     % endif
-    % for v in api.list[an]:
+    % for version in api.list[name]:
         <% 
             type_names = tc.keys()
-            with open(api_json_path(directories.api_base, an, v)) as fp:
+            with open(api_json_path(directories.api_base, name, version)) as fp:
               api_data = json.load(fp)
         %>\
+        <t>${name}</t>
         % if api_data is None:
             <% continue %>\
         % endif
-        <span class="lib">${an} ${v}</span> 
+        <span class="lib">${name} ${version}</span> 
         % for program_type in type_names:
             <% 
               ad = tc[program_type] 
               revision = api_data.get('revision', None)
             %>\
-            <a class="mod" href="${api_index(DOC_ROOT, an, v, ad.make, ad.cargo, revision)}" title="${ad.make.id.upper()} docs for the ${an} ${v}">${ad.make.id.upper()}</a>
+            <a class="mod" href="${api_index(DOC_ROOT, name, version, ad.make, ad.cargo, revision)}" title="${ad.make.id.upper()} docs for the ${name} ${version}">${ad.make.id.upper()}</a>
             % if program_type == 'api':
-            <a href="${crates_io_url(an, v)}/${crate_version(ad.cargo.build_version, revision)}"><img src="${url_info.asset_urls.crates_img}" title="This API on crates.io" height="16" width="16"/></a>
+            <a href="${crates_io_url(name, version)}/${crate_version(ad.cargo.build_version, revision)}"><img src="${url_info.asset_urls.crates_img}" title="This API on crates.io" height="16" width="16"/></a>
             % else:
-            , <button class="mono" onclick="onClick(this)" oncopy="onCopy(event)" title="Copy complete installation script to clipboard">cargo install ${library_to_crate_name(library_name(an, v))}-cli</button>
+            , <button class="mono" onclick="onClick(this)" oncopy="onCopy(event)" title="Copy complete installation script to clipboard">cargo install ${library_to_crate_name(library_name(name, version))}-cli</button>
             % endif
             % if not loop.last:
 ,           

--- a/src/mako/index.html.mako
+++ b/src/mako/index.html.mako
@@ -85,40 +85,66 @@ function onCopy(e) {
 </head>
 <body>
 <h1>${title}</h1>
-<ul>
-% for name in sorted(api.list.keys()):
-    % if name in api.blacklist:
-        <% continue %>\
-    % endif
-    % for version in api.list[name]:
-        <% 
-            type_names = tc.keys()
-            with open(api_json_path(directories.api_base, name, version)) as fp:
-              api_data = json.load(fp)
-        %>\
-        <t>${name}</t>
-        % if api_data is None:
+<table>
+    <thead>
+        <tr>
+            <th>API Name</th>
+            <th>API Docs</th>
+            <th>CLI Docs</th>
+            <th>Install</th>
+        </tr>
+    </thead>
+    <tbody>
+    % for name in sorted(api.list.keys()):
+        % if name in api.blacklist:
             <% continue %>\
         % endif
-        <span class="lib">${name} ${version}</span> 
-        % for program_type in type_names:
+        % for version in api.list[name]:
+        <tr>
             <% 
-              ad = tc[program_type] 
-              revision = api_data.get('revision', None)
+                # We know type_names is just ["api", "cli"]
+                type_names = tc.keys()
+                type_names = ["api", "cli"]
+                with open(api_json_path(directories.api_base, name, version)) as fp:
+                    api_data = json.load(fp)
             %>\
-            <a class="mod" href="${api_index(DOC_ROOT, name, version, ad.make, ad.cargo, revision)}" title="${ad.make.id.upper()} docs for the ${name} ${version}">${ad.make.id.upper()}</a>
-            % if program_type == 'api':
-            <a href="${crates_io_url(name, version)}/${crate_version(ad.cargo.build_version, revision)}"><img src="${url_info.asset_urls.crates_img}" title="This API on crates.io" height="16" width="16"/></a>
-            % else:
-            , <button class="mono" onclick="onClick(this)" oncopy="onCopy(event)" title="Copy complete installation script to clipboard">cargo install ${library_to_crate_name(library_name(name, version))}-cli</button>
+            % if api_data is None:
+                <% continue %>\
             % endif
-            % if not loop.last:
-,           
-            % endif
-        % endfor # each program type
-        <br/>
-    % endfor # each version
-% endfor # each API
-</ul>
+            <td>${name} (${version})</td> 
+            <td>
+                <% 
+                api_data = tc["api"] 
+                revision = api_data.get('revision', None)
+                %>\
+                <a class="mod" 
+                    href="${api_index(DOC_ROOT, name, version, api_data.make, api_data.cargo, revision)}" 
+                    title="${api_data.make.id.upper()} docs for the ${name} ${version}">
+                    ${api_data.make.id.upper()}
+                </a>
+                <a href="${crates_io_url(name, version)}/${crate_version(api_data.cargo.build_version, revision)}"><img src="${url_info.asset_urls.crates_img}" title="This API on crates.io" height="16" width="16"/></a>
+            </td>
+            <td>
+                <% 
+                api_data = tc["cli"] 
+                revision = api_data.get('revision', None)
+                %>\
+                <a href="${api_index(DOC_ROOT, name, version, api_data.make, api_data.cargo, revision)}" 
+                    title="${api_data.make.id.upper()} docs for the ${name} ${version}">
+                    ${api_data.make.id.upper()}
+                </a>
+            </td>
+            <td>
+                <button class="mono" onclick="onClick(this)" 
+                    oncopy="onCopy(event)" 
+                    title="Copy complete installation script to clipboard">
+                    cargo install ${library_to_crate_name(library_name(name, version))}-cli
+                </button>
+            </td>
+        </tr>
+        % endfor # each version
+    % endfor # each API
+</tbody>
+</table>
 </body>
 </html>

--- a/src/mako/index.html.mako
+++ b/src/mako/index.html.mako
@@ -27,22 +27,7 @@ DO NOT EDIT !
 -->
 <html>
 <head>
-<link rel="stylesheet" href="main.css">
-<style type="text/css">
-## .lib {
-##   color: #000000;
-##   font-size: 20px;
-##   float: left;
-##   width: 300px;
-## }
-## .mod {
-##   color: #4d76ae;
-##   font-size: 20px;
-## }
-## .mono {
-##   font-family: monospace;
-## }
-</style>
+<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" crossorigin="anonymous">
 <script type="text/javascript">
 alertShown = false
 function onClick(button) {
@@ -84,8 +69,9 @@ function onCopy(e) {
 	<title>${title}</title>
 </head>
 <body>
+    <div class="container">
 <h1>${title}</h1>
-<table>
+<table class="table table-hover">
     <thead>
         <tr>
             <th>API Name</th>
@@ -103,7 +89,7 @@ function onCopy(e) {
         <tr>
             <% 
                 # We know type_names is just ["api", "cli"]
-                type_names = tc.keys()
+                #type_names = tc.keys()
                 type_names = ["api", "cli"]
                 with open(api_json_path(directories.api_base, name, version)) as fp:
                     metadata = json.load(fp)
@@ -113,18 +99,21 @@ function onCopy(e) {
 
                 api_data = tc["api"]
                 api_revision = api_data.get('revision', None)
+
                 # TODO: Find out why the api link always ends in +00000 instead of +20161020
                 api_link = api_index(DOC_ROOT, name, version, api_data['make'], 
                     api_data['cargo'], api_revision)
 
-                crates_link = (crates_io_url(name, version) + 
-                    "/" + 
-                    crate_version(api_data.cargo.build_version, api_revision))
+                crates_link = crates_io_url(name, version) + "/" + crate_version(api_data.cargo.build_version, api_revision)
 
                 cli_data = tc["cli"]
                 cli_revision = cli_data.get('revision', None)
-                cli_link = api_index(DOC_ROOT, name, version, cli_data['make'], 
-                    cli_data['cargo'], cli_revision)
+                cli_link = api_index(DOC_ROOT, 
+                                     name, 
+                                     version, 
+                                     cli_data['make'], 
+                                     cli_data['cargo'], 
+                                     cli_revision)
             %>\
             <td>${name} (${version})</td> 
             <td>
@@ -137,10 +126,6 @@ function onCopy(e) {
                 </a>
             </td>
             <td>
-                <% 
-                api_data = tc["cli"] 
-                revision = api_data.get('revision', None)
-                %>\
                 <a href="${cli_link}" title="CLI docs for the ${name} ${version}">
                     CLI
                 </a>
@@ -157,5 +142,6 @@ function onCopy(e) {
     % endfor # each API
 </tbody>
 </table>
+</div>
 </body>
 </html>

--- a/src/mako/index.html.mako
+++ b/src/mako/index.html.mako
@@ -106,32 +106,43 @@ function onCopy(e) {
                 type_names = tc.keys()
                 type_names = ["api", "cli"]
                 with open(api_json_path(directories.api_base, name, version)) as fp:
-                    api_data = json.load(fp)
+                    metadata = json.load(fp)
+
+                if metadata is None:
+                    continue
+
+                api_data = tc["api"]
+                api_revision = api_data.get('revision', None)
+                # TODO: Find out why the api link always ends in +00000 instead of +20161020
+                api_link = api_index(DOC_ROOT, name, version, api_data['make'], 
+                    api_data['cargo'], api_revision)
+
+                crates_link = (crates_io_url(name, version) + 
+                    "/" + 
+                    crate_version(api_data.cargo.build_version, api_revision))
+
+                cli_data = tc["cli"]
+                cli_revision = cli_data.get('revision', None)
+                cli_link = api_index(DOC_ROOT, name, version, cli_data['make'], 
+                    cli_data['cargo'], cli_revision)
             %>\
-            % if api_data is None:
-                <% continue %>\
-            % endif
             <td>${name} (${version})</td> 
             <td>
-                <% 
-                api_data = tc["api"] 
-                revision = api_data.get('revision', None)
-                %>\
-                <a class="mod" 
-                    href="${api_index(DOC_ROOT, name, version, api_data.make, api_data.cargo, revision)}" 
-                    title="${api_data.make.id.upper()} docs for the ${name} ${version}">
-                    ${api_data.make.id.upper()}
+                <a href="${api_link}" title="API docs for the ${name} ${version}">
+                    API
                 </a>
-                <a href="${crates_io_url(name, version)}/${crate_version(api_data.cargo.build_version, revision)}"><img src="${url_info.asset_urls.crates_img}" title="This API on crates.io" height="16" width="16"/></a>
+                <a href="${crates_link}">
+                    <img src="${url_info.asset_urls.crates_img}" 
+                    title="This API on crates.io" height="16" width="16"/>
+                </a>
             </td>
             <td>
                 <% 
                 api_data = tc["cli"] 
                 revision = api_data.get('revision', None)
                 %>\
-                <a href="${api_index(DOC_ROOT, name, version, api_data.make, api_data.cargo, revision)}" 
-                    title="${api_data.make.id.upper()} docs for the ${name} ${version}">
-                    ${api_data.make.id.upper()}
+                <a href="${cli_link}" title="CLI docs for the ${name} ${version}">
+                    CLI
                 </a>
             </td>
             <td>

--- a/src/mako/index.html.mako
+++ b/src/mako/index.html.mako
@@ -27,8 +27,11 @@ DO NOT EDIT !
 -->
 <html>
 <head>
-<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" crossorigin="anonymous">
-<script type="text/javascript">
+  <link rel="stylesheet" 
+    href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" 
+    integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u"
+    crossorigin="anonymous">
+  <script type="text/javascript">
 alertShown = false
 function onClick(button) {
   selectElementContents(button)
@@ -65,8 +68,8 @@ function onCopy(e) {
   e.clipboardData.setData('text/plain', installation_script);
   e.preventDefault()
 }
-</script>
-	<title>${title}</title>
+  </script>
+  <title>${title}</title>
 </head>
 <body>
   <div class="container">
@@ -98,20 +101,18 @@ function onCopy(e) {
                 continue
 
             api_data = tc["api"]
-            api_revision = api_data.get('revision', None)
+            revision = metadata.get('revision', None)
 
-            # TODO: Find out why the api link always ends in +00000 instead of +20161020
             api_link = api_index(DOC_ROOT, name, version, api_data['make'], 
-                api_data['cargo'], api_revision)
+                api_data['cargo'], revision)
 
             crates_link = crates_io_url(name, version)
             crates_link += "/"
-            crates_link += crate_version(api_data.cargo.build_version, api_revision)
+            crates_link += crate_version(api_data.cargo.build_version, revision)
 
             cli_data = tc["cli"]
-            cli_revision = cli_data.get('revision', None)
             cli_link = api_index(DOC_ROOT, name, version, cli_data['make'], 
-                                 cli_data['cargo'], cli_revision)
+                                 cli_data['cargo'], revision)
         %>\
         <td>${name} (${version})</td> 
           <td>


### PR DESCRIPTION
I believe I've figured out why the lines were getting messed up. Basically, some API names were exceeding the 300px allocated to them by `.lib`, so they were being pushed down to a new line. This then messed everything up for the line below so that it starts 300px in.

I converted from the old span + br way of formatting to using tables to keep everything laid out. I hope you don't mind, but I added a link tag to pull in [Bootstrap]'s css from their CDN to make things look pretty.

At the moment the page looks something like this:
![screenshot_2017-04-01_024532](https://cloud.githubusercontent.com/assets/17380079/24564707/6a03d768-1685-11e7-887a-0f22cf2cb0b4.png)

(Fixes #166)

[Bootstrap]: http://getbootstrap.com/getting-started/#download-cdn