### PR TITLE
Enable working apis

### DIFF
--- a/etc/api/shared.yaml
+++ b/etc/api/shared.yaml
@@ -12,30 +12,15 @@ api:
     - kgsearch
     - mapsengine
     - firebaserules
-    - runtimeconfig
-    - analyticsreporting
-    # Doesn't work with stable due to a known issue serializing it using syntex_syntax
-    - servicecontrol
     - servicemanagement
     # defines its own `Option` type
     - serviceconsumermanagement
     # defines its own `Option` type
     - serviceuser
-    - language
-    - speech
-    - adexchangebuyer2
-    - clouderrorreporting
-    - vision
     - freebase
-    - acceleratedmobilepageurl
-    - cloudbuild
-    - cloudtrace
     - audit
     - cloudsearch
-    - cloudtrace
     - toolresults
-    - datastore
-    - consumersurveys
     - script
     # redefinition of types apparently
     - streetviewpublish

--- a/gen/acceleratedmobilepageurl1-cli/Cargo.toml
+++ b/gen/acceleratedmobilepageurl1-cli/Cargo.toml
@@ -1,0 +1,40 @@
+# DO NOT EDIT !
+# This file was generated automatically from 'src/mako/Cargo.toml.mako'
+# DO NOT EDIT !
+[package]
+
+name = "google-acceleratedmobilepageurl1-cli"
+version = "1.0.7+20171202"
+authors = ["Sebastian Thiel <byronimo@gmail.com>"]
+description = "A complete library to interact with acceleratedmobilepageurl (protocol v1)"
+repository = "https://github.com/Byron/google-apis-rs/tree/master/gen/acceleratedmobilepageurl1-cli"
+homepage = "https://developers.google.com/amp/cache/"
+documentation = "http://byron.github.io/google-apis-rs/google_acceleratedmobilepageurl1_cli"
+license = "MIT"
+keywords = ["acceleratedmobilepag", "google", "cli"]
+
+[[bin]]
+name = "acceleratedmobilepageurl1"
+
+[dev-dependencies]
+hyper-rustls = "^0.6"
+
+[dependencies]
+hyper = "^ 0.10"
+mime = "^ 0.2.0"
+serde = "^ 1.0"
+serde_json = "^ 1.0"
+serde_derive = "^ 1.0"
+yup-oauth2 = "^ 1.0"
+strsim = "^0.5"
+hyper-rustls = "^0.6"
+yup-hyper-mock = "^2.0"
+clap = "^2.0"
+
+[features]
+
+
+
+[dependencies.google-acceleratedmobilepageurl1]
+path = "../acceleratedmobilepageurl1"
+version = "1.0.7+20171202"

--- a/gen/acceleratedmobilepageurl1-cli/LICENSE.md
+++ b/gen/acceleratedmobilepageurl1-cli/LICENSE.md
@@ -1,0 +1,30 @@
+<!---
+DO NOT EDIT !
+This file was generated automatically from 'src/mako/LICENSE.md.mako'
+DO NOT EDIT !
+-->
+The MIT License (MIT)
+=====================
+
+Copyright © `2015-2016` `Sebastian Thiel`
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the “Software”), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.

--- a/gen/acceleratedmobilepageurl1-cli/README.md
+++ b/gen/acceleratedmobilepageurl1-cli/README.md
@@ -1,0 +1,110 @@
+<!---
+DO NOT EDIT !
+This file was generated automatically from 'src/mako/cli/README.md.mako'
+DO NOT EDIT !
+-->
+The `acceleratedmobilepageurl1` command-line interface *(CLI)* allows to use most features of the *Google acceleratedmobilepageurl* service from the comfort of your terminal.
+
+By default all output is printed to standard out, but flags can be set to direct it into a file independent of your shell's
+capabilities. Errors will be printed to standard error, and cause the program's exit code to be non-zero.
+
+If data-structures are requested, these will be returned as pretty-printed JSON, to be useful as input to other tools.
+
+Everything else about the *acceleratedmobilepageurl* API can be found at the
+[official documentation site](https://developers.google.com/amp/cache/).
+
+# Installation and Source Code
+
+Install the command-line interface with cargo using:
+
+```bash
+cargo install google-acceleratedmobilepageurl1-cli
+```
+
+Find the source code [on github](https://github.com/Byron/google-apis-rs/tree/master/gen/acceleratedmobilepageurl1-cli).
+
+# Usage
+
+This documentation was generated from the *acceleratedmobilepageurl* API at revision *20171202*. The CLI is at version *1.0.7*.
+
+```bash
+acceleratedmobilepageurl1 [options]
+        amp-urls
+                batch-get (-r <kv>)... [-p <v>]... [-o <out>]
+  acceleratedmobilepageurl1 --help
+
+Configuration:
+  --config-dir <folder>
+            A directory into which we will store our persistent data. Defaults to
+            a user-writable directory that we will create during the first invocation.
+            [default: ~/.google-service-cli]
+  --debug
+            Output all server communication to standard error. `tx` and `rx` are placed
+            into the same stream.
+  --debug-auth
+            Output all communication related to authentication to standard error. `tx`
+            and `rx` are placed into the same stream.
+
+```
+
+# Configuration
+
+The program will store all persistent data in the `~/.google-service-cli` directory in *JSON* files prefixed with `acceleratedmobilepageurl1-`.  You can change the directory used to store configuration with the `--config-dir` flag on a per-invocation basis.
+
+More information about the various kinds of persistent data are given in the following paragraphs.
+
+# Authentication
+
+Most APIs require a user to authenticate any request. If this is the case, the [scope][scopes] determines the 
+set of permissions granted. The granularity of these is usually no more than *read-only* or *full-access*.
+
+If not set, the system will automatically select the smallest feasible scope, e.g. when invoking a
+method that is read-only, it will ask only for a read-only scope. 
+You may use the `--scope` flag to specify a scope directly. 
+All applicable scopes are documented in the respective method's CLI documentation.
+
+The first time a scope is used, the user is asked for permission. Follow the instructions given 
+by the CLI to grant permissions, or to decline.
+
+If a scope was authenticated by the user, the respective information will be stored as *JSON* in the configuration
+directory, e.g. `~/.google-service-cli/acceleratedmobilepageurl1-token-<scope-hash>.json`. No manual management of these tokens
+is necessary.
+
+To revoke granted authentication, please refer to the [official documentation][revoke-access].
+
+# Application Secrets
+
+In order to allow any application to use Google services, it will need to be registered using the 
+[Google Developer Console][google-dev-console]. APIs the application may use are then enabled for it
+one by one. Most APIs can be used for free and have a daily quota.
+
+To allow more comfortable usage of the CLI without forcing anyone to register an own application, the CLI
+comes with a default application secret that is configured accordingly. This also means that heavy usage
+all around the world may deplete the daily quota.
+
+You can workaround this limitation by putting your own secrets file at this location: 
+`~/.google-service-cli/acceleratedmobilepageurl1-secret.json`, assuming that the required *acceleratedmobilepageurl* API 
+was enabled for it. Such a secret file can be downloaded in the *Google Developer Console* at 
+*APIs & auth -> Credentials -> Download JSON* and used as is.
+
+Learn more about how to setup Google projects and enable APIs using the [official documentation][google-project-new].
+
+
+# Debugging
+
+Even though the CLI does its best to provide usable error messages, sometimes it might be desirable to know
+what exactly led to a particular issue. This is done by allowing all client-server communication to be 
+output to standard error *as-is*.
+
+The `--debug` flag will print all client-server communication to standard error, whereas the `--debug-auth` flag
+will cause all communication related to authentication to standard error.
+If the `--debug` flag is set, error-results will be debug-printed, possibly yielding more information about the 
+issue at hand.
+
+You may consider redirecting standard error into a file for ease of use, e.g. `acceleratedmobilepageurl1 --debug <resource> <method> [options] 2>debug.txt`.
+
+
+[scopes]: https://developers.google.com/+/api/oauth#scopes
+[revoke-access]: http://webapps.stackexchange.com/a/30849
+[google-dev-console]: https://console.developers.google.com/
+[google-project-new]: https://developers.google.com/console/help/new/

--- a/gen/acceleratedmobilepageurl1-cli/mkdocs.yml
+++ b/gen/acceleratedmobilepageurl1-cli/mkdocs.yml
@@ -1,0 +1,17 @@
+site_name: acceleratedmobilepageurl v1.0.7+20171202
+site_url: http://byron.github.io/google-apis-rs/google-acceleratedmobilepageurl1-cli
+site_description: A complete library to interact with acceleratedmobilepageurl (protocol v1)
+
+repo_url: https://github.com/Byron/google-apis-rs/tree/master/gen/acceleratedmobilepageurl1-cli
+
+docs_dir: docs
+site_dir: build_html
+
+pages:
+- ['index.md', 'Home']
+- ['amp-urls_batch-get.md', 'Amp Urls', 'Batch Get']
+
+theme: readthedocs
+
+copyright: Copyright &copy; 2015-2016, `Sebastian Thiel`
+

--- a/gen/acceleratedmobilepageurl1-cli/src/cmn.rs
+++ b/gen/acceleratedmobilepageurl1-cli/src/cmn.rs
@@ -1,0 +1,799 @@
+// COPY OF 'src/rust/cli/cmn.rs'
+// DO NOT EDIT
+use oauth2::{ApplicationSecret, ConsoleApplicationSecret, TokenStorage, Token};
+use serde_json as json;
+use serde_json::value::Value;
+use mime::Mime;
+use clap::{App, SubCommand};
+use strsim;
+
+use std::fs;
+use std::env;
+use std::io;
+use std::error::Error as StdError;
+use std::fmt;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+use std::string::ToString;
+use std::io::{Write, Read, stdout};
+
+use std::default::Default;
+
+const FIELD_SEP: char = '.';
+
+
+pub enum ComplexType {
+    Pod,
+    Vec,
+    Map,
+}
+
+// Null,
+// Bool(bool),
+// I64(i64),
+// U64(u64),
+// F64(f64),
+// String(String),
+
+pub enum JsonType {
+    Boolean,
+    Int,
+    Uint,
+    Float,
+    String,
+}
+
+pub struct JsonTypeInfo {
+    pub jtype: JsonType,
+    pub ctype: ComplexType,
+}
+
+// Based on @erickt user comment. Thanks for the idea !
+// Remove all keys whose values are null from given value (changed in place)
+pub fn remove_json_null_values(value: &mut Value) {
+    match *value {
+        Value::Object(ref mut map) => {
+            let mut for_removal = Vec::new();
+
+            for (key, mut value) in map.iter_mut() {
+                if value.is_null() {
+                    for_removal.push(key.clone());
+                } else {
+                    remove_json_null_values(&mut value);
+                }
+            }
+
+            for key in &for_removal {
+                map.remove(key);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn did_you_mean<'a>(v: &str, possible_values: &[&'a str]) -> Option<&'a str> {
+
+    let mut candidate: Option<(f64, &str)> = None;
+    for pv in possible_values {
+        let confidence = strsim::jaro_winkler(v, pv);
+        if confidence > 0.8 &&
+           (candidate.is_none() || (candidate.as_ref().unwrap().0 < confidence)) {
+            candidate = Some((confidence, pv));
+        }
+    }
+    match candidate {
+        None => None,
+        Some((_, candidate)) => Some(candidate),
+    }
+}
+
+pub enum CallType {
+    Upload(UploadProtocol),
+    Standard,
+}
+
+arg_enum!{
+    pub enum UploadProtocol {
+        Simple,
+        Resumable
+    }
+}
+
+impl AsRef<str> for UploadProtocol {
+    fn as_ref(&self) -> &str {
+        match *self {
+            UploadProtocol::Simple => "simple",
+            UploadProtocol::Resumable => "resumable",
+        }
+    }
+}
+
+impl AsRef<str> for CallType {
+    fn as_ref(&self) -> &str {
+        match *self {
+            CallType::Upload(ref proto) => proto.as_ref(),
+            CallType::Standard => "standard-request",
+        }
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct FieldCursor(Vec<String>);
+
+impl ToString for  FieldCursor {
+    fn to_string(&self) -> String {
+        self.0.join(".")
+    }
+}
+
+impl From<&'static str> for FieldCursor {
+    fn from(value: &'static str) -> FieldCursor {
+        let mut res = FieldCursor::default();
+        res.set(value).unwrap();
+        res
+    }
+}
+
+fn assure_entry<'a, 'b>(m: &'a mut json::Map<String, Value>, k: &'b String) -> &'a mut Value {
+    if m.contains_key(k) {
+        return m.get_mut(k).expect("value to exist");
+    }
+    m.insert(k.to_owned(), Value::Object(Default::default()));
+    m.get_mut(k).expect("value to exist")
+}
+
+impl FieldCursor {
+    pub fn set(&mut self, value: &str) -> Result<(), CLIError> {
+        if value.len() == 0 {
+            return Err(CLIError::Field(FieldError::Empty));
+        }
+
+        let mut first_is_field_sep = false;
+        let mut char_count: usize = 0;
+        let mut last_c = FIELD_SEP;
+        let mut num_conscutive_field_seps = 0;
+
+        let mut field = String::new();
+        let mut fields = self.0.clone();
+
+        let push_field = |fs: &mut Vec<String>, f: &mut String| {
+            if f.len() > 0 {
+                fs.push(f.clone());
+                f.truncate(0);
+            }
+        };
+
+        for (cid, c) in value.chars().enumerate() {
+            char_count += 1;
+
+            if c == FIELD_SEP {
+                if cid == 0 {
+                    first_is_field_sep = true;
+                }
+                num_conscutive_field_seps += 1;
+                if cid > 0 && last_c == FIELD_SEP {
+                    if fields.pop().is_none() {
+                        return Err(CLIError::Field(FieldError::PopOnEmpty(value.to_string())));
+                    }
+                } else {
+                    push_field(&mut fields, &mut field);
+                }
+            } else {
+                num_conscutive_field_seps = 0;
+                if cid == 1 {
+                    if first_is_field_sep {
+                        fields.truncate(0);
+                    }
+                }
+                field.push(c);
+            }
+
+            last_c = c;
+        }
+
+        push_field(&mut fields, &mut field);
+
+        if char_count == 1 && first_is_field_sep {
+            fields.truncate(0);
+        }
+        if char_count > 1 && num_conscutive_field_seps == 1 {
+            return Err(CLIError::Field(FieldError::TrailingFieldSep(value.to_string())));
+        }
+
+        self.0 = fields;
+        Ok(())
+    }
+
+    pub fn did_you_mean(value: &str, possible_values: &[&str]) -> Option<String> {
+        if value.len() == 0 {
+            return None;
+        }
+
+        let mut last_c = FIELD_SEP;
+
+        let mut field = String::new();
+        let mut output = String::new();
+
+        let push_field = |fs: &mut String, f: &mut String| {
+            if f.len() > 0 {
+                fs.push_str(match did_you_mean(&f, possible_values) {
+                    Some(candidate) => candidate,
+                    None => &f,
+                });
+                f.truncate(0);
+            }
+        };
+
+        for (cid, c) in value.chars().enumerate() {
+            if c == FIELD_SEP {
+                if last_c != FIELD_SEP {
+                    push_field(&mut output, &mut field);
+                }
+                output.push(c);
+            } else {
+                field.push(c);
+            }
+
+            last_c = c;
+        }
+
+        push_field(&mut output, &mut field);
+
+        if &output == value {
+            None
+        } else {
+            Some(output)
+        }
+    }
+
+    pub fn set_json_value(&self,
+                          mut object: &mut Value,
+                          value: &str,
+                          type_info: JsonTypeInfo,
+                          err: &mut InvalidOptionsError,
+                          orig_cursor: &FieldCursor) {
+        assert!(self.0.len() > 0);
+
+        for field in &self.0[..self.0.len() - 1] {
+            let tmp = object;
+            object = match *tmp {
+                Value::Object(ref mut mapping) => {
+                    assure_entry(mapping, &field)
+                }
+                _ => panic!("We don't expect non-object Values here ..."),
+            };
+        }
+
+        match *object {
+            Value::Object(ref mut mapping) => {
+                let field = &self.0[self.0.len() - 1];
+                let to_jval = |value: &str,
+                               jtype: JsonType,
+                               err: &mut InvalidOptionsError|
+                               -> Value {
+                    match jtype {
+                        JsonType::Boolean =>
+                            Value::Bool(arg_from_str(value, err, &field, "boolean")),
+                        JsonType::Int =>
+                            Value::Number(json::Number::from_f64(arg_from_str(value,
+                                                                              err,
+                                                                              &field,
+                                                                              "int"))
+                                              .expect("valid f64")),
+                        JsonType::Uint =>
+                            Value::Number(json::Number::from_f64(arg_from_str(value,
+                                                                              err,
+                                                                              &field,
+                                                                              "uint"))
+                                              .expect("valid f64")),
+                        JsonType::Float =>
+                            Value::Number(json::Number::from_f64(arg_from_str(value,
+                                                                              err,
+                                                                              &field,
+                                                                              "float"))
+                                              .expect("valid f64")),
+                        JsonType::String => Value::String(value.to_owned()),
+                    }
+                };
+
+                match type_info.ctype {
+                    ComplexType::Pod => {
+                        if mapping.insert(field.to_owned(), to_jval(value, type_info.jtype, err))
+                                  .is_some() {
+                            err.issues.push(CLIError::Field(FieldError::Duplicate(orig_cursor.to_string())));
+                        }
+                    }
+                    ComplexType::Vec => {
+                        match *assure_entry(mapping, field) {
+                            Value::Array(ref mut values) =>
+                                values.push(to_jval(value, type_info.jtype, err)),
+                            _ => unreachable!(),
+                        }
+                    }
+                    ComplexType::Map => {
+                        let (key, value) = parse_kv_arg(value, err, true);
+                        let jval = to_jval(value.unwrap_or(""), type_info.jtype, err);
+
+                        match *assure_entry(mapping, &field) {
+
+                            Value::Object(ref mut value_map) => {
+                                if value_map.insert(key.to_owned(), jval).is_some() {
+                                    err.issues.push(CLIError::Field(FieldError::Duplicate(orig_cursor.to_string())));
+                                }
+                            }
+                            _ => unreachable!(),
+                        }
+                    }
+                }
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    pub fn num_fields(&self) -> usize {
+        self.0.len()
+    }
+}
+
+pub fn parse_kv_arg<'a>(kv: &'a str,
+                        err: &mut InvalidOptionsError,
+                        for_hashmap: bool)
+                        -> (&'a str, Option<&'a str>) {
+    let mut add_err = || {
+        err.issues.push(CLIError::InvalidKeyValueSyntax(kv.to_string(), for_hashmap))
+    };
+    match kv.find('=') {
+        None => {
+            add_err();
+            return (kv, None);
+        }
+        Some(pos) => {
+            let key = &kv[..pos];
+            if kv.len() <= pos + 1 {
+                add_err();
+                return (key, Some(""));
+            }
+            (key, Some(&kv[pos + 1..]))
+        }
+    }
+}
+
+pub fn calltype_from_str(name: &str,
+                         valid_protocols: Vec<String>,
+                         err: &mut InvalidOptionsError)
+                         -> CallType {
+    CallType::Upload(match UploadProtocol::from_str(name) {
+        Ok(up) => up,
+        Err(msg) => {
+            err.issues.push(CLIError::InvalidUploadProtocol(name.to_string(), valid_protocols));
+            UploadProtocol::Simple
+        }
+    })
+}
+
+pub fn input_file_from_opts(file_path: &str, err: &mut InvalidOptionsError) -> Option<fs::File> {
+    match fs::File::open(file_path) {
+        Ok(f) => Some(f),
+        Err(io_err) => {
+            err.issues.push(CLIError::Input(InputError::Io((file_path.to_string(), io_err))));
+            None
+        }
+    }
+}
+
+pub fn input_mime_from_opts(mime: &str, err: &mut InvalidOptionsError) -> Option<Mime> {
+    match mime.parse() {
+        Ok(m) => Some(m),
+        Err(_) => {
+            err.issues.push(CLIError::Input(InputError::Mime(mime.to_string())));
+            None
+        }
+    }
+}
+
+pub fn writer_from_opts(arg: Option<&str>) -> Result<Box<Write>, io::Error> {
+    let f = arg.unwrap_or("-");
+    match f {
+        "-" => Ok(Box::new(stdout())),
+        _ => match fs::OpenOptions::new().create(true).write(true).open(f) {
+            Ok(f) => Ok(Box::new(f)),
+            Err(io_err) => Err(io_err),
+        },
+    }
+}
+
+
+pub fn arg_from_str<'a, T>(arg: &str,
+                           err: &mut InvalidOptionsError,
+                           arg_name: &'a str,
+                           arg_type: &'a str)
+                           -> T
+    where T: FromStr + Default,
+          <T as FromStr>::Err: fmt::Display
+{
+    match FromStr::from_str(arg) {
+        Err(perr) => {
+            err.issues.push(CLIError::ParseError(arg_name.to_owned(),
+                                                 arg_type.to_owned(),
+                                                 arg.to_string(),
+                                                 format!("{}", perr)));
+            Default::default()
+        }
+        Ok(v) => v,
+    }
+}
+
+pub struct JsonTokenStorage {
+    pub program_name: &'static str,
+    pub db_dir: String,
+}
+
+impl JsonTokenStorage {
+    fn path(&self, scope_hash: u64) -> PathBuf {
+        Path::new(&self.db_dir).join(&format!("{}-token-{}.json", self.program_name, scope_hash))
+    }
+}
+
+
+#[derive(Debug)]
+pub enum TokenStorageError {
+    Json(json::Error),
+    Io(io::Error),
+}
+
+impl fmt::Display for TokenStorageError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            TokenStorageError::Json(ref err) => writeln!(f, "Could not serialize secrets: {}", err),
+            TokenStorageError::Io(ref err) => writeln!(f, "Failed to write secret token: {}", err),
+        }
+    }
+}
+
+impl StdError for TokenStorageError {
+    fn description(&self) -> &str {
+        "Failure when getting or setting the token storage"
+    }
+}
+
+
+impl TokenStorage for JsonTokenStorage {
+    type Error = TokenStorageError;
+
+    // NOTE: logging might be interesting, currently we swallow all errors
+    fn set(&mut self,
+           scope_hash: u64,
+           _: &Vec<&str>,
+           token: Option<Token>)
+           -> Result<(), TokenStorageError> {
+        match token {
+            None => {
+                match fs::remove_file(self.path(scope_hash)) {
+                    Err(err) => match err.kind() {
+                        io::ErrorKind::NotFound => Ok(()),
+                        _ => Err(TokenStorageError::Io(err)),
+                    },
+                    Ok(_) => Ok(()),
+                }
+            }
+            Some(token) => {
+                match fs::OpenOptions::new().create(true).write(true).open(&self.path(scope_hash)) {
+                    Ok(mut f) => {
+                        match json::to_writer_pretty(&mut f, &token) {
+                            Ok(_) => Ok(()),
+                            Err(serde_err) => Err(TokenStorageError::Json(serde_err)),
+                        }
+                    }
+                    Err(io_err) => Err(TokenStorageError::Io(io_err)),
+                }
+            }
+        }
+    }
+
+    fn get(&self, scope_hash: u64, _: &Vec<&str>) -> Result<Option<Token>, TokenStorageError> {
+        match fs::File::open(&self.path(scope_hash)) {
+            Ok(f) => {
+                match json::de::from_reader(f) {
+                    Ok(token) => Ok(Some(token)),
+                    Err(err) => Err(TokenStorageError::Json(err)),
+                }
+            }
+            Err(io_err) => {
+                match io_err.kind() {
+                    io::ErrorKind::NotFound => Ok(None),
+                    _ => Err(TokenStorageError::Io(io_err)),
+                }
+            }
+        }
+    }
+}
+
+
+#[derive(Debug)]
+pub enum ApplicationSecretError {
+    DecoderError((String, json::Error)),
+    FormatError(String),
+}
+
+impl fmt::Display for ApplicationSecretError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            ApplicationSecretError::DecoderError((ref path, ref err)) =>
+                writeln!(f,
+                         "Could not decode file at '{}' with error: {}.",
+                         path,
+                         err),
+            ApplicationSecretError::FormatError(ref path) =>
+                writeln!(f,
+                         "'installed' field is unset in secret file at '{}'.",
+                         path),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum ConfigurationError {
+    DirectoryCreationFailed((String, io::Error)),
+    DirectoryUnset,
+    HomeExpansionFailed(String),
+    Secret(ApplicationSecretError),
+    Io((String, io::Error)),
+}
+
+impl fmt::Display for ConfigurationError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            ConfigurationError::DirectoryCreationFailed((ref dir, ref err)) =>
+                writeln!(f,
+                         "Directory '{}' could not be created with error: {}.",
+                         dir,
+                         err),
+            ConfigurationError::DirectoryUnset => writeln!(f, "--config-dir was unset or empty."),
+            ConfigurationError::HomeExpansionFailed(ref dir) =>
+                writeln!(f,
+                         "Couldn't find HOME directory of current user, failed to expand '{}'.",
+                         dir),
+            ConfigurationError::Secret(ref err) => writeln!(f, "Secret -> {}", err),
+            ConfigurationError::Io((ref path, ref err)) =>
+                writeln!(f,
+                         "IO operation failed on path '{}' with error: {}.",
+                         path,
+                         err),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum InputError {
+    Io((String, io::Error)),
+    Mime(String),
+}
+
+impl fmt::Display for InputError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            InputError::Io((ref file_path, ref io_err)) =>
+                writeln!(f,
+                         "Failed to open '{}' for reading with error: {}.",
+                         file_path,
+                         io_err),
+            InputError::Mime(ref mime) => writeln!(f, "'{}' is not a known mime-type.", mime),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum FieldError {
+    PopOnEmpty(String),
+    TrailingFieldSep(String),
+    Unknown(String, Option<String>, Option<String>),
+    Duplicate(String),
+    Empty,
+}
+
+
+impl fmt::Display for FieldError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            FieldError::PopOnEmpty(ref field) =>
+                writeln!(f, "'{}': Cannot move up on empty field cursor.", field),
+            FieldError::TrailingFieldSep(ref field) =>
+                writeln!(f,
+                         "'{}': Single field separator may not be last character.",
+                         field),
+            FieldError::Unknown(ref field, ref suggestion, ref value) => {
+                let suffix = match *suggestion {
+                    Some(ref s) => {
+                        let kv = match *value {
+                            Some(ref v) => format!("{}={}", s, v),
+                            None => s.clone(),
+                        };
+                        format!(" Did you mean '{}' ?", kv)
+                    }
+                    None => String::new(),
+                };
+                writeln!(f, "Field '{}' does not exist.{}", field, suffix)
+            }
+            FieldError::Duplicate(ref cursor) =>
+                writeln!(f, "Value at '{}' was already set", cursor),
+            FieldError::Empty => writeln!(f, "Field names must not be empty."),
+        }
+    }
+}
+
+
+#[derive(Debug)]
+pub enum CLIError {
+    Configuration(ConfigurationError),
+    ParseError(String, String, String, String),
+    UnknownParameter(String, Vec<&'static str>),
+    InvalidUploadProtocol(String, Vec<String>),
+    InvalidKeyValueSyntax(String, bool),
+    Input(InputError),
+    Field(FieldError),
+    MissingCommandError,
+    MissingMethodError(String),
+}
+
+impl fmt::Display for CLIError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            CLIError::Configuration(ref err) => write!(f, "Configuration -> {}", err),
+            CLIError::Input(ref err) => write!(f, "Input -> {}", err),
+            CLIError::Field(ref err) => write!(f, "Field -> {}", err),
+            CLIError::InvalidUploadProtocol(ref proto_name, ref valid_names) =>
+                writeln!(f,
+                         "'{}' is not a valid upload protocol. Choose from one of {}.",
+                         proto_name,
+                         valid_names.join(", ")),
+            CLIError::ParseError(ref arg_name, ref type_name, ref value, ref err_desc) =>
+                writeln!(f,
+                         "Failed to parse argument '{}' with value '{}' as {} with error: {}.",
+                         arg_name,
+                         value,
+                         type_name,
+                         err_desc),
+            CLIError::UnknownParameter(ref param_name, ref possible_values) => {
+                let suffix = match did_you_mean(param_name, &possible_values) {
+                    Some(v) => format!(" Did you mean '{}' ?", v),
+                    None => String::new(),
+                };
+                write!(f, "Parameter '{}' is unknown.{}\n", param_name, suffix)
+            }
+            CLIError::InvalidKeyValueSyntax(ref kv, is_hashmap) => {
+                let hashmap_info = if is_hashmap {
+                    "hashmap "
+                } else {
+                    ""
+                };
+                writeln!(f,
+                         "'{}' does not match {}pattern <key>=<value>.",
+                         kv,
+                         hashmap_info)
+            }
+            CLIError::MissingCommandError => writeln!(f, "Please specify the main sub-command."),
+            CLIError::MissingMethodError(ref cmd) =>
+                writeln!(f,
+                         "Please specify the method to call on the '{}' command.",
+                         cmd),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct InvalidOptionsError {
+    pub issues: Vec<CLIError>,
+    pub exit_code: i32,
+}
+
+impl fmt::Display for InvalidOptionsError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        for issue in &self.issues {
+            try!(issue.fmt(f));
+        }
+        Ok(())
+    }
+}
+
+impl InvalidOptionsError {
+    pub fn single(err: CLIError, exit_code: i32) -> InvalidOptionsError {
+        InvalidOptionsError {
+            issues: vec![err],
+            exit_code: exit_code,
+        }
+    }
+
+    pub fn new() -> InvalidOptionsError {
+        InvalidOptionsError {
+            issues: Vec::new(),
+            exit_code: 1,
+        }
+    }
+}
+
+pub fn assure_config_dir_exists(dir: &str) -> Result<String, CLIError> {
+    let trdir = dir.trim();
+    if trdir.len() == 0 {
+        return Err(CLIError::Configuration(ConfigurationError::DirectoryUnset));
+    }
+
+    let expanded_config_dir = if trdir.as_bytes()[0] == b'~' {
+        match env::var("HOME").ok().or(env::var("UserProfile").ok()) {
+            None => return Err(CLIError::Configuration(ConfigurationError::HomeExpansionFailed(trdir.to_string()))),
+            Some(mut user) => {
+                user.push_str(&trdir[1..]);
+                user
+            }
+        }
+    } else {
+        trdir.to_string()
+    };
+
+    if let Err(err) = fs::create_dir(&expanded_config_dir) {
+        if err.kind() != io::ErrorKind::AlreadyExists {
+            return Err(CLIError::Configuration(
+                    ConfigurationError::DirectoryCreationFailed((expanded_config_dir, err))));
+        }
+    }
+
+    Ok(expanded_config_dir)
+}
+
+pub fn application_secret_from_directory(dir: &str,
+                                         secret_basename: &str,
+                                         json_console_secret: &str)
+                                         -> Result<ApplicationSecret, CLIError> {
+    let secret_path = Path::new(dir).join(secret_basename);
+    let secret_str = || secret_path.as_path().to_str().unwrap().to_string();
+    let secret_io_error = |io_err: io::Error| {
+        Err(CLIError::Configuration(ConfigurationError::Io((secret_str(), io_err))))
+    };
+
+    for _ in 0..2 {
+        match fs::File::open(&secret_path) {
+            Err(mut err) => {
+                if err.kind() == io::ErrorKind::NotFound {
+                    // Write our built-in one - user may adjust the written file at will
+
+                    err = match fs::OpenOptions::new()
+                                    .create(true)
+                                    .write(true)
+                                    .open(&secret_path) {
+                        Err(cfe) => cfe,
+                        Ok(mut f) => {
+                            // Assure we convert 'ugly' json string into pretty one
+                            let console_secret: ConsoleApplicationSecret =
+                                json::from_str(json_console_secret).unwrap();
+                            match json::to_writer_pretty(&mut f, &console_secret) {
+                                Err(serde_err) =>
+                                    panic!("Unexpected serde error: {:#?}", serde_err),
+                                Ok(_) => continue,
+                            }
+                        }
+                    };
+                    // fall through to IO error handling
+                }
+                return secret_io_error(err);
+            }
+            Ok(f) => {
+                match json::de::from_reader::<_, ConsoleApplicationSecret>(f) {
+                    Err(json_err) =>
+                        return Err(CLIError::Configuration(
+                            ConfigurationError::Secret(
+                                ApplicationSecretError::DecoderError(
+                                                (secret_str(), json_err)
+                                              )))),
+                    Ok(console_secret) => match console_secret.installed {
+                        Some(secret) => return Ok(secret),
+                        None => return Err(
+                                        CLIError::Configuration(
+                                        ConfigurationError::Secret(
+                                        ApplicationSecretError::FormatError(secret_str())
+                                        ))),
+                    },
+                }
+            }
+        }
+    }
+    unreachable!();
+}

--- a/gen/acceleratedmobilepageurl1-cli/src/main.rs
+++ b/gen/acceleratedmobilepageurl1-cli/src/main.rs
@@ -1,0 +1,353 @@
+// DO NOT EDIT !
+// This file was generated automatically from 'src/mako/cli/main.rs.mako'
+// DO NOT EDIT !
+#![allow(unused_variables, unused_imports, dead_code, unused_mut)]
+
+#[macro_use]
+extern crate clap;
+extern crate yup_oauth2 as oauth2;
+extern crate yup_hyper_mock as mock;
+extern crate hyper_rustls;
+extern crate serde;
+extern crate serde_json;
+extern crate hyper;
+extern crate mime;
+extern crate strsim;
+extern crate google_acceleratedmobilepageurl1 as api;
+
+use std::env;
+use std::io::{self, Write};
+use clap::{App, SubCommand, Arg};
+
+mod cmn;
+
+use cmn::{InvalidOptionsError, CLIError, JsonTokenStorage, arg_from_str, writer_from_opts, parse_kv_arg,
+          input_file_from_opts, input_mime_from_opts, FieldCursor, FieldError, CallType, UploadProtocol,
+          calltype_from_str, remove_json_null_values, ComplexType, JsonType, JsonTypeInfo};
+
+use std::default::Default;
+use std::str::FromStr;
+
+use oauth2::{Authenticator, DefaultAuthenticatorDelegate, FlowType};
+use serde_json as json;
+use clap::ArgMatches;
+
+enum DoitError {
+    IoError(String, io::Error),
+    ApiError(api::Error),
+}
+
+struct Engine<'n> {
+    opt: ArgMatches<'n>,
+    hub: api::Acceleratedmobilepageurl<hyper::Client, Authenticator<DefaultAuthenticatorDelegate, JsonTokenStorage, hyper::Client>>,
+    gp: Vec<&'static str>,
+    gpm: Vec<(&'static str, &'static str)>,
+}
+
+
+impl<'n> Engine<'n> {
+    fn _amp_urls_batch_get(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    "lookup-strategy" => Some(("lookupStrategy", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "urls" => Some(("urls", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Vec })),
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec!["lookup-strategy", "urls"]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::BatchGetAmpUrlsRequest = json::value::from_value(object).unwrap();
+        let mut call = self.hub.amp_urls().batch_get(request);
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _doit(&self, dry_run: bool) -> Result<Result<(), DoitError>, Option<InvalidOptionsError>> {
+        let mut err = InvalidOptionsError::new();
+        let mut call_result: Result<(), DoitError> = Ok(());
+        let mut err_opt: Option<InvalidOptionsError> = None;
+        match self.opt.subcommand() {
+            ("amp-urls", Some(opt)) => {
+                match opt.subcommand() {
+                    ("batch-get", Some(opt)) => {
+                        call_result = self._amp_urls_batch_get(opt, dry_run, &mut err);
+                    },
+                    _ => {
+                        err.issues.push(CLIError::MissingMethodError("amp-urls".to_string()));
+                        writeln!(io::stderr(), "{}\n", opt.usage()).ok();
+                    }
+                }
+            },
+            _ => {
+                err.issues.push(CLIError::MissingCommandError);
+                writeln!(io::stderr(), "{}\n", self.opt.usage()).ok();
+            }
+        }
+
+        if dry_run {
+            if err.issues.len() > 0 {
+                err_opt = Some(err);
+            }
+            Err(err_opt)
+        } else {
+            Ok(call_result)
+        }
+    }
+
+    // Please note that this call will fail if any part of the opt can't be handled
+    fn new(opt: ArgMatches<'n>) -> Result<Engine<'n>, InvalidOptionsError> {
+        let (config_dir, secret) = {
+            let config_dir = match cmn::assure_config_dir_exists(opt.value_of("folder").unwrap_or("~/.google-service-cli")) {
+                Err(e) => return Err(InvalidOptionsError::single(e, 3)),
+                Ok(p) => p,
+            };
+
+            match cmn::application_secret_from_directory(&config_dir, "acceleratedmobilepageurl1-secret.json",
+                                                         "{\"installed\":{\"auth_uri\":\"https://accounts.google.com/o/oauth2/auth\",\"client_secret\":\"hCsslbCUyfehWMmbkG8vTYxG\",\"token_uri\":\"https://accounts.google.com/o/oauth2/token\",\"client_email\":\"\",\"redirect_uris\":[\"urn:ietf:wg:oauth:2.0:oob\",\"oob\"],\"client_x509_cert_url\":\"\",\"client_id\":\"620010449518-9ngf7o4dhs0dka470npqvor6dc5lqb9b.apps.googleusercontent.com\",\"auth_provider_x509_cert_url\":\"https://www.googleapis.com/oauth2/v1/certs\"}}") {
+                Ok(secret) => (config_dir, secret),
+                Err(e) => return Err(InvalidOptionsError::single(e, 4))
+            }
+        };
+
+        let auth = Authenticator::new(  &secret, DefaultAuthenticatorDelegate,
+                                        if opt.is_present("debug-auth") {
+                                            hyper::Client::with_connector(mock::TeeConnector {
+                                                    connector: hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())
+                                                })
+                                        } else {
+                                            hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new()))
+                                        },
+                                        JsonTokenStorage {
+                                          program_name: "acceleratedmobilepageurl1",
+                                          db_dir: config_dir.clone(),
+                                        }, Some(FlowType::InstalledRedirect(54324)));
+
+        let client =
+            if opt.is_present("debug") {
+                hyper::Client::with_connector(mock::TeeConnector {
+                        connector: hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())
+                    })
+            } else {
+                hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new()))
+            };
+        let engine = Engine {
+            opt: opt,
+            hub: api::Acceleratedmobilepageurl::new(client, auth),
+            gp: vec!["$-xgafv", "access-token", "alt", "bearer-token", "callback", "fields", "key", "oauth-token", "pp", "pretty-print", "quota-user", "upload-type", "upload-protocol"],
+            gpm: vec![
+                    ("$-xgafv", "$.xgafv"),
+                    ("access-token", "access_token"),
+                    ("bearer-token", "bearer_token"),
+                    ("oauth-token", "oauth_token"),
+                    ("pretty-print", "prettyPrint"),
+                    ("quota-user", "quotaUser"),
+                    ("upload-type", "uploadType"),
+                    ("upload-protocol", "upload_protocol"),
+                ]
+        };
+
+        match engine._doit(true) {
+            Err(Some(err)) => Err(err),
+            Err(None)      => Ok(engine),
+            Ok(_)          => unreachable!(),
+        }
+    }
+
+    fn doit(&self) -> Result<(), DoitError> {
+        match self._doit(false) {
+            Ok(res) => res,
+            Err(_) => unreachable!(),
+        }
+    }
+}
+
+fn main() {
+    let mut exit_status = 0i32;
+    let arg_data = [
+        ("amp-urls", "methods: 'batch-get'", vec![
+            ("batch-get",
+                    Some(r##"Returns AMP URL(s) and equivalent
+        [AMP Cache URL(s)](/amp/cache/overview#amp-cache-url-format)."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_acceleratedmobilepageurl1_cli/amp-urls_batch-get",
+                  vec![
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ]),
+        
+    ];
+    
+    let mut app = App::new("acceleratedmobilepageurl1")
+           .author("Sebastian Thiel <byronimo@gmail.com>")
+           .version("1.0.7+20171202")
+           .about("Retrieves the list of AMP URLs (and equivalent AMP Cache URLs) for a given list of public URL(s).
+           ")
+           .after_help("All documentation details can be found at http://byron.github.io/google-apis-rs/google_acceleratedmobilepageurl1_cli")
+           .arg(Arg::with_name("folder")
+                   .long("config-dir")
+                   .help("A directory into which we will store our persistent data. Defaults to a user-writable directory that we will create during the first invocation.[default: ~/.google-service-cli")
+                   .multiple(false)
+                   .takes_value(true))
+           .arg(Arg::with_name("debug")
+                   .long("debug")
+                   .help("Output all server communication to standard error. `tx` and `rx` are placed into the same stream.")
+                   .multiple(false)
+                   .takes_value(false))
+           .arg(Arg::with_name("debug-auth")
+                   .long("debug-auth")
+                   .help("Output all communication related to authentication to standard error. `tx` and `rx` are placed into the same stream.")
+                   .multiple(false)
+                   .takes_value(false));
+           
+           for &(main_command_name, about, ref subcommands) in arg_data.iter() {
+               let mut mcmd = SubCommand::with_name(main_command_name).about(about);
+           
+               for &(sub_command_name, ref desc, url_info, ref args) in subcommands {
+                   let mut scmd = SubCommand::with_name(sub_command_name);
+                   if let &Some(desc) = desc {
+                       scmd = scmd.about(desc);
+                   }
+                   scmd = scmd.after_help(url_info);
+           
+                   for &(ref arg_name, ref flag, ref desc, ref required, ref multi) in args {
+                       let arg_name_str =
+                           match (arg_name, flag) {
+                                   (&Some(an), _       ) => an,
+                                   (_        , &Some(f)) => f,
+                                    _                    => unreachable!(),
+                            };
+                       let mut arg = Arg::with_name(arg_name_str)
+                                         .empty_values(false);
+                       if let &Some(short_flag) = flag {
+                           arg = arg.short(short_flag);
+                       }
+                       if let &Some(desc) = desc {
+                           arg = arg.help(desc);
+                       }
+                       if arg_name.is_some() && flag.is_some() {
+                           arg = arg.takes_value(true);
+                       }
+                       if let &Some(required) = required {
+                           arg = arg.required(required);
+                       }
+                       if let &Some(multi) = multi {
+                           arg = arg.multiple(multi);
+                       }
+                       scmd = scmd.arg(arg);
+                   }
+                   mcmd = mcmd.subcommand(scmd);
+               }
+               app = app.subcommand(mcmd);
+           }
+           
+        let matches = app.get_matches();
+
+    let debug = matches.is_present("debug");
+    match Engine::new(matches) {
+        Err(err) => {
+            exit_status = err.exit_code;
+            writeln!(io::stderr(), "{}", err).ok();
+        },
+        Ok(engine) => {
+            if let Err(doit_err) = engine.doit() {
+                exit_status = 1;
+                match doit_err {
+                    DoitError::IoError(path, err) => {
+                        writeln!(io::stderr(), "Failed to open output file '{}': {}", path, err).ok();
+                    },
+                    DoitError::ApiError(err) => {
+                        if debug {
+                            writeln!(io::stderr(), "{:#?}", err).ok();
+                        } else {
+                            writeln!(io::stderr(), "{}", err).ok();
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    std::process::exit(exit_status);
+}

--- a/gen/acceleratedmobilepageurl1/Cargo.toml
+++ b/gen/acceleratedmobilepageurl1/Cargo.toml
@@ -1,0 +1,31 @@
+# DO NOT EDIT !
+# This file was generated automatically from 'src/mako/Cargo.toml.mako'
+# DO NOT EDIT !
+[package]
+
+name = "google-acceleratedmobilepageurl1"
+version = "1.0.7+20171202"
+authors = ["Sebastian Thiel <byronimo@gmail.com>"]
+description = "A complete library to interact with acceleratedmobilepageurl (protocol v1)"
+repository = "https://github.com/Byron/google-apis-rs/tree/master/gen/acceleratedmobilepageurl1"
+homepage = "https://developers.google.com/amp/cache/"
+documentation = "https://docs.rs/google-acceleratedmobilepageurl1/1.0.7+20171202"
+license = "MIT"
+keywords = ["acceleratedmobilepag", "google", "protocol", "web", "api"]
+
+
+[dev-dependencies]
+hyper-rustls = "^0.6"
+
+[dependencies]
+hyper = "^ 0.10"
+mime = "^ 0.2.0"
+serde = "^ 1.0"
+serde_json = "^ 1.0"
+serde_derive = "^ 1.0"
+yup-oauth2 = "^ 1.0"
+url = "= 0.5"
+
+[features]
+
+

--- a/gen/acceleratedmobilepageurl1/LICENSE.md
+++ b/gen/acceleratedmobilepageurl1/LICENSE.md
@@ -1,0 +1,30 @@
+<!---
+DO NOT EDIT !
+This file was generated automatically from 'src/mako/LICENSE.md.mako'
+DO NOT EDIT !
+-->
+The MIT License (MIT)
+=====================
+
+Copyright © `2015-2016` `Sebastian Thiel`
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the “Software”), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.

--- a/gen/acceleratedmobilepageurl1/README.md
+++ b/gen/acceleratedmobilepageurl1/README.md
@@ -1,0 +1,180 @@
+<!---
+DO NOT EDIT !
+This file was generated automatically from 'src/mako/api/README.md.mako'
+DO NOT EDIT !
+-->
+The `google-acceleratedmobilepageurl1` library allows access to all features of the *Google acceleratedmobilepageurl* service.
+
+This documentation was generated from *acceleratedmobilepageurl* crate version *1.0.7+20171202*, where *20171202* is the exact revision of the *acceleratedmobilepageurl:v1* schema built by the [mako](http://www.makotemplates.org/) code generator *v1.0.7*.
+
+Everything else about the *acceleratedmobilepageurl* *v1* API can be found at the
+[official documentation site](https://developers.google.com/amp/cache/).
+# Features
+
+Handle the following *Resources* with ease from the central [hub](https://docs.rs/google-acceleratedmobilepageurl1/1.0.7+20171202/google_acceleratedmobilepageurl1/struct.Acceleratedmobilepageurl.html) ... 
+
+* [amp urls](https://docs.rs/google-acceleratedmobilepageurl1/1.0.7+20171202/google_acceleratedmobilepageurl1/struct.AmpUrl.html)
+ * [*batch get*](https://docs.rs/google-acceleratedmobilepageurl1/1.0.7+20171202/google_acceleratedmobilepageurl1/struct.AmpUrlBatchGetCall.html)
+
+
+
+
+# Structure of this Library
+
+The API is structured into the following primary items:
+
+* **[Hub](https://docs.rs/google-acceleratedmobilepageurl1/1.0.7+20171202/google_acceleratedmobilepageurl1/struct.Acceleratedmobilepageurl.html)**
+    * a central object to maintain state and allow accessing all *Activities*
+    * creates [*Method Builders*](https://docs.rs/google-acceleratedmobilepageurl1/1.0.7+20171202/google_acceleratedmobilepageurl1/trait.MethodsBuilder.html) which in turn
+      allow access to individual [*Call Builders*](https://docs.rs/google-acceleratedmobilepageurl1/1.0.7+20171202/google_acceleratedmobilepageurl1/trait.CallBuilder.html)
+* **[Resources](https://docs.rs/google-acceleratedmobilepageurl1/1.0.7+20171202/google_acceleratedmobilepageurl1/trait.Resource.html)**
+    * primary types that you can apply *Activities* to
+    * a collection of properties and *Parts*
+    * **[Parts](https://docs.rs/google-acceleratedmobilepageurl1/1.0.7+20171202/google_acceleratedmobilepageurl1/trait.Part.html)**
+        * a collection of properties
+        * never directly used in *Activities*
+* **[Activities](https://docs.rs/google-acceleratedmobilepageurl1/1.0.7+20171202/google_acceleratedmobilepageurl1/trait.CallBuilder.html)**
+    * operations to apply to *Resources*
+
+All *structures* are marked with applicable traits to further categorize them and ease browsing.
+
+Generally speaking, you can invoke *Activities* like this:
+
+```Rust,ignore
+let r = hub.resource().activity(...).doit()
+```
+
+Or specifically ...
+
+```ignore
+let r = hub.amp_urls().batch_get(...).doit()
+```
+
+The `resource()` and `activity(...)` calls create [builders][builder-pattern]. The second one dealing with `Activities` 
+supports various methods to configure the impending operation (not shown here). It is made such that all required arguments have to be 
+specified right away (i.e. `(...)`), whereas all optional ones can be [build up][builder-pattern] as desired.
+The `doit()` method performs the actual communication with the server and returns the respective result.
+
+# Usage
+
+## Setting up your Project
+
+To use this library, you would put the following lines into your `Cargo.toml` file:
+
+```toml
+[dependencies]
+google-acceleratedmobilepageurl1 = "*"
+```
+
+## A complete example
+
+```Rust
+extern crate hyper;
+extern crate hyper_rustls;
+extern crate yup_oauth2 as oauth2;
+extern crate google_acceleratedmobilepageurl1 as acceleratedmobilepageurl1;
+use acceleratedmobilepageurl1::BatchGetAmpUrlsRequest;
+use acceleratedmobilepageurl1::{Result, Error};
+use std::default::Default;
+use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+use acceleratedmobilepageurl1::Acceleratedmobilepageurl;
+
+// Get an ApplicationSecret instance by some means. It contains the `client_id` and 
+// `client_secret`, among other things.
+let secret: ApplicationSecret = Default::default();
+// Instantiate the authenticator. It will choose a suitable authentication flow for you, 
+// unless you replace  `None` with the desired Flow.
+// Provide your own `AuthenticatorDelegate` to adjust the way it operates and get feedback about 
+// what's going on. You probably want to bring in your own `TokenStorage` to persist tokens and
+// retrieve them from storage.
+let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+                              hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+                              <MemoryStorage as Default>::default(), None);
+let mut hub = Acceleratedmobilepageurl::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+// As the method needs a request, you would usually fill it with the desired information
+// into the respective structure. Some of the parts shown here might not be applicable !
+// Values shown here are possibly random and not representative !
+let mut req = BatchGetAmpUrlsRequest::default();
+
+// You can configure optional parameters by calling the respective setters at will, and
+// execute the final call using `doit()`.
+// Values shown here are possibly random and not representative !
+let result = hub.amp_urls().batch_get(req)
+             .doit();
+
+match result {
+    Err(e) => match e {
+        // The Error enum provides details about what exactly happened.
+        // You can also just use its `Debug`, `Display` or `Error` traits
+         Error::HttpError(_)
+        |Error::MissingAPIKey
+        |Error::MissingToken(_)
+        |Error::Cancelled
+        |Error::UploadSizeLimitExceeded(_, _)
+        |Error::Failure(_)
+        |Error::BadRequest(_)
+        |Error::FieldClash(_)
+        |Error::JsonDecodeError(_, _) => println!("{}", e),
+    },
+    Ok(res) => println!("Success: {:?}", res),
+}
+
+```
+## Handling Errors
+
+All errors produced by the system are provided either as [Result](https://docs.rs/google-acceleratedmobilepageurl1/1.0.7+20171202/google_acceleratedmobilepageurl1/enum.Result.html) enumeration as return value of 
+the doit() methods, or handed as possibly intermediate results to either the 
+[Hub Delegate](https://docs.rs/google-acceleratedmobilepageurl1/1.0.7+20171202/google_acceleratedmobilepageurl1/trait.Delegate.html), or the [Authenticator Delegate](https://docs.rs/yup-oauth2/*/yup_oauth2/trait.AuthenticatorDelegate.html).
+
+When delegates handle errors or intermediate values, they may have a chance to instruct the system to retry. This 
+makes the system potentially resilient to all kinds of errors.
+
+## Uploads and Downloads
+If a method supports downloads, the response body, which is part of the [Result](https://docs.rs/google-acceleratedmobilepageurl1/1.0.7+20171202/google_acceleratedmobilepageurl1/enum.Result.html), should be
+read by you to obtain the media.
+If such a method also supports a [Response Result](https://docs.rs/google-acceleratedmobilepageurl1/1.0.7+20171202/google_acceleratedmobilepageurl1/trait.ResponseResult.html), it will return that by default.
+You can see it as meta-data for the actual media. To trigger a media download, you will have to set up the builder by making
+this call: `.param("alt", "media")`.
+
+Methods supporting uploads can do so using up to 2 different protocols: 
+*simple* and *resumable*. The distinctiveness of each is represented by customized 
+`doit(...)` methods, which are then named `upload(...)` and `upload_resumable(...)` respectively.
+
+## Customization and Callbacks
+
+You may alter the way an `doit()` method is called by providing a [delegate](https://docs.rs/google-acceleratedmobilepageurl1/1.0.7+20171202/google_acceleratedmobilepageurl1/trait.Delegate.html) to the 
+[Method Builder](https://docs.rs/google-acceleratedmobilepageurl1/1.0.7+20171202/google_acceleratedmobilepageurl1/trait.CallBuilder.html) before making the final `doit()` call. 
+Respective methods will be called to provide progress information, as well as determine whether the system should 
+retry on failure.
+
+The [delegate trait](https://docs.rs/google-acceleratedmobilepageurl1/1.0.7+20171202/google_acceleratedmobilepageurl1/trait.Delegate.html) is default-implemented, allowing you to customize it with minimal effort.
+
+## Optional Parts in Server-Requests
+
+All structures provided by this library are made to be [enocodable](https://docs.rs/google-acceleratedmobilepageurl1/1.0.7+20171202/google_acceleratedmobilepageurl1/trait.RequestValue.html) and 
+[decodable](https://docs.rs/google-acceleratedmobilepageurl1/1.0.7+20171202/google_acceleratedmobilepageurl1/trait.ResponseResult.html) via *json*. Optionals are used to indicate that partial requests are responses 
+are valid.
+Most optionals are are considered [Parts](https://docs.rs/google-acceleratedmobilepageurl1/1.0.7+20171202/google_acceleratedmobilepageurl1/trait.Part.html) which are identifiable by name, which will be sent to 
+the server to indicate either the set parts of the request or the desired parts in the response.
+
+## Builder Arguments
+
+Using [method builders](https://docs.rs/google-acceleratedmobilepageurl1/1.0.7+20171202/google_acceleratedmobilepageurl1/trait.CallBuilder.html), you are able to prepare an action call by repeatedly calling it's methods.
+These will always take a single argument, for which the following statements are true.
+
+* [PODs][wiki-pod] are handed by copy
+* strings are passed as `&str`
+* [request values](https://docs.rs/google-acceleratedmobilepageurl1/1.0.7+20171202/google_acceleratedmobilepageurl1/trait.RequestValue.html) are moved
+
+Arguments will always be copied or cloned into the builder, to make them independent of their original life times.
+
+[wiki-pod]: http://en.wikipedia.org/wiki/Plain_old_data_structure
+[builder-pattern]: http://en.wikipedia.org/wiki/Builder_pattern
+[google-go-api]: https://github.com/google/google-api-go-client
+
+# License
+The **acceleratedmobilepageurl1** library was generated by Sebastian Thiel, and is placed 
+under the *MIT* license.
+You can read the full text at the repository's [license file][repo-license].
+
+[repo-license]: https://github.com/Byron/google-apis-rsblob/master/LICENSE.md

--- a/gen/acceleratedmobilepageurl1/src/cmn.rs
+++ b/gen/acceleratedmobilepageurl1/src/cmn.rs
@@ -1,0 +1,753 @@
+// COPY OF 'src/rust/api/cmn.rs'
+// DO NOT EDIT
+use std::io::{self, Read, Seek, Cursor, Write, SeekFrom};
+use std;
+use std::fmt::{self, Display};
+use std::str::FromStr;
+use std::error;
+use std::thread::sleep;
+use std::time::Duration;
+
+use mime::{Mime, TopLevel, SubLevel, Attr, Value};
+use oauth2::{TokenType, Retry, self};
+use hyper;
+use hyper::header::{ContentType, ContentLength, Headers, UserAgent, Authorization, Header,
+                    HeaderFormat, Bearer};
+use hyper::http::h1::LINE_ENDING;
+use hyper::method::Method;
+use hyper::status::StatusCode;
+
+use serde_json as json;
+
+/// Identifies the Hub. There is only one per library, this trait is supposed
+/// to make intended use more explicit.
+/// The hub allows to access all resource methods more easily.
+pub trait Hub {}
+
+/// Identifies types for building methods of a particular resource type
+pub trait MethodsBuilder {}
+
+/// Identifies types which represent builders for a particular resource method
+pub trait CallBuilder {}
+
+/// Identifies types which can be inserted and deleted.
+/// Types with this trait are most commonly used by clients of this API.
+pub trait Resource {}
+
+/// Identifies types which are used in API responses.
+pub trait ResponseResult {}
+
+/// Identifies types which are used in API requests.
+pub trait RequestValue {}
+
+/// Identifies types which are not actually used by the API
+/// This might be a bug within the google API schema.
+pub trait UnusedType {}
+
+/// Identifies types which are only used as part of other types, which
+/// usually are carrying the `Resource` trait.
+pub trait Part {}
+
+/// Identifies types which are only used by other types internally.
+/// They have no special meaning, this trait just marks them for completeness.
+pub trait NestedType {}
+
+/// A utility to specify reader types which provide seeking capabilities too
+pub trait ReadSeek: Seek + Read {}
+impl<T: Seek + Read> ReadSeek for T {}
+
+/// A trait for all types that can convert themselves into a *parts* string
+pub trait ToParts {
+    fn to_parts(&self) -> String;
+}
+
+/// A utility type which can decode a server response that indicates error
+#[derive(Deserialize)]
+pub struct JsonServerError {
+    pub error: String,
+    pub error_description: Option<String>
+}
+
+/// A utility to represent detailed errors we might see in case there are BadRequests.
+/// The latter happen if the sent parameters or request structures are unsound
+#[derive(Deserialize, Serialize, Debug)]
+pub struct ErrorResponse {
+    error: ServerError,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct ServerError {
+    errors: Vec<ServerMessage>,
+    code: u16,
+    message: String,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct ServerMessage {
+    domain: String,
+    reason: String,
+    message: String,
+    #[serde(rename="locationType")]
+    location_type: Option<String>,
+    location: Option<String>
+}
+
+#[derive(Copy, Clone)]
+pub struct DummyNetworkStream;
+
+impl Read for DummyNetworkStream {
+    fn read(&mut self, _: &mut [u8]) -> io::Result<usize> {
+        Ok(0)
+    }
+}
+
+impl Write for DummyNetworkStream {
+    fn write(&mut self, _: &[u8]) -> io::Result<usize> {
+        Ok(0)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl hyper::net::NetworkStream for DummyNetworkStream {
+    fn peer_addr(&mut self) -> io::Result<std::net::SocketAddr> {
+        Ok("127.0.0.1:1337".parse().unwrap())
+    }
+
+    fn set_read_timeout(&self, _dur: Option<Duration>) -> io::Result<()> {
+        Ok(())
+    }
+
+    fn set_write_timeout(&self, _dur: Option<Duration>) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+
+/// A trait specifying functionality to help controlling any request performed by the API.
+/// The trait has a conservative default implementation.
+///
+/// It contains methods to deal with all common issues, as well with the ones related to
+/// uploading media
+pub trait Delegate {
+
+    /// Called at the beginning of any API request. The delegate should store the method
+    /// information if he is interesting in knowing more context when further calls to it
+    /// are made.
+    /// The matching `finished()` call will always be made, no matter whether or not the API
+    /// request was successful. That way, the delegate may easily maintain a clean state
+    /// between various API calls.
+    fn begin(&mut self, MethodInfo) {}
+
+    /// Called whenever there is an [HttpError](http://hyperium.github.io/hyper/hyper/error/enum.HttpError.html), usually if there are network problems.
+    ///
+    /// If you choose to retry after a duration, the duration should be chosen using the
+    /// [exponential backoff algorithm](http://en.wikipedia.org/wiki/Exponential_backoff).
+    ///
+    /// Return retry information.
+    fn http_error(&mut self, &hyper::Error) -> Retry {
+        Retry::Abort
+    }
+
+    /// Called whenever there is the need for your applications API key after
+    /// the official authenticator implementation didn't provide one, for some reason.
+    /// If this method returns None as well, the underlying operation will fail
+    fn api_key(&mut self) -> Option<String> {
+        None
+    }
+
+    /// Called whenever the Authenticator didn't yield a token. The delegate
+    /// may attempt to provide one, or just take it as a general information about the
+    /// impending failure.
+    /// The given Error provides information about why the token couldn't be acquired in the
+    /// first place
+    fn token(&mut self, err: &error::Error) -> Option<oauth2::Token> {
+        let _ = err;
+        None
+    }
+
+    /// Called during resumable uploads to provide a URL for the impending upload.
+    /// It was saved after a previous call to `store_upload_url(...)`, and if not None,
+    /// will be used instead of asking the server for a new upload URL.
+    /// This is useful in case a previous resumable upload was aborted/canceled, but should now
+    /// be resumed.
+    /// The returned URL will be used exactly once - if it fails again and the delegate allows
+    /// to retry, we will ask the server for a new upload URL.
+    fn upload_url(&mut self) -> Option<String> {
+        None
+    }
+
+    /// Called after we have retrieved a new upload URL for a resumable upload to store it
+    /// in case we fail or cancel. That way, we can attempt to resume the upload later,
+    /// see `upload_url()`.
+    /// It will also be called with None after a successful upload, which allows the delegate
+    /// to forget the URL. That way, we will not attempt to resume an upload that has already
+    /// finished.
+    fn store_upload_url(&mut self, url: Option<&str>) {
+        let _ = url;
+    }
+
+    /// Called whenever a server response could not be decoded from json.
+    /// It's for informational purposes only, the caller will return with an error
+    /// accordingly.
+    ///
+    /// # Arguments
+    ///
+    /// * `json_encoded_value` - The json-encoded value which failed to decode.
+    /// * `json_decode_error`  - The decoder error
+    fn response_json_decode_error(&mut self, json_encoded_value: &str, json_decode_error: &json::Error) {
+        let _ = json_encoded_value;
+        let _ = json_decode_error;
+    }
+
+    /// Called whenever the http request returns with a non-success status code.
+    /// This can involve authentication issues, or anything else that very much
+    /// depends on the used API method.
+    /// The delegate should check the status, header and decoded json error to decide
+    /// whether to retry or not. In the latter case, the underlying call will fail.
+    ///
+    /// If you choose to retry after a duration, the duration should be chosen using the
+    /// [exponential backoff algorithm](http://en.wikipedia.org/wiki/Exponential_backoff).
+    fn http_failure(&mut self, _: &hyper::client::Response, Option<JsonServerError>, _: Option<ServerError>) -> Retry {
+        Retry::Abort
+    }
+
+    /// Called prior to sending the main request of the given method. It can be used to time
+    /// the call or to print progress information.
+    /// It's also useful as you can be sure that a request will definitely be made.
+    fn pre_request(&mut self) { }
+
+    /// Return the size of each chunk of a resumable upload.
+    /// Must be a power of two, with 1<<18 being the smallest allowed chunk size.
+    /// Will be called once before starting any resumable upload.
+    fn chunk_size(&mut self) -> u64 {
+        1 << 23
+    }
+
+    /// Called before the given chunk is uploaded to the server.
+    /// If true is returned, the upload will be interrupted.
+    /// However, it may be resumable if you stored the upload URL in a previous call
+    /// to `store_upload_url()`
+    fn cancel_chunk_upload(&mut self, chunk: &ContentRange) -> bool {
+        let _ = chunk;
+        false
+    }
+
+    /// Called before the API request method returns, in every case. It can be used to clean up
+    /// internal state between calls to the API.
+    /// This call always has a matching call to `begin(...)`.
+    ///
+    /// # Arguments
+    ///
+    /// * `is_success` - a true value indicates the operation was successful. If false, you should
+    ///                  discard all values stored during `store_upload_url`.
+    fn finished(&mut self, is_success: bool) {
+        let _ = is_success;
+    }
+}
+
+/// A delegate with a conservative default implementation, which is used if no other delegate is
+/// set.
+#[derive(Default)]
+pub struct DefaultDelegate;
+
+impl Delegate for DefaultDelegate {}
+
+
+#[derive(Debug)]
+pub enum Error {
+    /// The http connection failed
+    HttpError(hyper::Error),
+
+    /// An attempt was made to upload a resource with size stored in field `.0`
+    /// even though the maximum upload size is what is stored in field `.1`.
+    UploadSizeLimitExceeded(u64, u64),
+
+    /// Represents information about a request that was not understood by the server.
+    /// Details are included.
+    BadRequest(ErrorResponse),
+
+    /// We needed an API key for authentication, but didn't obtain one.
+    /// Neither through the authenticator, nor through the Delegate.
+    MissingAPIKey,
+
+    /// We required a Token, but didn't get one from the Authenticator
+    MissingToken(Box<error::Error>),
+
+    /// The delgate instructed to cancel the operation
+    Cancelled,
+
+    /// An additional, free form field clashed with one of the built-in optional ones
+    FieldClash(&'static str),
+
+    /// Shows that we failed to decode the server response.
+    /// This can happen if the protocol changes in conjunction with strict json decoding.
+    JsonDecodeError(String, json::Error),
+
+    /// Indicates an HTTP repsonse with a non-success status code
+    Failure(hyper::client::Response),
+}
+
+
+impl Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Error::HttpError(ref err) => err.fmt(f),
+            Error::UploadSizeLimitExceeded(ref resource_size, ref max_size) =>
+                writeln!(f, "The media size {} exceeds the maximum allowed upload size of {}"
+                         , resource_size, max_size),
+            Error::MissingAPIKey => {
+                (writeln!(f, "The application's API key was not found in the configuration")).ok();
+                writeln!(f, "It is used as there are no Scopes defined for this method.")
+            },
+            Error::BadRequest(ref err) => {
+                try!(writeln!(f, "Bad Request ({}): {}", err.error.code, err.error.message));
+                for err in err.error.errors.iter() {
+                    try!(writeln!(f, "    {}: {}, {}{}",
+                                            err.domain,
+                                            err.message,
+                                            err.reason,
+                                            match &err.location {
+                                                &Some(ref loc) => format!("@{}", loc),
+                                                &None => String::new(),
+                                            }));
+                }
+                Ok(())
+            },
+            Error::MissingToken(ref err) =>
+                writeln!(f, "Token retrieval failed with error: {}", err),
+            Error::Cancelled =>
+                writeln!(f, "Operation cancelled by delegate"),
+            Error::FieldClash(field) =>
+                writeln!(f, "The custom parameter '{}' is already provided natively by the CallBuilder.", field),
+            Error::JsonDecodeError(ref json_str, ref err)
+                => writeln!(f, "{}: {}", err, json_str),
+            Error::Failure(ref response) =>
+                writeln!(f, "Http status indicates failure: {:?}", response),
+        }
+    }
+}
+
+impl error::Error for Error {
+    fn description(&self) -> &str {
+        match *self {
+            Error::HttpError(ref err) => err.description(),
+            Error::JsonDecodeError(_, ref err) => err.description(),
+            _ => "NO DESCRIPTION POSSIBLE - use `Display.fmt()` instead"
+        }
+    }
+
+    fn cause(&self) -> Option<&error::Error> {
+        match *self {
+            Error::HttpError(ref err) => err.cause(),
+            Error::JsonDecodeError(_, ref err) => err.cause(),
+            _ => None
+        }
+    }
+}
+
+/// A universal result type used as return for all calls.
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Contains information about an API request.
+pub struct MethodInfo {
+    pub id: &'static str,
+    pub http_method: Method,
+}
+
+const BOUNDARY: &'static str = "MDuXWGyeE33QFXGchb2VFWc4Z7945d";
+
+/// Provides a `Read` interface that converts multiple parts into the protocol
+/// identified by [RFC2387](https://tools.ietf.org/html/rfc2387).
+/// **Note**: This implementation is just as rich as it needs to be to perform uploads
+/// to google APIs, and might not be a fully-featured implementation.
+#[derive(Default)]
+pub struct MultiPartReader<'a> {
+    raw_parts: Vec<(Headers, &'a mut Read)>,
+    current_part: Option<(Cursor<Vec<u8>>, &'a mut Read)>,
+    last_part_boundary: Option<Cursor<Vec<u8>>>,
+}
+
+impl<'a> MultiPartReader<'a> {
+
+    /// Reserve memory for exactly the given amount of parts
+    pub fn reserve_exact(&mut self, cap: usize) {
+        self.raw_parts.reserve_exact(cap);
+    }
+
+    /// Add a new part to the queue of parts to be read on the first `read` call.
+    ///
+    /// # Arguments
+    ///
+    /// `headers` - identifying the body of the part. It's similar to the header
+    ///             in an ordinary single-part call, and should thus contain the
+    ///             same information.
+    /// `reader`  - a reader providing the part's body
+    /// `size`    - the amount of bytes provided by the reader. It will be put onto the header as
+    ///             content-size.
+    /// `mime`    - It will be put onto the content type
+    pub fn add_part(&mut self, reader: &'a mut Read, size: u64, mime_type: Mime) -> &mut MultiPartReader<'a> {
+        let mut headers = Headers::new();
+        headers.set(ContentType(mime_type));
+        headers.set(ContentLength(size));
+        self.raw_parts.push((headers, reader));
+        self
+    }
+
+    /// Returns the mime-type representing our multi-part message.
+    /// Use it with the ContentType header.
+    pub fn mime_type(&self) -> Mime {
+        Mime(
+            TopLevel::Multipart,
+            SubLevel::Ext("Related".to_string()),
+            vec![(Attr::Ext("boundary".to_string()), Value::Ext(BOUNDARY.to_string()))],
+        )
+    }
+
+    /// Returns true if we are totally used
+    fn is_depleted(&self) -> bool {
+        self.raw_parts.len() == 0 && self.current_part.is_none() && self.last_part_boundary.is_none()
+    }
+
+    /// Returns true if we are handling our last part
+    fn is_last_part(&self) -> bool {
+        self.raw_parts.len() == 0 && self.current_part.is_some()
+    }
+}
+
+impl<'a> Read for MultiPartReader<'a> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        match (self.raw_parts.len(),
+               self.current_part.is_none(),
+               self.last_part_boundary.is_none()) {
+            (_, _, false) => {
+                let br = self.last_part_boundary.as_mut().unwrap().read(buf).unwrap_or(0);
+                if br < buf.len() {
+                    self.last_part_boundary = None;
+                }
+                return Ok(br)
+            },
+            (0, true, true) => return Ok(0),
+            (n, true, _) if n > 0 => {
+                let (headers, reader) = self.raw_parts.remove(0);
+                let mut c = Cursor::new(Vec::<u8>::new());
+                (write!(&mut c, "{}--{}{}{}{}", LINE_ENDING, BOUNDARY, LINE_ENDING,
+                                                headers, LINE_ENDING)).unwrap();
+                c.seek(SeekFrom::Start(0)).unwrap();
+                self.current_part = Some((c, reader));
+            }
+            _ => {},
+        }
+
+        // read headers as long as possible
+        let (hb, rr) = {
+            let &mut (ref mut c, ref mut reader) = self.current_part.as_mut().unwrap();
+            let b = c.read(buf).unwrap_or(0);
+            (b, reader.read(&mut buf[b..]))
+        };
+
+        match rr {
+            Ok(bytes_read) => {
+                if hb < buf.len() && bytes_read == 0 {
+                    if self.is_last_part() {
+                        // before clearing the last part, we will add the boundary that
+                        // will be written last
+                        self.last_part_boundary = Some(Cursor::new(
+                                                        format!("{}--{}--", LINE_ENDING, BOUNDARY).into_bytes()))
+                    }
+                    // We are depleted - this can trigger the next part to come in
+                    self.current_part = None;
+                }
+                let mut total_bytes_read = hb + bytes_read;
+                while total_bytes_read < buf.len() && !self.is_depleted() {
+                    match self.read(&mut buf[total_bytes_read ..]) {
+                        Ok(br) => total_bytes_read += br,
+                        Err(err) => return Err(err),
+                    }
+                }
+                Ok(total_bytes_read)
+            }
+            Err(err) => {
+                // fail permanently
+                self.current_part = None;
+                self.last_part_boundary = None;
+                self.raw_parts.clear();
+                Err(err)
+            }
+        }
+    }
+}
+
+/// The `X-Upload-Content-Type` header.
+///
+/// Generated via rustc --pretty expanded -Z unstable-options, and manually
+/// processed to be more readable.
+#[derive(PartialEq, Debug, Clone)]
+pub struct XUploadContentType(pub Mime);
+
+impl ::std::ops::Deref for XUploadContentType {
+    type Target = Mime;
+    fn deref<'a>(&'a self) -> &'a Mime { &self.0 }
+}
+impl ::std::ops::DerefMut for XUploadContentType {
+    fn deref_mut<'a>(&'a mut self) -> &'a mut Mime { &mut self.0 }
+}
+impl Header for XUploadContentType {
+    fn header_name() -> &'static str { "X-Upload-Content-Type" }
+    fn parse_header(raw: &[Vec<u8>]) -> hyper::error::Result<Self> {
+        hyper::header::parsing::from_one_raw_str(raw).map(XUploadContentType)
+    }
+}
+impl HeaderFormat for XUploadContentType {
+    fn fmt_header(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        Display::fmt(&**self, f)
+    }
+}
+impl Display for XUploadContentType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(&**self, f)
+    }
+}
+
+#[derive(Clone, PartialEq, Debug)]
+pub struct Chunk {
+    pub first: u64,
+    pub last: u64
+}
+
+impl fmt::Display for Chunk {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        (write!(fmt, "{}-{}", self.first, self.last)).ok();
+        Ok(())
+    }
+}
+
+impl FromStr for Chunk {
+    type Err = &'static str;
+
+    /// NOTE: only implements `%i-%i`, not `*`
+    fn from_str(s: &str) -> std::result::Result<Chunk, &'static str> {
+        let parts: Vec<&str> = s.split('-').collect();
+        if parts.len() != 2 {
+            return Err("Expected two parts: %i-%i")
+        }
+        Ok(
+            Chunk {
+                first: match FromStr::from_str(parts[0]) {
+                    Ok(d) => d,
+                    _ => return Err("Couldn't parse 'first' as digit")
+                },
+                last: match FromStr::from_str(parts[1]) {
+                    Ok(d) => d,
+                    _ => return Err("Couldn't parse 'last' as digit")
+                }
+            }
+        )
+    }
+}
+
+/// Implements the Content-Range header, for serialization only
+#[derive(Clone, PartialEq, Debug)]
+pub struct ContentRange {
+    pub range: Option<Chunk>,
+    pub total_length: u64,
+}
+
+impl Header for ContentRange {
+    fn header_name() -> &'static str {
+        "Content-Range"
+    }
+
+    /// We are not parsable, as parsing is done by the `Range` header
+    fn parse_header(_: &[Vec<u8>]) -> hyper::error::Result<Self> {
+        Err(hyper::error::Error::Method)
+    }
+}
+
+
+impl HeaderFormat for ContentRange {
+    fn fmt_header(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        try!(fmt.write_str("bytes "));
+        match self.range {
+            Some(ref c) => try!(c.fmt(fmt)),
+            None => try!(fmt.write_str("*"))
+        }
+        (write!(fmt, "/{}", self.total_length)).ok();
+        Ok(())
+    }
+}
+
+#[derive(Clone, PartialEq, Debug)]
+pub struct RangeResponseHeader(pub Chunk);
+
+impl Header for RangeResponseHeader {
+    fn header_name() -> &'static str {
+        "Range"
+    }
+
+    fn parse_header(raw: &[Vec<u8>]) -> hyper::error::Result<Self> {
+        if raw.len() > 0 {
+            let v = &raw[0];
+            if let Ok(s) = std::str::from_utf8(v) {
+                const PREFIX: &'static str = "bytes ";
+                if s.starts_with(PREFIX) {
+                    if let Ok(c) = <Chunk as FromStr>::from_str(&s[PREFIX.len()..]) {
+                        return  Ok(RangeResponseHeader(c))
+                    }
+                }
+            }
+        }
+        Err(hyper::error::Error::Method)
+    }
+}
+
+impl HeaderFormat for RangeResponseHeader {
+    /// No implmentation necessary, we just need to parse
+    fn fmt_header(&self, _: &mut fmt::Formatter) -> fmt::Result {
+        Err(fmt::Error)
+    }
+}
+
+/// A utility type to perform a resumable upload from start to end.
+pub struct ResumableUploadHelper<'a, A: 'a> {
+    pub client: &'a mut hyper::client::Client,
+    pub delegate: &'a mut Delegate,
+    pub start_at: Option<u64>,
+    pub auth: &'a mut A,
+    pub user_agent: &'a str,
+    pub auth_header: Authorization<Bearer>,
+    pub url: &'a str,
+    pub reader: &'a mut ReadSeek,
+    pub media_type: Mime,
+    pub content_length: u64
+}
+
+impl<'a, A> ResumableUploadHelper<'a, A>
+    where A: oauth2::GetToken {
+
+    fn query_transfer_status(&mut self) -> std::result::Result<u64, hyper::Result<hyper::client::Response>> {
+        loop {
+            match self.client.post(self.url)
+                .header(UserAgent(self.user_agent.to_string()))
+                .header(ContentRange { range: None, total_length: self.content_length })
+                .header(self.auth_header.clone())
+                .send() {
+                Ok(r) => {
+                    // 308 = resume-incomplete == PermanentRedirect
+                    let headers = r.headers.clone();
+                    let h: &RangeResponseHeader = match headers.get() {
+                        Some(hh) if r.status == StatusCode::PermanentRedirect => hh,
+                        None|Some(_) => {
+                            if let Retry::After(d) = self.delegate.http_failure(&r, None, None) {
+                                sleep(d);
+                                continue;
+                            }
+                            return Err(Ok(r))
+                        }
+                    };
+                    return Ok(h.0.last)
+                }
+                Err(err) => {
+                    if let Retry::After(d) = self.delegate.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    return Err(Err(err))
+                }
+            }
+        }
+    }
+
+    /// returns None if operation was cancelled by delegate, or the HttpResult.
+    /// It can be that we return the result just because we didn't understand the status code -
+    /// caller should check for status himself before assuming it's OK to use
+    pub fn upload(&mut self) -> Option<hyper::Result<hyper::client::Response>> {
+        let mut start = match self.start_at {
+            Some(s) => s,
+            None => match self.query_transfer_status() {
+                Ok(s) => s,
+                Err(result) => return Some(result)
+            }
+        };
+
+        const MIN_CHUNK_SIZE: u64 = 1 << 18;
+        let chunk_size = match self.delegate.chunk_size() {
+            cs if cs > MIN_CHUNK_SIZE => cs,
+            _ => MIN_CHUNK_SIZE
+        };
+
+        self.reader.seek(SeekFrom::Start(start)).unwrap();
+        loop {
+            let request_size = match self.content_length - start {
+                rs if rs > chunk_size => chunk_size,
+                rs => rs
+            };
+
+            let mut section_reader = self.reader.take(request_size);
+            let range_header = ContentRange {
+                range: Some(Chunk {first: start, last: start + request_size - 1}),
+                total_length: self.content_length
+            };
+            start += request_size;
+            if self.delegate.cancel_chunk_upload(&range_header) {
+                return None
+            }
+            let res = self.client.post(self.url)
+                                 .header(range_header)
+                                 .header(ContentType(self.media_type.clone()))
+                                 .header(UserAgent(self.user_agent.to_string()))
+                                 .body(&mut section_reader)
+                                 .send();
+            match res {
+                Ok(mut res) => {
+                    if res.status == StatusCode::PermanentRedirect  {
+                        continue
+                    }
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let Retry::After(d) = self.delegate.http_failure(&res,
+                                                        json::from_str(&json_err).ok(),
+                                                        json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                    }
+                    return Some(Ok(res))
+                },
+                Err(err) => {
+                    if let Retry::After(d) = self.delegate.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    return Some(Err(err))
+                }
+            }
+        }
+    }
+}
+
+// Copy of src/rust/cli/cmn.rs
+// TODO(ST): Allow sharing common code between program types
+pub fn remove_json_null_values(value: &mut json::value::Value) {
+    match *value {
+        json::value::Value::Object(ref mut map) => {
+            let mut for_removal = Vec::new();
+
+            for (key, mut value) in map.iter_mut() {
+                if value.is_null() {
+                    for_removal.push(key.clone());
+                } else {
+                    remove_json_null_values(&mut value);
+                }
+            }
+
+            for key in &for_removal {
+                map.remove(key);
+            }
+        }
+        _ => {}
+    }
+}

--- a/gen/acceleratedmobilepageurl1/src/lib.rs
+++ b/gen/acceleratedmobilepageurl1/src/lib.rs
@@ -1,0 +1,725 @@
+// DO NOT EDIT !
+// This file was generated automatically from 'src/mako/api/lib.rs.mako'
+// DO NOT EDIT !
+
+//! This documentation was generated from *acceleratedmobilepageurl* crate version *1.0.7+20171202*, where *20171202* is the exact revision of the *acceleratedmobilepageurl:v1* schema built by the [mako](http://www.makotemplates.org/) code generator *v1.0.7*.
+//! 
+//! Everything else about the *acceleratedmobilepageurl* *v1* API can be found at the
+//! [official documentation site](https://developers.google.com/amp/cache/).
+//! The original source code is [on github](https://github.com/Byron/google-apis-rs/tree/master/gen/acceleratedmobilepageurl1).
+//! # Features
+//! 
+//! Handle the following *Resources* with ease from the central [hub](struct.Acceleratedmobilepageurl.html) ... 
+//! 
+//! * [amp urls](struct.AmpUrl.html)
+//!  * [*batch get*](struct.AmpUrlBatchGetCall.html)
+//! 
+//! 
+//! 
+//! 
+//! Not what you are looking for ? Find all other Google APIs in their Rust [documentation index](http://byron.github.io/google-apis-rs).
+//! 
+//! # Structure of this Library
+//! 
+//! The API is structured into the following primary items:
+//! 
+//! * **[Hub](struct.Acceleratedmobilepageurl.html)**
+//!     * a central object to maintain state and allow accessing all *Activities*
+//!     * creates [*Method Builders*](trait.MethodsBuilder.html) which in turn
+//!       allow access to individual [*Call Builders*](trait.CallBuilder.html)
+//! * **[Resources](trait.Resource.html)**
+//!     * primary types that you can apply *Activities* to
+//!     * a collection of properties and *Parts*
+//!     * **[Parts](trait.Part.html)**
+//!         * a collection of properties
+//!         * never directly used in *Activities*
+//! * **[Activities](trait.CallBuilder.html)**
+//!     * operations to apply to *Resources*
+//! 
+//! All *structures* are marked with applicable traits to further categorize them and ease browsing.
+//! 
+//! Generally speaking, you can invoke *Activities* like this:
+//! 
+//! ```Rust,ignore
+//! let r = hub.resource().activity(...).doit()
+//! ```
+//! 
+//! Or specifically ...
+//! 
+//! ```ignore
+//! let r = hub.amp_urls().batch_get(...).doit()
+//! ```
+//! 
+//! The `resource()` and `activity(...)` calls create [builders][builder-pattern]. The second one dealing with `Activities` 
+//! supports various methods to configure the impending operation (not shown here). It is made such that all required arguments have to be 
+//! specified right away (i.e. `(...)`), whereas all optional ones can be [build up][builder-pattern] as desired.
+//! The `doit()` method performs the actual communication with the server and returns the respective result.
+//! 
+//! # Usage
+//! 
+//! ## Setting up your Project
+//! 
+//! To use this library, you would put the following lines into your `Cargo.toml` file:
+//! 
+//! ```toml
+//! [dependencies]
+//! google-acceleratedmobilepageurl1 = "*"
+//! ```
+//! 
+//! ## A complete example
+//! 
+//! ```test_harness,no_run
+//! extern crate hyper;
+//! extern crate hyper_rustls;
+//! extern crate yup_oauth2 as oauth2;
+//! extern crate google_acceleratedmobilepageurl1 as acceleratedmobilepageurl1;
+//! use acceleratedmobilepageurl1::BatchGetAmpUrlsRequest;
+//! use acceleratedmobilepageurl1::{Result, Error};
+//! # #[test] fn egal() {
+//! use std::default::Default;
+//! use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+//! use acceleratedmobilepageurl1::Acceleratedmobilepageurl;
+//! 
+//! // Get an ApplicationSecret instance by some means. It contains the `client_id` and 
+//! // `client_secret`, among other things.
+//! let secret: ApplicationSecret = Default::default();
+//! // Instantiate the authenticator. It will choose a suitable authentication flow for you, 
+//! // unless you replace  `None` with the desired Flow.
+//! // Provide your own `AuthenticatorDelegate` to adjust the way it operates and get feedback about 
+//! // what's going on. You probably want to bring in your own `TokenStorage` to persist tokens and
+//! // retrieve them from storage.
+//! let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+//!                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+//!                               <MemoryStorage as Default>::default(), None);
+//! let mut hub = Acceleratedmobilepageurl::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+//! // As the method needs a request, you would usually fill it with the desired information
+//! // into the respective structure. Some of the parts shown here might not be applicable !
+//! // Values shown here are possibly random and not representative !
+//! let mut req = BatchGetAmpUrlsRequest::default();
+//! 
+//! // You can configure optional parameters by calling the respective setters at will, and
+//! // execute the final call using `doit()`.
+//! // Values shown here are possibly random and not representative !
+//! let result = hub.amp_urls().batch_get(req)
+//!              .doit();
+//! 
+//! match result {
+//!     Err(e) => match e {
+//!         // The Error enum provides details about what exactly happened.
+//!         // You can also just use its `Debug`, `Display` or `Error` traits
+//!          Error::HttpError(_)
+//!         |Error::MissingAPIKey
+//!         |Error::MissingToken(_)
+//!         |Error::Cancelled
+//!         |Error::UploadSizeLimitExceeded(_, _)
+//!         |Error::Failure(_)
+//!         |Error::BadRequest(_)
+//!         |Error::FieldClash(_)
+//!         |Error::JsonDecodeError(_, _) => println!("{}", e),
+//!     },
+//!     Ok(res) => println!("Success: {:?}", res),
+//! }
+//! # }
+//! ```
+//! ## Handling Errors
+//! 
+//! All errors produced by the system are provided either as [Result](enum.Result.html) enumeration as return value of 
+//! the doit() methods, or handed as possibly intermediate results to either the 
+//! [Hub Delegate](trait.Delegate.html), or the [Authenticator Delegate](https://docs.rs/yup-oauth2/*/yup_oauth2/trait.AuthenticatorDelegate.html).
+//! 
+//! When delegates handle errors or intermediate values, they may have a chance to instruct the system to retry. This 
+//! makes the system potentially resilient to all kinds of errors.
+//! 
+//! ## Uploads and Downloads
+//! If a method supports downloads, the response body, which is part of the [Result](enum.Result.html), should be
+//! read by you to obtain the media.
+//! If such a method also supports a [Response Result](trait.ResponseResult.html), it will return that by default.
+//! You can see it as meta-data for the actual media. To trigger a media download, you will have to set up the builder by making
+//! this call: `.param("alt", "media")`.
+//! 
+//! Methods supporting uploads can do so using up to 2 different protocols: 
+//! *simple* and *resumable*. The distinctiveness of each is represented by customized 
+//! `doit(...)` methods, which are then named `upload(...)` and `upload_resumable(...)` respectively.
+//! 
+//! ## Customization and Callbacks
+//! 
+//! You may alter the way an `doit()` method is called by providing a [delegate](trait.Delegate.html) to the 
+//! [Method Builder](trait.CallBuilder.html) before making the final `doit()` call. 
+//! Respective methods will be called to provide progress information, as well as determine whether the system should 
+//! retry on failure.
+//! 
+//! The [delegate trait](trait.Delegate.html) is default-implemented, allowing you to customize it with minimal effort.
+//! 
+//! ## Optional Parts in Server-Requests
+//! 
+//! All structures provided by this library are made to be [enocodable](trait.RequestValue.html) and 
+//! [decodable](trait.ResponseResult.html) via *json*. Optionals are used to indicate that partial requests are responses 
+//! are valid.
+//! Most optionals are are considered [Parts](trait.Part.html) which are identifiable by name, which will be sent to 
+//! the server to indicate either the set parts of the request or the desired parts in the response.
+//! 
+//! ## Builder Arguments
+//! 
+//! Using [method builders](trait.CallBuilder.html), you are able to prepare an action call by repeatedly calling it's methods.
+//! These will always take a single argument, for which the following statements are true.
+//! 
+//! * [PODs][wiki-pod] are handed by copy
+//! * strings are passed as `&str`
+//! * [request values](trait.RequestValue.html) are moved
+//! 
+//! Arguments will always be copied or cloned into the builder, to make them independent of their original life times.
+//! 
+//! [wiki-pod]: http://en.wikipedia.org/wiki/Plain_old_data_structure
+//! [builder-pattern]: http://en.wikipedia.org/wiki/Builder_pattern
+//! [google-go-api]: https://github.com/google/google-api-go-client
+//! 
+//! 
+
+// Unused attributes happen thanks to defined, but unused structures
+// We don't warn about this, as depending on the API, some data structures or facilities are never used.
+// Instead of pre-determining this, we just disable the lint. It's manually tuned to not have any
+// unused imports in fully featured APIs. Same with unused_mut ... .
+#![allow(unused_imports, unused_mut, dead_code)]
+
+// DO NOT EDIT !
+// This file was generated automatically from 'src/mako/api/lib.rs.mako'
+// DO NOT EDIT !
+
+#[macro_use]
+extern crate serde_derive;
+
+extern crate hyper;
+extern crate serde;
+extern crate serde_json;
+extern crate yup_oauth2 as oauth2;
+extern crate mime;
+extern crate url;
+
+mod cmn;
+
+use std::collections::HashMap;
+use std::cell::RefCell;
+use std::borrow::BorrowMut;
+use std::default::Default;
+use std::collections::BTreeMap;
+use serde_json as json;
+use std::io;
+use std::fs;
+use std::mem;
+use std::thread::sleep;
+use std::time::Duration;
+
+pub use cmn::{MultiPartReader, ToParts, MethodInfo, Result, Error, CallBuilder, Hub, ReadSeek, Part,
+              ResponseResult, RequestValue, NestedType, Delegate, DefaultDelegate, MethodsBuilder,
+              Resource, ErrorResponse, remove_json_null_values};
+
+
+// ##############
+// UTILITIES ###
+// ############
+
+
+
+
+// ########
+// HUB ###
+// ######
+
+/// Central instance to access all Acceleratedmobilepageurl related resource activities
+///
+/// # Examples
+///
+/// Instantiate a new hub
+///
+/// ```test_harness,no_run
+/// extern crate hyper;
+/// extern crate hyper_rustls;
+/// extern crate yup_oauth2 as oauth2;
+/// extern crate google_acceleratedmobilepageurl1 as acceleratedmobilepageurl1;
+/// use acceleratedmobilepageurl1::BatchGetAmpUrlsRequest;
+/// use acceleratedmobilepageurl1::{Result, Error};
+/// # #[test] fn egal() {
+/// use std::default::Default;
+/// use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// use acceleratedmobilepageurl1::Acceleratedmobilepageurl;
+/// 
+/// // Get an ApplicationSecret instance by some means. It contains the `client_id` and 
+/// // `client_secret`, among other things.
+/// let secret: ApplicationSecret = Default::default();
+/// // Instantiate the authenticator. It will choose a suitable authentication flow for you, 
+/// // unless you replace  `None` with the desired Flow.
+/// // Provide your own `AuthenticatorDelegate` to adjust the way it operates and get feedback about 
+/// // what's going on. You probably want to bring in your own `TokenStorage` to persist tokens and
+/// // retrieve them from storage.
+/// let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+///                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+///                               <MemoryStorage as Default>::default(), None);
+/// let mut hub = Acceleratedmobilepageurl::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = BatchGetAmpUrlsRequest::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.amp_urls().batch_get(req)
+///              .doit();
+/// 
+/// match result {
+///     Err(e) => match e {
+///         // The Error enum provides details about what exactly happened.
+///         // You can also just use its `Debug`, `Display` or `Error` traits
+///          Error::HttpError(_)
+///         |Error::MissingAPIKey
+///         |Error::MissingToken(_)
+///         |Error::Cancelled
+///         |Error::UploadSizeLimitExceeded(_, _)
+///         |Error::Failure(_)
+///         |Error::BadRequest(_)
+///         |Error::FieldClash(_)
+///         |Error::JsonDecodeError(_, _) => println!("{}", e),
+///     },
+///     Ok(res) => println!("Success: {:?}", res),
+/// }
+/// # }
+/// ```
+pub struct Acceleratedmobilepageurl<C, A> {
+    client: RefCell<C>,
+    auth: RefCell<A>,
+    _user_agent: String,
+    _base_url: String,
+    _root_url: String,
+}
+
+impl<'a, C, A> Hub for Acceleratedmobilepageurl<C, A> {}
+
+impl<'a, C, A> Acceleratedmobilepageurl<C, A>
+    where  C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+    pub fn new(client: C, authenticator: A) -> Acceleratedmobilepageurl<C, A> {
+        Acceleratedmobilepageurl {
+            client: RefCell::new(client),
+            auth: RefCell::new(authenticator),
+            _user_agent: "google-api-rust-client/1.0.7".to_string(),
+            _base_url: "https://acceleratedmobilepageurl.googleapis.com/".to_string(),
+            _root_url: "https://acceleratedmobilepageurl.googleapis.com/".to_string(),
+        }
+    }
+
+    pub fn amp_urls(&'a self) -> AmpUrlMethods<'a, C, A> {
+        AmpUrlMethods { hub: &self }
+    }
+
+    /// Set the user-agent header field to use in all requests to the server.
+    /// It defaults to `google-api-rust-client/1.0.7`.
+    ///
+    /// Returns the previously set user-agent.
+    pub fn user_agent(&mut self, agent_name: String) -> String {
+        mem::replace(&mut self._user_agent, agent_name)
+    }
+
+    /// Set the base url to use in all requests to the server.
+    /// It defaults to `https://acceleratedmobilepageurl.googleapis.com/`.
+    ///
+    /// Returns the previously set base url.
+    pub fn base_url(&mut self, new_base_url: String) -> String {
+        mem::replace(&mut self._base_url, new_base_url)
+    }
+
+    /// Set the root url to use in all requests to the server.
+    /// It defaults to `https://acceleratedmobilepageurl.googleapis.com/`.
+    ///
+    /// Returns the previously set root url.
+    pub fn root_url(&mut self, new_root_url: String) -> String {
+        mem::replace(&mut self._root_url, new_root_url)
+    }
+}
+
+
+// ############
+// SCHEMAS ###
+// ##########
+/// Batch AMP URL response.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [batch get amp urls](struct.AmpUrlBatchGetCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct BatchGetAmpUrlsResponse {
+    /// For each URL in BatchAmpUrlsRequest, the URL response. The response might
+    /// not be in the same order as URLs in the batch request.
+    /// If BatchAmpUrlsRequest contains duplicate URLs, AmpUrl is generated
+    /// only once.
+    #[serde(rename="ampUrls")]
+    pub amp_urls: Option<Vec<AmpUrl>>,
+    /// The errors for requested URLs that have no AMP URL.
+    #[serde(rename="urlErrors")]
+    pub url_errors: Option<Vec<AmpUrlError>>,
+}
+
+impl ResponseResult for BatchGetAmpUrlsResponse {}
+
+
+/// AMP URL response for a requested URL.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [batch get amp urls](struct.AmpUrlBatchGetCall.html) (none)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct AmpUrl {
+    /// The AMP URL pointing to the publisher's web server.
+    #[serde(rename="ampUrl")]
+    pub amp_url: Option<String>,
+    /// The [AMP Cache URL](/amp/cache/overview#amp-cache-url-format) pointing to
+    /// the cached document in the Google AMP Cache.
+    #[serde(rename="cdnAmpUrl")]
+    pub cdn_amp_url: Option<String>,
+    /// The original non-AMP URL.
+    #[serde(rename="originalUrl")]
+    pub original_url: Option<String>,
+}
+
+impl Resource for AmpUrl {}
+
+
+/// AMP URL request for a batch of URLs.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [batch get amp urls](struct.AmpUrlBatchGetCall.html) (request)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct BatchGetAmpUrlsRequest {
+    /// The lookup_strategy being requested.
+    #[serde(rename="lookupStrategy")]
+    pub lookup_strategy: Option<String>,
+    /// List of URLs to look up for the paired AMP URLs.
+    /// The URLs are case-sensitive. Up to 50 URLs per lookup
+    /// (see [Usage Limits](/amp/cache/reference/limits)).
+    pub urls: Option<Vec<String>>,
+}
+
+impl RequestValue for BatchGetAmpUrlsRequest {}
+
+
+/// AMP URL Error resource for a requested URL that couldn't be found.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct AmpUrlError {
+    /// The error code of an API call.
+    #[serde(rename="errorCode")]
+    pub error_code: Option<String>,
+    /// An optional descriptive error message.
+    #[serde(rename="errorMessage")]
+    pub error_message: Option<String>,
+    /// The original non-AMP URL.
+    #[serde(rename="originalUrl")]
+    pub original_url: Option<String>,
+}
+
+impl Part for AmpUrlError {}
+
+
+
+// ###################
+// MethodBuilders ###
+// #################
+
+/// A builder providing access to all methods supported on *ampUrl* resources.
+/// It is not used directly, but through the `Acceleratedmobilepageurl` hub.
+///
+/// # Example
+///
+/// Instantiate a resource builder
+///
+/// ```test_harness,no_run
+/// extern crate hyper;
+/// extern crate hyper_rustls;
+/// extern crate yup_oauth2 as oauth2;
+/// extern crate google_acceleratedmobilepageurl1 as acceleratedmobilepageurl1;
+/// 
+/// # #[test] fn egal() {
+/// use std::default::Default;
+/// use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// use acceleratedmobilepageurl1::Acceleratedmobilepageurl;
+/// 
+/// let secret: ApplicationSecret = Default::default();
+/// let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+///                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+///                               <MemoryStorage as Default>::default(), None);
+/// let mut hub = Acceleratedmobilepageurl::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // Usually you wouldn't bind this to a variable, but keep calling *CallBuilders*
+/// // like `batch_get(...)`
+/// // to build up your call.
+/// let rb = hub.amp_urls();
+/// # }
+/// ```
+pub struct AmpUrlMethods<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a Acceleratedmobilepageurl<C, A>,
+}
+
+impl<'a, C, A> MethodsBuilder for AmpUrlMethods<'a, C, A> {}
+
+impl<'a, C, A> AmpUrlMethods<'a, C, A> {
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Returns AMP URL(s) and equivalent
+    /// [AMP Cache URL(s)](/amp/cache/overview#amp-cache-url-format).
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    pub fn batch_get(&self, request: BatchGetAmpUrlsRequest) -> AmpUrlBatchGetCall<'a, C, A> {
+        AmpUrlBatchGetCall {
+            hub: self.hub,
+            _request: request,
+            _delegate: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+}
+
+
+
+
+
+// ###################
+// CallBuilders   ###
+// #################
+
+/// Returns AMP URL(s) and equivalent
+/// [AMP Cache URL(s)](/amp/cache/overview#amp-cache-url-format).
+///
+/// A builder for the *batchGet* method supported by a *ampUrl* resource.
+/// It is not used directly, but through a `AmpUrlMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_acceleratedmobilepageurl1 as acceleratedmobilepageurl1;
+/// use acceleratedmobilepageurl1::BatchGetAmpUrlsRequest;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use acceleratedmobilepageurl1::Acceleratedmobilepageurl;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = Acceleratedmobilepageurl::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = BatchGetAmpUrlsRequest::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.amp_urls().batch_get(req)
+///              .doit();
+/// # }
+/// ```
+pub struct AmpUrlBatchGetCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a Acceleratedmobilepageurl<C, A>,
+    _request: BatchGetAmpUrlsRequest,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+}
+
+impl<'a, C, A> CallBuilder for AmpUrlBatchGetCall<'a, C, A> {}
+
+impl<'a, C, A> AmpUrlBatchGetCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, BatchGetAmpUrlsResponse)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "acceleratedmobilepageurl.ampUrls.batchGet",
+                               http_method: hyper::method::Method::Post });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((3 + self._additional_params.len()));
+        for &field in ["alt"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1/ampUrls:batchGet";
+        
+        let mut key = self.hub.auth.borrow_mut().api_key();
+        if key.is_none() {
+            key = dlg.api_key();
+        }
+        match key {
+            Some(value) => params.push(("key", value)),
+            None => {
+                dlg.finished(false);
+                return Err(Error::MissingAPIKey)
+            }
+        }
+
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Post, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: BatchGetAmpUrlsRequest) -> AmpUrlBatchGetCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> AmpUrlBatchGetCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> AmpUrlBatchGetCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+}
+
+

--- a/gen/adexchangebuyer2_v2_beta1-cli/Cargo.toml
+++ b/gen/adexchangebuyer2_v2_beta1-cli/Cargo.toml
@@ -1,0 +1,40 @@
+# DO NOT EDIT !
+# This file was generated automatically from 'src/mako/Cargo.toml.mako'
+# DO NOT EDIT !
+[package]
+
+name = "google-adexchangebuyer2_v2_beta1-cli"
+version = "1.0.7+20171208"
+authors = ["Sebastian Thiel <byronimo@gmail.com>"]
+description = "A complete library to interact with AdExchangeBuyerII (protocol v2beta1)"
+repository = "https://github.com/Byron/google-apis-rs/tree/master/gen/adexchangebuyer2_v2_beta1-cli"
+homepage = "https://developers.google.com/ad-exchange/buyer-rest/reference/rest/"
+documentation = "http://byron.github.io/google-apis-rs/google_adexchangebuyer2_v2_beta1_cli"
+license = "MIT"
+keywords = ["adexchangebuyer2", "google", "cli"]
+
+[[bin]]
+name = "adexchangebuyer2-v2-beta1"
+
+[dev-dependencies]
+hyper-rustls = "^0.6"
+
+[dependencies]
+hyper = "^ 0.10"
+mime = "^ 0.2.0"
+serde = "^ 1.0"
+serde_json = "^ 1.0"
+serde_derive = "^ 1.0"
+yup-oauth2 = "^ 1.0"
+strsim = "^0.5"
+hyper-rustls = "^0.6"
+yup-hyper-mock = "^2.0"
+clap = "^2.0"
+
+[features]
+
+
+
+[dependencies.google-adexchangebuyer2_v2_beta1]
+path = "../adexchangebuyer2_v2_beta1"
+version = "1.0.7+20171208"

--- a/gen/adexchangebuyer2_v2_beta1-cli/LICENSE.md
+++ b/gen/adexchangebuyer2_v2_beta1-cli/LICENSE.md
@@ -1,0 +1,30 @@
+<!---
+DO NOT EDIT !
+This file was generated automatically from 'src/mako/LICENSE.md.mako'
+DO NOT EDIT !
+-->
+The MIT License (MIT)
+=====================
+
+Copyright © `2015-2016` `Sebastian Thiel`
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the “Software”), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.

--- a/gen/adexchangebuyer2_v2_beta1-cli/README.md
+++ b/gen/adexchangebuyer2_v2_beta1-cli/README.md
@@ -1,0 +1,161 @@
+<!---
+DO NOT EDIT !
+This file was generated automatically from 'src/mako/cli/README.md.mako'
+DO NOT EDIT !
+-->
+The `adexchangebuyer2-v2-beta1` command-line interface *(CLI)* allows to use most features of the *Google AdExchangeBuyerII* service from the comfort of your terminal.
+
+By default all output is printed to standard out, but flags can be set to direct it into a file independent of your shell's
+capabilities. Errors will be printed to standard error, and cause the program's exit code to be non-zero.
+
+If data-structures are requested, these will be returned as pretty-printed JSON, to be useful as input to other tools.
+
+Everything else about the *AdExchangeBuyerII* API can be found at the
+[official documentation site](https://developers.google.com/ad-exchange/buyer-rest/reference/rest/).
+
+# Installation and Source Code
+
+Install the command-line interface with cargo using:
+
+```bash
+cargo install google-adexchangebuyer2_v2_beta1-cli
+```
+
+Find the source code [on github](https://github.com/Byron/google-apis-rs/tree/master/gen/adexchangebuyer2_v2_beta1-cli).
+
+# Usage
+
+This documentation was generated from the *AdExchangeBuyerII* API at revision *20171208*. The CLI is at version *1.0.7*.
+
+```bash
+adexchangebuyer2-v2-beta1 [options]
+        accounts
+                clients-create <account-id> (-r <kv>)... [-p <v>]... [-o <out>]
+                clients-get <account-id> <client-account-id> [-p <v>]... [-o <out>]
+                clients-invitations-create <account-id> <client-account-id> (-r <kv>)... [-p <v>]... [-o <out>]
+                clients-invitations-get <account-id> <client-account-id> <invitation-id> [-p <v>]... [-o <out>]
+                clients-invitations-list <account-id> <client-account-id> [-p <v>]... [-o <out>]
+                clients-list <account-id> [-p <v>]... [-o <out>]
+                clients-update <account-id> <client-account-id> (-r <kv>)... [-p <v>]... [-o <out>]
+                clients-users-get <account-id> <client-account-id> <user-id> [-p <v>]... [-o <out>]
+                clients-users-list <account-id> <client-account-id> [-p <v>]... [-o <out>]
+                clients-users-update <account-id> <client-account-id> <user-id> (-r <kv>)... [-p <v>]... [-o <out>]
+                creatives-create <account-id> (-r <kv>)... [-p <v>]... [-o <out>]
+                creatives-deal-associations-add <account-id> <creative-id> (-r <kv>)... [-p <v>]... [-o <out>]
+                creatives-deal-associations-list <account-id> <creative-id> [-p <v>]... [-o <out>]
+                creatives-deal-associations-remove <account-id> <creative-id> (-r <kv>)... [-p <v>]... [-o <out>]
+                creatives-get <account-id> <creative-id> [-p <v>]... [-o <out>]
+                creatives-list <account-id> [-p <v>]... [-o <out>]
+                creatives-stop-watching <account-id> <creative-id> (-r <kv>)... [-p <v>]... [-o <out>]
+                creatives-update <account-id> <creative-id> (-r <kv>)... [-p <v>]... [-o <out>]
+                creatives-watch <account-id> <creative-id> (-r <kv>)... [-p <v>]... [-o <out>]
+        bidders
+                accounts-filter-sets-bid-metrics-list <filter-set-name> [-p <v>]... [-o <out>]
+                accounts-filter-sets-bid-response-errors-list <filter-set-name> [-p <v>]... [-o <out>]
+                accounts-filter-sets-bid-responses-without-bids-list <filter-set-name> [-p <v>]... [-o <out>]
+                accounts-filter-sets-create <owner-name> (-r <kv>)... [-p <v>]... [-o <out>]
+                accounts-filter-sets-delete <name> [-p <v>]... [-o <out>]
+                accounts-filter-sets-filtered-bid-requests-list <filter-set-name> [-p <v>]... [-o <out>]
+                accounts-filter-sets-filtered-bids-creatives-list <filter-set-name> <creative-status-id> [-p <v>]... [-o <out>]
+                accounts-filter-sets-filtered-bids-details-list <filter-set-name> <creative-status-id> [-p <v>]... [-o <out>]
+                accounts-filter-sets-filtered-bids-list <filter-set-name> [-p <v>]... [-o <out>]
+                accounts-filter-sets-get <name> [-p <v>]... [-o <out>]
+                accounts-filter-sets-impression-metrics-list <filter-set-name> [-p <v>]... [-o <out>]
+                accounts-filter-sets-list <owner-name> [-p <v>]... [-o <out>]
+                accounts-filter-sets-losing-bids-list <filter-set-name> [-p <v>]... [-o <out>]
+                accounts-filter-sets-non-billable-winning-bids-list <filter-set-name> [-p <v>]... [-o <out>]
+                filter-sets-bid-metrics-list <filter-set-name> [-p <v>]... [-o <out>]
+                filter-sets-bid-response-errors-list <filter-set-name> [-p <v>]... [-o <out>]
+                filter-sets-bid-responses-without-bids-list <filter-set-name> [-p <v>]... [-o <out>]
+                filter-sets-create <owner-name> (-r <kv>)... [-p <v>]... [-o <out>]
+                filter-sets-delete <name> [-p <v>]... [-o <out>]
+                filter-sets-filtered-bid-requests-list <filter-set-name> [-p <v>]... [-o <out>]
+                filter-sets-filtered-bids-creatives-list <filter-set-name> <creative-status-id> [-p <v>]... [-o <out>]
+                filter-sets-filtered-bids-details-list <filter-set-name> <creative-status-id> [-p <v>]... [-o <out>]
+                filter-sets-filtered-bids-list <filter-set-name> [-p <v>]... [-o <out>]
+                filter-sets-get <name> [-p <v>]... [-o <out>]
+                filter-sets-impression-metrics-list <filter-set-name> [-p <v>]... [-o <out>]
+                filter-sets-list <owner-name> [-p <v>]... [-o <out>]
+                filter-sets-losing-bids-list <filter-set-name> [-p <v>]... [-o <out>]
+                filter-sets-non-billable-winning-bids-list <filter-set-name> [-p <v>]... [-o <out>]
+  adexchangebuyer2-v2-beta1 --help
+
+Configuration:
+  [--scope <url>]...
+            Specify the authentication a method should be executed in. Each scope
+            requires the user to grant this application permission to use it.
+            If unset, it defaults to the shortest scope url for a particular method.
+  --config-dir <folder>
+            A directory into which we will store our persistent data. Defaults to
+            a user-writable directory that we will create during the first invocation.
+            [default: ~/.google-service-cli]
+  --debug
+            Output all server communication to standard error. `tx` and `rx` are placed
+            into the same stream.
+  --debug-auth
+            Output all communication related to authentication to standard error. `tx`
+            and `rx` are placed into the same stream.
+
+```
+
+# Configuration
+
+The program will store all persistent data in the `~/.google-service-cli` directory in *JSON* files prefixed with `adexchangebuyer2-v2-beta1-`.  You can change the directory used to store configuration with the `--config-dir` flag on a per-invocation basis.
+
+More information about the various kinds of persistent data are given in the following paragraphs.
+
+# Authentication
+
+Most APIs require a user to authenticate any request. If this is the case, the [scope][scopes] determines the 
+set of permissions granted. The granularity of these is usually no more than *read-only* or *full-access*.
+
+If not set, the system will automatically select the smallest feasible scope, e.g. when invoking a
+method that is read-only, it will ask only for a read-only scope. 
+You may use the `--scope` flag to specify a scope directly. 
+All applicable scopes are documented in the respective method's CLI documentation.
+
+The first time a scope is used, the user is asked for permission. Follow the instructions given 
+by the CLI to grant permissions, or to decline.
+
+If a scope was authenticated by the user, the respective information will be stored as *JSON* in the configuration
+directory, e.g. `~/.google-service-cli/adexchangebuyer2-v2-beta1-token-<scope-hash>.json`. No manual management of these tokens
+is necessary.
+
+To revoke granted authentication, please refer to the [official documentation][revoke-access].
+
+# Application Secrets
+
+In order to allow any application to use Google services, it will need to be registered using the 
+[Google Developer Console][google-dev-console]. APIs the application may use are then enabled for it
+one by one. Most APIs can be used for free and have a daily quota.
+
+To allow more comfortable usage of the CLI without forcing anyone to register an own application, the CLI
+comes with a default application secret that is configured accordingly. This also means that heavy usage
+all around the world may deplete the daily quota.
+
+You can workaround this limitation by putting your own secrets file at this location: 
+`~/.google-service-cli/adexchangebuyer2-v2-beta1-secret.json`, assuming that the required *adexchangebuyer2* API 
+was enabled for it. Such a secret file can be downloaded in the *Google Developer Console* at 
+*APIs & auth -> Credentials -> Download JSON* and used as is.
+
+Learn more about how to setup Google projects and enable APIs using the [official documentation][google-project-new].
+
+
+# Debugging
+
+Even though the CLI does its best to provide usable error messages, sometimes it might be desirable to know
+what exactly led to a particular issue. This is done by allowing all client-server communication to be 
+output to standard error *as-is*.
+
+The `--debug` flag will print all client-server communication to standard error, whereas the `--debug-auth` flag
+will cause all communication related to authentication to standard error.
+If the `--debug` flag is set, error-results will be debug-printed, possibly yielding more information about the 
+issue at hand.
+
+You may consider redirecting standard error into a file for ease of use, e.g. `adexchangebuyer2-v2-beta1 --debug <resource> <method> [options] 2>debug.txt`.
+
+
+[scopes]: https://developers.google.com/+/api/oauth#scopes
+[revoke-access]: http://webapps.stackexchange.com/a/30849
+[google-dev-console]: https://console.developers.google.com/
+[google-project-new]: https://developers.google.com/console/help/new/

--- a/gen/adexchangebuyer2_v2_beta1-cli/mkdocs.yml
+++ b/gen/adexchangebuyer2_v2_beta1-cli/mkdocs.yml
@@ -1,0 +1,63 @@
+site_name: AdExchangeBuyerII v1.0.7+20171208
+site_url: http://byron.github.io/google-apis-rs/google-adexchangebuyer2_v2_beta1-cli
+site_description: A complete library to interact with AdExchangeBuyerII (protocol v2beta1)
+
+repo_url: https://github.com/Byron/google-apis-rs/tree/master/gen/adexchangebuyer2_v2_beta1-cli
+
+docs_dir: docs
+site_dir: build_html
+
+pages:
+- ['index.md', 'Home']
+- ['accounts_clients-create.md', 'Accounts', 'Clients Create']
+- ['accounts_clients-get.md', 'Accounts', 'Clients Get']
+- ['accounts_clients-invitations-create.md', 'Accounts', 'Clients Invitations Create']
+- ['accounts_clients-invitations-get.md', 'Accounts', 'Clients Invitations Get']
+- ['accounts_clients-invitations-list.md', 'Accounts', 'Clients Invitations List']
+- ['accounts_clients-list.md', 'Accounts', 'Clients List']
+- ['accounts_clients-update.md', 'Accounts', 'Clients Update']
+- ['accounts_clients-users-get.md', 'Accounts', 'Clients Users Get']
+- ['accounts_clients-users-list.md', 'Accounts', 'Clients Users List']
+- ['accounts_clients-users-update.md', 'Accounts', 'Clients Users Update']
+- ['accounts_creatives-create.md', 'Accounts', 'Creatives Create']
+- ['accounts_creatives-deal-associations-add.md', 'Accounts', 'Creatives Deal Associations Add']
+- ['accounts_creatives-deal-associations-list.md', 'Accounts', 'Creatives Deal Associations List']
+- ['accounts_creatives-deal-associations-remove.md', 'Accounts', 'Creatives Deal Associations Remove']
+- ['accounts_creatives-get.md', 'Accounts', 'Creatives Get']
+- ['accounts_creatives-list.md', 'Accounts', 'Creatives List']
+- ['accounts_creatives-stop-watching.md', 'Accounts', 'Creatives Stop Watching']
+- ['accounts_creatives-update.md', 'Accounts', 'Creatives Update']
+- ['accounts_creatives-watch.md', 'Accounts', 'Creatives Watch']
+- ['bidders_accounts-filter-sets-bid-metrics-list.md', 'Bidders', 'Accounts Filter Sets Bid Metrics List']
+- ['bidders_accounts-filter-sets-bid-response-errors-list.md', 'Bidders', 'Accounts Filter Sets Bid Response Errors List']
+- ['bidders_accounts-filter-sets-bid-responses-without-bids-list.md', 'Bidders', 'Accounts Filter Sets Bid Responses Without Bids List']
+- ['bidders_accounts-filter-sets-create.md', 'Bidders', 'Accounts Filter Sets Create']
+- ['bidders_accounts-filter-sets-delete.md', 'Bidders', 'Accounts Filter Sets Delete']
+- ['bidders_accounts-filter-sets-filtered-bid-requests-list.md', 'Bidders', 'Accounts Filter Sets Filtered Bid Requests List']
+- ['bidders_accounts-filter-sets-filtered-bids-creatives-list.md', 'Bidders', 'Accounts Filter Sets Filtered Bids Creatives List']
+- ['bidders_accounts-filter-sets-filtered-bids-details-list.md', 'Bidders', 'Accounts Filter Sets Filtered Bids Details List']
+- ['bidders_accounts-filter-sets-filtered-bids-list.md', 'Bidders', 'Accounts Filter Sets Filtered Bids List']
+- ['bidders_accounts-filter-sets-get.md', 'Bidders', 'Accounts Filter Sets Get']
+- ['bidders_accounts-filter-sets-impression-metrics-list.md', 'Bidders', 'Accounts Filter Sets Impression Metrics List']
+- ['bidders_accounts-filter-sets-list.md', 'Bidders', 'Accounts Filter Sets List']
+- ['bidders_accounts-filter-sets-losing-bids-list.md', 'Bidders', 'Accounts Filter Sets Losing Bids List']
+- ['bidders_accounts-filter-sets-non-billable-winning-bids-list.md', 'Bidders', 'Accounts Filter Sets Non Billable Winning Bids List']
+- ['bidders_filter-sets-bid-metrics-list.md', 'Bidders', 'Filter Sets Bid Metrics List']
+- ['bidders_filter-sets-bid-response-errors-list.md', 'Bidders', 'Filter Sets Bid Response Errors List']
+- ['bidders_filter-sets-bid-responses-without-bids-list.md', 'Bidders', 'Filter Sets Bid Responses Without Bids List']
+- ['bidders_filter-sets-create.md', 'Bidders', 'Filter Sets Create']
+- ['bidders_filter-sets-delete.md', 'Bidders', 'Filter Sets Delete']
+- ['bidders_filter-sets-filtered-bid-requests-list.md', 'Bidders', 'Filter Sets Filtered Bid Requests List']
+- ['bidders_filter-sets-filtered-bids-creatives-list.md', 'Bidders', 'Filter Sets Filtered Bids Creatives List']
+- ['bidders_filter-sets-filtered-bids-details-list.md', 'Bidders', 'Filter Sets Filtered Bids Details List']
+- ['bidders_filter-sets-filtered-bids-list.md', 'Bidders', 'Filter Sets Filtered Bids List']
+- ['bidders_filter-sets-get.md', 'Bidders', 'Filter Sets Get']
+- ['bidders_filter-sets-impression-metrics-list.md', 'Bidders', 'Filter Sets Impression Metrics List']
+- ['bidders_filter-sets-list.md', 'Bidders', 'Filter Sets List']
+- ['bidders_filter-sets-losing-bids-list.md', 'Bidders', 'Filter Sets Losing Bids List']
+- ['bidders_filter-sets-non-billable-winning-bids-list.md', 'Bidders', 'Filter Sets Non Billable Winning Bids List']
+
+theme: readthedocs
+
+copyright: Copyright &copy; 2015-2016, `Sebastian Thiel`
+

--- a/gen/adexchangebuyer2_v2_beta1-cli/src/cmn.rs
+++ b/gen/adexchangebuyer2_v2_beta1-cli/src/cmn.rs
@@ -1,0 +1,799 @@
+// COPY OF 'src/rust/cli/cmn.rs'
+// DO NOT EDIT
+use oauth2::{ApplicationSecret, ConsoleApplicationSecret, TokenStorage, Token};
+use serde_json as json;
+use serde_json::value::Value;
+use mime::Mime;
+use clap::{App, SubCommand};
+use strsim;
+
+use std::fs;
+use std::env;
+use std::io;
+use std::error::Error as StdError;
+use std::fmt;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+use std::string::ToString;
+use std::io::{Write, Read, stdout};
+
+use std::default::Default;
+
+const FIELD_SEP: char = '.';
+
+
+pub enum ComplexType {
+    Pod,
+    Vec,
+    Map,
+}
+
+// Null,
+// Bool(bool),
+// I64(i64),
+// U64(u64),
+// F64(f64),
+// String(String),
+
+pub enum JsonType {
+    Boolean,
+    Int,
+    Uint,
+    Float,
+    String,
+}
+
+pub struct JsonTypeInfo {
+    pub jtype: JsonType,
+    pub ctype: ComplexType,
+}
+
+// Based on @erickt user comment. Thanks for the idea !
+// Remove all keys whose values are null from given value (changed in place)
+pub fn remove_json_null_values(value: &mut Value) {
+    match *value {
+        Value::Object(ref mut map) => {
+            let mut for_removal = Vec::new();
+
+            for (key, mut value) in map.iter_mut() {
+                if value.is_null() {
+                    for_removal.push(key.clone());
+                } else {
+                    remove_json_null_values(&mut value);
+                }
+            }
+
+            for key in &for_removal {
+                map.remove(key);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn did_you_mean<'a>(v: &str, possible_values: &[&'a str]) -> Option<&'a str> {
+
+    let mut candidate: Option<(f64, &str)> = None;
+    for pv in possible_values {
+        let confidence = strsim::jaro_winkler(v, pv);
+        if confidence > 0.8 &&
+           (candidate.is_none() || (candidate.as_ref().unwrap().0 < confidence)) {
+            candidate = Some((confidence, pv));
+        }
+    }
+    match candidate {
+        None => None,
+        Some((_, candidate)) => Some(candidate),
+    }
+}
+
+pub enum CallType {
+    Upload(UploadProtocol),
+    Standard,
+}
+
+arg_enum!{
+    pub enum UploadProtocol {
+        Simple,
+        Resumable
+    }
+}
+
+impl AsRef<str> for UploadProtocol {
+    fn as_ref(&self) -> &str {
+        match *self {
+            UploadProtocol::Simple => "simple",
+            UploadProtocol::Resumable => "resumable",
+        }
+    }
+}
+
+impl AsRef<str> for CallType {
+    fn as_ref(&self) -> &str {
+        match *self {
+            CallType::Upload(ref proto) => proto.as_ref(),
+            CallType::Standard => "standard-request",
+        }
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct FieldCursor(Vec<String>);
+
+impl ToString for  FieldCursor {
+    fn to_string(&self) -> String {
+        self.0.join(".")
+    }
+}
+
+impl From<&'static str> for FieldCursor {
+    fn from(value: &'static str) -> FieldCursor {
+        let mut res = FieldCursor::default();
+        res.set(value).unwrap();
+        res
+    }
+}
+
+fn assure_entry<'a, 'b>(m: &'a mut json::Map<String, Value>, k: &'b String) -> &'a mut Value {
+    if m.contains_key(k) {
+        return m.get_mut(k).expect("value to exist");
+    }
+    m.insert(k.to_owned(), Value::Object(Default::default()));
+    m.get_mut(k).expect("value to exist")
+}
+
+impl FieldCursor {
+    pub fn set(&mut self, value: &str) -> Result<(), CLIError> {
+        if value.len() == 0 {
+            return Err(CLIError::Field(FieldError::Empty));
+        }
+
+        let mut first_is_field_sep = false;
+        let mut char_count: usize = 0;
+        let mut last_c = FIELD_SEP;
+        let mut num_conscutive_field_seps = 0;
+
+        let mut field = String::new();
+        let mut fields = self.0.clone();
+
+        let push_field = |fs: &mut Vec<String>, f: &mut String| {
+            if f.len() > 0 {
+                fs.push(f.clone());
+                f.truncate(0);
+            }
+        };
+
+        for (cid, c) in value.chars().enumerate() {
+            char_count += 1;
+
+            if c == FIELD_SEP {
+                if cid == 0 {
+                    first_is_field_sep = true;
+                }
+                num_conscutive_field_seps += 1;
+                if cid > 0 && last_c == FIELD_SEP {
+                    if fields.pop().is_none() {
+                        return Err(CLIError::Field(FieldError::PopOnEmpty(value.to_string())));
+                    }
+                } else {
+                    push_field(&mut fields, &mut field);
+                }
+            } else {
+                num_conscutive_field_seps = 0;
+                if cid == 1 {
+                    if first_is_field_sep {
+                        fields.truncate(0);
+                    }
+                }
+                field.push(c);
+            }
+
+            last_c = c;
+        }
+
+        push_field(&mut fields, &mut field);
+
+        if char_count == 1 && first_is_field_sep {
+            fields.truncate(0);
+        }
+        if char_count > 1 && num_conscutive_field_seps == 1 {
+            return Err(CLIError::Field(FieldError::TrailingFieldSep(value.to_string())));
+        }
+
+        self.0 = fields;
+        Ok(())
+    }
+
+    pub fn did_you_mean(value: &str, possible_values: &[&str]) -> Option<String> {
+        if value.len() == 0 {
+            return None;
+        }
+
+        let mut last_c = FIELD_SEP;
+
+        let mut field = String::new();
+        let mut output = String::new();
+
+        let push_field = |fs: &mut String, f: &mut String| {
+            if f.len() > 0 {
+                fs.push_str(match did_you_mean(&f, possible_values) {
+                    Some(candidate) => candidate,
+                    None => &f,
+                });
+                f.truncate(0);
+            }
+        };
+
+        for (cid, c) in value.chars().enumerate() {
+            if c == FIELD_SEP {
+                if last_c != FIELD_SEP {
+                    push_field(&mut output, &mut field);
+                }
+                output.push(c);
+            } else {
+                field.push(c);
+            }
+
+            last_c = c;
+        }
+
+        push_field(&mut output, &mut field);
+
+        if &output == value {
+            None
+        } else {
+            Some(output)
+        }
+    }
+
+    pub fn set_json_value(&self,
+                          mut object: &mut Value,
+                          value: &str,
+                          type_info: JsonTypeInfo,
+                          err: &mut InvalidOptionsError,
+                          orig_cursor: &FieldCursor) {
+        assert!(self.0.len() > 0);
+
+        for field in &self.0[..self.0.len() - 1] {
+            let tmp = object;
+            object = match *tmp {
+                Value::Object(ref mut mapping) => {
+                    assure_entry(mapping, &field)
+                }
+                _ => panic!("We don't expect non-object Values here ..."),
+            };
+        }
+
+        match *object {
+            Value::Object(ref mut mapping) => {
+                let field = &self.0[self.0.len() - 1];
+                let to_jval = |value: &str,
+                               jtype: JsonType,
+                               err: &mut InvalidOptionsError|
+                               -> Value {
+                    match jtype {
+                        JsonType::Boolean =>
+                            Value::Bool(arg_from_str(value, err, &field, "boolean")),
+                        JsonType::Int =>
+                            Value::Number(json::Number::from_f64(arg_from_str(value,
+                                                                              err,
+                                                                              &field,
+                                                                              "int"))
+                                              .expect("valid f64")),
+                        JsonType::Uint =>
+                            Value::Number(json::Number::from_f64(arg_from_str(value,
+                                                                              err,
+                                                                              &field,
+                                                                              "uint"))
+                                              .expect("valid f64")),
+                        JsonType::Float =>
+                            Value::Number(json::Number::from_f64(arg_from_str(value,
+                                                                              err,
+                                                                              &field,
+                                                                              "float"))
+                                              .expect("valid f64")),
+                        JsonType::String => Value::String(value.to_owned()),
+                    }
+                };
+
+                match type_info.ctype {
+                    ComplexType::Pod => {
+                        if mapping.insert(field.to_owned(), to_jval(value, type_info.jtype, err))
+                                  .is_some() {
+                            err.issues.push(CLIError::Field(FieldError::Duplicate(orig_cursor.to_string())));
+                        }
+                    }
+                    ComplexType::Vec => {
+                        match *assure_entry(mapping, field) {
+                            Value::Array(ref mut values) =>
+                                values.push(to_jval(value, type_info.jtype, err)),
+                            _ => unreachable!(),
+                        }
+                    }
+                    ComplexType::Map => {
+                        let (key, value) = parse_kv_arg(value, err, true);
+                        let jval = to_jval(value.unwrap_or(""), type_info.jtype, err);
+
+                        match *assure_entry(mapping, &field) {
+
+                            Value::Object(ref mut value_map) => {
+                                if value_map.insert(key.to_owned(), jval).is_some() {
+                                    err.issues.push(CLIError::Field(FieldError::Duplicate(orig_cursor.to_string())));
+                                }
+                            }
+                            _ => unreachable!(),
+                        }
+                    }
+                }
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    pub fn num_fields(&self) -> usize {
+        self.0.len()
+    }
+}
+
+pub fn parse_kv_arg<'a>(kv: &'a str,
+                        err: &mut InvalidOptionsError,
+                        for_hashmap: bool)
+                        -> (&'a str, Option<&'a str>) {
+    let mut add_err = || {
+        err.issues.push(CLIError::InvalidKeyValueSyntax(kv.to_string(), for_hashmap))
+    };
+    match kv.find('=') {
+        None => {
+            add_err();
+            return (kv, None);
+        }
+        Some(pos) => {
+            let key = &kv[..pos];
+            if kv.len() <= pos + 1 {
+                add_err();
+                return (key, Some(""));
+            }
+            (key, Some(&kv[pos + 1..]))
+        }
+    }
+}
+
+pub fn calltype_from_str(name: &str,
+                         valid_protocols: Vec<String>,
+                         err: &mut InvalidOptionsError)
+                         -> CallType {
+    CallType::Upload(match UploadProtocol::from_str(name) {
+        Ok(up) => up,
+        Err(msg) => {
+            err.issues.push(CLIError::InvalidUploadProtocol(name.to_string(), valid_protocols));
+            UploadProtocol::Simple
+        }
+    })
+}
+
+pub fn input_file_from_opts(file_path: &str, err: &mut InvalidOptionsError) -> Option<fs::File> {
+    match fs::File::open(file_path) {
+        Ok(f) => Some(f),
+        Err(io_err) => {
+            err.issues.push(CLIError::Input(InputError::Io((file_path.to_string(), io_err))));
+            None
+        }
+    }
+}
+
+pub fn input_mime_from_opts(mime: &str, err: &mut InvalidOptionsError) -> Option<Mime> {
+    match mime.parse() {
+        Ok(m) => Some(m),
+        Err(_) => {
+            err.issues.push(CLIError::Input(InputError::Mime(mime.to_string())));
+            None
+        }
+    }
+}
+
+pub fn writer_from_opts(arg: Option<&str>) -> Result<Box<Write>, io::Error> {
+    let f = arg.unwrap_or("-");
+    match f {
+        "-" => Ok(Box::new(stdout())),
+        _ => match fs::OpenOptions::new().create(true).write(true).open(f) {
+            Ok(f) => Ok(Box::new(f)),
+            Err(io_err) => Err(io_err),
+        },
+    }
+}
+
+
+pub fn arg_from_str<'a, T>(arg: &str,
+                           err: &mut InvalidOptionsError,
+                           arg_name: &'a str,
+                           arg_type: &'a str)
+                           -> T
+    where T: FromStr + Default,
+          <T as FromStr>::Err: fmt::Display
+{
+    match FromStr::from_str(arg) {
+        Err(perr) => {
+            err.issues.push(CLIError::ParseError(arg_name.to_owned(),
+                                                 arg_type.to_owned(),
+                                                 arg.to_string(),
+                                                 format!("{}", perr)));
+            Default::default()
+        }
+        Ok(v) => v,
+    }
+}
+
+pub struct JsonTokenStorage {
+    pub program_name: &'static str,
+    pub db_dir: String,
+}
+
+impl JsonTokenStorage {
+    fn path(&self, scope_hash: u64) -> PathBuf {
+        Path::new(&self.db_dir).join(&format!("{}-token-{}.json", self.program_name, scope_hash))
+    }
+}
+
+
+#[derive(Debug)]
+pub enum TokenStorageError {
+    Json(json::Error),
+    Io(io::Error),
+}
+
+impl fmt::Display for TokenStorageError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            TokenStorageError::Json(ref err) => writeln!(f, "Could not serialize secrets: {}", err),
+            TokenStorageError::Io(ref err) => writeln!(f, "Failed to write secret token: {}", err),
+        }
+    }
+}
+
+impl StdError for TokenStorageError {
+    fn description(&self) -> &str {
+        "Failure when getting or setting the token storage"
+    }
+}
+
+
+impl TokenStorage for JsonTokenStorage {
+    type Error = TokenStorageError;
+
+    // NOTE: logging might be interesting, currently we swallow all errors
+    fn set(&mut self,
+           scope_hash: u64,
+           _: &Vec<&str>,
+           token: Option<Token>)
+           -> Result<(), TokenStorageError> {
+        match token {
+            None => {
+                match fs::remove_file(self.path(scope_hash)) {
+                    Err(err) => match err.kind() {
+                        io::ErrorKind::NotFound => Ok(()),
+                        _ => Err(TokenStorageError::Io(err)),
+                    },
+                    Ok(_) => Ok(()),
+                }
+            }
+            Some(token) => {
+                match fs::OpenOptions::new().create(true).write(true).open(&self.path(scope_hash)) {
+                    Ok(mut f) => {
+                        match json::to_writer_pretty(&mut f, &token) {
+                            Ok(_) => Ok(()),
+                            Err(serde_err) => Err(TokenStorageError::Json(serde_err)),
+                        }
+                    }
+                    Err(io_err) => Err(TokenStorageError::Io(io_err)),
+                }
+            }
+        }
+    }
+
+    fn get(&self, scope_hash: u64, _: &Vec<&str>) -> Result<Option<Token>, TokenStorageError> {
+        match fs::File::open(&self.path(scope_hash)) {
+            Ok(f) => {
+                match json::de::from_reader(f) {
+                    Ok(token) => Ok(Some(token)),
+                    Err(err) => Err(TokenStorageError::Json(err)),
+                }
+            }
+            Err(io_err) => {
+                match io_err.kind() {
+                    io::ErrorKind::NotFound => Ok(None),
+                    _ => Err(TokenStorageError::Io(io_err)),
+                }
+            }
+        }
+    }
+}
+
+
+#[derive(Debug)]
+pub enum ApplicationSecretError {
+    DecoderError((String, json::Error)),
+    FormatError(String),
+}
+
+impl fmt::Display for ApplicationSecretError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            ApplicationSecretError::DecoderError((ref path, ref err)) =>
+                writeln!(f,
+                         "Could not decode file at '{}' with error: {}.",
+                         path,
+                         err),
+            ApplicationSecretError::FormatError(ref path) =>
+                writeln!(f,
+                         "'installed' field is unset in secret file at '{}'.",
+                         path),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum ConfigurationError {
+    DirectoryCreationFailed((String, io::Error)),
+    DirectoryUnset,
+    HomeExpansionFailed(String),
+    Secret(ApplicationSecretError),
+    Io((String, io::Error)),
+}
+
+impl fmt::Display for ConfigurationError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            ConfigurationError::DirectoryCreationFailed((ref dir, ref err)) =>
+                writeln!(f,
+                         "Directory '{}' could not be created with error: {}.",
+                         dir,
+                         err),
+            ConfigurationError::DirectoryUnset => writeln!(f, "--config-dir was unset or empty."),
+            ConfigurationError::HomeExpansionFailed(ref dir) =>
+                writeln!(f,
+                         "Couldn't find HOME directory of current user, failed to expand '{}'.",
+                         dir),
+            ConfigurationError::Secret(ref err) => writeln!(f, "Secret -> {}", err),
+            ConfigurationError::Io((ref path, ref err)) =>
+                writeln!(f,
+                         "IO operation failed on path '{}' with error: {}.",
+                         path,
+                         err),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum InputError {
+    Io((String, io::Error)),
+    Mime(String),
+}
+
+impl fmt::Display for InputError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            InputError::Io((ref file_path, ref io_err)) =>
+                writeln!(f,
+                         "Failed to open '{}' for reading with error: {}.",
+                         file_path,
+                         io_err),
+            InputError::Mime(ref mime) => writeln!(f, "'{}' is not a known mime-type.", mime),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum FieldError {
+    PopOnEmpty(String),
+    TrailingFieldSep(String),
+    Unknown(String, Option<String>, Option<String>),
+    Duplicate(String),
+    Empty,
+}
+
+
+impl fmt::Display for FieldError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            FieldError::PopOnEmpty(ref field) =>
+                writeln!(f, "'{}': Cannot move up on empty field cursor.", field),
+            FieldError::TrailingFieldSep(ref field) =>
+                writeln!(f,
+                         "'{}': Single field separator may not be last character.",
+                         field),
+            FieldError::Unknown(ref field, ref suggestion, ref value) => {
+                let suffix = match *suggestion {
+                    Some(ref s) => {
+                        let kv = match *value {
+                            Some(ref v) => format!("{}={}", s, v),
+                            None => s.clone(),
+                        };
+                        format!(" Did you mean '{}' ?", kv)
+                    }
+                    None => String::new(),
+                };
+                writeln!(f, "Field '{}' does not exist.{}", field, suffix)
+            }
+            FieldError::Duplicate(ref cursor) =>
+                writeln!(f, "Value at '{}' was already set", cursor),
+            FieldError::Empty => writeln!(f, "Field names must not be empty."),
+        }
+    }
+}
+
+
+#[derive(Debug)]
+pub enum CLIError {
+    Configuration(ConfigurationError),
+    ParseError(String, String, String, String),
+    UnknownParameter(String, Vec<&'static str>),
+    InvalidUploadProtocol(String, Vec<String>),
+    InvalidKeyValueSyntax(String, bool),
+    Input(InputError),
+    Field(FieldError),
+    MissingCommandError,
+    MissingMethodError(String),
+}
+
+impl fmt::Display for CLIError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            CLIError::Configuration(ref err) => write!(f, "Configuration -> {}", err),
+            CLIError::Input(ref err) => write!(f, "Input -> {}", err),
+            CLIError::Field(ref err) => write!(f, "Field -> {}", err),
+            CLIError::InvalidUploadProtocol(ref proto_name, ref valid_names) =>
+                writeln!(f,
+                         "'{}' is not a valid upload protocol. Choose from one of {}.",
+                         proto_name,
+                         valid_names.join(", ")),
+            CLIError::ParseError(ref arg_name, ref type_name, ref value, ref err_desc) =>
+                writeln!(f,
+                         "Failed to parse argument '{}' with value '{}' as {} with error: {}.",
+                         arg_name,
+                         value,
+                         type_name,
+                         err_desc),
+            CLIError::UnknownParameter(ref param_name, ref possible_values) => {
+                let suffix = match did_you_mean(param_name, &possible_values) {
+                    Some(v) => format!(" Did you mean '{}' ?", v),
+                    None => String::new(),
+                };
+                write!(f, "Parameter '{}' is unknown.{}\n", param_name, suffix)
+            }
+            CLIError::InvalidKeyValueSyntax(ref kv, is_hashmap) => {
+                let hashmap_info = if is_hashmap {
+                    "hashmap "
+                } else {
+                    ""
+                };
+                writeln!(f,
+                         "'{}' does not match {}pattern <key>=<value>.",
+                         kv,
+                         hashmap_info)
+            }
+            CLIError::MissingCommandError => writeln!(f, "Please specify the main sub-command."),
+            CLIError::MissingMethodError(ref cmd) =>
+                writeln!(f,
+                         "Please specify the method to call on the '{}' command.",
+                         cmd),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct InvalidOptionsError {
+    pub issues: Vec<CLIError>,
+    pub exit_code: i32,
+}
+
+impl fmt::Display for InvalidOptionsError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        for issue in &self.issues {
+            try!(issue.fmt(f));
+        }
+        Ok(())
+    }
+}
+
+impl InvalidOptionsError {
+    pub fn single(err: CLIError, exit_code: i32) -> InvalidOptionsError {
+        InvalidOptionsError {
+            issues: vec![err],
+            exit_code: exit_code,
+        }
+    }
+
+    pub fn new() -> InvalidOptionsError {
+        InvalidOptionsError {
+            issues: Vec::new(),
+            exit_code: 1,
+        }
+    }
+}
+
+pub fn assure_config_dir_exists(dir: &str) -> Result<String, CLIError> {
+    let trdir = dir.trim();
+    if trdir.len() == 0 {
+        return Err(CLIError::Configuration(ConfigurationError::DirectoryUnset));
+    }
+
+    let expanded_config_dir = if trdir.as_bytes()[0] == b'~' {
+        match env::var("HOME").ok().or(env::var("UserProfile").ok()) {
+            None => return Err(CLIError::Configuration(ConfigurationError::HomeExpansionFailed(trdir.to_string()))),
+            Some(mut user) => {
+                user.push_str(&trdir[1..]);
+                user
+            }
+        }
+    } else {
+        trdir.to_string()
+    };
+
+    if let Err(err) = fs::create_dir(&expanded_config_dir) {
+        if err.kind() != io::ErrorKind::AlreadyExists {
+            return Err(CLIError::Configuration(
+                    ConfigurationError::DirectoryCreationFailed((expanded_config_dir, err))));
+        }
+    }
+
+    Ok(expanded_config_dir)
+}
+
+pub fn application_secret_from_directory(dir: &str,
+                                         secret_basename: &str,
+                                         json_console_secret: &str)
+                                         -> Result<ApplicationSecret, CLIError> {
+    let secret_path = Path::new(dir).join(secret_basename);
+    let secret_str = || secret_path.as_path().to_str().unwrap().to_string();
+    let secret_io_error = |io_err: io::Error| {
+        Err(CLIError::Configuration(ConfigurationError::Io((secret_str(), io_err))))
+    };
+
+    for _ in 0..2 {
+        match fs::File::open(&secret_path) {
+            Err(mut err) => {
+                if err.kind() == io::ErrorKind::NotFound {
+                    // Write our built-in one - user may adjust the written file at will
+
+                    err = match fs::OpenOptions::new()
+                                    .create(true)
+                                    .write(true)
+                                    .open(&secret_path) {
+                        Err(cfe) => cfe,
+                        Ok(mut f) => {
+                            // Assure we convert 'ugly' json string into pretty one
+                            let console_secret: ConsoleApplicationSecret =
+                                json::from_str(json_console_secret).unwrap();
+                            match json::to_writer_pretty(&mut f, &console_secret) {
+                                Err(serde_err) =>
+                                    panic!("Unexpected serde error: {:#?}", serde_err),
+                                Ok(_) => continue,
+                            }
+                        }
+                    };
+                    // fall through to IO error handling
+                }
+                return secret_io_error(err);
+            }
+            Ok(f) => {
+                match json::de::from_reader::<_, ConsoleApplicationSecret>(f) {
+                    Err(json_err) =>
+                        return Err(CLIError::Configuration(
+                            ConfigurationError::Secret(
+                                ApplicationSecretError::DecoderError(
+                                                (secret_str(), json_err)
+                                              )))),
+                    Ok(console_secret) => match console_secret.installed {
+                        Some(secret) => return Ok(secret),
+                        None => return Err(
+                                        CLIError::Configuration(
+                                        ConfigurationError::Secret(
+                                        ApplicationSecretError::FormatError(secret_str())
+                                        ))),
+                    },
+                }
+            }
+        }
+    }
+    unreachable!();
+}

--- a/gen/adexchangebuyer2_v2_beta1-cli/src/main.rs
+++ b/gen/adexchangebuyer2_v2_beta1-cli/src/main.rs
@@ -1,0 +1,5185 @@
+// DO NOT EDIT !
+// This file was generated automatically from 'src/mako/cli/main.rs.mako'
+// DO NOT EDIT !
+#![allow(unused_variables, unused_imports, dead_code, unused_mut)]
+
+#[macro_use]
+extern crate clap;
+extern crate yup_oauth2 as oauth2;
+extern crate yup_hyper_mock as mock;
+extern crate hyper_rustls;
+extern crate serde;
+extern crate serde_json;
+extern crate hyper;
+extern crate mime;
+extern crate strsim;
+extern crate google_adexchangebuyer2_v2_beta1 as api;
+
+use std::env;
+use std::io::{self, Write};
+use clap::{App, SubCommand, Arg};
+
+mod cmn;
+
+use cmn::{InvalidOptionsError, CLIError, JsonTokenStorage, arg_from_str, writer_from_opts, parse_kv_arg,
+          input_file_from_opts, input_mime_from_opts, FieldCursor, FieldError, CallType, UploadProtocol,
+          calltype_from_str, remove_json_null_values, ComplexType, JsonType, JsonTypeInfo};
+
+use std::default::Default;
+use std::str::FromStr;
+
+use oauth2::{Authenticator, DefaultAuthenticatorDelegate, FlowType};
+use serde_json as json;
+use clap::ArgMatches;
+
+enum DoitError {
+    IoError(String, io::Error),
+    ApiError(api::Error),
+}
+
+struct Engine<'n> {
+    opt: ArgMatches<'n>,
+    hub: api::AdExchangeBuyerII<hyper::Client, Authenticator<DefaultAuthenticatorDelegate, JsonTokenStorage, hyper::Client>>,
+    gp: Vec<&'static str>,
+    gpm: Vec<(&'static str, &'static str)>,
+}
+
+
+impl<'n> Engine<'n> {
+    fn _accounts_clients_create(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    "status" => Some(("status", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "client-account-id" => Some(("clientAccountId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "partner-client-id" => Some(("partnerClientId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "entity-name" => Some(("entityName", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "entity-type" => Some(("entityType", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "role" => Some(("role", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "visible-to-seller" => Some(("visibleToSeller", JsonTypeInfo { jtype: JsonType::Boolean, ctype: ComplexType::Pod })),
+                    "entity-id" => Some(("entityId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "client-name" => Some(("clientName", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec!["client-account-id", "client-name", "entity-id", "entity-name", "entity-type", "partner-client-id", "role", "status", "visible-to-seller"]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::Client = json::value::from_value(object).unwrap();
+        let mut call = self.hub.accounts().clients_create(request, opt.value_of("account-id").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _accounts_clients_get(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let mut call = self.hub.accounts().clients_get(opt.value_of("account-id").unwrap_or(""), opt.value_of("client-account-id").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _accounts_clients_invitations_create(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    "invitation-id" => Some(("invitationId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "client-account-id" => Some(("clientAccountId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "email" => Some(("email", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec!["client-account-id", "email", "invitation-id"]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::ClientUserInvitation = json::value::from_value(object).unwrap();
+        let mut call = self.hub.accounts().clients_invitations_create(request, opt.value_of("account-id").unwrap_or(""), opt.value_of("client-account-id").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _accounts_clients_invitations_get(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let mut call = self.hub.accounts().clients_invitations_get(opt.value_of("account-id").unwrap_or(""), opt.value_of("client-account-id").unwrap_or(""), opt.value_of("invitation-id").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _accounts_clients_invitations_list(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let mut call = self.hub.accounts().clients_invitations_list(opt.value_of("account-id").unwrap_or(""), opt.value_of("client-account-id").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                "page-token" => {
+                    call = call.page_token(value.unwrap_or(""));
+                },
+                "page-size" => {
+                    call = call.page_size(arg_from_str(value.unwrap_or("-0"), err, "page-size", "integer"));
+                },
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v.extend(["page-token", "page-size"].iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _accounts_clients_list(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let mut call = self.hub.accounts().clients_list(opt.value_of("account-id").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                "partner-client-id" => {
+                    call = call.partner_client_id(value.unwrap_or(""));
+                },
+                "page-token" => {
+                    call = call.page_token(value.unwrap_or(""));
+                },
+                "page-size" => {
+                    call = call.page_size(arg_from_str(value.unwrap_or("-0"), err, "page-size", "integer"));
+                },
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v.extend(["page-token", "partner-client-id", "page-size"].iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _accounts_clients_update(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    "status" => Some(("status", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "client-account-id" => Some(("clientAccountId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "partner-client-id" => Some(("partnerClientId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "entity-name" => Some(("entityName", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "entity-type" => Some(("entityType", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "role" => Some(("role", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "visible-to-seller" => Some(("visibleToSeller", JsonTypeInfo { jtype: JsonType::Boolean, ctype: ComplexType::Pod })),
+                    "entity-id" => Some(("entityId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "client-name" => Some(("clientName", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec!["client-account-id", "client-name", "entity-id", "entity-name", "entity-type", "partner-client-id", "role", "status", "visible-to-seller"]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::Client = json::value::from_value(object).unwrap();
+        let mut call = self.hub.accounts().clients_update(request, opt.value_of("account-id").unwrap_or(""), opt.value_of("client-account-id").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _accounts_clients_users_get(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let mut call = self.hub.accounts().clients_users_get(opt.value_of("account-id").unwrap_or(""), opt.value_of("client-account-id").unwrap_or(""), opt.value_of("user-id").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _accounts_clients_users_list(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let mut call = self.hub.accounts().clients_users_list(opt.value_of("account-id").unwrap_or(""), opt.value_of("client-account-id").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                "page-token" => {
+                    call = call.page_token(value.unwrap_or(""));
+                },
+                "page-size" => {
+                    call = call.page_size(arg_from_str(value.unwrap_or("-0"), err, "page-size", "integer"));
+                },
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v.extend(["page-token", "page-size"].iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _accounts_clients_users_update(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    "status" => Some(("status", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "client-account-id" => Some(("clientAccountId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "user-id" => Some(("userId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "email" => Some(("email", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec!["client-account-id", "email", "status", "user-id"]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::ClientUser = json::value::from_value(object).unwrap();
+        let mut call = self.hub.accounts().clients_users_update(request, opt.value_of("account-id").unwrap_or(""), opt.value_of("client-account-id").unwrap_or(""), opt.value_of("user-id").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _accounts_creatives_create(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    "impression-tracking-urls" => Some(("impressionTrackingUrls", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Vec })),
+                    "version" => Some(("version", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Pod })),
+                    "filtering-stats.date.month" => Some(("filteringStats.date.month", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Pod })),
+                    "filtering-stats.date.day" => Some(("filteringStats.date.day", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Pod })),
+                    "filtering-stats.date.year" => Some(("filteringStats.date.year", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Pod })),
+                    "detected-languages" => Some(("detectedLanguages", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Vec })),
+                    "advertiser-name" => Some(("advertiserName", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "click-through-urls" => Some(("clickThroughUrls", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Vec })),
+                    "video.video-url" => Some(("video.videoUrl", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "detected-sensitive-categories" => Some(("detectedSensitiveCategories", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Vec })),
+                    "creative-id" => Some(("creativeId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "detected-advertiser-ids" => Some(("detectedAdvertiserIds", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Vec })),
+                    "ad-choices-destination-url" => Some(("adChoicesDestinationUrl", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "account-id" => Some(("accountId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "vendor-ids" => Some(("vendorIds", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Vec })),
+                    "agency-id" => Some(("agencyId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "html.snippet" => Some(("html.snippet", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "html.width" => Some(("html.width", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Pod })),
+                    "html.height" => Some(("html.height", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Pod })),
+                    "api-update-time" => Some(("apiUpdateTime", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "native.body" => Some(("native.body", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "native.video-url" => Some(("native.videoUrl", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "native.headline" => Some(("native.headline", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "native.image.url" => Some(("native.image.url", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "native.image.width" => Some(("native.image.width", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Pod })),
+                    "native.image.height" => Some(("native.image.height", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Pod })),
+                    "native.star-rating" => Some(("native.starRating", JsonTypeInfo { jtype: JsonType::Float, ctype: ComplexType::Pod })),
+                    "native.store-url" => Some(("native.storeUrl", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "native.advertiser-name" => Some(("native.advertiserName", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "native.price-display-text" => Some(("native.priceDisplayText", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "native.call-to-action" => Some(("native.callToAction", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "native.logo.url" => Some(("native.logo.url", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "native.logo.width" => Some(("native.logo.width", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Pod })),
+                    "native.logo.height" => Some(("native.logo.height", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Pod })),
+                    "native.app-icon.url" => Some(("native.appIcon.url", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "native.app-icon.width" => Some(("native.appIcon.width", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Pod })),
+                    "native.app-icon.height" => Some(("native.appIcon.height", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Pod })),
+                    "native.click-tracking-url" => Some(("native.clickTrackingUrl", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "native.click-link-url" => Some(("native.clickLinkUrl", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "detected-product-categories" => Some(("detectedProductCategories", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Vec })),
+                    "detected-domains" => Some(("detectedDomains", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Vec })),
+                    "attributes" => Some(("attributes", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Vec })),
+                    "deals-status" => Some(("dealsStatus", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "restricted-categories" => Some(("restrictedCategories", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Vec })),
+                    "open-auction-status" => Some(("openAuctionStatus", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec!["account-id", "ad-choices-destination-url", "advertiser-name", "agency-id", "api-update-time", "app-icon", "attributes", "body", "call-to-action", "click-link-url", "click-through-urls", "click-tracking-url", "creative-id", "date", "day", "deals-status", "detected-advertiser-ids", "detected-domains", "detected-languages", "detected-product-categories", "detected-sensitive-categories", "filtering-stats", "headline", "height", "html", "image", "impression-tracking-urls", "logo", "month", "native", "open-auction-status", "price-display-text", "restricted-categories", "snippet", "star-rating", "store-url", "url", "vendor-ids", "version", "video", "video-url", "width", "year"]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::Creative = json::value::from_value(object).unwrap();
+        let mut call = self.hub.accounts().creatives_create(request, opt.value_of("account-id").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                "duplicate-id-mode" => {
+                    call = call.duplicate_id_mode(value.unwrap_or(""));
+                },
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v.extend(["duplicate-id-mode"].iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _accounts_creatives_deal_associations_add(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    "association.deals-id" => Some(("association.dealsId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "association.creative-id" => Some(("association.creativeId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "association.account-id" => Some(("association.accountId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec!["account-id", "association", "creative-id", "deals-id"]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::AddDealAssociationRequest = json::value::from_value(object).unwrap();
+        let mut call = self.hub.accounts().creatives_deal_associations_add(request, opt.value_of("account-id").unwrap_or(""), opt.value_of("creative-id").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _accounts_creatives_deal_associations_list(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let mut call = self.hub.accounts().creatives_deal_associations_list(opt.value_of("account-id").unwrap_or(""), opt.value_of("creative-id").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                "query" => {
+                    call = call.query(value.unwrap_or(""));
+                },
+                "page-token" => {
+                    call = call.page_token(value.unwrap_or(""));
+                },
+                "page-size" => {
+                    call = call.page_size(arg_from_str(value.unwrap_or("-0"), err, "page-size", "integer"));
+                },
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v.extend(["query", "page-size", "page-token"].iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _accounts_creatives_deal_associations_remove(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    "association.deals-id" => Some(("association.dealsId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "association.creative-id" => Some(("association.creativeId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "association.account-id" => Some(("association.accountId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec!["account-id", "association", "creative-id", "deals-id"]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::RemoveDealAssociationRequest = json::value::from_value(object).unwrap();
+        let mut call = self.hub.accounts().creatives_deal_associations_remove(request, opt.value_of("account-id").unwrap_or(""), opt.value_of("creative-id").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _accounts_creatives_get(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let mut call = self.hub.accounts().creatives_get(opt.value_of("account-id").unwrap_or(""), opt.value_of("creative-id").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _accounts_creatives_list(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let mut call = self.hub.accounts().creatives_list(opt.value_of("account-id").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                "query" => {
+                    call = call.query(value.unwrap_or(""));
+                },
+                "page-token" => {
+                    call = call.page_token(value.unwrap_or(""));
+                },
+                "page-size" => {
+                    call = call.page_size(arg_from_str(value.unwrap_or("-0"), err, "page-size", "integer"));
+                },
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v.extend(["query", "page-size", "page-token"].iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _accounts_creatives_stop_watching(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec![]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::StopWatchingCreativeRequest = json::value::from_value(object).unwrap();
+        let mut call = self.hub.accounts().creatives_stop_watching(request, opt.value_of("account-id").unwrap_or(""), opt.value_of("creative-id").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _accounts_creatives_update(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    "impression-tracking-urls" => Some(("impressionTrackingUrls", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Vec })),
+                    "version" => Some(("version", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Pod })),
+                    "filtering-stats.date.month" => Some(("filteringStats.date.month", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Pod })),
+                    "filtering-stats.date.day" => Some(("filteringStats.date.day", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Pod })),
+                    "filtering-stats.date.year" => Some(("filteringStats.date.year", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Pod })),
+                    "detected-languages" => Some(("detectedLanguages", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Vec })),
+                    "advertiser-name" => Some(("advertiserName", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "click-through-urls" => Some(("clickThroughUrls", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Vec })),
+                    "video.video-url" => Some(("video.videoUrl", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "detected-sensitive-categories" => Some(("detectedSensitiveCategories", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Vec })),
+                    "creative-id" => Some(("creativeId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "detected-advertiser-ids" => Some(("detectedAdvertiserIds", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Vec })),
+                    "ad-choices-destination-url" => Some(("adChoicesDestinationUrl", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "account-id" => Some(("accountId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "vendor-ids" => Some(("vendorIds", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Vec })),
+                    "agency-id" => Some(("agencyId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "html.snippet" => Some(("html.snippet", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "html.width" => Some(("html.width", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Pod })),
+                    "html.height" => Some(("html.height", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Pod })),
+                    "api-update-time" => Some(("apiUpdateTime", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "native.body" => Some(("native.body", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "native.video-url" => Some(("native.videoUrl", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "native.headline" => Some(("native.headline", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "native.image.url" => Some(("native.image.url", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "native.image.width" => Some(("native.image.width", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Pod })),
+                    "native.image.height" => Some(("native.image.height", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Pod })),
+                    "native.star-rating" => Some(("native.starRating", JsonTypeInfo { jtype: JsonType::Float, ctype: ComplexType::Pod })),
+                    "native.store-url" => Some(("native.storeUrl", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "native.advertiser-name" => Some(("native.advertiserName", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "native.price-display-text" => Some(("native.priceDisplayText", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "native.call-to-action" => Some(("native.callToAction", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "native.logo.url" => Some(("native.logo.url", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "native.logo.width" => Some(("native.logo.width", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Pod })),
+                    "native.logo.height" => Some(("native.logo.height", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Pod })),
+                    "native.app-icon.url" => Some(("native.appIcon.url", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "native.app-icon.width" => Some(("native.appIcon.width", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Pod })),
+                    "native.app-icon.height" => Some(("native.appIcon.height", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Pod })),
+                    "native.click-tracking-url" => Some(("native.clickTrackingUrl", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "native.click-link-url" => Some(("native.clickLinkUrl", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "detected-product-categories" => Some(("detectedProductCategories", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Vec })),
+                    "detected-domains" => Some(("detectedDomains", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Vec })),
+                    "attributes" => Some(("attributes", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Vec })),
+                    "deals-status" => Some(("dealsStatus", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "restricted-categories" => Some(("restrictedCategories", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Vec })),
+                    "open-auction-status" => Some(("openAuctionStatus", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec!["account-id", "ad-choices-destination-url", "advertiser-name", "agency-id", "api-update-time", "app-icon", "attributes", "body", "call-to-action", "click-link-url", "click-through-urls", "click-tracking-url", "creative-id", "date", "day", "deals-status", "detected-advertiser-ids", "detected-domains", "detected-languages", "detected-product-categories", "detected-sensitive-categories", "filtering-stats", "headline", "height", "html", "image", "impression-tracking-urls", "logo", "month", "native", "open-auction-status", "price-display-text", "restricted-categories", "snippet", "star-rating", "store-url", "url", "vendor-ids", "version", "video", "video-url", "width", "year"]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::Creative = json::value::from_value(object).unwrap();
+        let mut call = self.hub.accounts().creatives_update(request, opt.value_of("account-id").unwrap_or(""), opt.value_of("creative-id").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _accounts_creatives_watch(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    "topic" => Some(("topic", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec!["topic"]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::WatchCreativeRequest = json::value::from_value(object).unwrap();
+        let mut call = self.hub.accounts().creatives_watch(request, opt.value_of("account-id").unwrap_or(""), opt.value_of("creative-id").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _bidders_accounts_filter_sets_bid_metrics_list(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let mut call = self.hub.bidders().accounts_filter_sets_bid_metrics_list(opt.value_of("filter-set-name").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                "page-token" => {
+                    call = call.page_token(value.unwrap_or(""));
+                },
+                "page-size" => {
+                    call = call.page_size(arg_from_str(value.unwrap_or("-0"), err, "page-size", "integer"));
+                },
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v.extend(["page-token", "page-size"].iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _bidders_accounts_filter_sets_bid_response_errors_list(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let mut call = self.hub.bidders().accounts_filter_sets_bid_response_errors_list(opt.value_of("filter-set-name").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                "page-token" => {
+                    call = call.page_token(value.unwrap_or(""));
+                },
+                "page-size" => {
+                    call = call.page_size(arg_from_str(value.unwrap_or("-0"), err, "page-size", "integer"));
+                },
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v.extend(["page-token", "page-size"].iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _bidders_accounts_filter_sets_bid_responses_without_bids_list(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let mut call = self.hub.bidders().accounts_filter_sets_bid_responses_without_bids_list(opt.value_of("filter-set-name").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                "page-token" => {
+                    call = call.page_token(value.unwrap_or(""));
+                },
+                "page-size" => {
+                    call = call.page_size(arg_from_str(value.unwrap_or("-0"), err, "page-size", "integer"));
+                },
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v.extend(["page-token", "page-size"].iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _bidders_accounts_filter_sets_create(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    "time-series-granularity" => Some(("timeSeriesGranularity", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "name" => Some(("name", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "creative-id" => Some(("creativeId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "format" => Some(("format", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "relative-date-range.duration-days" => Some(("relativeDateRange.durationDays", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Pod })),
+                    "relative-date-range.offset-days" => Some(("relativeDateRange.offsetDays", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Pod })),
+                    "deal-id" => Some(("dealId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "environment" => Some(("environment", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "platforms" => Some(("platforms", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Vec })),
+                    "absolute-date-range.start-date.month" => Some(("absoluteDateRange.startDate.month", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Pod })),
+                    "absolute-date-range.start-date.day" => Some(("absoluteDateRange.startDate.day", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Pod })),
+                    "absolute-date-range.start-date.year" => Some(("absoluteDateRange.startDate.year", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Pod })),
+                    "absolute-date-range.end-date.month" => Some(("absoluteDateRange.endDate.month", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Pod })),
+                    "absolute-date-range.end-date.day" => Some(("absoluteDateRange.endDate.day", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Pod })),
+                    "absolute-date-range.end-date.year" => Some(("absoluteDateRange.endDate.year", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Pod })),
+                    "formats" => Some(("formats", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Vec })),
+                    "realtime-time-range.start-timestamp" => Some(("realtimeTimeRange.startTimestamp", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "seller-network-ids" => Some(("sellerNetworkIds", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Vec })),
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec!["absolute-date-range", "creative-id", "day", "deal-id", "duration-days", "end-date", "environment", "format", "formats", "month", "name", "offset-days", "platforms", "realtime-time-range", "relative-date-range", "seller-network-ids", "start-date", "start-timestamp", "time-series-granularity", "year"]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::FilterSet = json::value::from_value(object).unwrap();
+        let mut call = self.hub.bidders().accounts_filter_sets_create(request, opt.value_of("owner-name").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                "is-transient" => {
+                    call = call.is_transient(arg_from_str(value.unwrap_or("false"), err, "is-transient", "boolean"));
+                },
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v.extend(["is-transient"].iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _bidders_accounts_filter_sets_delete(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let mut call = self.hub.bidders().accounts_filter_sets_delete(opt.value_of("name").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _bidders_accounts_filter_sets_filtered_bid_requests_list(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let mut call = self.hub.bidders().accounts_filter_sets_filtered_bid_requests_list(opt.value_of("filter-set-name").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                "page-token" => {
+                    call = call.page_token(value.unwrap_or(""));
+                },
+                "page-size" => {
+                    call = call.page_size(arg_from_str(value.unwrap_or("-0"), err, "page-size", "integer"));
+                },
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v.extend(["page-token", "page-size"].iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _bidders_accounts_filter_sets_filtered_bids_creatives_list(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let creative_status_id: i32 = arg_from_str(&opt.value_of("creative-status-id").unwrap_or(""), err, "<creative-status-id>", "integer");
+        let mut call = self.hub.bidders().accounts_filter_sets_filtered_bids_creatives_list(opt.value_of("filter-set-name").unwrap_or(""), creative_status_id);
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                "page-token" => {
+                    call = call.page_token(value.unwrap_or(""));
+                },
+                "page-size" => {
+                    call = call.page_size(arg_from_str(value.unwrap_or("-0"), err, "page-size", "integer"));
+                },
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v.extend(["page-token", "page-size"].iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _bidders_accounts_filter_sets_filtered_bids_details_list(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let creative_status_id: i32 = arg_from_str(&opt.value_of("creative-status-id").unwrap_or(""), err, "<creative-status-id>", "integer");
+        let mut call = self.hub.bidders().accounts_filter_sets_filtered_bids_details_list(opt.value_of("filter-set-name").unwrap_or(""), creative_status_id);
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                "page-token" => {
+                    call = call.page_token(value.unwrap_or(""));
+                },
+                "page-size" => {
+                    call = call.page_size(arg_from_str(value.unwrap_or("-0"), err, "page-size", "integer"));
+                },
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v.extend(["page-token", "page-size"].iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _bidders_accounts_filter_sets_filtered_bids_list(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let mut call = self.hub.bidders().accounts_filter_sets_filtered_bids_list(opt.value_of("filter-set-name").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                "page-token" => {
+                    call = call.page_token(value.unwrap_or(""));
+                },
+                "page-size" => {
+                    call = call.page_size(arg_from_str(value.unwrap_or("-0"), err, "page-size", "integer"));
+                },
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v.extend(["page-token", "page-size"].iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _bidders_accounts_filter_sets_get(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let mut call = self.hub.bidders().accounts_filter_sets_get(opt.value_of("name").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _bidders_accounts_filter_sets_impression_metrics_list(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let mut call = self.hub.bidders().accounts_filter_sets_impression_metrics_list(opt.value_of("filter-set-name").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                "page-token" => {
+                    call = call.page_token(value.unwrap_or(""));
+                },
+                "page-size" => {
+                    call = call.page_size(arg_from_str(value.unwrap_or("-0"), err, "page-size", "integer"));
+                },
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v.extend(["page-token", "page-size"].iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _bidders_accounts_filter_sets_list(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let mut call = self.hub.bidders().accounts_filter_sets_list(opt.value_of("owner-name").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                "page-token" => {
+                    call = call.page_token(value.unwrap_or(""));
+                },
+                "page-size" => {
+                    call = call.page_size(arg_from_str(value.unwrap_or("-0"), err, "page-size", "integer"));
+                },
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v.extend(["page-token", "page-size"].iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _bidders_accounts_filter_sets_losing_bids_list(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let mut call = self.hub.bidders().accounts_filter_sets_losing_bids_list(opt.value_of("filter-set-name").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                "page-token" => {
+                    call = call.page_token(value.unwrap_or(""));
+                },
+                "page-size" => {
+                    call = call.page_size(arg_from_str(value.unwrap_or("-0"), err, "page-size", "integer"));
+                },
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v.extend(["page-token", "page-size"].iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _bidders_accounts_filter_sets_non_billable_winning_bids_list(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let mut call = self.hub.bidders().accounts_filter_sets_non_billable_winning_bids_list(opt.value_of("filter-set-name").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                "page-token" => {
+                    call = call.page_token(value.unwrap_or(""));
+                },
+                "page-size" => {
+                    call = call.page_size(arg_from_str(value.unwrap_or("-0"), err, "page-size", "integer"));
+                },
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v.extend(["page-token", "page-size"].iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _bidders_filter_sets_bid_metrics_list(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let mut call = self.hub.bidders().filter_sets_bid_metrics_list(opt.value_of("filter-set-name").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                "page-token" => {
+                    call = call.page_token(value.unwrap_or(""));
+                },
+                "page-size" => {
+                    call = call.page_size(arg_from_str(value.unwrap_or("-0"), err, "page-size", "integer"));
+                },
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v.extend(["page-token", "page-size"].iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _bidders_filter_sets_bid_response_errors_list(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let mut call = self.hub.bidders().filter_sets_bid_response_errors_list(opt.value_of("filter-set-name").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                "page-token" => {
+                    call = call.page_token(value.unwrap_or(""));
+                },
+                "page-size" => {
+                    call = call.page_size(arg_from_str(value.unwrap_or("-0"), err, "page-size", "integer"));
+                },
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v.extend(["page-token", "page-size"].iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _bidders_filter_sets_bid_responses_without_bids_list(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let mut call = self.hub.bidders().filter_sets_bid_responses_without_bids_list(opt.value_of("filter-set-name").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                "page-token" => {
+                    call = call.page_token(value.unwrap_or(""));
+                },
+                "page-size" => {
+                    call = call.page_size(arg_from_str(value.unwrap_or("-0"), err, "page-size", "integer"));
+                },
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v.extend(["page-token", "page-size"].iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _bidders_filter_sets_create(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    "time-series-granularity" => Some(("timeSeriesGranularity", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "name" => Some(("name", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "creative-id" => Some(("creativeId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "format" => Some(("format", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "relative-date-range.duration-days" => Some(("relativeDateRange.durationDays", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Pod })),
+                    "relative-date-range.offset-days" => Some(("relativeDateRange.offsetDays", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Pod })),
+                    "deal-id" => Some(("dealId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "environment" => Some(("environment", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "platforms" => Some(("platforms", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Vec })),
+                    "absolute-date-range.start-date.month" => Some(("absoluteDateRange.startDate.month", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Pod })),
+                    "absolute-date-range.start-date.day" => Some(("absoluteDateRange.startDate.day", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Pod })),
+                    "absolute-date-range.start-date.year" => Some(("absoluteDateRange.startDate.year", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Pod })),
+                    "absolute-date-range.end-date.month" => Some(("absoluteDateRange.endDate.month", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Pod })),
+                    "absolute-date-range.end-date.day" => Some(("absoluteDateRange.endDate.day", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Pod })),
+                    "absolute-date-range.end-date.year" => Some(("absoluteDateRange.endDate.year", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Pod })),
+                    "formats" => Some(("formats", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Vec })),
+                    "realtime-time-range.start-timestamp" => Some(("realtimeTimeRange.startTimestamp", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "seller-network-ids" => Some(("sellerNetworkIds", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Vec })),
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec!["absolute-date-range", "creative-id", "day", "deal-id", "duration-days", "end-date", "environment", "format", "formats", "month", "name", "offset-days", "platforms", "realtime-time-range", "relative-date-range", "seller-network-ids", "start-date", "start-timestamp", "time-series-granularity", "year"]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::FilterSet = json::value::from_value(object).unwrap();
+        let mut call = self.hub.bidders().filter_sets_create(request, opt.value_of("owner-name").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                "is-transient" => {
+                    call = call.is_transient(arg_from_str(value.unwrap_or("false"), err, "is-transient", "boolean"));
+                },
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v.extend(["is-transient"].iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _bidders_filter_sets_delete(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let mut call = self.hub.bidders().filter_sets_delete(opt.value_of("name").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _bidders_filter_sets_filtered_bid_requests_list(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let mut call = self.hub.bidders().filter_sets_filtered_bid_requests_list(opt.value_of("filter-set-name").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                "page-token" => {
+                    call = call.page_token(value.unwrap_or(""));
+                },
+                "page-size" => {
+                    call = call.page_size(arg_from_str(value.unwrap_or("-0"), err, "page-size", "integer"));
+                },
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v.extend(["page-token", "page-size"].iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _bidders_filter_sets_filtered_bids_creatives_list(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let creative_status_id: i32 = arg_from_str(&opt.value_of("creative-status-id").unwrap_or(""), err, "<creative-status-id>", "integer");
+        let mut call = self.hub.bidders().filter_sets_filtered_bids_creatives_list(opt.value_of("filter-set-name").unwrap_or(""), creative_status_id);
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                "page-token" => {
+                    call = call.page_token(value.unwrap_or(""));
+                },
+                "page-size" => {
+                    call = call.page_size(arg_from_str(value.unwrap_or("-0"), err, "page-size", "integer"));
+                },
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v.extend(["page-token", "page-size"].iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _bidders_filter_sets_filtered_bids_details_list(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let creative_status_id: i32 = arg_from_str(&opt.value_of("creative-status-id").unwrap_or(""), err, "<creative-status-id>", "integer");
+        let mut call = self.hub.bidders().filter_sets_filtered_bids_details_list(opt.value_of("filter-set-name").unwrap_or(""), creative_status_id);
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                "page-token" => {
+                    call = call.page_token(value.unwrap_or(""));
+                },
+                "page-size" => {
+                    call = call.page_size(arg_from_str(value.unwrap_or("-0"), err, "page-size", "integer"));
+                },
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v.extend(["page-token", "page-size"].iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _bidders_filter_sets_filtered_bids_list(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let mut call = self.hub.bidders().filter_sets_filtered_bids_list(opt.value_of("filter-set-name").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                "page-token" => {
+                    call = call.page_token(value.unwrap_or(""));
+                },
+                "page-size" => {
+                    call = call.page_size(arg_from_str(value.unwrap_or("-0"), err, "page-size", "integer"));
+                },
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v.extend(["page-token", "page-size"].iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _bidders_filter_sets_get(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let mut call = self.hub.bidders().filter_sets_get(opt.value_of("name").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _bidders_filter_sets_impression_metrics_list(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let mut call = self.hub.bidders().filter_sets_impression_metrics_list(opt.value_of("filter-set-name").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                "page-token" => {
+                    call = call.page_token(value.unwrap_or(""));
+                },
+                "page-size" => {
+                    call = call.page_size(arg_from_str(value.unwrap_or("-0"), err, "page-size", "integer"));
+                },
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v.extend(["page-token", "page-size"].iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _bidders_filter_sets_list(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let mut call = self.hub.bidders().filter_sets_list(opt.value_of("owner-name").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                "page-token" => {
+                    call = call.page_token(value.unwrap_or(""));
+                },
+                "page-size" => {
+                    call = call.page_size(arg_from_str(value.unwrap_or("-0"), err, "page-size", "integer"));
+                },
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v.extend(["page-token", "page-size"].iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _bidders_filter_sets_losing_bids_list(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let mut call = self.hub.bidders().filter_sets_losing_bids_list(opt.value_of("filter-set-name").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                "page-token" => {
+                    call = call.page_token(value.unwrap_or(""));
+                },
+                "page-size" => {
+                    call = call.page_size(arg_from_str(value.unwrap_or("-0"), err, "page-size", "integer"));
+                },
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v.extend(["page-token", "page-size"].iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _bidders_filter_sets_non_billable_winning_bids_list(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let mut call = self.hub.bidders().filter_sets_non_billable_winning_bids_list(opt.value_of("filter-set-name").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                "page-token" => {
+                    call = call.page_token(value.unwrap_or(""));
+                },
+                "page-size" => {
+                    call = call.page_size(arg_from_str(value.unwrap_or("-0"), err, "page-size", "integer"));
+                },
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v.extend(["page-token", "page-size"].iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _doit(&self, dry_run: bool) -> Result<Result<(), DoitError>, Option<InvalidOptionsError>> {
+        let mut err = InvalidOptionsError::new();
+        let mut call_result: Result<(), DoitError> = Ok(());
+        let mut err_opt: Option<InvalidOptionsError> = None;
+        match self.opt.subcommand() {
+            ("accounts", Some(opt)) => {
+                match opt.subcommand() {
+                    ("clients-create", Some(opt)) => {
+                        call_result = self._accounts_clients_create(opt, dry_run, &mut err);
+                    },
+                    ("clients-get", Some(opt)) => {
+                        call_result = self._accounts_clients_get(opt, dry_run, &mut err);
+                    },
+                    ("clients-invitations-create", Some(opt)) => {
+                        call_result = self._accounts_clients_invitations_create(opt, dry_run, &mut err);
+                    },
+                    ("clients-invitations-get", Some(opt)) => {
+                        call_result = self._accounts_clients_invitations_get(opt, dry_run, &mut err);
+                    },
+                    ("clients-invitations-list", Some(opt)) => {
+                        call_result = self._accounts_clients_invitations_list(opt, dry_run, &mut err);
+                    },
+                    ("clients-list", Some(opt)) => {
+                        call_result = self._accounts_clients_list(opt, dry_run, &mut err);
+                    },
+                    ("clients-update", Some(opt)) => {
+                        call_result = self._accounts_clients_update(opt, dry_run, &mut err);
+                    },
+                    ("clients-users-get", Some(opt)) => {
+                        call_result = self._accounts_clients_users_get(opt, dry_run, &mut err);
+                    },
+                    ("clients-users-list", Some(opt)) => {
+                        call_result = self._accounts_clients_users_list(opt, dry_run, &mut err);
+                    },
+                    ("clients-users-update", Some(opt)) => {
+                        call_result = self._accounts_clients_users_update(opt, dry_run, &mut err);
+                    },
+                    ("creatives-create", Some(opt)) => {
+                        call_result = self._accounts_creatives_create(opt, dry_run, &mut err);
+                    },
+                    ("creatives-deal-associations-add", Some(opt)) => {
+                        call_result = self._accounts_creatives_deal_associations_add(opt, dry_run, &mut err);
+                    },
+                    ("creatives-deal-associations-list", Some(opt)) => {
+                        call_result = self._accounts_creatives_deal_associations_list(opt, dry_run, &mut err);
+                    },
+                    ("creatives-deal-associations-remove", Some(opt)) => {
+                        call_result = self._accounts_creatives_deal_associations_remove(opt, dry_run, &mut err);
+                    },
+                    ("creatives-get", Some(opt)) => {
+                        call_result = self._accounts_creatives_get(opt, dry_run, &mut err);
+                    },
+                    ("creatives-list", Some(opt)) => {
+                        call_result = self._accounts_creatives_list(opt, dry_run, &mut err);
+                    },
+                    ("creatives-stop-watching", Some(opt)) => {
+                        call_result = self._accounts_creatives_stop_watching(opt, dry_run, &mut err);
+                    },
+                    ("creatives-update", Some(opt)) => {
+                        call_result = self._accounts_creatives_update(opt, dry_run, &mut err);
+                    },
+                    ("creatives-watch", Some(opt)) => {
+                        call_result = self._accounts_creatives_watch(opt, dry_run, &mut err);
+                    },
+                    _ => {
+                        err.issues.push(CLIError::MissingMethodError("accounts".to_string()));
+                        writeln!(io::stderr(), "{}\n", opt.usage()).ok();
+                    }
+                }
+            },
+            ("bidders", Some(opt)) => {
+                match opt.subcommand() {
+                    ("accounts-filter-sets-bid-metrics-list", Some(opt)) => {
+                        call_result = self._bidders_accounts_filter_sets_bid_metrics_list(opt, dry_run, &mut err);
+                    },
+                    ("accounts-filter-sets-bid-response-errors-list", Some(opt)) => {
+                        call_result = self._bidders_accounts_filter_sets_bid_response_errors_list(opt, dry_run, &mut err);
+                    },
+                    ("accounts-filter-sets-bid-responses-without-bids-list", Some(opt)) => {
+                        call_result = self._bidders_accounts_filter_sets_bid_responses_without_bids_list(opt, dry_run, &mut err);
+                    },
+                    ("accounts-filter-sets-create", Some(opt)) => {
+                        call_result = self._bidders_accounts_filter_sets_create(opt, dry_run, &mut err);
+                    },
+                    ("accounts-filter-sets-delete", Some(opt)) => {
+                        call_result = self._bidders_accounts_filter_sets_delete(opt, dry_run, &mut err);
+                    },
+                    ("accounts-filter-sets-filtered-bid-requests-list", Some(opt)) => {
+                        call_result = self._bidders_accounts_filter_sets_filtered_bid_requests_list(opt, dry_run, &mut err);
+                    },
+                    ("accounts-filter-sets-filtered-bids-creatives-list", Some(opt)) => {
+                        call_result = self._bidders_accounts_filter_sets_filtered_bids_creatives_list(opt, dry_run, &mut err);
+                    },
+                    ("accounts-filter-sets-filtered-bids-details-list", Some(opt)) => {
+                        call_result = self._bidders_accounts_filter_sets_filtered_bids_details_list(opt, dry_run, &mut err);
+                    },
+                    ("accounts-filter-sets-filtered-bids-list", Some(opt)) => {
+                        call_result = self._bidders_accounts_filter_sets_filtered_bids_list(opt, dry_run, &mut err);
+                    },
+                    ("accounts-filter-sets-get", Some(opt)) => {
+                        call_result = self._bidders_accounts_filter_sets_get(opt, dry_run, &mut err);
+                    },
+                    ("accounts-filter-sets-impression-metrics-list", Some(opt)) => {
+                        call_result = self._bidders_accounts_filter_sets_impression_metrics_list(opt, dry_run, &mut err);
+                    },
+                    ("accounts-filter-sets-list", Some(opt)) => {
+                        call_result = self._bidders_accounts_filter_sets_list(opt, dry_run, &mut err);
+                    },
+                    ("accounts-filter-sets-losing-bids-list", Some(opt)) => {
+                        call_result = self._bidders_accounts_filter_sets_losing_bids_list(opt, dry_run, &mut err);
+                    },
+                    ("accounts-filter-sets-non-billable-winning-bids-list", Some(opt)) => {
+                        call_result = self._bidders_accounts_filter_sets_non_billable_winning_bids_list(opt, dry_run, &mut err);
+                    },
+                    ("filter-sets-bid-metrics-list", Some(opt)) => {
+                        call_result = self._bidders_filter_sets_bid_metrics_list(opt, dry_run, &mut err);
+                    },
+                    ("filter-sets-bid-response-errors-list", Some(opt)) => {
+                        call_result = self._bidders_filter_sets_bid_response_errors_list(opt, dry_run, &mut err);
+                    },
+                    ("filter-sets-bid-responses-without-bids-list", Some(opt)) => {
+                        call_result = self._bidders_filter_sets_bid_responses_without_bids_list(opt, dry_run, &mut err);
+                    },
+                    ("filter-sets-create", Some(opt)) => {
+                        call_result = self._bidders_filter_sets_create(opt, dry_run, &mut err);
+                    },
+                    ("filter-sets-delete", Some(opt)) => {
+                        call_result = self._bidders_filter_sets_delete(opt, dry_run, &mut err);
+                    },
+                    ("filter-sets-filtered-bid-requests-list", Some(opt)) => {
+                        call_result = self._bidders_filter_sets_filtered_bid_requests_list(opt, dry_run, &mut err);
+                    },
+                    ("filter-sets-filtered-bids-creatives-list", Some(opt)) => {
+                        call_result = self._bidders_filter_sets_filtered_bids_creatives_list(opt, dry_run, &mut err);
+                    },
+                    ("filter-sets-filtered-bids-details-list", Some(opt)) => {
+                        call_result = self._bidders_filter_sets_filtered_bids_details_list(opt, dry_run, &mut err);
+                    },
+                    ("filter-sets-filtered-bids-list", Some(opt)) => {
+                        call_result = self._bidders_filter_sets_filtered_bids_list(opt, dry_run, &mut err);
+                    },
+                    ("filter-sets-get", Some(opt)) => {
+                        call_result = self._bidders_filter_sets_get(opt, dry_run, &mut err);
+                    },
+                    ("filter-sets-impression-metrics-list", Some(opt)) => {
+                        call_result = self._bidders_filter_sets_impression_metrics_list(opt, dry_run, &mut err);
+                    },
+                    ("filter-sets-list", Some(opt)) => {
+                        call_result = self._bidders_filter_sets_list(opt, dry_run, &mut err);
+                    },
+                    ("filter-sets-losing-bids-list", Some(opt)) => {
+                        call_result = self._bidders_filter_sets_losing_bids_list(opt, dry_run, &mut err);
+                    },
+                    ("filter-sets-non-billable-winning-bids-list", Some(opt)) => {
+                        call_result = self._bidders_filter_sets_non_billable_winning_bids_list(opt, dry_run, &mut err);
+                    },
+                    _ => {
+                        err.issues.push(CLIError::MissingMethodError("bidders".to_string()));
+                        writeln!(io::stderr(), "{}\n", opt.usage()).ok();
+                    }
+                }
+            },
+            _ => {
+                err.issues.push(CLIError::MissingCommandError);
+                writeln!(io::stderr(), "{}\n", self.opt.usage()).ok();
+            }
+        }
+
+        if dry_run {
+            if err.issues.len() > 0 {
+                err_opt = Some(err);
+            }
+            Err(err_opt)
+        } else {
+            Ok(call_result)
+        }
+    }
+
+    // Please note that this call will fail if any part of the opt can't be handled
+    fn new(opt: ArgMatches<'n>) -> Result<Engine<'n>, InvalidOptionsError> {
+        let (config_dir, secret) = {
+            let config_dir = match cmn::assure_config_dir_exists(opt.value_of("folder").unwrap_or("~/.google-service-cli")) {
+                Err(e) => return Err(InvalidOptionsError::single(e, 3)),
+                Ok(p) => p,
+            };
+
+            match cmn::application_secret_from_directory(&config_dir, "adexchangebuyer2-v2-beta1-secret.json",
+                                                         "{\"installed\":{\"auth_uri\":\"https://accounts.google.com/o/oauth2/auth\",\"client_secret\":\"hCsslbCUyfehWMmbkG8vTYxG\",\"token_uri\":\"https://accounts.google.com/o/oauth2/token\",\"client_email\":\"\",\"redirect_uris\":[\"urn:ietf:wg:oauth:2.0:oob\",\"oob\"],\"client_x509_cert_url\":\"\",\"client_id\":\"620010449518-9ngf7o4dhs0dka470npqvor6dc5lqb9b.apps.googleusercontent.com\",\"auth_provider_x509_cert_url\":\"https://www.googleapis.com/oauth2/v1/certs\"}}") {
+                Ok(secret) => (config_dir, secret),
+                Err(e) => return Err(InvalidOptionsError::single(e, 4))
+            }
+        };
+
+        let auth = Authenticator::new(  &secret, DefaultAuthenticatorDelegate,
+                                        if opt.is_present("debug-auth") {
+                                            hyper::Client::with_connector(mock::TeeConnector {
+                                                    connector: hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())
+                                                })
+                                        } else {
+                                            hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new()))
+                                        },
+                                        JsonTokenStorage {
+                                          program_name: "adexchangebuyer2-v2-beta1",
+                                          db_dir: config_dir.clone(),
+                                        }, Some(FlowType::InstalledRedirect(54324)));
+
+        let client =
+            if opt.is_present("debug") {
+                hyper::Client::with_connector(mock::TeeConnector {
+                        connector: hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())
+                    })
+            } else {
+                hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new()))
+            };
+        let engine = Engine {
+            opt: opt,
+            hub: api::AdExchangeBuyerII::new(client, auth),
+            gp: vec!["$-xgafv", "access-token", "alt", "bearer-token", "callback", "fields", "key", "oauth-token", "pp", "pretty-print", "quota-user", "upload-type", "upload-protocol"],
+            gpm: vec![
+                    ("$-xgafv", "$.xgafv"),
+                    ("access-token", "access_token"),
+                    ("bearer-token", "bearer_token"),
+                    ("oauth-token", "oauth_token"),
+                    ("pretty-print", "prettyPrint"),
+                    ("quota-user", "quotaUser"),
+                    ("upload-type", "uploadType"),
+                    ("upload-protocol", "upload_protocol"),
+                ]
+        };
+
+        match engine._doit(true) {
+            Err(Some(err)) => Err(err),
+            Err(None)      => Ok(engine),
+            Ok(_)          => unreachable!(),
+        }
+    }
+
+    fn doit(&self) -> Result<(), DoitError> {
+        match self._doit(false) {
+            Ok(res) => res,
+            Err(_) => unreachable!(),
+        }
+    }
+}
+
+fn main() {
+    let mut exit_status = 0i32;
+    let arg_data = [
+        ("accounts", "methods: 'clients-create', 'clients-get', 'clients-invitations-create', 'clients-invitations-get', 'clients-invitations-list', 'clients-list', 'clients-update', 'clients-users-get', 'clients-users-list', 'clients-users-update', 'creatives-create', 'creatives-deal-associations-add', 'creatives-deal-associations-list', 'creatives-deal-associations-remove', 'creatives-get', 'creatives-list', 'creatives-stop-watching', 'creatives-update' and 'creatives-watch'", vec![
+            ("clients-create",
+                    Some(r##"Creates a new client buyer."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_adexchangebuyer2_v2_beta1_cli/accounts_clients-create",
+                  vec![
+                    (Some(r##"account-id"##),
+                     None,
+                     Some(r##"Unique numerical account ID for the buyer of which the client buyer
+        is a customer; the sponsor buyer to create a client for. (required)"##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("clients-get",
+                    Some(r##"Gets a client buyer with a given client account ID."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_adexchangebuyer2_v2_beta1_cli/accounts_clients-get",
+                  vec![
+                    (Some(r##"account-id"##),
+                     None,
+                     Some(r##"Numerical account ID of the client's sponsor buyer. (required)"##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"client-account-id"##),
+                     None,
+                     Some(r##"Numerical account ID of the client buyer to retrieve. (required)"##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("clients-invitations-create",
+                    Some(r##"Creates and sends out an email invitation to access
+        an Ad Exchange client buyer account."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_adexchangebuyer2_v2_beta1_cli/accounts_clients-invitations-create",
+                  vec![
+                    (Some(r##"account-id"##),
+                     None,
+                     Some(r##"Numerical account ID of the client's sponsor buyer. (required)"##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"client-account-id"##),
+                     None,
+                     Some(r##"Numerical account ID of the client buyer that the user
+        should be associated with. (required)"##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("clients-invitations-get",
+                    Some(r##"Retrieves an existing client user invitation."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_adexchangebuyer2_v2_beta1_cli/accounts_clients-invitations-get",
+                  vec![
+                    (Some(r##"account-id"##),
+                     None,
+                     Some(r##"Numerical account ID of the client's sponsor buyer. (required)"##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"client-account-id"##),
+                     None,
+                     Some(r##"Numerical account ID of the client buyer that the user invitation
+        to be retrieved is associated with. (required)"##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"invitation-id"##),
+                     None,
+                     Some(r##"Numerical identifier of the user invitation to retrieve. (required)"##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("clients-invitations-list",
+                    Some(r##"Lists all the client users invitations for a client
+        with a given account ID."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_adexchangebuyer2_v2_beta1_cli/accounts_clients-invitations-list",
+                  vec![
+                    (Some(r##"account-id"##),
+                     None,
+                     Some(r##"Numerical account ID of the client's sponsor buyer. (required)"##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"client-account-id"##),
+                     None,
+                     Some(r##"Numerical account ID of the client buyer to list invitations for.
+        (required)
+        You must either specify a string representation of a
+        numerical account identifier or the `-` character
+        to list all the invitations for all the clients
+        of a given sponsor buyer."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("clients-list",
+                    Some(r##"Lists all the clients for the current sponsor buyer."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_adexchangebuyer2_v2_beta1_cli/accounts_clients-list",
+                  vec![
+                    (Some(r##"account-id"##),
+                     None,
+                     Some(r##"Unique numerical account ID of the sponsor buyer to list the clients for."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("clients-update",
+                    Some(r##"Updates an existing client buyer."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_adexchangebuyer2_v2_beta1_cli/accounts_clients-update",
+                  vec![
+                    (Some(r##"account-id"##),
+                     None,
+                     Some(r##"Unique numerical account ID for the buyer of which the client buyer
+        is a customer; the sponsor buyer to update a client for. (required)"##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"client-account-id"##),
+                     None,
+                     Some(r##"Unique numerical account ID of the client to update. (required)"##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("clients-users-get",
+                    Some(r##"Retrieves an existing client user."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_adexchangebuyer2_v2_beta1_cli/accounts_clients-users-get",
+                  vec![
+                    (Some(r##"account-id"##),
+                     None,
+                     Some(r##"Numerical account ID of the client's sponsor buyer. (required)"##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"client-account-id"##),
+                     None,
+                     Some(r##"Numerical account ID of the client buyer
+        that the user to be retrieved is associated with. (required)"##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"user-id"##),
+                     None,
+                     Some(r##"Numerical identifier of the user to retrieve. (required)"##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("clients-users-list",
+                    Some(r##"Lists all the known client users for a specified
+        sponsor buyer account ID."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_adexchangebuyer2_v2_beta1_cli/accounts_clients-users-list",
+                  vec![
+                    (Some(r##"account-id"##),
+                     None,
+                     Some(r##"Numerical account ID of the sponsor buyer of the client to list users for.
+        (required)"##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"client-account-id"##),
+                     None,
+                     Some(r##"The account ID of the client buyer to list users for. (required)
+        You must specify either a string representation of a
+        numerical account identifier or the `-` character
+        to list all the client users for all the clients
+        of a given sponsor buyer."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("clients-users-update",
+                    Some(r##"Updates an existing client user.
+        Only the user status can be changed on update."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_adexchangebuyer2_v2_beta1_cli/accounts_clients-users-update",
+                  vec![
+                    (Some(r##"account-id"##),
+                     None,
+                     Some(r##"Numerical account ID of the client's sponsor buyer. (required)"##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"client-account-id"##),
+                     None,
+                     Some(r##"Numerical account ID of the client buyer that the user to be retrieved
+        is associated with. (required)"##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"user-id"##),
+                     None,
+                     Some(r##"Numerical identifier of the user to retrieve. (required)"##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("creatives-create",
+                    Some(r##"Creates a creative."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_adexchangebuyer2_v2_beta1_cli/accounts_creatives-create",
+                  vec![
+                    (Some(r##"account-id"##),
+                     None,
+                     Some(r##"The account that this creative belongs to.
+        Can be used to filter the response of the
+        creatives.list
+        method."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("creatives-deal-associations-add",
+                    Some(r##"Associate an existing deal with a creative."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_adexchangebuyer2_v2_beta1_cli/accounts_creatives-deal-associations-add",
+                  vec![
+                    (Some(r##"account-id"##),
+                     None,
+                     Some(r##"The account the creative belongs to."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"creative-id"##),
+                     None,
+                     Some(r##"The ID of the creative associated with the deal."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("creatives-deal-associations-list",
+                    Some(r##"List all creative-deal associations."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_adexchangebuyer2_v2_beta1_cli/accounts_creatives-deal-associations-list",
+                  vec![
+                    (Some(r##"account-id"##),
+                     None,
+                     Some(r##"The account to list the associations from.
+        Specify "-" to list all creatives the current user has access to."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"creative-id"##),
+                     None,
+                     Some(r##"The creative ID to list the associations from.
+        Specify "-" to list all creatives under the above account."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("creatives-deal-associations-remove",
+                    Some(r##"Remove the association between a deal and a creative."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_adexchangebuyer2_v2_beta1_cli/accounts_creatives-deal-associations-remove",
+                  vec![
+                    (Some(r##"account-id"##),
+                     None,
+                     Some(r##"The account the creative belongs to."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"creative-id"##),
+                     None,
+                     Some(r##"The ID of the creative associated with the deal."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("creatives-get",
+                    Some(r##"Gets a creative."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_adexchangebuyer2_v2_beta1_cli/accounts_creatives-get",
+                  vec![
+                    (Some(r##"account-id"##),
+                     None,
+                     Some(r##"The account the creative belongs to."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"creative-id"##),
+                     None,
+                     Some(r##"The ID of the creative to retrieve."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("creatives-list",
+                    Some(r##"Lists creatives."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_adexchangebuyer2_v2_beta1_cli/accounts_creatives-list",
+                  vec![
+                    (Some(r##"account-id"##),
+                     None,
+                     Some(r##"The account to list the creatives from.
+        Specify "-" to list all creatives the current user has access to."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("creatives-stop-watching",
+                    Some(r##"Stops watching a creative. Will stop push notifications being sent to the
+        topics when the creative changes status."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_adexchangebuyer2_v2_beta1_cli/accounts_creatives-stop-watching",
+                  vec![
+                    (Some(r##"account-id"##),
+                     None,
+                     Some(r##"The account of the creative to stop notifications for."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"creative-id"##),
+                     None,
+                     Some(r##"The creative ID of the creative to stop notifications for.
+        Specify "-" to specify stopping account level notifications."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("creatives-update",
+                    Some(r##"Updates a creative."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_adexchangebuyer2_v2_beta1_cli/accounts_creatives-update",
+                  vec![
+                    (Some(r##"account-id"##),
+                     None,
+                     Some(r##"The account that this creative belongs to.
+        Can be used to filter the response of the
+        creatives.list
+        method."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"creative-id"##),
+                     None,
+                     Some(r##"The buyer-defined creative ID of this creative.
+        Can be used to filter the response of the
+        creatives.list
+        method."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("creatives-watch",
+                    Some(r##"Watches a creative. Will result in push notifications being sent to the
+        topic when the creative changes status."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_adexchangebuyer2_v2_beta1_cli/accounts_creatives-watch",
+                  vec![
+                    (Some(r##"account-id"##),
+                     None,
+                     Some(r##"The account of the creative to watch."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"creative-id"##),
+                     None,
+                     Some(r##"The creative ID to watch for status changes.
+        Specify "-" to watch all creatives under the above account.
+        If both creative-level and account-level notifications are
+        sent, only a single notification will be sent to the
+        creative-level notification topic."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ]),
+        
+        ("bidders", "methods: 'accounts-filter-sets-bid-metrics-list', 'accounts-filter-sets-bid-response-errors-list', 'accounts-filter-sets-bid-responses-without-bids-list', 'accounts-filter-sets-create', 'accounts-filter-sets-delete', 'accounts-filter-sets-filtered-bid-requests-list', 'accounts-filter-sets-filtered-bids-creatives-list', 'accounts-filter-sets-filtered-bids-details-list', 'accounts-filter-sets-filtered-bids-list', 'accounts-filter-sets-get', 'accounts-filter-sets-impression-metrics-list', 'accounts-filter-sets-list', 'accounts-filter-sets-losing-bids-list', 'accounts-filter-sets-non-billable-winning-bids-list', 'filter-sets-bid-metrics-list', 'filter-sets-bid-response-errors-list', 'filter-sets-bid-responses-without-bids-list', 'filter-sets-create', 'filter-sets-delete', 'filter-sets-filtered-bid-requests-list', 'filter-sets-filtered-bids-creatives-list', 'filter-sets-filtered-bids-details-list', 'filter-sets-filtered-bids-list', 'filter-sets-get', 'filter-sets-impression-metrics-list', 'filter-sets-list', 'filter-sets-losing-bids-list' and 'filter-sets-non-billable-winning-bids-list'", vec![
+            ("accounts-filter-sets-bid-metrics-list",
+                    Some(r##"Lists all metrics that are measured in terms of number of bids."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_adexchangebuyer2_v2_beta1_cli/bidders_accounts-filter-sets-bid-metrics-list",
+                  vec![
+                    (Some(r##"filter-set-name"##),
+                     None,
+                     Some(r##"Name of the filter set that should be applied to the requested metrics.
+        For example:
+        
+        - For a bidder-level filter set for bidder 123:
+          `bidders/123/filterSets/abc`
+        
+        - For an account-level filter set for the buyer account representing bidder
+          123: `bidders/123/accounts/123/filterSets/abc`
+        
+        - For an account-level filter set for the child seat buyer account 456
+          whose bidder is 123: `bidders/123/accounts/456/filterSets/abc`"##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("accounts-filter-sets-bid-response-errors-list",
+                    Some(r##"List all errors that occurred in bid responses, with the number of bid
+        responses affected for each reason."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_adexchangebuyer2_v2_beta1_cli/bidders_accounts-filter-sets-bid-response-errors-list",
+                  vec![
+                    (Some(r##"filter-set-name"##),
+                     None,
+                     Some(r##"Name of the filter set that should be applied to the requested metrics.
+        For example:
+        
+        - For a bidder-level filter set for bidder 123:
+          `bidders/123/filterSets/abc`
+        
+        - For an account-level filter set for the buyer account representing bidder
+          123: `bidders/123/accounts/123/filterSets/abc`
+        
+        - For an account-level filter set for the child seat buyer account 456
+          whose bidder is 123: `bidders/123/accounts/456/filterSets/abc`"##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("accounts-filter-sets-bid-responses-without-bids-list",
+                    Some(r##"List all reasons for which bid responses were considered to have no
+        applicable bids, with the number of bid responses affected for each reason."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_adexchangebuyer2_v2_beta1_cli/bidders_accounts-filter-sets-bid-responses-without-bids-list",
+                  vec![
+                    (Some(r##"filter-set-name"##),
+                     None,
+                     Some(r##"Name of the filter set that should be applied to the requested metrics.
+        For example:
+        
+        - For a bidder-level filter set for bidder 123:
+          `bidders/123/filterSets/abc`
+        
+        - For an account-level filter set for the buyer account representing bidder
+          123: `bidders/123/accounts/123/filterSets/abc`
+        
+        - For an account-level filter set for the child seat buyer account 456
+          whose bidder is 123: `bidders/123/accounts/456/filterSets/abc`"##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("accounts-filter-sets-create",
+                    Some(r##"Creates the specified filter set for the account with the given account ID."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_adexchangebuyer2_v2_beta1_cli/bidders_accounts-filter-sets-create",
+                  vec![
+                    (Some(r##"owner-name"##),
+                     None,
+                     Some(r##"Name of the owner (bidder or account) of the filter set to be created.
+        For example:
+        
+        - For a bidder-level filter set for bidder 123: `bidders/123`
+        
+        - For an account-level filter set for the buyer account representing bidder
+          123: `bidders/123/accounts/123`
+        
+        - For an account-level filter set for the child seat buyer account 456
+          whose bidder is 123: `bidders/123/accounts/456`"##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("accounts-filter-sets-delete",
+                    Some(r##"Deletes the requested filter set from the account with the given account
+        ID."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_adexchangebuyer2_v2_beta1_cli/bidders_accounts-filter-sets-delete",
+                  vec![
+                    (Some(r##"name"##),
+                     None,
+                     Some(r##"Full name of the resource to delete.
+        For example:
+        
+        - For a bidder-level filter set for bidder 123:
+          `bidders/123/filterSets/abc`
+        
+        - For an account-level filter set for the buyer account representing bidder
+          123: `bidders/123/accounts/123/filterSets/abc`
+        
+        - For an account-level filter set for the child seat buyer account 456
+          whose bidder is 123: `bidders/123/accounts/456/filterSets/abc`"##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("accounts-filter-sets-filtered-bid-requests-list",
+                    Some(r##"List all reasons that caused a bid request not to be sent for an
+        impression, with the number of bid requests not sent for each reason."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_adexchangebuyer2_v2_beta1_cli/bidders_accounts-filter-sets-filtered-bid-requests-list",
+                  vec![
+                    (Some(r##"filter-set-name"##),
+                     None,
+                     Some(r##"Name of the filter set that should be applied to the requested metrics.
+        For example:
+        
+        - For a bidder-level filter set for bidder 123:
+          `bidders/123/filterSets/abc`
+        
+        - For an account-level filter set for the buyer account representing bidder
+          123: `bidders/123/accounts/123/filterSets/abc`
+        
+        - For an account-level filter set for the child seat buyer account 456
+          whose bidder is 123: `bidders/123/accounts/456/filterSets/abc`"##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("accounts-filter-sets-filtered-bids-creatives-list",
+                    Some(r##"List all creatives associated with a specific reason for which bids were
+        filtered, with the number of bids filtered for each creative."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_adexchangebuyer2_v2_beta1_cli/bidders_accounts-filter-sets-filtered-bids-creatives-list",
+                  vec![
+                    (Some(r##"filter-set-name"##),
+                     None,
+                     Some(r##"Name of the filter set that should be applied to the requested metrics.
+        For example:
+        
+        - For a bidder-level filter set for bidder 123:
+          `bidders/123/filterSets/abc`
+        
+        - For an account-level filter set for the buyer account representing bidder
+          123: `bidders/123/accounts/123/filterSets/abc`
+        
+        - For an account-level filter set for the child seat buyer account 456
+          whose bidder is 123: `bidders/123/accounts/456/filterSets/abc`"##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"creative-status-id"##),
+                     None,
+                     Some(r##"The ID of the creative status for which to retrieve a breakdown by
+        creative.
+        See
+        [creative-status-codes](https://developers.google.com/ad-exchange/rtb/downloads/creative-status-codes)."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("accounts-filter-sets-filtered-bids-details-list",
+                    Some(r##"List all details associated with a specific reason for which bids were
+        filtered, with the number of bids filtered for each detail."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_adexchangebuyer2_v2_beta1_cli/bidders_accounts-filter-sets-filtered-bids-details-list",
+                  vec![
+                    (Some(r##"filter-set-name"##),
+                     None,
+                     Some(r##"Name of the filter set that should be applied to the requested metrics.
+        For example:
+        
+        - For a bidder-level filter set for bidder 123:
+          `bidders/123/filterSets/abc`
+        
+        - For an account-level filter set for the buyer account representing bidder
+          123: `bidders/123/accounts/123/filterSets/abc`
+        
+        - For an account-level filter set for the child seat buyer account 456
+          whose bidder is 123: `bidders/123/accounts/456/filterSets/abc`"##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"creative-status-id"##),
+                     None,
+                     Some(r##"The ID of the creative status for which to retrieve a breakdown by detail.
+        See
+        [creative-status-codes](https://developers.google.com/ad-exchange/rtb/downloads/creative-status-codes).
+        Details are only available for statuses 10, 14, 15, 17, 18, 19, 86, and 87."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("accounts-filter-sets-filtered-bids-list",
+                    Some(r##"List all reasons for which bids were filtered, with the number of bids
+        filtered for each reason."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_adexchangebuyer2_v2_beta1_cli/bidders_accounts-filter-sets-filtered-bids-list",
+                  vec![
+                    (Some(r##"filter-set-name"##),
+                     None,
+                     Some(r##"Name of the filter set that should be applied to the requested metrics.
+        For example:
+        
+        - For a bidder-level filter set for bidder 123:
+          `bidders/123/filterSets/abc`
+        
+        - For an account-level filter set for the buyer account representing bidder
+          123: `bidders/123/accounts/123/filterSets/abc`
+        
+        - For an account-level filter set for the child seat buyer account 456
+          whose bidder is 123: `bidders/123/accounts/456/filterSets/abc`"##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("accounts-filter-sets-get",
+                    Some(r##"Retrieves the requested filter set for the account with the given account
+        ID."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_adexchangebuyer2_v2_beta1_cli/bidders_accounts-filter-sets-get",
+                  vec![
+                    (Some(r##"name"##),
+                     None,
+                     Some(r##"Full name of the resource being requested.
+        For example:
+        
+        - For a bidder-level filter set for bidder 123:
+          `bidders/123/filterSets/abc`
+        
+        - For an account-level filter set for the buyer account representing bidder
+          123: `bidders/123/accounts/123/filterSets/abc`
+        
+        - For an account-level filter set for the child seat buyer account 456
+          whose bidder is 123: `bidders/123/accounts/456/filterSets/abc`"##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("accounts-filter-sets-impression-metrics-list",
+                    Some(r##"Lists all metrics that are measured in terms of number of impressions."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_adexchangebuyer2_v2_beta1_cli/bidders_accounts-filter-sets-impression-metrics-list",
+                  vec![
+                    (Some(r##"filter-set-name"##),
+                     None,
+                     Some(r##"Name of the filter set that should be applied to the requested metrics.
+        For example:
+        
+        - For a bidder-level filter set for bidder 123:
+          `bidders/123/filterSets/abc`
+        
+        - For an account-level filter set for the buyer account representing bidder
+          123: `bidders/123/accounts/123/filterSets/abc`
+        
+        - For an account-level filter set for the child seat buyer account 456
+          whose bidder is 123: `bidders/123/accounts/456/filterSets/abc`"##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("accounts-filter-sets-list",
+                    Some(r##"Lists all filter sets for the account with the given account ID."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_adexchangebuyer2_v2_beta1_cli/bidders_accounts-filter-sets-list",
+                  vec![
+                    (Some(r##"owner-name"##),
+                     None,
+                     Some(r##"Name of the owner (bidder or account) of the filter sets to be listed.
+        For example:
+        
+        - For a bidder-level filter set for bidder 123: `bidders/123`
+        
+        - For an account-level filter set for the buyer account representing bidder
+          123: `bidders/123/accounts/123`
+        
+        - For an account-level filter set for the child seat buyer account 456
+          whose bidder is 123: `bidders/123/accounts/456`"##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("accounts-filter-sets-losing-bids-list",
+                    Some(r##"List all reasons for which bids lost in the auction, with the number of
+        bids that lost for each reason."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_adexchangebuyer2_v2_beta1_cli/bidders_accounts-filter-sets-losing-bids-list",
+                  vec![
+                    (Some(r##"filter-set-name"##),
+                     None,
+                     Some(r##"Name of the filter set that should be applied to the requested metrics.
+        For example:
+        
+        - For a bidder-level filter set for bidder 123:
+          `bidders/123/filterSets/abc`
+        
+        - For an account-level filter set for the buyer account representing bidder
+          123: `bidders/123/accounts/123/filterSets/abc`
+        
+        - For an account-level filter set for the child seat buyer account 456
+          whose bidder is 123: `bidders/123/accounts/456/filterSets/abc`"##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("accounts-filter-sets-non-billable-winning-bids-list",
+                    Some(r##"List all reasons for which winning bids were not billable, with the number
+        of bids not billed for each reason."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_adexchangebuyer2_v2_beta1_cli/bidders_accounts-filter-sets-non-billable-winning-bids-list",
+                  vec![
+                    (Some(r##"filter-set-name"##),
+                     None,
+                     Some(r##"Name of the filter set that should be applied to the requested metrics.
+        For example:
+        
+        - For a bidder-level filter set for bidder 123:
+          `bidders/123/filterSets/abc`
+        
+        - For an account-level filter set for the buyer account representing bidder
+          123: `bidders/123/accounts/123/filterSets/abc`
+        
+        - For an account-level filter set for the child seat buyer account 456
+          whose bidder is 123: `bidders/123/accounts/456/filterSets/abc`"##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("filter-sets-bid-metrics-list",
+                    Some(r##"Lists all metrics that are measured in terms of number of bids."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_adexchangebuyer2_v2_beta1_cli/bidders_filter-sets-bid-metrics-list",
+                  vec![
+                    (Some(r##"filter-set-name"##),
+                     None,
+                     Some(r##"Name of the filter set that should be applied to the requested metrics.
+        For example:
+        
+        - For a bidder-level filter set for bidder 123:
+          `bidders/123/filterSets/abc`
+        
+        - For an account-level filter set for the buyer account representing bidder
+          123: `bidders/123/accounts/123/filterSets/abc`
+        
+        - For an account-level filter set for the child seat buyer account 456
+          whose bidder is 123: `bidders/123/accounts/456/filterSets/abc`"##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("filter-sets-bid-response-errors-list",
+                    Some(r##"List all errors that occurred in bid responses, with the number of bid
+        responses affected for each reason."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_adexchangebuyer2_v2_beta1_cli/bidders_filter-sets-bid-response-errors-list",
+                  vec![
+                    (Some(r##"filter-set-name"##),
+                     None,
+                     Some(r##"Name of the filter set that should be applied to the requested metrics.
+        For example:
+        
+        - For a bidder-level filter set for bidder 123:
+          `bidders/123/filterSets/abc`
+        
+        - For an account-level filter set for the buyer account representing bidder
+          123: `bidders/123/accounts/123/filterSets/abc`
+        
+        - For an account-level filter set for the child seat buyer account 456
+          whose bidder is 123: `bidders/123/accounts/456/filterSets/abc`"##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("filter-sets-bid-responses-without-bids-list",
+                    Some(r##"List all reasons for which bid responses were considered to have no
+        applicable bids, with the number of bid responses affected for each reason."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_adexchangebuyer2_v2_beta1_cli/bidders_filter-sets-bid-responses-without-bids-list",
+                  vec![
+                    (Some(r##"filter-set-name"##),
+                     None,
+                     Some(r##"Name of the filter set that should be applied to the requested metrics.
+        For example:
+        
+        - For a bidder-level filter set for bidder 123:
+          `bidders/123/filterSets/abc`
+        
+        - For an account-level filter set for the buyer account representing bidder
+          123: `bidders/123/accounts/123/filterSets/abc`
+        
+        - For an account-level filter set for the child seat buyer account 456
+          whose bidder is 123: `bidders/123/accounts/456/filterSets/abc`"##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("filter-sets-create",
+                    Some(r##"Creates the specified filter set for the account with the given account ID."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_adexchangebuyer2_v2_beta1_cli/bidders_filter-sets-create",
+                  vec![
+                    (Some(r##"owner-name"##),
+                     None,
+                     Some(r##"Name of the owner (bidder or account) of the filter set to be created.
+        For example:
+        
+        - For a bidder-level filter set for bidder 123: `bidders/123`
+        
+        - For an account-level filter set for the buyer account representing bidder
+          123: `bidders/123/accounts/123`
+        
+        - For an account-level filter set for the child seat buyer account 456
+          whose bidder is 123: `bidders/123/accounts/456`"##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("filter-sets-delete",
+                    Some(r##"Deletes the requested filter set from the account with the given account
+        ID."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_adexchangebuyer2_v2_beta1_cli/bidders_filter-sets-delete",
+                  vec![
+                    (Some(r##"name"##),
+                     None,
+                     Some(r##"Full name of the resource to delete.
+        For example:
+        
+        - For a bidder-level filter set for bidder 123:
+          `bidders/123/filterSets/abc`
+        
+        - For an account-level filter set for the buyer account representing bidder
+          123: `bidders/123/accounts/123/filterSets/abc`
+        
+        - For an account-level filter set for the child seat buyer account 456
+          whose bidder is 123: `bidders/123/accounts/456/filterSets/abc`"##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("filter-sets-filtered-bid-requests-list",
+                    Some(r##"List all reasons that caused a bid request not to be sent for an
+        impression, with the number of bid requests not sent for each reason."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_adexchangebuyer2_v2_beta1_cli/bidders_filter-sets-filtered-bid-requests-list",
+                  vec![
+                    (Some(r##"filter-set-name"##),
+                     None,
+                     Some(r##"Name of the filter set that should be applied to the requested metrics.
+        For example:
+        
+        - For a bidder-level filter set for bidder 123:
+          `bidders/123/filterSets/abc`
+        
+        - For an account-level filter set for the buyer account representing bidder
+          123: `bidders/123/accounts/123/filterSets/abc`
+        
+        - For an account-level filter set for the child seat buyer account 456
+          whose bidder is 123: `bidders/123/accounts/456/filterSets/abc`"##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("filter-sets-filtered-bids-creatives-list",
+                    Some(r##"List all creatives associated with a specific reason for which bids were
+        filtered, with the number of bids filtered for each creative."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_adexchangebuyer2_v2_beta1_cli/bidders_filter-sets-filtered-bids-creatives-list",
+                  vec![
+                    (Some(r##"filter-set-name"##),
+                     None,
+                     Some(r##"Name of the filter set that should be applied to the requested metrics.
+        For example:
+        
+        - For a bidder-level filter set for bidder 123:
+          `bidders/123/filterSets/abc`
+        
+        - For an account-level filter set for the buyer account representing bidder
+          123: `bidders/123/accounts/123/filterSets/abc`
+        
+        - For an account-level filter set for the child seat buyer account 456
+          whose bidder is 123: `bidders/123/accounts/456/filterSets/abc`"##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"creative-status-id"##),
+                     None,
+                     Some(r##"The ID of the creative status for which to retrieve a breakdown by
+        creative.
+        See
+        [creative-status-codes](https://developers.google.com/ad-exchange/rtb/downloads/creative-status-codes)."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("filter-sets-filtered-bids-details-list",
+                    Some(r##"List all details associated with a specific reason for which bids were
+        filtered, with the number of bids filtered for each detail."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_adexchangebuyer2_v2_beta1_cli/bidders_filter-sets-filtered-bids-details-list",
+                  vec![
+                    (Some(r##"filter-set-name"##),
+                     None,
+                     Some(r##"Name of the filter set that should be applied to the requested metrics.
+        For example:
+        
+        - For a bidder-level filter set for bidder 123:
+          `bidders/123/filterSets/abc`
+        
+        - For an account-level filter set for the buyer account representing bidder
+          123: `bidders/123/accounts/123/filterSets/abc`
+        
+        - For an account-level filter set for the child seat buyer account 456
+          whose bidder is 123: `bidders/123/accounts/456/filterSets/abc`"##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"creative-status-id"##),
+                     None,
+                     Some(r##"The ID of the creative status for which to retrieve a breakdown by detail.
+        See
+        [creative-status-codes](https://developers.google.com/ad-exchange/rtb/downloads/creative-status-codes).
+        Details are only available for statuses 10, 14, 15, 17, 18, 19, 86, and 87."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("filter-sets-filtered-bids-list",
+                    Some(r##"List all reasons for which bids were filtered, with the number of bids
+        filtered for each reason."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_adexchangebuyer2_v2_beta1_cli/bidders_filter-sets-filtered-bids-list",
+                  vec![
+                    (Some(r##"filter-set-name"##),
+                     None,
+                     Some(r##"Name of the filter set that should be applied to the requested metrics.
+        For example:
+        
+        - For a bidder-level filter set for bidder 123:
+          `bidders/123/filterSets/abc`
+        
+        - For an account-level filter set for the buyer account representing bidder
+          123: `bidders/123/accounts/123/filterSets/abc`
+        
+        - For an account-level filter set for the child seat buyer account 456
+          whose bidder is 123: `bidders/123/accounts/456/filterSets/abc`"##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("filter-sets-get",
+                    Some(r##"Retrieves the requested filter set for the account with the given account
+        ID."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_adexchangebuyer2_v2_beta1_cli/bidders_filter-sets-get",
+                  vec![
+                    (Some(r##"name"##),
+                     None,
+                     Some(r##"Full name of the resource being requested.
+        For example:
+        
+        - For a bidder-level filter set for bidder 123:
+          `bidders/123/filterSets/abc`
+        
+        - For an account-level filter set for the buyer account representing bidder
+          123: `bidders/123/accounts/123/filterSets/abc`
+        
+        - For an account-level filter set for the child seat buyer account 456
+          whose bidder is 123: `bidders/123/accounts/456/filterSets/abc`"##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("filter-sets-impression-metrics-list",
+                    Some(r##"Lists all metrics that are measured in terms of number of impressions."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_adexchangebuyer2_v2_beta1_cli/bidders_filter-sets-impression-metrics-list",
+                  vec![
+                    (Some(r##"filter-set-name"##),
+                     None,
+                     Some(r##"Name of the filter set that should be applied to the requested metrics.
+        For example:
+        
+        - For a bidder-level filter set for bidder 123:
+          `bidders/123/filterSets/abc`
+        
+        - For an account-level filter set for the buyer account representing bidder
+          123: `bidders/123/accounts/123/filterSets/abc`
+        
+        - For an account-level filter set for the child seat buyer account 456
+          whose bidder is 123: `bidders/123/accounts/456/filterSets/abc`"##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("filter-sets-list",
+                    Some(r##"Lists all filter sets for the account with the given account ID."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_adexchangebuyer2_v2_beta1_cli/bidders_filter-sets-list",
+                  vec![
+                    (Some(r##"owner-name"##),
+                     None,
+                     Some(r##"Name of the owner (bidder or account) of the filter sets to be listed.
+        For example:
+        
+        - For a bidder-level filter set for bidder 123: `bidders/123`
+        
+        - For an account-level filter set for the buyer account representing bidder
+          123: `bidders/123/accounts/123`
+        
+        - For an account-level filter set for the child seat buyer account 456
+          whose bidder is 123: `bidders/123/accounts/456`"##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("filter-sets-losing-bids-list",
+                    Some(r##"List all reasons for which bids lost in the auction, with the number of
+        bids that lost for each reason."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_adexchangebuyer2_v2_beta1_cli/bidders_filter-sets-losing-bids-list",
+                  vec![
+                    (Some(r##"filter-set-name"##),
+                     None,
+                     Some(r##"Name of the filter set that should be applied to the requested metrics.
+        For example:
+        
+        - For a bidder-level filter set for bidder 123:
+          `bidders/123/filterSets/abc`
+        
+        - For an account-level filter set for the buyer account representing bidder
+          123: `bidders/123/accounts/123/filterSets/abc`
+        
+        - For an account-level filter set for the child seat buyer account 456
+          whose bidder is 123: `bidders/123/accounts/456/filterSets/abc`"##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("filter-sets-non-billable-winning-bids-list",
+                    Some(r##"List all reasons for which winning bids were not billable, with the number
+        of bids not billed for each reason."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_adexchangebuyer2_v2_beta1_cli/bidders_filter-sets-non-billable-winning-bids-list",
+                  vec![
+                    (Some(r##"filter-set-name"##),
+                     None,
+                     Some(r##"Name of the filter set that should be applied to the requested metrics.
+        For example:
+        
+        - For a bidder-level filter set for bidder 123:
+          `bidders/123/filterSets/abc`
+        
+        - For an account-level filter set for the buyer account representing bidder
+          123: `bidders/123/accounts/123/filterSets/abc`
+        
+        - For an account-level filter set for the child seat buyer account 456
+          whose bidder is 123: `bidders/123/accounts/456/filterSets/abc`"##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ]),
+        
+    ];
+    
+    let mut app = App::new("adexchangebuyer2-v2-beta1")
+           .author("Sebastian Thiel <byronimo@gmail.com>")
+           .version("1.0.7+20171208")
+           .about("Accesses the latest features for managing Ad Exchange accounts, Real-Time Bidding configurations and auction metrics, and Marketplace programmatic deals.")
+           .after_help("All documentation details can be found at http://byron.github.io/google-apis-rs/google_adexchangebuyer2_v2_beta1_cli")
+           .arg(Arg::with_name("url")
+                   .long("scope")
+                   .help("Specify the authentication a method should be executed in. Each scope requires the user to grant this application permission to use it.If unset, it defaults to the shortest scope url for a particular method.")
+                   .multiple(true)
+                   .takes_value(true))
+           .arg(Arg::with_name("folder")
+                   .long("config-dir")
+                   .help("A directory into which we will store our persistent data. Defaults to a user-writable directory that we will create during the first invocation.[default: ~/.google-service-cli")
+                   .multiple(false)
+                   .takes_value(true))
+           .arg(Arg::with_name("debug")
+                   .long("debug")
+                   .help("Output all server communication to standard error. `tx` and `rx` are placed into the same stream.")
+                   .multiple(false)
+                   .takes_value(false))
+           .arg(Arg::with_name("debug-auth")
+                   .long("debug-auth")
+                   .help("Output all communication related to authentication to standard error. `tx` and `rx` are placed into the same stream.")
+                   .multiple(false)
+                   .takes_value(false));
+           
+           for &(main_command_name, about, ref subcommands) in arg_data.iter() {
+               let mut mcmd = SubCommand::with_name(main_command_name).about(about);
+           
+               for &(sub_command_name, ref desc, url_info, ref args) in subcommands {
+                   let mut scmd = SubCommand::with_name(sub_command_name);
+                   if let &Some(desc) = desc {
+                       scmd = scmd.about(desc);
+                   }
+                   scmd = scmd.after_help(url_info);
+           
+                   for &(ref arg_name, ref flag, ref desc, ref required, ref multi) in args {
+                       let arg_name_str =
+                           match (arg_name, flag) {
+                                   (&Some(an), _       ) => an,
+                                   (_        , &Some(f)) => f,
+                                    _                    => unreachable!(),
+                            };
+                       let mut arg = Arg::with_name(arg_name_str)
+                                         .empty_values(false);
+                       if let &Some(short_flag) = flag {
+                           arg = arg.short(short_flag);
+                       }
+                       if let &Some(desc) = desc {
+                           arg = arg.help(desc);
+                       }
+                       if arg_name.is_some() && flag.is_some() {
+                           arg = arg.takes_value(true);
+                       }
+                       if let &Some(required) = required {
+                           arg = arg.required(required);
+                       }
+                       if let &Some(multi) = multi {
+                           arg = arg.multiple(multi);
+                       }
+                       scmd = scmd.arg(arg);
+                   }
+                   mcmd = mcmd.subcommand(scmd);
+               }
+               app = app.subcommand(mcmd);
+           }
+           
+        let matches = app.get_matches();
+
+    let debug = matches.is_present("debug");
+    match Engine::new(matches) {
+        Err(err) => {
+            exit_status = err.exit_code;
+            writeln!(io::stderr(), "{}", err).ok();
+        },
+        Ok(engine) => {
+            if let Err(doit_err) = engine.doit() {
+                exit_status = 1;
+                match doit_err {
+                    DoitError::IoError(path, err) => {
+                        writeln!(io::stderr(), "Failed to open output file '{}': {}", path, err).ok();
+                    },
+                    DoitError::ApiError(err) => {
+                        if debug {
+                            writeln!(io::stderr(), "{:#?}", err).ok();
+                        } else {
+                            writeln!(io::stderr(), "{}", err).ok();
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    std::process::exit(exit_status);
+}

--- a/gen/adexchangebuyer2_v2_beta1/Cargo.toml
+++ b/gen/adexchangebuyer2_v2_beta1/Cargo.toml
@@ -1,0 +1,31 @@
+# DO NOT EDIT !
+# This file was generated automatically from 'src/mako/Cargo.toml.mako'
+# DO NOT EDIT !
+[package]
+
+name = "google-adexchangebuyer2_v2_beta1"
+version = "1.0.7+20171208"
+authors = ["Sebastian Thiel <byronimo@gmail.com>"]
+description = "A complete library to interact with AdExchangeBuyerII (protocol v2beta1)"
+repository = "https://github.com/Byron/google-apis-rs/tree/master/gen/adexchangebuyer2_v2_beta1"
+homepage = "https://developers.google.com/ad-exchange/buyer-rest/reference/rest/"
+documentation = "https://docs.rs/google-adexchangebuyer2_v2_beta1/1.0.7+20171208"
+license = "MIT"
+keywords = ["adexchangebuyer2", "google", "protocol", "web", "api"]
+
+
+[dev-dependencies]
+hyper-rustls = "^0.6"
+
+[dependencies]
+hyper = "^ 0.10"
+mime = "^ 0.2.0"
+serde = "^ 1.0"
+serde_json = "^ 1.0"
+serde_derive = "^ 1.0"
+yup-oauth2 = "^ 1.0"
+url = "= 0.5"
+
+[features]
+
+

--- a/gen/adexchangebuyer2_v2_beta1/LICENSE.md
+++ b/gen/adexchangebuyer2_v2_beta1/LICENSE.md
@@ -1,0 +1,30 @@
+<!---
+DO NOT EDIT !
+This file was generated automatically from 'src/mako/LICENSE.md.mako'
+DO NOT EDIT !
+-->
+The MIT License (MIT)
+=====================
+
+Copyright © `2015-2016` `Sebastian Thiel`
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the “Software”), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.

--- a/gen/adexchangebuyer2_v2_beta1/README.md
+++ b/gen/adexchangebuyer2_v2_beta1/README.md
@@ -1,0 +1,187 @@
+<!---
+DO NOT EDIT !
+This file was generated automatically from 'src/mako/api/README.md.mako'
+DO NOT EDIT !
+-->
+The `google-adexchangebuyer2_v2_beta1` library allows access to all features of the *Google AdExchangeBuyerII* service.
+
+This documentation was generated from *AdExchangeBuyerII* crate version *1.0.7+20171208*, where *20171208* is the exact revision of the *adexchangebuyer2:v2beta1* schema built by the [mako](http://www.makotemplates.org/) code generator *v1.0.7*.
+
+Everything else about the *AdExchangeBuyerII* *v2_beta1* API can be found at the
+[official documentation site](https://developers.google.com/ad-exchange/buyer-rest/reference/rest/).
+# Features
+
+Handle the following *Resources* with ease from the central [hub](https://docs.rs/google-adexchangebuyer2_v2_beta1/1.0.7+20171208/google_adexchangebuyer2_v2_beta1/struct.AdExchangeBuyerII.html) ... 
+
+* accounts
+ * [*clients create*](https://docs.rs/google-adexchangebuyer2_v2_beta1/1.0.7+20171208/google_adexchangebuyer2_v2_beta1/struct.AccountClientCreateCall.html), [*clients get*](https://docs.rs/google-adexchangebuyer2_v2_beta1/1.0.7+20171208/google_adexchangebuyer2_v2_beta1/struct.AccountClientGetCall.html), [*clients invitations create*](https://docs.rs/google-adexchangebuyer2_v2_beta1/1.0.7+20171208/google_adexchangebuyer2_v2_beta1/struct.AccountClientInvitationCreateCall.html), [*clients invitations get*](https://docs.rs/google-adexchangebuyer2_v2_beta1/1.0.7+20171208/google_adexchangebuyer2_v2_beta1/struct.AccountClientInvitationGetCall.html), [*clients invitations list*](https://docs.rs/google-adexchangebuyer2_v2_beta1/1.0.7+20171208/google_adexchangebuyer2_v2_beta1/struct.AccountClientInvitationListCall.html), [*clients list*](https://docs.rs/google-adexchangebuyer2_v2_beta1/1.0.7+20171208/google_adexchangebuyer2_v2_beta1/struct.AccountClientListCall.html), [*clients update*](https://docs.rs/google-adexchangebuyer2_v2_beta1/1.0.7+20171208/google_adexchangebuyer2_v2_beta1/struct.AccountClientUpdateCall.html), [*clients users get*](https://docs.rs/google-adexchangebuyer2_v2_beta1/1.0.7+20171208/google_adexchangebuyer2_v2_beta1/struct.AccountClientUserGetCall.html), [*clients users list*](https://docs.rs/google-adexchangebuyer2_v2_beta1/1.0.7+20171208/google_adexchangebuyer2_v2_beta1/struct.AccountClientUserListCall.html), [*clients users update*](https://docs.rs/google-adexchangebuyer2_v2_beta1/1.0.7+20171208/google_adexchangebuyer2_v2_beta1/struct.AccountClientUserUpdateCall.html), [*creatives create*](https://docs.rs/google-adexchangebuyer2_v2_beta1/1.0.7+20171208/google_adexchangebuyer2_v2_beta1/struct.AccountCreativeCreateCall.html), [*creatives deal associations add*](https://docs.rs/google-adexchangebuyer2_v2_beta1/1.0.7+20171208/google_adexchangebuyer2_v2_beta1/struct.AccountCreativeDealAssociationAddCall.html), [*creatives deal associations list*](https://docs.rs/google-adexchangebuyer2_v2_beta1/1.0.7+20171208/google_adexchangebuyer2_v2_beta1/struct.AccountCreativeDealAssociationListCall.html), [*creatives deal associations remove*](https://docs.rs/google-adexchangebuyer2_v2_beta1/1.0.7+20171208/google_adexchangebuyer2_v2_beta1/struct.AccountCreativeDealAssociationRemoveCall.html), [*creatives get*](https://docs.rs/google-adexchangebuyer2_v2_beta1/1.0.7+20171208/google_adexchangebuyer2_v2_beta1/struct.AccountCreativeGetCall.html), [*creatives list*](https://docs.rs/google-adexchangebuyer2_v2_beta1/1.0.7+20171208/google_adexchangebuyer2_v2_beta1/struct.AccountCreativeListCall.html), [*creatives stop watching*](https://docs.rs/google-adexchangebuyer2_v2_beta1/1.0.7+20171208/google_adexchangebuyer2_v2_beta1/struct.AccountCreativeStopWatchingCall.html), [*creatives update*](https://docs.rs/google-adexchangebuyer2_v2_beta1/1.0.7+20171208/google_adexchangebuyer2_v2_beta1/struct.AccountCreativeUpdateCall.html) and [*creatives watch*](https://docs.rs/google-adexchangebuyer2_v2_beta1/1.0.7+20171208/google_adexchangebuyer2_v2_beta1/struct.AccountCreativeWatchCall.html)
+* bidders
+ * [*accounts filter sets bid metrics list*](https://docs.rs/google-adexchangebuyer2_v2_beta1/1.0.7+20171208/google_adexchangebuyer2_v2_beta1/struct.BidderAccountFilterSetBidMetricListCall.html), [*accounts filter sets bid response errors list*](https://docs.rs/google-adexchangebuyer2_v2_beta1/1.0.7+20171208/google_adexchangebuyer2_v2_beta1/struct.BidderAccountFilterSetBidResponseErrorListCall.html), [*accounts filter sets bid responses without bids list*](https://docs.rs/google-adexchangebuyer2_v2_beta1/1.0.7+20171208/google_adexchangebuyer2_v2_beta1/struct.BidderAccountFilterSetBidResponsesWithoutBidListCall.html), [*accounts filter sets create*](https://docs.rs/google-adexchangebuyer2_v2_beta1/1.0.7+20171208/google_adexchangebuyer2_v2_beta1/struct.BidderAccountFilterSetCreateCall.html), [*accounts filter sets delete*](https://docs.rs/google-adexchangebuyer2_v2_beta1/1.0.7+20171208/google_adexchangebuyer2_v2_beta1/struct.BidderAccountFilterSetDeleteCall.html), [*accounts filter sets filtered bid requests list*](https://docs.rs/google-adexchangebuyer2_v2_beta1/1.0.7+20171208/google_adexchangebuyer2_v2_beta1/struct.BidderAccountFilterSetFilteredBidRequestListCall.html), [*accounts filter sets filtered bids creatives list*](https://docs.rs/google-adexchangebuyer2_v2_beta1/1.0.7+20171208/google_adexchangebuyer2_v2_beta1/struct.BidderAccountFilterSetFilteredBidCreativeListCall.html), [*accounts filter sets filtered bids details list*](https://docs.rs/google-adexchangebuyer2_v2_beta1/1.0.7+20171208/google_adexchangebuyer2_v2_beta1/struct.BidderAccountFilterSetFilteredBidDetailListCall.html), [*accounts filter sets filtered bids list*](https://docs.rs/google-adexchangebuyer2_v2_beta1/1.0.7+20171208/google_adexchangebuyer2_v2_beta1/struct.BidderAccountFilterSetFilteredBidListCall.html), [*accounts filter sets get*](https://docs.rs/google-adexchangebuyer2_v2_beta1/1.0.7+20171208/google_adexchangebuyer2_v2_beta1/struct.BidderAccountFilterSetGetCall.html), [*accounts filter sets impression metrics list*](https://docs.rs/google-adexchangebuyer2_v2_beta1/1.0.7+20171208/google_adexchangebuyer2_v2_beta1/struct.BidderAccountFilterSetImpressionMetricListCall.html), [*accounts filter sets list*](https://docs.rs/google-adexchangebuyer2_v2_beta1/1.0.7+20171208/google_adexchangebuyer2_v2_beta1/struct.BidderAccountFilterSetListCall.html), [*accounts filter sets losing bids list*](https://docs.rs/google-adexchangebuyer2_v2_beta1/1.0.7+20171208/google_adexchangebuyer2_v2_beta1/struct.BidderAccountFilterSetLosingBidListCall.html), [*accounts filter sets non billable winning bids list*](https://docs.rs/google-adexchangebuyer2_v2_beta1/1.0.7+20171208/google_adexchangebuyer2_v2_beta1/struct.BidderAccountFilterSetNonBillableWinningBidListCall.html), [*filter sets bid metrics list*](https://docs.rs/google-adexchangebuyer2_v2_beta1/1.0.7+20171208/google_adexchangebuyer2_v2_beta1/struct.BidderFilterSetBidMetricListCall.html), [*filter sets bid response errors list*](https://docs.rs/google-adexchangebuyer2_v2_beta1/1.0.7+20171208/google_adexchangebuyer2_v2_beta1/struct.BidderFilterSetBidResponseErrorListCall.html), [*filter sets bid responses without bids list*](https://docs.rs/google-adexchangebuyer2_v2_beta1/1.0.7+20171208/google_adexchangebuyer2_v2_beta1/struct.BidderFilterSetBidResponsesWithoutBidListCall.html), [*filter sets create*](https://docs.rs/google-adexchangebuyer2_v2_beta1/1.0.7+20171208/google_adexchangebuyer2_v2_beta1/struct.BidderFilterSetCreateCall.html), [*filter sets delete*](https://docs.rs/google-adexchangebuyer2_v2_beta1/1.0.7+20171208/google_adexchangebuyer2_v2_beta1/struct.BidderFilterSetDeleteCall.html), [*filter sets filtered bid requests list*](https://docs.rs/google-adexchangebuyer2_v2_beta1/1.0.7+20171208/google_adexchangebuyer2_v2_beta1/struct.BidderFilterSetFilteredBidRequestListCall.html), [*filter sets filtered bids creatives list*](https://docs.rs/google-adexchangebuyer2_v2_beta1/1.0.7+20171208/google_adexchangebuyer2_v2_beta1/struct.BidderFilterSetFilteredBidCreativeListCall.html), [*filter sets filtered bids details list*](https://docs.rs/google-adexchangebuyer2_v2_beta1/1.0.7+20171208/google_adexchangebuyer2_v2_beta1/struct.BidderFilterSetFilteredBidDetailListCall.html), [*filter sets filtered bids list*](https://docs.rs/google-adexchangebuyer2_v2_beta1/1.0.7+20171208/google_adexchangebuyer2_v2_beta1/struct.BidderFilterSetFilteredBidListCall.html), [*filter sets get*](https://docs.rs/google-adexchangebuyer2_v2_beta1/1.0.7+20171208/google_adexchangebuyer2_v2_beta1/struct.BidderFilterSetGetCall.html), [*filter sets impression metrics list*](https://docs.rs/google-adexchangebuyer2_v2_beta1/1.0.7+20171208/google_adexchangebuyer2_v2_beta1/struct.BidderFilterSetImpressionMetricListCall.html), [*filter sets list*](https://docs.rs/google-adexchangebuyer2_v2_beta1/1.0.7+20171208/google_adexchangebuyer2_v2_beta1/struct.BidderFilterSetListCall.html), [*filter sets losing bids list*](https://docs.rs/google-adexchangebuyer2_v2_beta1/1.0.7+20171208/google_adexchangebuyer2_v2_beta1/struct.BidderFilterSetLosingBidListCall.html) and [*filter sets non billable winning bids list*](https://docs.rs/google-adexchangebuyer2_v2_beta1/1.0.7+20171208/google_adexchangebuyer2_v2_beta1/struct.BidderFilterSetNonBillableWinningBidListCall.html)
+
+
+
+
+# Structure of this Library
+
+The API is structured into the following primary items:
+
+* **[Hub](https://docs.rs/google-adexchangebuyer2_v2_beta1/1.0.7+20171208/google_adexchangebuyer2_v2_beta1/struct.AdExchangeBuyerII.html)**
+    * a central object to maintain state and allow accessing all *Activities*
+    * creates [*Method Builders*](https://docs.rs/google-adexchangebuyer2_v2_beta1/1.0.7+20171208/google_adexchangebuyer2_v2_beta1/trait.MethodsBuilder.html) which in turn
+      allow access to individual [*Call Builders*](https://docs.rs/google-adexchangebuyer2_v2_beta1/1.0.7+20171208/google_adexchangebuyer2_v2_beta1/trait.CallBuilder.html)
+* **[Resources](https://docs.rs/google-adexchangebuyer2_v2_beta1/1.0.7+20171208/google_adexchangebuyer2_v2_beta1/trait.Resource.html)**
+    * primary types that you can apply *Activities* to
+    * a collection of properties and *Parts*
+    * **[Parts](https://docs.rs/google-adexchangebuyer2_v2_beta1/1.0.7+20171208/google_adexchangebuyer2_v2_beta1/trait.Part.html)**
+        * a collection of properties
+        * never directly used in *Activities*
+* **[Activities](https://docs.rs/google-adexchangebuyer2_v2_beta1/1.0.7+20171208/google_adexchangebuyer2_v2_beta1/trait.CallBuilder.html)**
+    * operations to apply to *Resources*
+
+All *structures* are marked with applicable traits to further categorize them and ease browsing.
+
+Generally speaking, you can invoke *Activities* like this:
+
+```Rust,ignore
+let r = hub.resource().activity(...).doit()
+```
+
+Or specifically ...
+
+```ignore
+let r = hub.bidders().accounts_filter_sets_delete(...).doit()
+let r = hub.accounts().creatives_deal_associations_add(...).doit()
+let r = hub.accounts().creatives_deal_associations_remove(...).doit()
+let r = hub.accounts().creatives_watch(...).doit()
+let r = hub.bidders().filter_sets_delete(...).doit()
+let r = hub.accounts().creatives_stop_watching(...).doit()
+```
+
+The `resource()` and `activity(...)` calls create [builders][builder-pattern]. The second one dealing with `Activities` 
+supports various methods to configure the impending operation (not shown here). It is made such that all required arguments have to be 
+specified right away (i.e. `(...)`), whereas all optional ones can be [build up][builder-pattern] as desired.
+The `doit()` method performs the actual communication with the server and returns the respective result.
+
+# Usage
+
+## Setting up your Project
+
+To use this library, you would put the following lines into your `Cargo.toml` file:
+
+```toml
+[dependencies]
+google-adexchangebuyer2_v2_beta1 = "*"
+```
+
+## A complete example
+
+```Rust
+extern crate hyper;
+extern crate hyper_rustls;
+extern crate yup_oauth2 as oauth2;
+extern crate google_adexchangebuyer2_v2_beta1 as adexchangebuyer2_v2_beta1;
+use adexchangebuyer2_v2_beta1::AddDealAssociationRequest;
+use adexchangebuyer2_v2_beta1::{Result, Error};
+use std::default::Default;
+use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+use adexchangebuyer2_v2_beta1::AdExchangeBuyerII;
+
+// Get an ApplicationSecret instance by some means. It contains the `client_id` and 
+// `client_secret`, among other things.
+let secret: ApplicationSecret = Default::default();
+// Instantiate the authenticator. It will choose a suitable authentication flow for you, 
+// unless you replace  `None` with the desired Flow.
+// Provide your own `AuthenticatorDelegate` to adjust the way it operates and get feedback about 
+// what's going on. You probably want to bring in your own `TokenStorage` to persist tokens and
+// retrieve them from storage.
+let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+                              hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+                              <MemoryStorage as Default>::default(), None);
+let mut hub = AdExchangeBuyerII::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+// As the method needs a request, you would usually fill it with the desired information
+// into the respective structure. Some of the parts shown here might not be applicable !
+// Values shown here are possibly random and not representative !
+let mut req = AddDealAssociationRequest::default();
+
+// You can configure optional parameters by calling the respective setters at will, and
+// execute the final call using `doit()`.
+// Values shown here are possibly random and not representative !
+let result = hub.accounts().creatives_deal_associations_add(req, "accountId", "creativeId")
+             .doit();
+
+match result {
+    Err(e) => match e {
+        // The Error enum provides details about what exactly happened.
+        // You can also just use its `Debug`, `Display` or `Error` traits
+         Error::HttpError(_)
+        |Error::MissingAPIKey
+        |Error::MissingToken(_)
+        |Error::Cancelled
+        |Error::UploadSizeLimitExceeded(_, _)
+        |Error::Failure(_)
+        |Error::BadRequest(_)
+        |Error::FieldClash(_)
+        |Error::JsonDecodeError(_, _) => println!("{}", e),
+    },
+    Ok(res) => println!("Success: {:?}", res),
+}
+
+```
+## Handling Errors
+
+All errors produced by the system are provided either as [Result](https://docs.rs/google-adexchangebuyer2_v2_beta1/1.0.7+20171208/google_adexchangebuyer2_v2_beta1/enum.Result.html) enumeration as return value of 
+the doit() methods, or handed as possibly intermediate results to either the 
+[Hub Delegate](https://docs.rs/google-adexchangebuyer2_v2_beta1/1.0.7+20171208/google_adexchangebuyer2_v2_beta1/trait.Delegate.html), or the [Authenticator Delegate](https://docs.rs/yup-oauth2/*/yup_oauth2/trait.AuthenticatorDelegate.html).
+
+When delegates handle errors or intermediate values, they may have a chance to instruct the system to retry. This 
+makes the system potentially resilient to all kinds of errors.
+
+## Uploads and Downloads
+If a method supports downloads, the response body, which is part of the [Result](https://docs.rs/google-adexchangebuyer2_v2_beta1/1.0.7+20171208/google_adexchangebuyer2_v2_beta1/enum.Result.html), should be
+read by you to obtain the media.
+If such a method also supports a [Response Result](https://docs.rs/google-adexchangebuyer2_v2_beta1/1.0.7+20171208/google_adexchangebuyer2_v2_beta1/trait.ResponseResult.html), it will return that by default.
+You can see it as meta-data for the actual media. To trigger a media download, you will have to set up the builder by making
+this call: `.param("alt", "media")`.
+
+Methods supporting uploads can do so using up to 2 different protocols: 
+*simple* and *resumable*. The distinctiveness of each is represented by customized 
+`doit(...)` methods, which are then named `upload(...)` and `upload_resumable(...)` respectively.
+
+## Customization and Callbacks
+
+You may alter the way an `doit()` method is called by providing a [delegate](https://docs.rs/google-adexchangebuyer2_v2_beta1/1.0.7+20171208/google_adexchangebuyer2_v2_beta1/trait.Delegate.html) to the 
+[Method Builder](https://docs.rs/google-adexchangebuyer2_v2_beta1/1.0.7+20171208/google_adexchangebuyer2_v2_beta1/trait.CallBuilder.html) before making the final `doit()` call. 
+Respective methods will be called to provide progress information, as well as determine whether the system should 
+retry on failure.
+
+The [delegate trait](https://docs.rs/google-adexchangebuyer2_v2_beta1/1.0.7+20171208/google_adexchangebuyer2_v2_beta1/trait.Delegate.html) is default-implemented, allowing you to customize it with minimal effort.
+
+## Optional Parts in Server-Requests
+
+All structures provided by this library are made to be [enocodable](https://docs.rs/google-adexchangebuyer2_v2_beta1/1.0.7+20171208/google_adexchangebuyer2_v2_beta1/trait.RequestValue.html) and 
+[decodable](https://docs.rs/google-adexchangebuyer2_v2_beta1/1.0.7+20171208/google_adexchangebuyer2_v2_beta1/trait.ResponseResult.html) via *json*. Optionals are used to indicate that partial requests are responses 
+are valid.
+Most optionals are are considered [Parts](https://docs.rs/google-adexchangebuyer2_v2_beta1/1.0.7+20171208/google_adexchangebuyer2_v2_beta1/trait.Part.html) which are identifiable by name, which will be sent to 
+the server to indicate either the set parts of the request or the desired parts in the response.
+
+## Builder Arguments
+
+Using [method builders](https://docs.rs/google-adexchangebuyer2_v2_beta1/1.0.7+20171208/google_adexchangebuyer2_v2_beta1/trait.CallBuilder.html), you are able to prepare an action call by repeatedly calling it's methods.
+These will always take a single argument, for which the following statements are true.
+
+* [PODs][wiki-pod] are handed by copy
+* strings are passed as `&str`
+* [request values](https://docs.rs/google-adexchangebuyer2_v2_beta1/1.0.7+20171208/google_adexchangebuyer2_v2_beta1/trait.RequestValue.html) are moved
+
+Arguments will always be copied or cloned into the builder, to make them independent of their original life times.
+
+[wiki-pod]: http://en.wikipedia.org/wiki/Plain_old_data_structure
+[builder-pattern]: http://en.wikipedia.org/wiki/Builder_pattern
+[google-go-api]: https://github.com/google/google-api-go-client
+
+# License
+The **adexchangebuyer2_v2_beta1** library was generated by Sebastian Thiel, and is placed 
+under the *MIT* license.
+You can read the full text at the repository's [license file][repo-license].
+
+[repo-license]: https://github.com/Byron/google-apis-rsblob/master/LICENSE.md

--- a/gen/adexchangebuyer2_v2_beta1/src/cmn.rs
+++ b/gen/adexchangebuyer2_v2_beta1/src/cmn.rs
@@ -1,0 +1,753 @@
+// COPY OF 'src/rust/api/cmn.rs'
+// DO NOT EDIT
+use std::io::{self, Read, Seek, Cursor, Write, SeekFrom};
+use std;
+use std::fmt::{self, Display};
+use std::str::FromStr;
+use std::error;
+use std::thread::sleep;
+use std::time::Duration;
+
+use mime::{Mime, TopLevel, SubLevel, Attr, Value};
+use oauth2::{TokenType, Retry, self};
+use hyper;
+use hyper::header::{ContentType, ContentLength, Headers, UserAgent, Authorization, Header,
+                    HeaderFormat, Bearer};
+use hyper::http::h1::LINE_ENDING;
+use hyper::method::Method;
+use hyper::status::StatusCode;
+
+use serde_json as json;
+
+/// Identifies the Hub. There is only one per library, this trait is supposed
+/// to make intended use more explicit.
+/// The hub allows to access all resource methods more easily.
+pub trait Hub {}
+
+/// Identifies types for building methods of a particular resource type
+pub trait MethodsBuilder {}
+
+/// Identifies types which represent builders for a particular resource method
+pub trait CallBuilder {}
+
+/// Identifies types which can be inserted and deleted.
+/// Types with this trait are most commonly used by clients of this API.
+pub trait Resource {}
+
+/// Identifies types which are used in API responses.
+pub trait ResponseResult {}
+
+/// Identifies types which are used in API requests.
+pub trait RequestValue {}
+
+/// Identifies types which are not actually used by the API
+/// This might be a bug within the google API schema.
+pub trait UnusedType {}
+
+/// Identifies types which are only used as part of other types, which
+/// usually are carrying the `Resource` trait.
+pub trait Part {}
+
+/// Identifies types which are only used by other types internally.
+/// They have no special meaning, this trait just marks them for completeness.
+pub trait NestedType {}
+
+/// A utility to specify reader types which provide seeking capabilities too
+pub trait ReadSeek: Seek + Read {}
+impl<T: Seek + Read> ReadSeek for T {}
+
+/// A trait for all types that can convert themselves into a *parts* string
+pub trait ToParts {
+    fn to_parts(&self) -> String;
+}
+
+/// A utility type which can decode a server response that indicates error
+#[derive(Deserialize)]
+pub struct JsonServerError {
+    pub error: String,
+    pub error_description: Option<String>
+}
+
+/// A utility to represent detailed errors we might see in case there are BadRequests.
+/// The latter happen if the sent parameters or request structures are unsound
+#[derive(Deserialize, Serialize, Debug)]
+pub struct ErrorResponse {
+    error: ServerError,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct ServerError {
+    errors: Vec<ServerMessage>,
+    code: u16,
+    message: String,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct ServerMessage {
+    domain: String,
+    reason: String,
+    message: String,
+    #[serde(rename="locationType")]
+    location_type: Option<String>,
+    location: Option<String>
+}
+
+#[derive(Copy, Clone)]
+pub struct DummyNetworkStream;
+
+impl Read for DummyNetworkStream {
+    fn read(&mut self, _: &mut [u8]) -> io::Result<usize> {
+        Ok(0)
+    }
+}
+
+impl Write for DummyNetworkStream {
+    fn write(&mut self, _: &[u8]) -> io::Result<usize> {
+        Ok(0)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl hyper::net::NetworkStream for DummyNetworkStream {
+    fn peer_addr(&mut self) -> io::Result<std::net::SocketAddr> {
+        Ok("127.0.0.1:1337".parse().unwrap())
+    }
+
+    fn set_read_timeout(&self, _dur: Option<Duration>) -> io::Result<()> {
+        Ok(())
+    }
+
+    fn set_write_timeout(&self, _dur: Option<Duration>) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+
+/// A trait specifying functionality to help controlling any request performed by the API.
+/// The trait has a conservative default implementation.
+///
+/// It contains methods to deal with all common issues, as well with the ones related to
+/// uploading media
+pub trait Delegate {
+
+    /// Called at the beginning of any API request. The delegate should store the method
+    /// information if he is interesting in knowing more context when further calls to it
+    /// are made.
+    /// The matching `finished()` call will always be made, no matter whether or not the API
+    /// request was successful. That way, the delegate may easily maintain a clean state
+    /// between various API calls.
+    fn begin(&mut self, MethodInfo) {}
+
+    /// Called whenever there is an [HttpError](http://hyperium.github.io/hyper/hyper/error/enum.HttpError.html), usually if there are network problems.
+    ///
+    /// If you choose to retry after a duration, the duration should be chosen using the
+    /// [exponential backoff algorithm](http://en.wikipedia.org/wiki/Exponential_backoff).
+    ///
+    /// Return retry information.
+    fn http_error(&mut self, &hyper::Error) -> Retry {
+        Retry::Abort
+    }
+
+    /// Called whenever there is the need for your applications API key after
+    /// the official authenticator implementation didn't provide one, for some reason.
+    /// If this method returns None as well, the underlying operation will fail
+    fn api_key(&mut self) -> Option<String> {
+        None
+    }
+
+    /// Called whenever the Authenticator didn't yield a token. The delegate
+    /// may attempt to provide one, or just take it as a general information about the
+    /// impending failure.
+    /// The given Error provides information about why the token couldn't be acquired in the
+    /// first place
+    fn token(&mut self, err: &error::Error) -> Option<oauth2::Token> {
+        let _ = err;
+        None
+    }
+
+    /// Called during resumable uploads to provide a URL for the impending upload.
+    /// It was saved after a previous call to `store_upload_url(...)`, and if not None,
+    /// will be used instead of asking the server for a new upload URL.
+    /// This is useful in case a previous resumable upload was aborted/canceled, but should now
+    /// be resumed.
+    /// The returned URL will be used exactly once - if it fails again and the delegate allows
+    /// to retry, we will ask the server for a new upload URL.
+    fn upload_url(&mut self) -> Option<String> {
+        None
+    }
+
+    /// Called after we have retrieved a new upload URL for a resumable upload to store it
+    /// in case we fail or cancel. That way, we can attempt to resume the upload later,
+    /// see `upload_url()`.
+    /// It will also be called with None after a successful upload, which allows the delegate
+    /// to forget the URL. That way, we will not attempt to resume an upload that has already
+    /// finished.
+    fn store_upload_url(&mut self, url: Option<&str>) {
+        let _ = url;
+    }
+
+    /// Called whenever a server response could not be decoded from json.
+    /// It's for informational purposes only, the caller will return with an error
+    /// accordingly.
+    ///
+    /// # Arguments
+    ///
+    /// * `json_encoded_value` - The json-encoded value which failed to decode.
+    /// * `json_decode_error`  - The decoder error
+    fn response_json_decode_error(&mut self, json_encoded_value: &str, json_decode_error: &json::Error) {
+        let _ = json_encoded_value;
+        let _ = json_decode_error;
+    }
+
+    /// Called whenever the http request returns with a non-success status code.
+    /// This can involve authentication issues, or anything else that very much
+    /// depends on the used API method.
+    /// The delegate should check the status, header and decoded json error to decide
+    /// whether to retry or not. In the latter case, the underlying call will fail.
+    ///
+    /// If you choose to retry after a duration, the duration should be chosen using the
+    /// [exponential backoff algorithm](http://en.wikipedia.org/wiki/Exponential_backoff).
+    fn http_failure(&mut self, _: &hyper::client::Response, Option<JsonServerError>, _: Option<ServerError>) -> Retry {
+        Retry::Abort
+    }
+
+    /// Called prior to sending the main request of the given method. It can be used to time
+    /// the call or to print progress information.
+    /// It's also useful as you can be sure that a request will definitely be made.
+    fn pre_request(&mut self) { }
+
+    /// Return the size of each chunk of a resumable upload.
+    /// Must be a power of two, with 1<<18 being the smallest allowed chunk size.
+    /// Will be called once before starting any resumable upload.
+    fn chunk_size(&mut self) -> u64 {
+        1 << 23
+    }
+
+    /// Called before the given chunk is uploaded to the server.
+    /// If true is returned, the upload will be interrupted.
+    /// However, it may be resumable if you stored the upload URL in a previous call
+    /// to `store_upload_url()`
+    fn cancel_chunk_upload(&mut self, chunk: &ContentRange) -> bool {
+        let _ = chunk;
+        false
+    }
+
+    /// Called before the API request method returns, in every case. It can be used to clean up
+    /// internal state between calls to the API.
+    /// This call always has a matching call to `begin(...)`.
+    ///
+    /// # Arguments
+    ///
+    /// * `is_success` - a true value indicates the operation was successful. If false, you should
+    ///                  discard all values stored during `store_upload_url`.
+    fn finished(&mut self, is_success: bool) {
+        let _ = is_success;
+    }
+}
+
+/// A delegate with a conservative default implementation, which is used if no other delegate is
+/// set.
+#[derive(Default)]
+pub struct DefaultDelegate;
+
+impl Delegate for DefaultDelegate {}
+
+
+#[derive(Debug)]
+pub enum Error {
+    /// The http connection failed
+    HttpError(hyper::Error),
+
+    /// An attempt was made to upload a resource with size stored in field `.0`
+    /// even though the maximum upload size is what is stored in field `.1`.
+    UploadSizeLimitExceeded(u64, u64),
+
+    /// Represents information about a request that was not understood by the server.
+    /// Details are included.
+    BadRequest(ErrorResponse),
+
+    /// We needed an API key for authentication, but didn't obtain one.
+    /// Neither through the authenticator, nor through the Delegate.
+    MissingAPIKey,
+
+    /// We required a Token, but didn't get one from the Authenticator
+    MissingToken(Box<error::Error>),
+
+    /// The delgate instructed to cancel the operation
+    Cancelled,
+
+    /// An additional, free form field clashed with one of the built-in optional ones
+    FieldClash(&'static str),
+
+    /// Shows that we failed to decode the server response.
+    /// This can happen if the protocol changes in conjunction with strict json decoding.
+    JsonDecodeError(String, json::Error),
+
+    /// Indicates an HTTP repsonse with a non-success status code
+    Failure(hyper::client::Response),
+}
+
+
+impl Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Error::HttpError(ref err) => err.fmt(f),
+            Error::UploadSizeLimitExceeded(ref resource_size, ref max_size) =>
+                writeln!(f, "The media size {} exceeds the maximum allowed upload size of {}"
+                         , resource_size, max_size),
+            Error::MissingAPIKey => {
+                (writeln!(f, "The application's API key was not found in the configuration")).ok();
+                writeln!(f, "It is used as there are no Scopes defined for this method.")
+            },
+            Error::BadRequest(ref err) => {
+                try!(writeln!(f, "Bad Request ({}): {}", err.error.code, err.error.message));
+                for err in err.error.errors.iter() {
+                    try!(writeln!(f, "    {}: {}, {}{}",
+                                            err.domain,
+                                            err.message,
+                                            err.reason,
+                                            match &err.location {
+                                                &Some(ref loc) => format!("@{}", loc),
+                                                &None => String::new(),
+                                            }));
+                }
+                Ok(())
+            },
+            Error::MissingToken(ref err) =>
+                writeln!(f, "Token retrieval failed with error: {}", err),
+            Error::Cancelled =>
+                writeln!(f, "Operation cancelled by delegate"),
+            Error::FieldClash(field) =>
+                writeln!(f, "The custom parameter '{}' is already provided natively by the CallBuilder.", field),
+            Error::JsonDecodeError(ref json_str, ref err)
+                => writeln!(f, "{}: {}", err, json_str),
+            Error::Failure(ref response) =>
+                writeln!(f, "Http status indicates failure: {:?}", response),
+        }
+    }
+}
+
+impl error::Error for Error {
+    fn description(&self) -> &str {
+        match *self {
+            Error::HttpError(ref err) => err.description(),
+            Error::JsonDecodeError(_, ref err) => err.description(),
+            _ => "NO DESCRIPTION POSSIBLE - use `Display.fmt()` instead"
+        }
+    }
+
+    fn cause(&self) -> Option<&error::Error> {
+        match *self {
+            Error::HttpError(ref err) => err.cause(),
+            Error::JsonDecodeError(_, ref err) => err.cause(),
+            _ => None
+        }
+    }
+}
+
+/// A universal result type used as return for all calls.
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Contains information about an API request.
+pub struct MethodInfo {
+    pub id: &'static str,
+    pub http_method: Method,
+}
+
+const BOUNDARY: &'static str = "MDuXWGyeE33QFXGchb2VFWc4Z7945d";
+
+/// Provides a `Read` interface that converts multiple parts into the protocol
+/// identified by [RFC2387](https://tools.ietf.org/html/rfc2387).
+/// **Note**: This implementation is just as rich as it needs to be to perform uploads
+/// to google APIs, and might not be a fully-featured implementation.
+#[derive(Default)]
+pub struct MultiPartReader<'a> {
+    raw_parts: Vec<(Headers, &'a mut Read)>,
+    current_part: Option<(Cursor<Vec<u8>>, &'a mut Read)>,
+    last_part_boundary: Option<Cursor<Vec<u8>>>,
+}
+
+impl<'a> MultiPartReader<'a> {
+
+    /// Reserve memory for exactly the given amount of parts
+    pub fn reserve_exact(&mut self, cap: usize) {
+        self.raw_parts.reserve_exact(cap);
+    }
+
+    /// Add a new part to the queue of parts to be read on the first `read` call.
+    ///
+    /// # Arguments
+    ///
+    /// `headers` - identifying the body of the part. It's similar to the header
+    ///             in an ordinary single-part call, and should thus contain the
+    ///             same information.
+    /// `reader`  - a reader providing the part's body
+    /// `size`    - the amount of bytes provided by the reader. It will be put onto the header as
+    ///             content-size.
+    /// `mime`    - It will be put onto the content type
+    pub fn add_part(&mut self, reader: &'a mut Read, size: u64, mime_type: Mime) -> &mut MultiPartReader<'a> {
+        let mut headers = Headers::new();
+        headers.set(ContentType(mime_type));
+        headers.set(ContentLength(size));
+        self.raw_parts.push((headers, reader));
+        self
+    }
+
+    /// Returns the mime-type representing our multi-part message.
+    /// Use it with the ContentType header.
+    pub fn mime_type(&self) -> Mime {
+        Mime(
+            TopLevel::Multipart,
+            SubLevel::Ext("Related".to_string()),
+            vec![(Attr::Ext("boundary".to_string()), Value::Ext(BOUNDARY.to_string()))],
+        )
+    }
+
+    /// Returns true if we are totally used
+    fn is_depleted(&self) -> bool {
+        self.raw_parts.len() == 0 && self.current_part.is_none() && self.last_part_boundary.is_none()
+    }
+
+    /// Returns true if we are handling our last part
+    fn is_last_part(&self) -> bool {
+        self.raw_parts.len() == 0 && self.current_part.is_some()
+    }
+}
+
+impl<'a> Read for MultiPartReader<'a> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        match (self.raw_parts.len(),
+               self.current_part.is_none(),
+               self.last_part_boundary.is_none()) {
+            (_, _, false) => {
+                let br = self.last_part_boundary.as_mut().unwrap().read(buf).unwrap_or(0);
+                if br < buf.len() {
+                    self.last_part_boundary = None;
+                }
+                return Ok(br)
+            },
+            (0, true, true) => return Ok(0),
+            (n, true, _) if n > 0 => {
+                let (headers, reader) = self.raw_parts.remove(0);
+                let mut c = Cursor::new(Vec::<u8>::new());
+                (write!(&mut c, "{}--{}{}{}{}", LINE_ENDING, BOUNDARY, LINE_ENDING,
+                                                headers, LINE_ENDING)).unwrap();
+                c.seek(SeekFrom::Start(0)).unwrap();
+                self.current_part = Some((c, reader));
+            }
+            _ => {},
+        }
+
+        // read headers as long as possible
+        let (hb, rr) = {
+            let &mut (ref mut c, ref mut reader) = self.current_part.as_mut().unwrap();
+            let b = c.read(buf).unwrap_or(0);
+            (b, reader.read(&mut buf[b..]))
+        };
+
+        match rr {
+            Ok(bytes_read) => {
+                if hb < buf.len() && bytes_read == 0 {
+                    if self.is_last_part() {
+                        // before clearing the last part, we will add the boundary that
+                        // will be written last
+                        self.last_part_boundary = Some(Cursor::new(
+                                                        format!("{}--{}--", LINE_ENDING, BOUNDARY).into_bytes()))
+                    }
+                    // We are depleted - this can trigger the next part to come in
+                    self.current_part = None;
+                }
+                let mut total_bytes_read = hb + bytes_read;
+                while total_bytes_read < buf.len() && !self.is_depleted() {
+                    match self.read(&mut buf[total_bytes_read ..]) {
+                        Ok(br) => total_bytes_read += br,
+                        Err(err) => return Err(err),
+                    }
+                }
+                Ok(total_bytes_read)
+            }
+            Err(err) => {
+                // fail permanently
+                self.current_part = None;
+                self.last_part_boundary = None;
+                self.raw_parts.clear();
+                Err(err)
+            }
+        }
+    }
+}
+
+/// The `X-Upload-Content-Type` header.
+///
+/// Generated via rustc --pretty expanded -Z unstable-options, and manually
+/// processed to be more readable.
+#[derive(PartialEq, Debug, Clone)]
+pub struct XUploadContentType(pub Mime);
+
+impl ::std::ops::Deref for XUploadContentType {
+    type Target = Mime;
+    fn deref<'a>(&'a self) -> &'a Mime { &self.0 }
+}
+impl ::std::ops::DerefMut for XUploadContentType {
+    fn deref_mut<'a>(&'a mut self) -> &'a mut Mime { &mut self.0 }
+}
+impl Header for XUploadContentType {
+    fn header_name() -> &'static str { "X-Upload-Content-Type" }
+    fn parse_header(raw: &[Vec<u8>]) -> hyper::error::Result<Self> {
+        hyper::header::parsing::from_one_raw_str(raw).map(XUploadContentType)
+    }
+}
+impl HeaderFormat for XUploadContentType {
+    fn fmt_header(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        Display::fmt(&**self, f)
+    }
+}
+impl Display for XUploadContentType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(&**self, f)
+    }
+}
+
+#[derive(Clone, PartialEq, Debug)]
+pub struct Chunk {
+    pub first: u64,
+    pub last: u64
+}
+
+impl fmt::Display for Chunk {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        (write!(fmt, "{}-{}", self.first, self.last)).ok();
+        Ok(())
+    }
+}
+
+impl FromStr for Chunk {
+    type Err = &'static str;
+
+    /// NOTE: only implements `%i-%i`, not `*`
+    fn from_str(s: &str) -> std::result::Result<Chunk, &'static str> {
+        let parts: Vec<&str> = s.split('-').collect();
+        if parts.len() != 2 {
+            return Err("Expected two parts: %i-%i")
+        }
+        Ok(
+            Chunk {
+                first: match FromStr::from_str(parts[0]) {
+                    Ok(d) => d,
+                    _ => return Err("Couldn't parse 'first' as digit")
+                },
+                last: match FromStr::from_str(parts[1]) {
+                    Ok(d) => d,
+                    _ => return Err("Couldn't parse 'last' as digit")
+                }
+            }
+        )
+    }
+}
+
+/// Implements the Content-Range header, for serialization only
+#[derive(Clone, PartialEq, Debug)]
+pub struct ContentRange {
+    pub range: Option<Chunk>,
+    pub total_length: u64,
+}
+
+impl Header for ContentRange {
+    fn header_name() -> &'static str {
+        "Content-Range"
+    }
+
+    /// We are not parsable, as parsing is done by the `Range` header
+    fn parse_header(_: &[Vec<u8>]) -> hyper::error::Result<Self> {
+        Err(hyper::error::Error::Method)
+    }
+}
+
+
+impl HeaderFormat for ContentRange {
+    fn fmt_header(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        try!(fmt.write_str("bytes "));
+        match self.range {
+            Some(ref c) => try!(c.fmt(fmt)),
+            None => try!(fmt.write_str("*"))
+        }
+        (write!(fmt, "/{}", self.total_length)).ok();
+        Ok(())
+    }
+}
+
+#[derive(Clone, PartialEq, Debug)]
+pub struct RangeResponseHeader(pub Chunk);
+
+impl Header for RangeResponseHeader {
+    fn header_name() -> &'static str {
+        "Range"
+    }
+
+    fn parse_header(raw: &[Vec<u8>]) -> hyper::error::Result<Self> {
+        if raw.len() > 0 {
+            let v = &raw[0];
+            if let Ok(s) = std::str::from_utf8(v) {
+                const PREFIX: &'static str = "bytes ";
+                if s.starts_with(PREFIX) {
+                    if let Ok(c) = <Chunk as FromStr>::from_str(&s[PREFIX.len()..]) {
+                        return  Ok(RangeResponseHeader(c))
+                    }
+                }
+            }
+        }
+        Err(hyper::error::Error::Method)
+    }
+}
+
+impl HeaderFormat for RangeResponseHeader {
+    /// No implmentation necessary, we just need to parse
+    fn fmt_header(&self, _: &mut fmt::Formatter) -> fmt::Result {
+        Err(fmt::Error)
+    }
+}
+
+/// A utility type to perform a resumable upload from start to end.
+pub struct ResumableUploadHelper<'a, A: 'a> {
+    pub client: &'a mut hyper::client::Client,
+    pub delegate: &'a mut Delegate,
+    pub start_at: Option<u64>,
+    pub auth: &'a mut A,
+    pub user_agent: &'a str,
+    pub auth_header: Authorization<Bearer>,
+    pub url: &'a str,
+    pub reader: &'a mut ReadSeek,
+    pub media_type: Mime,
+    pub content_length: u64
+}
+
+impl<'a, A> ResumableUploadHelper<'a, A>
+    where A: oauth2::GetToken {
+
+    fn query_transfer_status(&mut self) -> std::result::Result<u64, hyper::Result<hyper::client::Response>> {
+        loop {
+            match self.client.post(self.url)
+                .header(UserAgent(self.user_agent.to_string()))
+                .header(ContentRange { range: None, total_length: self.content_length })
+                .header(self.auth_header.clone())
+                .send() {
+                Ok(r) => {
+                    // 308 = resume-incomplete == PermanentRedirect
+                    let headers = r.headers.clone();
+                    let h: &RangeResponseHeader = match headers.get() {
+                        Some(hh) if r.status == StatusCode::PermanentRedirect => hh,
+                        None|Some(_) => {
+                            if let Retry::After(d) = self.delegate.http_failure(&r, None, None) {
+                                sleep(d);
+                                continue;
+                            }
+                            return Err(Ok(r))
+                        }
+                    };
+                    return Ok(h.0.last)
+                }
+                Err(err) => {
+                    if let Retry::After(d) = self.delegate.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    return Err(Err(err))
+                }
+            }
+        }
+    }
+
+    /// returns None if operation was cancelled by delegate, or the HttpResult.
+    /// It can be that we return the result just because we didn't understand the status code -
+    /// caller should check for status himself before assuming it's OK to use
+    pub fn upload(&mut self) -> Option<hyper::Result<hyper::client::Response>> {
+        let mut start = match self.start_at {
+            Some(s) => s,
+            None => match self.query_transfer_status() {
+                Ok(s) => s,
+                Err(result) => return Some(result)
+            }
+        };
+
+        const MIN_CHUNK_SIZE: u64 = 1 << 18;
+        let chunk_size = match self.delegate.chunk_size() {
+            cs if cs > MIN_CHUNK_SIZE => cs,
+            _ => MIN_CHUNK_SIZE
+        };
+
+        self.reader.seek(SeekFrom::Start(start)).unwrap();
+        loop {
+            let request_size = match self.content_length - start {
+                rs if rs > chunk_size => chunk_size,
+                rs => rs
+            };
+
+            let mut section_reader = self.reader.take(request_size);
+            let range_header = ContentRange {
+                range: Some(Chunk {first: start, last: start + request_size - 1}),
+                total_length: self.content_length
+            };
+            start += request_size;
+            if self.delegate.cancel_chunk_upload(&range_header) {
+                return None
+            }
+            let res = self.client.post(self.url)
+                                 .header(range_header)
+                                 .header(ContentType(self.media_type.clone()))
+                                 .header(UserAgent(self.user_agent.to_string()))
+                                 .body(&mut section_reader)
+                                 .send();
+            match res {
+                Ok(mut res) => {
+                    if res.status == StatusCode::PermanentRedirect  {
+                        continue
+                    }
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let Retry::After(d) = self.delegate.http_failure(&res,
+                                                        json::from_str(&json_err).ok(),
+                                                        json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                    }
+                    return Some(Ok(res))
+                },
+                Err(err) => {
+                    if let Retry::After(d) = self.delegate.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    return Some(Err(err))
+                }
+            }
+        }
+    }
+}
+
+// Copy of src/rust/cli/cmn.rs
+// TODO(ST): Allow sharing common code between program types
+pub fn remove_json_null_values(value: &mut json::value::Value) {
+    match *value {
+        json::value::Value::Object(ref mut map) => {
+            let mut for_removal = Vec::new();
+
+            for (key, mut value) in map.iter_mut() {
+                if value.is_null() {
+                    for_removal.push(key.clone());
+                } else {
+                    remove_json_null_values(&mut value);
+                }
+            }
+
+            for key in &for_removal {
+                map.remove(key);
+            }
+        }
+        _ => {}
+    }
+}

--- a/gen/adexchangebuyer2_v2_beta1/src/lib.rs
+++ b/gen/adexchangebuyer2_v2_beta1/src/lib.rs
@@ -1,0 +1,16923 @@
+// DO NOT EDIT !
+// This file was generated automatically from 'src/mako/api/lib.rs.mako'
+// DO NOT EDIT !
+
+//! This documentation was generated from *AdExchangeBuyerII* crate version *1.0.7+20171208*, where *20171208* is the exact revision of the *adexchangebuyer2:v2beta1* schema built by the [mako](http://www.makotemplates.org/) code generator *v1.0.7*.
+//! 
+//! Everything else about the *AdExchangeBuyerII* *v2_beta1* API can be found at the
+//! [official documentation site](https://developers.google.com/ad-exchange/buyer-rest/reference/rest/).
+//! The original source code is [on github](https://github.com/Byron/google-apis-rs/tree/master/gen/adexchangebuyer2_v2_beta1).
+//! # Features
+//! 
+//! Handle the following *Resources* with ease from the central [hub](struct.AdExchangeBuyerII.html) ... 
+//! 
+//! * accounts
+//!  * [*clients create*](struct.AccountClientCreateCall.html), [*clients get*](struct.AccountClientGetCall.html), [*clients invitations create*](struct.AccountClientInvitationCreateCall.html), [*clients invitations get*](struct.AccountClientInvitationGetCall.html), [*clients invitations list*](struct.AccountClientInvitationListCall.html), [*clients list*](struct.AccountClientListCall.html), [*clients update*](struct.AccountClientUpdateCall.html), [*clients users get*](struct.AccountClientUserGetCall.html), [*clients users list*](struct.AccountClientUserListCall.html), [*clients users update*](struct.AccountClientUserUpdateCall.html), [*creatives create*](struct.AccountCreativeCreateCall.html), [*creatives deal associations add*](struct.AccountCreativeDealAssociationAddCall.html), [*creatives deal associations list*](struct.AccountCreativeDealAssociationListCall.html), [*creatives deal associations remove*](struct.AccountCreativeDealAssociationRemoveCall.html), [*creatives get*](struct.AccountCreativeGetCall.html), [*creatives list*](struct.AccountCreativeListCall.html), [*creatives stop watching*](struct.AccountCreativeStopWatchingCall.html), [*creatives update*](struct.AccountCreativeUpdateCall.html) and [*creatives watch*](struct.AccountCreativeWatchCall.html)
+//! * bidders
+//!  * [*accounts filter sets bid metrics list*](struct.BidderAccountFilterSetBidMetricListCall.html), [*accounts filter sets bid response errors list*](struct.BidderAccountFilterSetBidResponseErrorListCall.html), [*accounts filter sets bid responses without bids list*](struct.BidderAccountFilterSetBidResponsesWithoutBidListCall.html), [*accounts filter sets create*](struct.BidderAccountFilterSetCreateCall.html), [*accounts filter sets delete*](struct.BidderAccountFilterSetDeleteCall.html), [*accounts filter sets filtered bid requests list*](struct.BidderAccountFilterSetFilteredBidRequestListCall.html), [*accounts filter sets filtered bids creatives list*](struct.BidderAccountFilterSetFilteredBidCreativeListCall.html), [*accounts filter sets filtered bids details list*](struct.BidderAccountFilterSetFilteredBidDetailListCall.html), [*accounts filter sets filtered bids list*](struct.BidderAccountFilterSetFilteredBidListCall.html), [*accounts filter sets get*](struct.BidderAccountFilterSetGetCall.html), [*accounts filter sets impression metrics list*](struct.BidderAccountFilterSetImpressionMetricListCall.html), [*accounts filter sets list*](struct.BidderAccountFilterSetListCall.html), [*accounts filter sets losing bids list*](struct.BidderAccountFilterSetLosingBidListCall.html), [*accounts filter sets non billable winning bids list*](struct.BidderAccountFilterSetNonBillableWinningBidListCall.html), [*filter sets bid metrics list*](struct.BidderFilterSetBidMetricListCall.html), [*filter sets bid response errors list*](struct.BidderFilterSetBidResponseErrorListCall.html), [*filter sets bid responses without bids list*](struct.BidderFilterSetBidResponsesWithoutBidListCall.html), [*filter sets create*](struct.BidderFilterSetCreateCall.html), [*filter sets delete*](struct.BidderFilterSetDeleteCall.html), [*filter sets filtered bid requests list*](struct.BidderFilterSetFilteredBidRequestListCall.html), [*filter sets filtered bids creatives list*](struct.BidderFilterSetFilteredBidCreativeListCall.html), [*filter sets filtered bids details list*](struct.BidderFilterSetFilteredBidDetailListCall.html), [*filter sets filtered bids list*](struct.BidderFilterSetFilteredBidListCall.html), [*filter sets get*](struct.BidderFilterSetGetCall.html), [*filter sets impression metrics list*](struct.BidderFilterSetImpressionMetricListCall.html), [*filter sets list*](struct.BidderFilterSetListCall.html), [*filter sets losing bids list*](struct.BidderFilterSetLosingBidListCall.html) and [*filter sets non billable winning bids list*](struct.BidderFilterSetNonBillableWinningBidListCall.html)
+//! 
+//! 
+//! 
+//! 
+//! Not what you are looking for ? Find all other Google APIs in their Rust [documentation index](http://byron.github.io/google-apis-rs).
+//! 
+//! # Structure of this Library
+//! 
+//! The API is structured into the following primary items:
+//! 
+//! * **[Hub](struct.AdExchangeBuyerII.html)**
+//!     * a central object to maintain state and allow accessing all *Activities*
+//!     * creates [*Method Builders*](trait.MethodsBuilder.html) which in turn
+//!       allow access to individual [*Call Builders*](trait.CallBuilder.html)
+//! * **[Resources](trait.Resource.html)**
+//!     * primary types that you can apply *Activities* to
+//!     * a collection of properties and *Parts*
+//!     * **[Parts](trait.Part.html)**
+//!         * a collection of properties
+//!         * never directly used in *Activities*
+//! * **[Activities](trait.CallBuilder.html)**
+//!     * operations to apply to *Resources*
+//! 
+//! All *structures* are marked with applicable traits to further categorize them and ease browsing.
+//! 
+//! Generally speaking, you can invoke *Activities* like this:
+//! 
+//! ```Rust,ignore
+//! let r = hub.resource().activity(...).doit()
+//! ```
+//! 
+//! Or specifically ...
+//! 
+//! ```ignore
+//! let r = hub.bidders().accounts_filter_sets_delete(...).doit()
+//! let r = hub.accounts().creatives_deal_associations_add(...).doit()
+//! let r = hub.accounts().creatives_deal_associations_remove(...).doit()
+//! let r = hub.accounts().creatives_watch(...).doit()
+//! let r = hub.bidders().filter_sets_delete(...).doit()
+//! let r = hub.accounts().creatives_stop_watching(...).doit()
+//! ```
+//! 
+//! The `resource()` and `activity(...)` calls create [builders][builder-pattern]. The second one dealing with `Activities` 
+//! supports various methods to configure the impending operation (not shown here). It is made such that all required arguments have to be 
+//! specified right away (i.e. `(...)`), whereas all optional ones can be [build up][builder-pattern] as desired.
+//! The `doit()` method performs the actual communication with the server and returns the respective result.
+//! 
+//! # Usage
+//! 
+//! ## Setting up your Project
+//! 
+//! To use this library, you would put the following lines into your `Cargo.toml` file:
+//! 
+//! ```toml
+//! [dependencies]
+//! google-adexchangebuyer2_v2_beta1 = "*"
+//! ```
+//! 
+//! ## A complete example
+//! 
+//! ```test_harness,no_run
+//! extern crate hyper;
+//! extern crate hyper_rustls;
+//! extern crate yup_oauth2 as oauth2;
+//! extern crate google_adexchangebuyer2_v2_beta1 as adexchangebuyer2_v2_beta1;
+//! use adexchangebuyer2_v2_beta1::AddDealAssociationRequest;
+//! use adexchangebuyer2_v2_beta1::{Result, Error};
+//! # #[test] fn egal() {
+//! use std::default::Default;
+//! use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+//! use adexchangebuyer2_v2_beta1::AdExchangeBuyerII;
+//! 
+//! // Get an ApplicationSecret instance by some means. It contains the `client_id` and 
+//! // `client_secret`, among other things.
+//! let secret: ApplicationSecret = Default::default();
+//! // Instantiate the authenticator. It will choose a suitable authentication flow for you, 
+//! // unless you replace  `None` with the desired Flow.
+//! // Provide your own `AuthenticatorDelegate` to adjust the way it operates and get feedback about 
+//! // what's going on. You probably want to bring in your own `TokenStorage` to persist tokens and
+//! // retrieve them from storage.
+//! let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+//!                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+//!                               <MemoryStorage as Default>::default(), None);
+//! let mut hub = AdExchangeBuyerII::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+//! // As the method needs a request, you would usually fill it with the desired information
+//! // into the respective structure. Some of the parts shown here might not be applicable !
+//! // Values shown here are possibly random and not representative !
+//! let mut req = AddDealAssociationRequest::default();
+//! 
+//! // You can configure optional parameters by calling the respective setters at will, and
+//! // execute the final call using `doit()`.
+//! // Values shown here are possibly random and not representative !
+//! let result = hub.accounts().creatives_deal_associations_add(req, "accountId", "creativeId")
+//!              .doit();
+//! 
+//! match result {
+//!     Err(e) => match e {
+//!         // The Error enum provides details about what exactly happened.
+//!         // You can also just use its `Debug`, `Display` or `Error` traits
+//!          Error::HttpError(_)
+//!         |Error::MissingAPIKey
+//!         |Error::MissingToken(_)
+//!         |Error::Cancelled
+//!         |Error::UploadSizeLimitExceeded(_, _)
+//!         |Error::Failure(_)
+//!         |Error::BadRequest(_)
+//!         |Error::FieldClash(_)
+//!         |Error::JsonDecodeError(_, _) => println!("{}", e),
+//!     },
+//!     Ok(res) => println!("Success: {:?}", res),
+//! }
+//! # }
+//! ```
+//! ## Handling Errors
+//! 
+//! All errors produced by the system are provided either as [Result](enum.Result.html) enumeration as return value of 
+//! the doit() methods, or handed as possibly intermediate results to either the 
+//! [Hub Delegate](trait.Delegate.html), or the [Authenticator Delegate](https://docs.rs/yup-oauth2/*/yup_oauth2/trait.AuthenticatorDelegate.html).
+//! 
+//! When delegates handle errors or intermediate values, they may have a chance to instruct the system to retry. This 
+//! makes the system potentially resilient to all kinds of errors.
+//! 
+//! ## Uploads and Downloads
+//! If a method supports downloads, the response body, which is part of the [Result](enum.Result.html), should be
+//! read by you to obtain the media.
+//! If such a method also supports a [Response Result](trait.ResponseResult.html), it will return that by default.
+//! You can see it as meta-data for the actual media. To trigger a media download, you will have to set up the builder by making
+//! this call: `.param("alt", "media")`.
+//! 
+//! Methods supporting uploads can do so using up to 2 different protocols: 
+//! *simple* and *resumable*. The distinctiveness of each is represented by customized 
+//! `doit(...)` methods, which are then named `upload(...)` and `upload_resumable(...)` respectively.
+//! 
+//! ## Customization and Callbacks
+//! 
+//! You may alter the way an `doit()` method is called by providing a [delegate](trait.Delegate.html) to the 
+//! [Method Builder](trait.CallBuilder.html) before making the final `doit()` call. 
+//! Respective methods will be called to provide progress information, as well as determine whether the system should 
+//! retry on failure.
+//! 
+//! The [delegate trait](trait.Delegate.html) is default-implemented, allowing you to customize it with minimal effort.
+//! 
+//! ## Optional Parts in Server-Requests
+//! 
+//! All structures provided by this library are made to be [enocodable](trait.RequestValue.html) and 
+//! [decodable](trait.ResponseResult.html) via *json*. Optionals are used to indicate that partial requests are responses 
+//! are valid.
+//! Most optionals are are considered [Parts](trait.Part.html) which are identifiable by name, which will be sent to 
+//! the server to indicate either the set parts of the request or the desired parts in the response.
+//! 
+//! ## Builder Arguments
+//! 
+//! Using [method builders](trait.CallBuilder.html), you are able to prepare an action call by repeatedly calling it's methods.
+//! These will always take a single argument, for which the following statements are true.
+//! 
+//! * [PODs][wiki-pod] are handed by copy
+//! * strings are passed as `&str`
+//! * [request values](trait.RequestValue.html) are moved
+//! 
+//! Arguments will always be copied or cloned into the builder, to make them independent of their original life times.
+//! 
+//! [wiki-pod]: http://en.wikipedia.org/wiki/Plain_old_data_structure
+//! [builder-pattern]: http://en.wikipedia.org/wiki/Builder_pattern
+//! [google-go-api]: https://github.com/google/google-api-go-client
+//! 
+//! 
+
+// Unused attributes happen thanks to defined, but unused structures
+// We don't warn about this, as depending on the API, some data structures or facilities are never used.
+// Instead of pre-determining this, we just disable the lint. It's manually tuned to not have any
+// unused imports in fully featured APIs. Same with unused_mut ... .
+#![allow(unused_imports, unused_mut, dead_code)]
+
+// DO NOT EDIT !
+// This file was generated automatically from 'src/mako/api/lib.rs.mako'
+// DO NOT EDIT !
+
+#[macro_use]
+extern crate serde_derive;
+
+extern crate hyper;
+extern crate serde;
+extern crate serde_json;
+extern crate yup_oauth2 as oauth2;
+extern crate mime;
+extern crate url;
+
+mod cmn;
+
+use std::collections::HashMap;
+use std::cell::RefCell;
+use std::borrow::BorrowMut;
+use std::default::Default;
+use std::collections::BTreeMap;
+use serde_json as json;
+use std::io;
+use std::fs;
+use std::mem;
+use std::thread::sleep;
+use std::time::Duration;
+
+pub use cmn::{MultiPartReader, ToParts, MethodInfo, Result, Error, CallBuilder, Hub, ReadSeek, Part,
+              ResponseResult, RequestValue, NestedType, Delegate, DefaultDelegate, MethodsBuilder,
+              Resource, ErrorResponse, remove_json_null_values};
+
+
+// ##############
+// UTILITIES ###
+// ############
+
+/// Identifies the an OAuth2 authorization scope.
+/// A scope is needed when requesting an
+/// [authorization token](https://developers.google.com/youtube/v3/guides/authentication).
+#[derive(PartialEq, Eq, Hash)]
+pub enum Scope {
+    /// Manage your Ad Exchange buyer account configuration
+    AdexchangeBuyer,
+}
+
+impl AsRef<str> for Scope {
+    fn as_ref(&self) -> &str {
+        match *self {
+            Scope::AdexchangeBuyer => "https://www.googleapis.com/auth/adexchange.buyer",
+        }
+    }
+}
+
+impl Default for Scope {
+    fn default() -> Scope {
+        Scope::AdexchangeBuyer
+    }
+}
+
+
+
+// ########
+// HUB ###
+// ######
+
+/// Central instance to access all AdExchangeBuyerII related resource activities
+///
+/// # Examples
+///
+/// Instantiate a new hub
+///
+/// ```test_harness,no_run
+/// extern crate hyper;
+/// extern crate hyper_rustls;
+/// extern crate yup_oauth2 as oauth2;
+/// extern crate google_adexchangebuyer2_v2_beta1 as adexchangebuyer2_v2_beta1;
+/// use adexchangebuyer2_v2_beta1::AddDealAssociationRequest;
+/// use adexchangebuyer2_v2_beta1::{Result, Error};
+/// # #[test] fn egal() {
+/// use std::default::Default;
+/// use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// use adexchangebuyer2_v2_beta1::AdExchangeBuyerII;
+/// 
+/// // Get an ApplicationSecret instance by some means. It contains the `client_id` and 
+/// // `client_secret`, among other things.
+/// let secret: ApplicationSecret = Default::default();
+/// // Instantiate the authenticator. It will choose a suitable authentication flow for you, 
+/// // unless you replace  `None` with the desired Flow.
+/// // Provide your own `AuthenticatorDelegate` to adjust the way it operates and get feedback about 
+/// // what's going on. You probably want to bring in your own `TokenStorage` to persist tokens and
+/// // retrieve them from storage.
+/// let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+///                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+///                               <MemoryStorage as Default>::default(), None);
+/// let mut hub = AdExchangeBuyerII::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = AddDealAssociationRequest::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.accounts().creatives_deal_associations_add(req, "accountId", "creativeId")
+///              .doit();
+/// 
+/// match result {
+///     Err(e) => match e {
+///         // The Error enum provides details about what exactly happened.
+///         // You can also just use its `Debug`, `Display` or `Error` traits
+///          Error::HttpError(_)
+///         |Error::MissingAPIKey
+///         |Error::MissingToken(_)
+///         |Error::Cancelled
+///         |Error::UploadSizeLimitExceeded(_, _)
+///         |Error::Failure(_)
+///         |Error::BadRequest(_)
+///         |Error::FieldClash(_)
+///         |Error::JsonDecodeError(_, _) => println!("{}", e),
+///     },
+///     Ok(res) => println!("Success: {:?}", res),
+/// }
+/// # }
+/// ```
+pub struct AdExchangeBuyerII<C, A> {
+    client: RefCell<C>,
+    auth: RefCell<A>,
+    _user_agent: String,
+    _base_url: String,
+    _root_url: String,
+}
+
+impl<'a, C, A> Hub for AdExchangeBuyerII<C, A> {}
+
+impl<'a, C, A> AdExchangeBuyerII<C, A>
+    where  C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+    pub fn new(client: C, authenticator: A) -> AdExchangeBuyerII<C, A> {
+        AdExchangeBuyerII {
+            client: RefCell::new(client),
+            auth: RefCell::new(authenticator),
+            _user_agent: "google-api-rust-client/1.0.7".to_string(),
+            _base_url: "https://adexchangebuyer.googleapis.com/".to_string(),
+            _root_url: "https://adexchangebuyer.googleapis.com/".to_string(),
+        }
+    }
+
+    pub fn accounts(&'a self) -> AccountMethods<'a, C, A> {
+        AccountMethods { hub: &self }
+    }
+    pub fn bidders(&'a self) -> BidderMethods<'a, C, A> {
+        BidderMethods { hub: &self }
+    }
+
+    /// Set the user-agent header field to use in all requests to the server.
+    /// It defaults to `google-api-rust-client/1.0.7`.
+    ///
+    /// Returns the previously set user-agent.
+    pub fn user_agent(&mut self, agent_name: String) -> String {
+        mem::replace(&mut self._user_agent, agent_name)
+    }
+
+    /// Set the base url to use in all requests to the server.
+    /// It defaults to `https://adexchangebuyer.googleapis.com/`.
+    ///
+    /// Returns the previously set base url.
+    pub fn base_url(&mut self, new_base_url: String) -> String {
+        mem::replace(&mut self._base_url, new_base_url)
+    }
+
+    /// Set the root url to use in all requests to the server.
+    /// It defaults to `https://adexchangebuyer.googleapis.com/`.
+    ///
+    /// Returns the previously set root url.
+    pub fn root_url(&mut self, new_root_url: String) -> String {
+        mem::replace(&mut self._root_url, new_root_url)
+    }
+}
+
+
+// ############
+// SCHEMAS ###
+// ##########
+/// Response message for listing all reasons that bid requests were filtered and
+/// not sent to the buyer.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [filter sets filtered bid requests list bidders](struct.BidderFilterSetFilteredBidRequestListCall.html) (response)
+/// * [accounts filter sets filtered bid requests list bidders](struct.BidderAccountFilterSetFilteredBidRequestListCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct ListFilteredBidRequestsResponse {
+    /// List of rows, with counts of filtered bid requests aggregated by callout
+    /// status.
+    #[serde(rename="calloutStatusRows")]
+    pub callout_status_rows: Option<Vec<CalloutStatusRow>>,
+    /// A token to retrieve the next page of results.
+    /// Pass this value in the
+    /// ListFilteredBidRequestsRequest.pageToken
+    /// field in the subsequent call to the filteredBidRequests.list
+    /// method to retrieve the next page of results.
+    #[serde(rename="nextPageToken")]
+    pub next_page_token: Option<String>,
+}
+
+impl ResponseResult for ListFilteredBidRequestsResponse {}
+
+
+/// A metric value, with an expected value and a variance; represents a count
+/// that may be either exact or estimated (i.e. when sampled).
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct MetricValue {
+    /// The variance (i.e. square of the standard deviation) of the metric value.
+    /// If value is exact, variance is 0.
+    /// Can be used to calculate margin of error as a percentage of value, using
+    /// the following formula, where Z is the standard constant that depends on the
+    /// desired size of the confidence interval (e.g. for 90% confidence interval,
+    /// use Z = 1.645):
+    /// 
+    ///   marginOfError = 100 * Z * sqrt(variance) / value
+    pub variance: Option<String>,
+    /// The expected value of the metric.
+    pub value: Option<String>,
+}
+
+impl Part for MetricValue {}
+
+
+/// The number of filtered bids with the specified dimension values that have the
+/// specified creative.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct FilteredBidCreativeRow {
+    /// The ID of the creative.
+    #[serde(rename="creativeId")]
+    pub creative_id: Option<String>,
+    /// The number of bids with the specified creative.
+    #[serde(rename="bidCount")]
+    pub bid_count: Option<MetricValue>,
+    /// The values of all dimensions associated with metric values in this row.
+    #[serde(rename="rowDimensions")]
+    pub row_dimensions: Option<RowDimensions>,
+}
+
+impl Part for FilteredBidCreativeRow {}
+
+
+/// Response message for listing all reasons that bids were filtered from the
+/// auction.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [accounts filter sets filtered bids list bidders](struct.BidderAccountFilterSetFilteredBidListCall.html) (response)
+/// * [filter sets filtered bids list bidders](struct.BidderFilterSetFilteredBidListCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct ListFilteredBidsResponse {
+    /// A token to retrieve the next page of results.
+    /// Pass this value in the
+    /// ListFilteredBidsRequest.pageToken
+    /// field in the subsequent call to the filteredBids.list
+    /// method to retrieve the next page of results.
+    #[serde(rename="nextPageToken")]
+    pub next_page_token: Option<String>,
+    /// List of rows, with counts of filtered bids aggregated by filtering reason
+    /// (i.e. creative status).
+    #[serde(rename="creativeStatusRows")]
+    pub creative_status_rows: Option<Vec<CreativeStatusRow>>,
+}
+
+impl ResponseResult for ListFilteredBidsResponse {}
+
+
+/// @OutputOnly The reason and details for a disapproval.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Disapproval {
+    /// The categorized reason for disapproval.
+    pub reason: Option<String>,
+    /// Additional details about the reason for disapproval.
+    pub details: Option<Vec<String>>,
+}
+
+impl Part for Disapproval {}
+
+
+/// A creative and its classification data.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [creatives update accounts](struct.AccountCreativeUpdateCall.html) (request|response)
+/// * [creatives get accounts](struct.AccountCreativeGetCall.html) (response)
+/// * [creatives create accounts](struct.AccountCreativeCreateCall.html) (request|response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Creative {
+    /// @OutputOnly Shows any corrections that were applied to this creative.
+    pub corrections: Option<Vec<Correction>>,
+    /// The set of URLs to be called to record an impression.
+    #[serde(rename="impressionTrackingUrls")]
+    pub impression_tracking_urls: Option<Vec<String>>,
+    /// The agency ID for this creative.
+    #[serde(rename="agencyId")]
+    pub agency_id: Option<String>,
+    /// @OutputOnly The filtering stats for this creative.
+    #[serde(rename="filteringStats")]
+    pub filtering_stats: Option<FilteringStats>,
+    /// @OutputOnly
+    /// The detected languages for this creative. The order is arbitrary. The codes
+    /// are 2 or 5 characters and are documented at
+    /// https://developers.google.com/adwords/api/docs/appendix/languagecodes.
+    #[serde(rename="detectedLanguages")]
+    pub detected_languages: Option<Vec<String>>,
+    /// The name of the company being advertised in the creative.
+    #[serde(rename="advertiserName")]
+    pub advertiser_name: Option<String>,
+    /// The set of destination URLs for the creative.
+    #[serde(rename="clickThroughUrls")]
+    pub click_through_urls: Option<Vec<String>>,
+    /// A video creative.
+    pub video: Option<VideoContent>,
+    /// @OutputOnly Detected sensitive categories, if any.
+    /// See the ad-sensitive-categories.txt file in the technical documentation for
+    /// a list of IDs. You should use these IDs along with the
+    /// excluded-sensitive-category field in the bid request to filter your bids.
+    #[serde(rename="detectedSensitiveCategories")]
+    pub detected_sensitive_categories: Option<Vec<i32>>,
+    /// @OutputOnly The top-level deals status of this creative.
+    /// If disapproved, an entry for 'auctionType=DIRECT_DEALS' (or 'ALL') in
+    /// serving_restrictions will also exist. Note
+    /// that this may be nuanced with other contextual restrictions, in which case,
+    /// it may be preferable to read from serving_restrictions directly.
+    /// Can be used to filter the response of the
+    /// creatives.list
+    /// method.
+    #[serde(rename="dealsStatus")]
+    pub deals_status: Option<String>,
+    /// The buyer-defined creative ID of this creative.
+    /// Can be used to filter the response of the
+    /// creatives.list
+    /// method.
+    #[serde(rename="creativeId")]
+    pub creative_id: Option<String>,
+    /// @OutputOnly Detected advertiser IDs, if any.
+    #[serde(rename="detectedAdvertiserIds")]
+    pub detected_advertiser_ids: Option<Vec<String>>,
+    /// The link to AdChoices destination page.
+    #[serde(rename="adChoicesDestinationUrl")]
+    pub ad_choices_destination_url: Option<String>,
+    /// @OutputOnly The top-level open auction status of this creative.
+    /// If disapproved, an entry for 'auctionType = OPEN_AUCTION' (or 'ALL') in
+    /// serving_restrictions will also exist. Note
+    /// that this may be nuanced with other contextual restrictions, in which case,
+    /// it may be preferable to read from serving_restrictions directly.
+    /// Can be used to filter the response of the
+    /// creatives.list
+    /// method.
+    #[serde(rename="openAuctionStatus")]
+    pub open_auction_status: Option<String>,
+    /// The account that this creative belongs to.
+    /// Can be used to filter the response of the
+    /// creatives.list
+    /// method.
+    #[serde(rename="accountId")]
+    pub account_id: Option<String>,
+    /// All vendor IDs for the ads that may be shown from this creative.
+    /// See https://storage.googleapis.com/adx-rtb-dictionaries/vendors.txt
+    /// for possible values.
+    #[serde(rename="vendorIds")]
+    pub vendor_ids: Option<Vec<i32>>,
+    /// @OutputOnly Detected product categories, if any.
+    /// See the ad-product-categories.txt file in the technical documentation
+    /// for a list of IDs.
+    #[serde(rename="detectedProductCategories")]
+    pub detected_product_categories: Option<Vec<i32>>,
+    /// @OutputOnly The granular status of this ad in specific contexts.
+    /// A context here relates to where something ultimately serves (for example,
+    /// a physical location, a platform, an HTTPS vs HTTP request, or the type
+    /// of auction).
+    #[serde(rename="servingRestrictions")]
+    pub serving_restrictions: Option<Vec<ServingRestriction>>,
+    /// An HTML creative.
+    pub html: Option<HtmlContent>,
+    /// @OutputOnly The version of this creative.
+    pub version: Option<i32>,
+    /// @OutputOnly The last update timestamp of the creative via API.
+    #[serde(rename="apiUpdateTime")]
+    pub api_update_time: Option<String>,
+    /// All restricted categories for the ads that may be shown from this creative.
+    #[serde(rename="restrictedCategories")]
+    pub restricted_categories: Option<Vec<String>>,
+    /// @OutputOnly
+    /// The detected domains for this creative.
+    #[serde(rename="detectedDomains")]
+    pub detected_domains: Option<Vec<String>>,
+    /// All attributes for the ads that may be shown from this creative.
+    /// Can be used to filter the response of the
+    /// creatives.list
+    /// method.
+    pub attributes: Option<Vec<String>>,
+    /// A native creative.
+    pub native: Option<NativeContent>,
+}
+
+impl RequestValue for Creative {}
+impl ResponseResult for Creative {}
+
+
+/// @OutputOnly Filtering reasons for this creative during a period of a single
+/// day (from midnight to midnight Pacific).
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct FilteringStats {
+    /// The set of filtering reasons for this date.
+    pub reasons: Option<Vec<Reason>>,
+    /// The day during which the data was collected.
+    /// The data is collected from 00:00:00 to 23:59:59 PT.
+    /// During switches from PST to PDT and back, the day may
+    /// contain 23 or 25 hours of data instead of the usual 24.
+    pub date: Option<Date>,
+}
+
+impl Part for FilteringStats {}
+
+
+/// Response message for listing all reasons that bid responses were considered
+/// to have no applicable bids.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [accounts filter sets bid responses without bids list bidders](struct.BidderAccountFilterSetBidResponsesWithoutBidListCall.html) (response)
+/// * [filter sets bid responses without bids list bidders](struct.BidderFilterSetBidResponsesWithoutBidListCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct ListBidResponsesWithoutBidsResponse {
+    /// A token to retrieve the next page of results.
+    /// Pass this value in the
+    /// ListBidResponsesWithoutBidsRequest.pageToken
+    /// field in the subsequent call to the bidResponsesWithoutBids.list
+    /// method to retrieve the next page of results.
+    #[serde(rename="nextPageToken")]
+    pub next_page_token: Option<String>,
+    /// List of rows, with counts of bid responses without bids aggregated by
+    /// status.
+    #[serde(rename="bidResponseWithoutBidsStatusRows")]
+    pub bid_response_without_bids_status_rows: Option<Vec<BidResponseWithoutBidsStatusRow>>,
+}
+
+impl ResponseResult for ListBidResponsesWithoutBidsResponse {}
+
+
+/// An invitation for a new client user to get access to the Ad Exchange
+/// Buyer UI.
+/// All fields are required unless otherwise specified.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [clients invitations create accounts](struct.AccountClientInvitationCreateCall.html) (request|response)
+/// * [clients invitations get accounts](struct.AccountClientInvitationGetCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct ClientUserInvitation {
+    /// The unique numerical ID of the invitation that is sent to the user.
+    /// The value of this field is ignored in create operations.
+    #[serde(rename="invitationId")]
+    pub invitation_id: Option<String>,
+    /// Numerical account ID of the client buyer
+    /// that the invited user is associated with.
+    /// The value of this field is ignored in create operations.
+    #[serde(rename="clientAccountId")]
+    pub client_account_id: Option<String>,
+    /// The email address to which the invitation is sent. Email
+    /// addresses should be unique among all client users under each sponsor
+    /// buyer.
+    pub email: Option<String>,
+}
+
+impl RequestValue for ClientUserInvitation {}
+impl ResponseResult for ClientUserInvitation {}
+
+
+/// A response may include multiple rows, breaking down along various dimensions.
+/// Encapsulates the values of all dimensions for a given row.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct RowDimensions {
+    /// The time interval that this row represents.
+    #[serde(rename="timeInterval")]
+    pub time_interval: Option<TimeInterval>,
+}
+
+impl Part for RowDimensions {}
+
+
+/// Response message for listing all details associated with a given filtered bid
+/// reason.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [accounts filter sets filtered bids details list bidders](struct.BidderAccountFilterSetFilteredBidDetailListCall.html) (response)
+/// * [filter sets filtered bids details list bidders](struct.BidderFilterSetFilteredBidDetailListCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct ListCreativeStatusBreakdownByDetailResponse {
+    /// A token to retrieve the next page of results.
+    /// Pass this value in the
+    /// ListCreativeStatusBreakdownByDetailRequest.pageToken
+    /// field in the subsequent call to the filteredBids.details.list
+    /// method to retrieve the next page of results.
+    #[serde(rename="nextPageToken")]
+    pub next_page_token: Option<String>,
+    /// The type of detail that the detail IDs represent.
+    #[serde(rename="detailType")]
+    pub detail_type: Option<String>,
+    /// List of rows, with counts of bids with a given creative status aggregated
+    /// by detail.
+    #[serde(rename="filteredBidDetailRows")]
+    pub filtered_bid_detail_rows: Option<Vec<FilteredBidDetailRow>>,
+}
+
+impl ResponseResult for ListCreativeStatusBreakdownByDetailResponse {}
+
+
+/// Response message for listing filter sets.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [accounts filter sets list bidders](struct.BidderAccountFilterSetListCall.html) (response)
+/// * [filter sets list bidders](struct.BidderFilterSetListCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct ListFilterSetsResponse {
+    /// A token to retrieve the next page of results.
+    /// Pass this value in the
+    /// ListFilterSetsRequest.pageToken
+    /// field in the subsequent call to the
+    /// accounts.filterSets.list
+    /// method to retrieve the next page of results.
+    #[serde(rename="nextPageToken")]
+    pub next_page_token: Option<String>,
+    /// The filter sets belonging to the buyer.
+    #[serde(rename="filterSets")]
+    pub filter_sets: Option<Vec<FilterSet>>,
+}
+
+impl ResponseResult for ListFilterSetsResponse {}
+
+
+/// Video content for a creative.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct VideoContent {
+    /// The URL to fetch a video ad.
+    #[serde(rename="videoUrl")]
+    pub video_url: Option<String>,
+}
+
+impl Part for VideoContent {}
+
+
+/// The number of impressions with the specified dimension values where the
+/// corresponding bid request or bid response was not successful, as described by
+/// the specified callout status.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct CalloutStatusRow {
+    /// The values of all dimensions associated with metric values in this row.
+    #[serde(rename="rowDimensions")]
+    pub row_dimensions: Option<RowDimensions>,
+    /// The ID of the callout status.
+    /// See [callout-status-codes](https://developers.google.com/ad-exchange/rtb/downloads/callout-status-codes).
+    #[serde(rename="calloutStatusId")]
+    pub callout_status_id: Option<i32>,
+    /// The number of impressions for which there was a bid request or bid response
+    /// with the specified callout status.
+    #[serde(rename="impressionCount")]
+    pub impression_count: Option<MetricValue>,
+}
+
+impl Part for CalloutStatusRow {}
+
+
+/// Response message for listing all reasons that bid responses resulted in an
+/// error.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [filter sets bid response errors list bidders](struct.BidderFilterSetBidResponseErrorListCall.html) (response)
+/// * [accounts filter sets bid response errors list bidders](struct.BidderAccountFilterSetBidResponseErrorListCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct ListBidResponseErrorsResponse {
+    /// List of rows, with counts of bid responses aggregated by callout status.
+    #[serde(rename="calloutStatusRows")]
+    pub callout_status_rows: Option<Vec<CalloutStatusRow>>,
+    /// A token to retrieve the next page of results.
+    /// Pass this value in the
+    /// ListBidResponseErrorsRequest.pageToken
+    /// field in the subsequent call to the bidResponseErrors.list
+    /// method to retrieve the next page of results.
+    #[serde(rename="nextPageToken")]
+    pub next_page_token: Option<String>,
+}
+
+impl ResponseResult for ListBidResponseErrorsResponse {}
+
+
+/// A relative date range, specified by an offset and a duration.
+/// The supported range of dates begins 30 days before today and ends today.
+/// I.e. the limits for these values are:
+/// offset_days >= 0
+/// duration_days >= 1
+/// offset_days + duration_days <= 30
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct RelativeDateRange {
+    /// The number of days in the requested date range. E.g. for a range spanning
+    /// today, 1. For a range spanning the last 7 days, 7.
+    #[serde(rename="durationDays")]
+    pub duration_days: Option<i32>,
+    /// The end date of the filter set, specified as the number of days before
+    /// today. E.g. for a range where the last date is today, 0.
+    #[serde(rename="offsetDays")]
+    pub offset_days: Option<i32>,
+}
+
+impl Part for RelativeDateRange {}
+
+
+/// @OutputOnly The app type the restriction applies to for mobile device.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct AppContext {
+    /// The app types this restriction applies to.
+    #[serde(rename="appTypes")]
+    pub app_types: Option<Vec<String>>,
+}
+
+impl Part for AppContext {}
+
+
+/// A specific filtering status and how many times it occurred.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Reason {
+    /// The filtering status code. Please refer to the
+    /// [creative-status-codes.txt](https://storage.googleapis.com/adx-rtb-dictionaries/creative-status-codes.txt)
+    /// file for different statuses.
+    pub status: Option<i32>,
+    /// The number of times the creative was filtered for the status. The
+    /// count is aggregated across all publishers on the exchange.
+    pub count: Option<String>,
+}
+
+impl Part for Reason {}
+
+
+/// An absolute date range, specified by its start date and end date.
+/// The supported range of dates begins 30 days before today and ends today.
+/// Validity checked upon filter set creation. If a filter set with an absolute
+/// date range is run at a later date more than 30 days after start_date, it will
+/// fail.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct AbsoluteDateRange {
+    /// The start date of the range (inclusive).
+    /// Must be within the 30 days leading up to current date, and must be equal to
+    /// or before end_date.
+    #[serde(rename="startDate")]
+    pub start_date: Option<Date>,
+    /// The end date of the range (inclusive).
+    /// Must be within the 30 days leading up to current date, and must be equal to
+    /// or after start_date.
+    #[serde(rename="endDate")]
+    pub end_date: Option<Date>,
+}
+
+impl Part for AbsoluteDateRange {}
+
+
+/// A generic empty message that you can re-use to avoid defining duplicated
+/// empty messages in your APIs. A typical example is to use it as the request
+/// or the response type of an API method. For instance:
+/// 
+///     service Foo {
+///       rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
+///     }
+/// 
+/// The JSON representation for `Empty` is empty JSON object `{}`.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [accounts filter sets delete bidders](struct.BidderAccountFilterSetDeleteCall.html) (response)
+/// * [creatives deal associations add accounts](struct.AccountCreativeDealAssociationAddCall.html) (response)
+/// * [creatives deal associations remove accounts](struct.AccountCreativeDealAssociationRemoveCall.html) (response)
+/// * [creatives watch accounts](struct.AccountCreativeWatchCall.html) (response)
+/// * [filter sets delete bidders](struct.BidderFilterSetDeleteCall.html) (response)
+/// * [creatives stop watching accounts](struct.AccountCreativeStopWatchingCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Empty { _never_set: Option<bool> }
+
+impl ResponseResult for Empty {}
+
+
+/// A request for removing the association between a deal and a creative.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [creatives deal associations remove accounts](struct.AccountCreativeDealAssociationRemoveCall.html) (request)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct RemoveDealAssociationRequest {
+    /// The association between a creative and a deal that should be removed.
+    pub association: Option<CreativeDealAssociation>,
+}
+
+impl RequestValue for RemoveDealAssociationRequest {}
+
+
+/// The number of impressions with the specified dimension values that were
+/// considered to have no applicable bids, as described by the specified status.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct BidResponseWithoutBidsStatusRow {
+    /// The status specifying why the bid responses were considered to have no
+    /// applicable bids.
+    pub status: Option<String>,
+    /// The values of all dimensions associated with metric values in this row.
+    #[serde(rename="rowDimensions")]
+    pub row_dimensions: Option<RowDimensions>,
+    /// The number of impressions for which there was a bid response with the
+    /// specified status.
+    #[serde(rename="impressionCount")]
+    pub impression_count: Option<MetricValue>,
+}
+
+impl Part for BidResponseWithoutBidsStatusRow {}
+
+
+/// Represents a whole calendar date, e.g. date of birth. The time of day and
+/// time zone are either specified elsewhere or are not significant. The date
+/// is relative to the Proleptic Gregorian Calendar. The day may be 0 to
+/// represent a year and month where the day is not significant, e.g. credit card
+/// expiration date. The year may be 0 to represent a month and day independent
+/// of year, e.g. anniversary date. Related types are google.type.TimeOfDay
+/// and `google.protobuf.Timestamp`.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Date {
+    /// Year of date. Must be from 1 to 9999, or 0 if specifying a date without
+    /// a year.
+    pub year: Option<i32>,
+    /// Day of month. Must be from 1 to 31 and valid for the year and month, or 0
+    /// if specifying a year/month where the day is not significant.
+    pub day: Option<i32>,
+    /// Month of year. Must be from 1 to 12.
+    pub month: Option<i32>,
+}
+
+impl Part for Date {}
+
+
+/// Native content for a creative.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct NativeContent {
+    /// A long description of the ad.
+    pub body: Option<String>,
+    /// The URL to fetch a native video ad.
+    #[serde(rename="videoUrl")]
+    pub video_url: Option<String>,
+    /// A short title for the ad.
+    pub headline: Option<String>,
+    /// A large image.
+    pub image: Option<Image>,
+    /// The URL to use for click tracking.
+    #[serde(rename="clickTrackingUrl")]
+    pub click_tracking_url: Option<String>,
+    /// The app rating in the app store. Must be in the range [0-5].
+    #[serde(rename="starRating")]
+    pub star_rating: Option<f64>,
+    /// The name of the advertiser or sponsor, to be displayed in the ad creative.
+    #[serde(rename="advertiserName")]
+    pub advertiser_name: Option<String>,
+    /// The price of the promoted app including currency info.
+    #[serde(rename="priceDisplayText")]
+    pub price_display_text: Option<String>,
+    /// A label for the button that the user is supposed to click.
+    #[serde(rename="callToAction")]
+    pub call_to_action: Option<String>,
+    /// The app icon, for app download ads.
+    #[serde(rename="appIcon")]
+    pub app_icon: Option<Image>,
+    /// A smaller image, for the advertiser's logo.
+    pub logo: Option<Image>,
+    /// The URL to the app store to purchase/download the promoted app.
+    #[serde(rename="storeUrl")]
+    pub store_url: Option<String>,
+    /// The URL that the browser/SDK will load when the user clicks the ad.
+    #[serde(rename="clickLinkUrl")]
+    pub click_link_url: Option<String>,
+}
+
+impl Part for NativeContent {}
+
+
+/// There is no detailed description.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [clients list accounts](struct.AccountClientListCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct ListClientsResponse {
+    /// A token to retrieve the next page of results.
+    /// Pass this value in the
+    /// ListClientsRequest.pageToken
+    /// field in the subsequent call to the
+    /// accounts.clients.list method
+    /// to retrieve the next page of results.
+    #[serde(rename="nextPageToken")]
+    pub next_page_token: Option<String>,
+    /// The returned list of clients.
+    pub clients: Option<Vec<Client>>,
+}
+
+impl ResponseResult for ListClientsResponse {}
+
+
+/// A client user is created under a client buyer and has restricted access to
+/// the Ad Exchange Marketplace and certain other sections
+/// of the Ad Exchange Buyer UI based on the role
+/// granted to the associated client buyer.
+/// 
+/// The only way a new client user can be created is via accepting an
+/// email invitation
+/// (see the
+/// accounts.clients.invitations.create
+/// method).
+/// 
+/// All fields are required unless otherwise specified.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [clients users update accounts](struct.AccountClientUserUpdateCall.html) (request|response)
+/// * [clients users get accounts](struct.AccountClientUserGetCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct ClientUser {
+    /// The status of the client user.
+    pub status: Option<String>,
+    /// Numerical account ID of the client buyer
+    /// with which the user is associated; the
+    /// buyer must be a client of the current sponsor buyer.
+    /// The value of this field is ignored in an update operation.
+    #[serde(rename="clientAccountId")]
+    pub client_account_id: Option<String>,
+    /// The unique numerical ID of the client user
+    /// that has accepted an invitation.
+    /// The value of this field is ignored in an update operation.
+    #[serde(rename="userId")]
+    pub user_id: Option<String>,
+    /// User's email address. The value of this field
+    /// is ignored in an update operation.
+    pub email: Option<String>,
+}
+
+impl RequestValue for ClientUser {}
+impl ResponseResult for ClientUser {}
+
+
+/// @OutputOnly The Geo criteria the restriction applies to.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct LocationContext {
+    /// IDs representing the geo location for this context.
+    /// Please refer to the
+    /// [geo-table.csv](https://storage.googleapis.com/adx-rtb-dictionaries/geo-table.csv)
+    /// file for different geo criteria IDs.
+    #[serde(rename="geoCriteriaIds")]
+    pub geo_criteria_ids: Option<Vec<i32>>,
+}
+
+impl Part for LocationContext {}
+
+
+/// An interval of time, with an absolute start and end.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct TimeInterval {
+    /// The timestamp marking the end of the range (exclusive) for which data is
+    /// included.
+    #[serde(rename="endTime")]
+    pub end_time: Option<String>,
+    /// The timestamp marking the start of the range (inclusive) for which data is
+    /// included.
+    #[serde(rename="startTime")]
+    pub start_time: Option<String>,
+}
+
+impl Part for TimeInterval {}
+
+
+/// Response message for listing the metrics that are measured in number of
+/// impressions.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [accounts filter sets impression metrics list bidders](struct.BidderAccountFilterSetImpressionMetricListCall.html) (response)
+/// * [filter sets impression metrics list bidders](struct.BidderFilterSetImpressionMetricListCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct ListImpressionMetricsResponse {
+    /// A token to retrieve the next page of results.
+    /// Pass this value in the
+    /// ListImpressionMetricsRequest.pageToken
+    /// field in the subsequent call to the impressionMetrics.list
+    /// method to retrieve the next page of results.
+    #[serde(rename="nextPageToken")]
+    pub next_page_token: Option<String>,
+    /// List of rows, each containing a set of impression metrics.
+    #[serde(rename="impressionMetricsRows")]
+    pub impression_metrics_rows: Option<Vec<ImpressionMetricsRow>>,
+}
+
+impl ResponseResult for ListImpressionMetricsResponse {}
+
+
+/// @OutputOnly A security context.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct SecurityContext {
+    /// The security types in this context.
+    pub securities: Option<Vec<String>>,
+}
+
+impl Part for SecurityContext {}
+
+
+/// A response for listing creative and deal associations
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [creatives deal associations list accounts](struct.AccountCreativeDealAssociationListCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct ListDealAssociationsResponse {
+    /// A token to retrieve the next page of results.
+    /// Pass this value in the
+    /// ListDealAssociationsRequest.page_token
+    /// field in the subsequent call to 'ListDealAssociation' method to retrieve
+    /// the next page of results.
+    #[serde(rename="nextPageToken")]
+    pub next_page_token: Option<String>,
+    /// The list of associations.
+    pub associations: Option<Vec<CreativeDealAssociation>>,
+}
+
+impl ResponseResult for ListDealAssociationsResponse {}
+
+
+/// A request for stopping notifications for changes to creative Status.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [creatives stop watching accounts](struct.AccountCreativeStopWatchingCall.html) (request)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct StopWatchingCreativeRequest { _never_set: Option<bool> }
+
+impl RequestValue for StopWatchingCreativeRequest {}
+
+
+/// A request for watching changes to creative Status.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [creatives watch accounts](struct.AccountCreativeWatchCall.html) (request)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct WatchCreativeRequest {
+    /// The Pub/Sub topic to publish notifications to.
+    /// This topic must already exist and must give permission to
+    /// ad-exchange-buyside-reports@google.com to write to the topic.
+    /// This should be the full resource name in
+    /// "projects/{project_id}/topics/{topic_id}" format.
+    pub topic: Option<String>,
+}
+
+impl RequestValue for WatchCreativeRequest {}
+
+
+/// A response for listing creatives.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [creatives list accounts](struct.AccountCreativeListCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct ListCreativesResponse {
+    /// A token to retrieve the next page of results.
+    /// Pass this value in the
+    /// ListCreativesRequest.page_token
+    /// field in the subsequent call to `ListCreatives` method to retrieve the next
+    /// page of results.
+    #[serde(rename="nextPageToken")]
+    pub next_page_token: Option<String>,
+    /// The list of creatives.
+    pub creatives: Option<Vec<Creative>>,
+}
+
+impl ResponseResult for ListCreativesResponse {}
+
+
+/// Response message for listing the metrics that are measured in number of bids.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [filter sets bid metrics list bidders](struct.BidderFilterSetBidMetricListCall.html) (response)
+/// * [accounts filter sets bid metrics list bidders](struct.BidderAccountFilterSetBidMetricListCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct ListBidMetricsResponse {
+    /// A token to retrieve the next page of results.
+    /// Pass this value in the
+    /// ListBidMetricsRequest.pageToken
+    /// field in the subsequent call to the bidMetrics.list
+    /// method to retrieve the next page of results.
+    #[serde(rename="nextPageToken")]
+    pub next_page_token: Option<String>,
+    /// List of rows, each containing a set of bid metrics.
+    #[serde(rename="bidMetricsRows")]
+    pub bid_metrics_rows: Option<Vec<BidMetricsRow>>,
+}
+
+impl ResponseResult for ListBidMetricsResponse {}
+
+
+/// HTML content for a creative.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct HtmlContent {
+    /// The HTML snippet that displays the ad when inserted in the web page.
+    pub snippet: Option<String>,
+    /// The width of the HTML snippet in pixels.
+    pub width: Option<i32>,
+    /// The height of the HTML snippet in pixels.
+    pub height: Option<i32>,
+}
+
+impl Part for HtmlContent {}
+
+
+/// Response message for listing all creatives associated with a given filtered
+/// bid reason.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [accounts filter sets filtered bids creatives list bidders](struct.BidderAccountFilterSetFilteredBidCreativeListCall.html) (response)
+/// * [filter sets filtered bids creatives list bidders](struct.BidderFilterSetFilteredBidCreativeListCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct ListCreativeStatusBreakdownByCreativeResponse {
+    /// A token to retrieve the next page of results.
+    /// Pass this value in the
+    /// ListCreativeStatusBreakdownByCreativeRequest.pageToken
+    /// field in the subsequent call to the filteredBids.creatives.list
+    /// method to retrieve the next page of results.
+    #[serde(rename="nextPageToken")]
+    pub next_page_token: Option<String>,
+    /// List of rows, with counts of bids with a given creative status aggregated
+    /// by creative.
+    #[serde(rename="filteredBidCreativeRows")]
+    pub filtered_bid_creative_rows: Option<Vec<FilteredBidCreativeRow>>,
+}
+
+impl ResponseResult for ListCreativeStatusBreakdownByCreativeResponse {}
+
+
+/// A client resource represents a client buyer&mdash;an agency,
+/// a brand, or an advertiser customer of the sponsor buyer.
+/// Users associated with the client buyer have restricted access to
+/// the Ad Exchange Marketplace and certain other sections
+/// of the Ad Exchange Buyer UI based on the role
+/// granted to the client buyer.
+/// All fields are required unless otherwise specified.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [clients update accounts](struct.AccountClientUpdateCall.html) (request|response)
+/// * [clients create accounts](struct.AccountClientCreateCall.html) (request|response)
+/// * [clients get accounts](struct.AccountClientGetCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Client {
+    /// The status of the client buyer.
+    pub status: Option<String>,
+    /// The globally-unique numerical ID of the client.
+    /// The value of this field is ignored in create and update operations.
+    #[serde(rename="clientAccountId")]
+    pub client_account_id: Option<String>,
+    /// The type of the client entity: `ADVERTISER`, `BRAND`, or `AGENCY`.
+    #[serde(rename="entityType")]
+    pub entity_type: Option<String>,
+    /// The name of the entity. This field is automatically fetched based on
+    /// the type and ID.
+    /// The value of this field is ignored in create and update operations.
+    #[serde(rename="entityName")]
+    pub entity_name: Option<String>,
+    /// Optional arbitrary unique identifier of this client buyer from the
+    /// standpoint of its Ad Exchange sponsor buyer.
+    /// 
+    /// This field can be used to associate a client buyer with the identifier
+    /// in the namespace of its sponsor buyer, lookup client buyers by that
+    /// identifier and verify whether an Ad Exchange counterpart of a given client
+    /// buyer already exists.
+    /// 
+    /// If present, must be unique among all the client buyers for its
+    /// Ad Exchange sponsor buyer.
+    #[serde(rename="partnerClientId")]
+    pub partner_client_id: Option<String>,
+    /// The role which is assigned to the client buyer. Each role implies a set of
+    /// permissions granted to the client. Must be one of `CLIENT_DEAL_VIEWER`,
+    /// `CLIENT_DEAL_NEGOTIATOR` or `CLIENT_DEAL_APPROVER`.
+    pub role: Option<String>,
+    /// Whether the client buyer will be visible to sellers.
+    #[serde(rename="visibleToSeller")]
+    pub visible_to_seller: Option<bool>,
+    /// Numerical identifier of the client entity.
+    /// The entity can be an advertiser, a brand, or an agency.
+    /// This identifier is unique among all the entities with the same type.
+    /// 
+    /// A list of all known advertisers with their identifiers is available in the
+    /// [advertisers.txt](https://storage.googleapis.com/adx-rtb-dictionaries/advertisers.txt)
+    /// file.
+    /// 
+    /// A list of all known brands with their identifiers is available in the
+    /// [brands.txt](https://storage.googleapis.com/adx-rtb-dictionaries/brands.txt)
+    /// file.
+    /// 
+    /// A list of all known agencies with their identifiers is available in the
+    /// [agencies.txt](https://storage.googleapis.com/adx-rtb-dictionaries/agencies.txt)
+    /// file.
+    #[serde(rename="entityId")]
+    pub entity_id: Option<String>,
+    /// Name used to represent this client to publishers.
+    /// You may have multiple clients that map to the same entity,
+    /// but for each client the combination of `clientName` and entity
+    /// must be unique.
+    /// You can specify this field as empty.
+    #[serde(rename="clientName")]
+    pub client_name: Option<String>,
+}
+
+impl RequestValue for Client {}
+impl ResponseResult for Client {}
+
+
+/// The number of bids with the specified dimension values that did not win the
+/// auction (either were filtered pre-auction or lost the auction), as described
+/// by the specified creative status.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct CreativeStatusRow {
+    /// The values of all dimensions associated with metric values in this row.
+    #[serde(rename="rowDimensions")]
+    pub row_dimensions: Option<RowDimensions>,
+    /// The ID of the creative status.
+    /// See [creative-status-codes](https://developers.google.com/ad-exchange/rtb/downloads/creative-status-codes).
+    #[serde(rename="creativeStatusId")]
+    pub creative_status_id: Option<i32>,
+    /// The number of bids with the specified status.
+    #[serde(rename="bidCount")]
+    pub bid_count: Option<MetricValue>,
+}
+
+impl Part for CreativeStatusRow {}
+
+
+/// @OutputOnly Shows any corrections that were applied to this creative.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Correction {
+    /// The contexts for the correction.
+    pub contexts: Option<Vec<ServingContext>>,
+    /// The type of correction that was applied to the creative.
+    #[serde(rename="type")]
+    pub type_: Option<String>,
+    /// Additional details about what was corrected.
+    pub details: Option<Vec<String>>,
+}
+
+impl Part for Correction {}
+
+
+/// @OutputOnly The type of platform the restriction applies to.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct PlatformContext {
+    /// The platforms this restriction applies to.
+    pub platforms: Option<Vec<String>>,
+}
+
+impl Part for PlatformContext {}
+
+
+/// The number of filtered bids with the specified dimension values, among those
+/// filtered due to the requested filtering reason (i.e. creative status), that
+/// have the specified detail.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct FilteredBidDetailRow {
+    /// The ID of the detail. The associated value can be looked up in the
+    /// dictionary file corresponding to the DetailType in the response message.
+    #[serde(rename="detailId")]
+    pub detail_id: Option<i32>,
+    /// The values of all dimensions associated with metric values in this row.
+    #[serde(rename="rowDimensions")]
+    pub row_dimensions: Option<RowDimensions>,
+    /// The number of bids with the specified detail.
+    #[serde(rename="bidCount")]
+    pub bid_count: Option<MetricValue>,
+}
+
+impl Part for FilteredBidDetailRow {}
+
+
+/// @OutputOnly A representation of the status of an ad in a
+/// specific context. A context here relates to where something ultimately serves
+/// (for example, a user or publisher geo, a platform, an HTTPS vs HTTP request,
+/// or the type of auction).
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct ServingRestriction {
+    /// The contexts for the restriction.
+    pub contexts: Option<Vec<ServingContext>>,
+    /// The status of the creative in this context (for example, it has been
+    /// explicitly disapproved or is pending review).
+    pub status: Option<String>,
+    /// Any disapprovals bound to this restriction.
+    /// Only present if status=DISAPPROVED.
+    /// Can be used to filter the response of the
+    /// creatives.list
+    /// method.
+    #[serde(rename="disapprovalReasons")]
+    pub disapproval_reasons: Option<Vec<Disapproval>>,
+}
+
+impl Part for ServingRestriction {}
+
+
+/// A request for associating a deal and a creative.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [creatives deal associations add accounts](struct.AccountCreativeDealAssociationAddCall.html) (request)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct AddDealAssociationRequest {
+    /// The association between a creative and a deal that should be added.
+    pub association: Option<CreativeDealAssociation>,
+}
+
+impl RequestValue for AddDealAssociationRequest {}
+
+
+/// The number of winning bids with the specified dimension values for which the
+/// buyer was not billed, as described by the specified status.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct NonBillableWinningBidStatusRow {
+    /// The status specifying why the winning bids were not billed.
+    pub status: Option<String>,
+    /// The number of bids with the specified status.
+    #[serde(rename="bidCount")]
+    pub bid_count: Option<MetricValue>,
+    /// The values of all dimensions associated with metric values in this row.
+    #[serde(rename="rowDimensions")]
+    pub row_dimensions: Option<RowDimensions>,
+}
+
+impl Part for NonBillableWinningBidStatusRow {}
+
+
+/// An image resource. You may provide a larger image than was requested,
+/// so long as the aspect ratio is preserved.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Image {
+    /// The URL of the image.
+    pub url: Option<String>,
+    /// Image width in pixels.
+    pub width: Option<i32>,
+    /// Image height in pixels.
+    pub height: Option<i32>,
+}
+
+impl Part for Image {}
+
+
+/// The serving context for this restriction.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct ServingContext {
+    /// Matches impressions coming from a particular platform.
+    pub platform: Option<PlatformContext>,
+    /// Matches all contexts.
+    pub all: Option<String>,
+    /// Matches impressions coming from users *or* publishers in a specific
+    /// location.
+    pub location: Option<LocationContext>,
+    /// Matches impressions for a particular app type.
+    #[serde(rename="appType")]
+    pub app_type: Option<AppContext>,
+    /// Matches impressions for a particular auction type.
+    #[serde(rename="auctionType")]
+    pub auction_type: Option<AuctionContext>,
+    /// Matches impressions for a particular security type.
+    #[serde(rename="securityType")]
+    pub security_type: Option<SecurityContext>,
+}
+
+impl Part for ServingContext {}
+
+
+/// There is no detailed description.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [clients invitations list accounts](struct.AccountClientInvitationListCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct ListClientUserInvitationsResponse {
+    /// A token to retrieve the next page of results.
+    /// Pass this value in the
+    /// ListClientUserInvitationsRequest.pageToken
+    /// field in the subsequent call to the
+    /// clients.invitations.list
+    /// method to retrieve the next
+    /// page of results.
+    #[serde(rename="nextPageToken")]
+    pub next_page_token: Option<String>,
+    /// The returned list of client users.
+    pub invitations: Option<Vec<ClientUserInvitation>>,
+}
+
+impl ResponseResult for ListClientUserInvitationsResponse {}
+
+
+/// @OutputOnly The auction type the restriction applies to.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct AuctionContext {
+    /// The auction types this restriction applies to.
+    #[serde(rename="auctionTypes")]
+    pub auction_types: Option<Vec<String>>,
+}
+
+impl Part for AuctionContext {}
+
+
+/// The set of metrics that are measured in numbers of impressions, representing
+/// how many impressions with the specified dimension values were considered
+/// eligible at each stage of the bidding funnel.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct ImpressionMetricsRow {
+    /// The number of impressions available to the buyer on Ad Exchange.
+    /// In some cases this value may be unavailable.
+    #[serde(rename="availableImpressions")]
+    pub available_impressions: Option<MetricValue>,
+    /// The number of impressions for which Ad Exchange received a response from
+    /// the buyer that contained at least one applicable bid.
+    #[serde(rename="responsesWithBids")]
+    pub responses_with_bids: Option<MetricValue>,
+    /// The values of all dimensions associated with metric values in this row.
+    #[serde(rename="rowDimensions")]
+    pub row_dimensions: Option<RowDimensions>,
+    /// The number of impressions for which the buyer successfully sent a response
+    /// to Ad Exchange.
+    #[serde(rename="successfulResponses")]
+    pub successful_responses: Option<MetricValue>,
+    /// The number of impressions that match the buyer's inventory pretargeting.
+    #[serde(rename="inventoryMatches")]
+    pub inventory_matches: Option<MetricValue>,
+    /// The number of impressions for which Ad Exchange sent the buyer a bid
+    /// request.
+    #[serde(rename="bidRequests")]
+    pub bid_requests: Option<MetricValue>,
+}
+
+impl Part for ImpressionMetricsRow {}
+
+
+/// The set of metrics that are measured in numbers of bids, representing how
+/// many bids with the specified dimension values were considered eligible at
+/// each stage of the bidding funnel;
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct BidMetricsRow {
+    /// The number of bids that won an impression.
+    #[serde(rename="impressionsWon")]
+    pub impressions_won: Option<MetricValue>,
+    /// The values of all dimensions associated with metric values in this row.
+    #[serde(rename="rowDimensions")]
+    pub row_dimensions: Option<RowDimensions>,
+    /// The number of bids for which the buyer was billed.
+    #[serde(rename="billedImpressions")]
+    pub billed_impressions: Option<MetricValue>,
+    /// The number of bids for which the corresponding impression was viewable (as
+    /// defined by Active View).
+    #[serde(rename="viewableImpressions")]
+    pub viewable_impressions: Option<MetricValue>,
+    /// The number of bids that were permitted to compete in the auction.
+    #[serde(rename="bidsInAuction")]
+    pub bids_in_auction: Option<MetricValue>,
+    /// The number of bids for which the corresponding impression was measurable
+    /// for viewability (as defined by Active View).
+    #[serde(rename="measurableImpressions")]
+    pub measurable_impressions: Option<MetricValue>,
+    /// The number of bids that Ad Exchange received from the buyer.
+    pub bids: Option<MetricValue>,
+}
+
+impl Part for BidMetricsRow {}
+
+
+/// The association between a creative and a deal.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct CreativeDealAssociation {
+    /// The externalDealId for the deal associated with the creative.
+    #[serde(rename="dealsId")]
+    pub deals_id: Option<String>,
+    /// The ID of the creative associated with the deal.
+    #[serde(rename="creativeId")]
+    pub creative_id: Option<String>,
+    /// The account the creative belongs to.
+    #[serde(rename="accountId")]
+    pub account_id: Option<String>,
+}
+
+impl Part for CreativeDealAssociation {}
+
+
+/// Response message for listing all reasons that bids lost in the auction.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [filter sets losing bids list bidders](struct.BidderFilterSetLosingBidListCall.html) (response)
+/// * [accounts filter sets losing bids list bidders](struct.BidderAccountFilterSetLosingBidListCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct ListLosingBidsResponse {
+    /// A token to retrieve the next page of results.
+    /// Pass this value in the
+    /// ListLosingBidsRequest.pageToken
+    /// field in the subsequent call to the losingBids.list
+    /// method to retrieve the next page of results.
+    #[serde(rename="nextPageToken")]
+    pub next_page_token: Option<String>,
+    /// List of rows, with counts of losing bids aggregated by loss reason (i.e.
+    /// creative status).
+    #[serde(rename="creativeStatusRows")]
+    pub creative_status_rows: Option<Vec<CreativeStatusRow>>,
+}
+
+impl ResponseResult for ListLosingBidsResponse {}
+
+
+/// An open-ended realtime time range specified by the start timestamp.
+/// For filter sets that specify a realtime time range RTB metrics continue to
+/// be aggregated throughout the lifetime of the filter set.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct RealtimeTimeRange {
+    /// The start timestamp of the real-time RTB metrics aggregation.
+    #[serde(rename="startTimestamp")]
+    pub start_timestamp: Option<String>,
+}
+
+impl Part for RealtimeTimeRange {}
+
+
+/// A set of filters that is applied to a request for data.
+/// Within a filter set, an AND operation is performed across the filters
+/// represented by each field. An OR operation is performed across the filters
+/// represented by the multiple values of a repeated field. E.g.
+/// "format=VIDEO AND deal_id=12 AND (seller_network_id=34 OR
+/// seller_network_id=56)"
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [accounts filter sets create bidders](struct.BidderAccountFilterSetCreateCall.html) (request|response)
+/// * [filter sets get bidders](struct.BidderFilterSetGetCall.html) (response)
+/// * [accounts filter sets get bidders](struct.BidderAccountFilterSetGetCall.html) (response)
+/// * [filter sets create bidders](struct.BidderFilterSetCreateCall.html) (request|response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct FilterSet {
+    /// A user-defined name of the filter set. Filter set names must be unique
+    /// globally and match one of the patterns:
+    /// 
+    /// - `bidders/*/filterSets/*` (for accessing bidder-level troubleshooting
+    /// data)
+    /// - `bidders/*/accounts/*/filterSets/*` (for accessing account-level
+    /// troubleshooting data)
+    /// 
+    /// This field is required in create operations.
+    pub name: Option<String>,
+    /// DEPRECATED: use repeated formats field instead.
+    /// The format on which to filter; optional.
+    pub format: Option<String>,
+    /// The list of IDs of the seller (publisher) networks on which to filter;
+    /// may be empty. The filters represented by multiple seller network IDs are
+    /// ORed together (i.e. if non-empty, results must match any one of the
+    /// publisher networks).
+    /// See [seller-network-ids](https://developers.google.com/ad-exchange/rtb/downloads/seller-network-ids)
+    /// file for the set of existing seller network IDs.
+    #[serde(rename="sellerNetworkIds")]
+    pub seller_network_ids: Option<Vec<i32>>,
+    /// A relative date range, defined by an offset from today and a duration.
+    /// Interpreted relative to Pacific time zone.
+    #[serde(rename="relativeDateRange")]
+    pub relative_date_range: Option<RelativeDateRange>,
+    /// An open-ended realtime time range, defined by the aggregation start
+    /// timestamp.
+    #[serde(rename="realtimeTimeRange")]
+    pub realtime_time_range: Option<RealtimeTimeRange>,
+    /// The ID of the deal on which to filter; optional. This field may be set
+    /// only for a filter set that accesses account-level troubleshooting data,
+    /// i.e. one whose name matches the `bidders/*/accounts/*/filterSets/*`
+    /// pattern.
+    #[serde(rename="dealId")]
+    pub deal_id: Option<String>,
+    /// The environment on which to filter; optional.
+    pub environment: Option<String>,
+    /// The list of platforms on which to filter; may be empty. The filters
+    /// represented by multiple platforms are ORed together (i.e. if non-empty,
+    /// results must match any one of the platforms).
+    pub platforms: Option<Vec<String>>,
+    /// An absolute date range, defined by a start date and an end date.
+    /// Interpreted relative to Pacific time zone.
+    #[serde(rename="absoluteDateRange")]
+    pub absolute_date_range: Option<AbsoluteDateRange>,
+    /// The list of formats on which to filter; may be empty. The filters
+    /// represented by multiple formats are ORed together (i.e. if non-empty,
+    /// results must match any one of the formats).
+    pub formats: Option<Vec<String>>,
+    /// The ID of the creative on which to filter; optional. This field may be set
+    /// only for a filter set that accesses account-level troubleshooting data,
+    /// i.e. one whose name matches the `bidders/*/accounts/*/filterSets/*`
+    /// pattern.
+    #[serde(rename="creativeId")]
+    pub creative_id: Option<String>,
+    /// The granularity of time intervals if a time series breakdown is desired;
+    /// optional.
+    #[serde(rename="timeSeriesGranularity")]
+    pub time_series_granularity: Option<String>,
+}
+
+impl RequestValue for FilterSet {}
+impl ResponseResult for FilterSet {}
+
+
+/// There is no detailed description.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [clients users list accounts](struct.AccountClientUserListCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct ListClientUsersResponse {
+    /// A token to retrieve the next page of results.
+    /// Pass this value in the
+    /// ListClientUsersRequest.pageToken
+    /// field in the subsequent call to the
+    /// clients.invitations.list
+    /// method to retrieve the next
+    /// page of results.
+    #[serde(rename="nextPageToken")]
+    pub next_page_token: Option<String>,
+    /// The returned list of client users.
+    pub users: Option<Vec<ClientUser>>,
+}
+
+impl ResponseResult for ListClientUsersResponse {}
+
+
+/// Response message for listing all reasons for which a buyer was not billed for
+/// a winning bid.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [filter sets non billable winning bids list bidders](struct.BidderFilterSetNonBillableWinningBidListCall.html) (response)
+/// * [accounts filter sets non billable winning bids list bidders](struct.BidderAccountFilterSetNonBillableWinningBidListCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct ListNonBillableWinningBidsResponse {
+    /// A token to retrieve the next page of results.
+    /// Pass this value in the
+    /// ListNonBillableWinningBidsRequest.pageToken
+    /// field in the subsequent call to the nonBillableWinningBids.list
+    /// method to retrieve the next page of results.
+    #[serde(rename="nextPageToken")]
+    pub next_page_token: Option<String>,
+    /// List of rows, with counts of bids not billed aggregated by reason.
+    #[serde(rename="nonBillableWinningBidStatusRows")]
+    pub non_billable_winning_bid_status_rows: Option<Vec<NonBillableWinningBidStatusRow>>,
+}
+
+impl ResponseResult for ListNonBillableWinningBidsResponse {}
+
+
+
+// ###################
+// MethodBuilders ###
+// #################
+
+/// A builder providing access to all methods supported on *bidder* resources.
+/// It is not used directly, but through the `AdExchangeBuyerII` hub.
+///
+/// # Example
+///
+/// Instantiate a resource builder
+///
+/// ```test_harness,no_run
+/// extern crate hyper;
+/// extern crate hyper_rustls;
+/// extern crate yup_oauth2 as oauth2;
+/// extern crate google_adexchangebuyer2_v2_beta1 as adexchangebuyer2_v2_beta1;
+/// 
+/// # #[test] fn egal() {
+/// use std::default::Default;
+/// use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// use adexchangebuyer2_v2_beta1::AdExchangeBuyerII;
+/// 
+/// let secret: ApplicationSecret = Default::default();
+/// let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+///                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+///                               <MemoryStorage as Default>::default(), None);
+/// let mut hub = AdExchangeBuyerII::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // Usually you wouldn't bind this to a variable, but keep calling *CallBuilders*
+/// // like `accounts_filter_sets_bid_metrics_list(...)`, `accounts_filter_sets_bid_response_errors_list(...)`, `accounts_filter_sets_bid_responses_without_bids_list(...)`, `accounts_filter_sets_create(...)`, `accounts_filter_sets_delete(...)`, `accounts_filter_sets_filtered_bid_requests_list(...)`, `accounts_filter_sets_filtered_bids_creatives_list(...)`, `accounts_filter_sets_filtered_bids_details_list(...)`, `accounts_filter_sets_filtered_bids_list(...)`, `accounts_filter_sets_get(...)`, `accounts_filter_sets_impression_metrics_list(...)`, `accounts_filter_sets_list(...)`, `accounts_filter_sets_losing_bids_list(...)`, `accounts_filter_sets_non_billable_winning_bids_list(...)`, `filter_sets_bid_metrics_list(...)`, `filter_sets_bid_response_errors_list(...)`, `filter_sets_bid_responses_without_bids_list(...)`, `filter_sets_create(...)`, `filter_sets_delete(...)`, `filter_sets_filtered_bid_requests_list(...)`, `filter_sets_filtered_bids_creatives_list(...)`, `filter_sets_filtered_bids_details_list(...)`, `filter_sets_filtered_bids_list(...)`, `filter_sets_get(...)`, `filter_sets_impression_metrics_list(...)`, `filter_sets_list(...)`, `filter_sets_losing_bids_list(...)` and `filter_sets_non_billable_winning_bids_list(...)`
+/// // to build up your call.
+/// let rb = hub.bidders();
+/// # }
+/// ```
+pub struct BidderMethods<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a AdExchangeBuyerII<C, A>,
+}
+
+impl<'a, C, A> MethodsBuilder for BidderMethods<'a, C, A> {}
+
+impl<'a, C, A> BidderMethods<'a, C, A> {
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Retrieves the requested filter set for the account with the given account
+    /// ID.
+    /// 
+    /// # Arguments
+    ///
+    /// * `name` - Full name of the resource being requested.
+    ///            For example:
+    ///            - For a bidder-level filter set for bidder 123:
+    ///              `bidders/123/filterSets/abc`
+    ///            - For an account-level filter set for the buyer account representing bidder
+    ///              123: `bidders/123/accounts/123/filterSets/abc`
+    ///            - For an account-level filter set for the child seat buyer account 456
+    ///              whose bidder is 123: `bidders/123/accounts/456/filterSets/abc`
+    pub fn accounts_filter_sets_get(&self, name: &str) -> BidderAccountFilterSetGetCall<'a, C, A> {
+        BidderAccountFilterSetGetCall {
+            hub: self.hub,
+            _name: name.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// List all reasons for which bids were filtered, with the number of bids
+    /// filtered for each reason.
+    /// 
+    /// # Arguments
+    ///
+    /// * `filterSetName` - Name of the filter set that should be applied to the requested metrics.
+    ///                     For example:
+    ///                     - For a bidder-level filter set for bidder 123:
+    ///                       `bidders/123/filterSets/abc`
+    ///                     - For an account-level filter set for the buyer account representing bidder
+    ///                       123: `bidders/123/accounts/123/filterSets/abc`
+    ///                     - For an account-level filter set for the child seat buyer account 456
+    ///                       whose bidder is 123: `bidders/123/accounts/456/filterSets/abc`
+    pub fn filter_sets_filtered_bids_list(&self, filter_set_name: &str) -> BidderFilterSetFilteredBidListCall<'a, C, A> {
+        BidderFilterSetFilteredBidListCall {
+            hub: self.hub,
+            _filter_set_name: filter_set_name.to_string(),
+            _page_token: Default::default(),
+            _page_size: Default::default(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Lists all filter sets for the account with the given account ID.
+    /// 
+    /// # Arguments
+    ///
+    /// * `ownerName` - Name of the owner (bidder or account) of the filter sets to be listed.
+    ///                 For example:
+    ///                 - For a bidder-level filter set for bidder 123: `bidders/123`
+    ///                 - For an account-level filter set for the buyer account representing bidder
+    ///                   123: `bidders/123/accounts/123`
+    ///                 - For an account-level filter set for the child seat buyer account 456
+    ///                   whose bidder is 123: `bidders/123/accounts/456`
+    pub fn filter_sets_list(&self, owner_name: &str) -> BidderFilterSetListCall<'a, C, A> {
+        BidderFilterSetListCall {
+            hub: self.hub,
+            _owner_name: owner_name.to_string(),
+            _page_token: Default::default(),
+            _page_size: Default::default(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Creates the specified filter set for the account with the given account ID.
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    /// * `ownerName` - Name of the owner (bidder or account) of the filter set to be created.
+    ///                 For example:
+    ///                 - For a bidder-level filter set for bidder 123: `bidders/123`
+    ///                 - For an account-level filter set for the buyer account representing bidder
+    ///                   123: `bidders/123/accounts/123`
+    ///                 - For an account-level filter set for the child seat buyer account 456
+    ///                   whose bidder is 123: `bidders/123/accounts/456`
+    pub fn accounts_filter_sets_create(&self, request: FilterSet, owner_name: &str) -> BidderAccountFilterSetCreateCall<'a, C, A> {
+        BidderAccountFilterSetCreateCall {
+            hub: self.hub,
+            _request: request,
+            _owner_name: owner_name.to_string(),
+            _is_transient: Default::default(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Lists all metrics that are measured in terms of number of bids.
+    /// 
+    /// # Arguments
+    ///
+    /// * `filterSetName` - Name of the filter set that should be applied to the requested metrics.
+    ///                     For example:
+    ///                     - For a bidder-level filter set for bidder 123:
+    ///                       `bidders/123/filterSets/abc`
+    ///                     - For an account-level filter set for the buyer account representing bidder
+    ///                       123: `bidders/123/accounts/123/filterSets/abc`
+    ///                     - For an account-level filter set for the child seat buyer account 456
+    ///                       whose bidder is 123: `bidders/123/accounts/456/filterSets/abc`
+    pub fn accounts_filter_sets_bid_metrics_list(&self, filter_set_name: &str) -> BidderAccountFilterSetBidMetricListCall<'a, C, A> {
+        BidderAccountFilterSetBidMetricListCall {
+            hub: self.hub,
+            _filter_set_name: filter_set_name.to_string(),
+            _page_token: Default::default(),
+            _page_size: Default::default(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// List all creatives associated with a specific reason for which bids were
+    /// filtered, with the number of bids filtered for each creative.
+    /// 
+    /// # Arguments
+    ///
+    /// * `filterSetName` - Name of the filter set that should be applied to the requested metrics.
+    ///                     For example:
+    ///                     - For a bidder-level filter set for bidder 123:
+    ///                       `bidders/123/filterSets/abc`
+    ///                     - For an account-level filter set for the buyer account representing bidder
+    ///                       123: `bidders/123/accounts/123/filterSets/abc`
+    ///                     - For an account-level filter set for the child seat buyer account 456
+    ///                       whose bidder is 123: `bidders/123/accounts/456/filterSets/abc`
+    /// * `creativeStatusId` - The ID of the creative status for which to retrieve a breakdown by
+    ///                        creative.
+    ///                        See
+    ///                        [creative-status-codes](https://developers.google.com/ad-exchange/rtb/downloads/creative-status-codes).
+    pub fn accounts_filter_sets_filtered_bids_creatives_list(&self, filter_set_name: &str, creative_status_id: i32) -> BidderAccountFilterSetFilteredBidCreativeListCall<'a, C, A> {
+        BidderAccountFilterSetFilteredBidCreativeListCall {
+            hub: self.hub,
+            _filter_set_name: filter_set_name.to_string(),
+            _creative_status_id: creative_status_id,
+            _page_token: Default::default(),
+            _page_size: Default::default(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Deletes the requested filter set from the account with the given account
+    /// ID.
+    /// 
+    /// # Arguments
+    ///
+    /// * `name` - Full name of the resource to delete.
+    ///            For example:
+    ///            - For a bidder-level filter set for bidder 123:
+    ///              `bidders/123/filterSets/abc`
+    ///            - For an account-level filter set for the buyer account representing bidder
+    ///              123: `bidders/123/accounts/123/filterSets/abc`
+    ///            - For an account-level filter set for the child seat buyer account 456
+    ///              whose bidder is 123: `bidders/123/accounts/456/filterSets/abc`
+    pub fn accounts_filter_sets_delete(&self, name: &str) -> BidderAccountFilterSetDeleteCall<'a, C, A> {
+        BidderAccountFilterSetDeleteCall {
+            hub: self.hub,
+            _name: name.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// List all reasons that caused a bid request not to be sent for an
+    /// impression, with the number of bid requests not sent for each reason.
+    /// 
+    /// # Arguments
+    ///
+    /// * `filterSetName` - Name of the filter set that should be applied to the requested metrics.
+    ///                     For example:
+    ///                     - For a bidder-level filter set for bidder 123:
+    ///                       `bidders/123/filterSets/abc`
+    ///                     - For an account-level filter set for the buyer account representing bidder
+    ///                       123: `bidders/123/accounts/123/filterSets/abc`
+    ///                     - For an account-level filter set for the child seat buyer account 456
+    ///                       whose bidder is 123: `bidders/123/accounts/456/filterSets/abc`
+    pub fn accounts_filter_sets_filtered_bid_requests_list(&self, filter_set_name: &str) -> BidderAccountFilterSetFilteredBidRequestListCall<'a, C, A> {
+        BidderAccountFilterSetFilteredBidRequestListCall {
+            hub: self.hub,
+            _filter_set_name: filter_set_name.to_string(),
+            _page_token: Default::default(),
+            _page_size: Default::default(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// List all creatives associated with a specific reason for which bids were
+    /// filtered, with the number of bids filtered for each creative.
+    /// 
+    /// # Arguments
+    ///
+    /// * `filterSetName` - Name of the filter set that should be applied to the requested metrics.
+    ///                     For example:
+    ///                     - For a bidder-level filter set for bidder 123:
+    ///                       `bidders/123/filterSets/abc`
+    ///                     - For an account-level filter set for the buyer account representing bidder
+    ///                       123: `bidders/123/accounts/123/filterSets/abc`
+    ///                     - For an account-level filter set for the child seat buyer account 456
+    ///                       whose bidder is 123: `bidders/123/accounts/456/filterSets/abc`
+    /// * `creativeStatusId` - The ID of the creative status for which to retrieve a breakdown by
+    ///                        creative.
+    ///                        See
+    ///                        [creative-status-codes](https://developers.google.com/ad-exchange/rtb/downloads/creative-status-codes).
+    pub fn filter_sets_filtered_bids_creatives_list(&self, filter_set_name: &str, creative_status_id: i32) -> BidderFilterSetFilteredBidCreativeListCall<'a, C, A> {
+        BidderFilterSetFilteredBidCreativeListCall {
+            hub: self.hub,
+            _filter_set_name: filter_set_name.to_string(),
+            _creative_status_id: creative_status_id,
+            _page_token: Default::default(),
+            _page_size: Default::default(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Retrieves the requested filter set for the account with the given account
+    /// ID.
+    /// 
+    /// # Arguments
+    ///
+    /// * `name` - Full name of the resource being requested.
+    ///            For example:
+    ///            - For a bidder-level filter set for bidder 123:
+    ///              `bidders/123/filterSets/abc`
+    ///            - For an account-level filter set for the buyer account representing bidder
+    ///              123: `bidders/123/accounts/123/filterSets/abc`
+    ///            - For an account-level filter set for the child seat buyer account 456
+    ///              whose bidder is 123: `bidders/123/accounts/456/filterSets/abc`
+    pub fn filter_sets_get(&self, name: &str) -> BidderFilterSetGetCall<'a, C, A> {
+        BidderFilterSetGetCall {
+            hub: self.hub,
+            _name: name.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Lists all filter sets for the account with the given account ID.
+    /// 
+    /// # Arguments
+    ///
+    /// * `ownerName` - Name of the owner (bidder or account) of the filter sets to be listed.
+    ///                 For example:
+    ///                 - For a bidder-level filter set for bidder 123: `bidders/123`
+    ///                 - For an account-level filter set for the buyer account representing bidder
+    ///                   123: `bidders/123/accounts/123`
+    ///                 - For an account-level filter set for the child seat buyer account 456
+    ///                   whose bidder is 123: `bidders/123/accounts/456`
+    pub fn accounts_filter_sets_list(&self, owner_name: &str) -> BidderAccountFilterSetListCall<'a, C, A> {
+        BidderAccountFilterSetListCall {
+            hub: self.hub,
+            _owner_name: owner_name.to_string(),
+            _page_token: Default::default(),
+            _page_size: Default::default(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// List all errors that occurred in bid responses, with the number of bid
+    /// responses affected for each reason.
+    /// 
+    /// # Arguments
+    ///
+    /// * `filterSetName` - Name of the filter set that should be applied to the requested metrics.
+    ///                     For example:
+    ///                     - For a bidder-level filter set for bidder 123:
+    ///                       `bidders/123/filterSets/abc`
+    ///                     - For an account-level filter set for the buyer account representing bidder
+    ///                       123: `bidders/123/accounts/123/filterSets/abc`
+    ///                     - For an account-level filter set for the child seat buyer account 456
+    ///                       whose bidder is 123: `bidders/123/accounts/456/filterSets/abc`
+    pub fn accounts_filter_sets_bid_response_errors_list(&self, filter_set_name: &str) -> BidderAccountFilterSetBidResponseErrorListCall<'a, C, A> {
+        BidderAccountFilterSetBidResponseErrorListCall {
+            hub: self.hub,
+            _filter_set_name: filter_set_name.to_string(),
+            _page_token: Default::default(),
+            _page_size: Default::default(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Deletes the requested filter set from the account with the given account
+    /// ID.
+    /// 
+    /// # Arguments
+    ///
+    /// * `name` - Full name of the resource to delete.
+    ///            For example:
+    ///            - For a bidder-level filter set for bidder 123:
+    ///              `bidders/123/filterSets/abc`
+    ///            - For an account-level filter set for the buyer account representing bidder
+    ///              123: `bidders/123/accounts/123/filterSets/abc`
+    ///            - For an account-level filter set for the child seat buyer account 456
+    ///              whose bidder is 123: `bidders/123/accounts/456/filterSets/abc`
+    pub fn filter_sets_delete(&self, name: &str) -> BidderFilterSetDeleteCall<'a, C, A> {
+        BidderFilterSetDeleteCall {
+            hub: self.hub,
+            _name: name.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Lists all metrics that are measured in terms of number of impressions.
+    /// 
+    /// # Arguments
+    ///
+    /// * `filterSetName` - Name of the filter set that should be applied to the requested metrics.
+    ///                     For example:
+    ///                     - For a bidder-level filter set for bidder 123:
+    ///                       `bidders/123/filterSets/abc`
+    ///                     - For an account-level filter set for the buyer account representing bidder
+    ///                       123: `bidders/123/accounts/123/filterSets/abc`
+    ///                     - For an account-level filter set for the child seat buyer account 456
+    ///                       whose bidder is 123: `bidders/123/accounts/456/filterSets/abc`
+    pub fn accounts_filter_sets_impression_metrics_list(&self, filter_set_name: &str) -> BidderAccountFilterSetImpressionMetricListCall<'a, C, A> {
+        BidderAccountFilterSetImpressionMetricListCall {
+            hub: self.hub,
+            _filter_set_name: filter_set_name.to_string(),
+            _page_token: Default::default(),
+            _page_size: Default::default(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// List all reasons for which bids lost in the auction, with the number of
+    /// bids that lost for each reason.
+    /// 
+    /// # Arguments
+    ///
+    /// * `filterSetName` - Name of the filter set that should be applied to the requested metrics.
+    ///                     For example:
+    ///                     - For a bidder-level filter set for bidder 123:
+    ///                       `bidders/123/filterSets/abc`
+    ///                     - For an account-level filter set for the buyer account representing bidder
+    ///                       123: `bidders/123/accounts/123/filterSets/abc`
+    ///                     - For an account-level filter set for the child seat buyer account 456
+    ///                       whose bidder is 123: `bidders/123/accounts/456/filterSets/abc`
+    pub fn filter_sets_losing_bids_list(&self, filter_set_name: &str) -> BidderFilterSetLosingBidListCall<'a, C, A> {
+        BidderFilterSetLosingBidListCall {
+            hub: self.hub,
+            _filter_set_name: filter_set_name.to_string(),
+            _page_token: Default::default(),
+            _page_size: Default::default(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// List all details associated with a specific reason for which bids were
+    /// filtered, with the number of bids filtered for each detail.
+    /// 
+    /// # Arguments
+    ///
+    /// * `filterSetName` - Name of the filter set that should be applied to the requested metrics.
+    ///                     For example:
+    ///                     - For a bidder-level filter set for bidder 123:
+    ///                       `bidders/123/filterSets/abc`
+    ///                     - For an account-level filter set for the buyer account representing bidder
+    ///                       123: `bidders/123/accounts/123/filterSets/abc`
+    ///                     - For an account-level filter set for the child seat buyer account 456
+    ///                       whose bidder is 123: `bidders/123/accounts/456/filterSets/abc`
+    /// * `creativeStatusId` - The ID of the creative status for which to retrieve a breakdown by detail.
+    ///                        See
+    ///                        [creative-status-codes](https://developers.google.com/ad-exchange/rtb/downloads/creative-status-codes).
+    ///                        Details are only available for statuses 10, 14, 15, 17, 18, 19, 86, and 87.
+    pub fn accounts_filter_sets_filtered_bids_details_list(&self, filter_set_name: &str, creative_status_id: i32) -> BidderAccountFilterSetFilteredBidDetailListCall<'a, C, A> {
+        BidderAccountFilterSetFilteredBidDetailListCall {
+            hub: self.hub,
+            _filter_set_name: filter_set_name.to_string(),
+            _creative_status_id: creative_status_id,
+            _page_token: Default::default(),
+            _page_size: Default::default(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// List all reasons for which bids were filtered, with the number of bids
+    /// filtered for each reason.
+    /// 
+    /// # Arguments
+    ///
+    /// * `filterSetName` - Name of the filter set that should be applied to the requested metrics.
+    ///                     For example:
+    ///                     - For a bidder-level filter set for bidder 123:
+    ///                       `bidders/123/filterSets/abc`
+    ///                     - For an account-level filter set for the buyer account representing bidder
+    ///                       123: `bidders/123/accounts/123/filterSets/abc`
+    ///                     - For an account-level filter set for the child seat buyer account 456
+    ///                       whose bidder is 123: `bidders/123/accounts/456/filterSets/abc`
+    pub fn accounts_filter_sets_filtered_bids_list(&self, filter_set_name: &str) -> BidderAccountFilterSetFilteredBidListCall<'a, C, A> {
+        BidderAccountFilterSetFilteredBidListCall {
+            hub: self.hub,
+            _filter_set_name: filter_set_name.to_string(),
+            _page_token: Default::default(),
+            _page_size: Default::default(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// List all reasons that caused a bid request not to be sent for an
+    /// impression, with the number of bid requests not sent for each reason.
+    /// 
+    /// # Arguments
+    ///
+    /// * `filterSetName` - Name of the filter set that should be applied to the requested metrics.
+    ///                     For example:
+    ///                     - For a bidder-level filter set for bidder 123:
+    ///                       `bidders/123/filterSets/abc`
+    ///                     - For an account-level filter set for the buyer account representing bidder
+    ///                       123: `bidders/123/accounts/123/filterSets/abc`
+    ///                     - For an account-level filter set for the child seat buyer account 456
+    ///                       whose bidder is 123: `bidders/123/accounts/456/filterSets/abc`
+    pub fn filter_sets_filtered_bid_requests_list(&self, filter_set_name: &str) -> BidderFilterSetFilteredBidRequestListCall<'a, C, A> {
+        BidderFilterSetFilteredBidRequestListCall {
+            hub: self.hub,
+            _filter_set_name: filter_set_name.to_string(),
+            _page_token: Default::default(),
+            _page_size: Default::default(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// List all reasons for which bid responses were considered to have no
+    /// applicable bids, with the number of bid responses affected for each reason.
+    /// 
+    /// # Arguments
+    ///
+    /// * `filterSetName` - Name of the filter set that should be applied to the requested metrics.
+    ///                     For example:
+    ///                     - For a bidder-level filter set for bidder 123:
+    ///                       `bidders/123/filterSets/abc`
+    ///                     - For an account-level filter set for the buyer account representing bidder
+    ///                       123: `bidders/123/accounts/123/filterSets/abc`
+    ///                     - For an account-level filter set for the child seat buyer account 456
+    ///                       whose bidder is 123: `bidders/123/accounts/456/filterSets/abc`
+    pub fn accounts_filter_sets_bid_responses_without_bids_list(&self, filter_set_name: &str) -> BidderAccountFilterSetBidResponsesWithoutBidListCall<'a, C, A> {
+        BidderAccountFilterSetBidResponsesWithoutBidListCall {
+            hub: self.hub,
+            _filter_set_name: filter_set_name.to_string(),
+            _page_token: Default::default(),
+            _page_size: Default::default(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// List all reasons for which bids lost in the auction, with the number of
+    /// bids that lost for each reason.
+    /// 
+    /// # Arguments
+    ///
+    /// * `filterSetName` - Name of the filter set that should be applied to the requested metrics.
+    ///                     For example:
+    ///                     - For a bidder-level filter set for bidder 123:
+    ///                       `bidders/123/filterSets/abc`
+    ///                     - For an account-level filter set for the buyer account representing bidder
+    ///                       123: `bidders/123/accounts/123/filterSets/abc`
+    ///                     - For an account-level filter set for the child seat buyer account 456
+    ///                       whose bidder is 123: `bidders/123/accounts/456/filterSets/abc`
+    pub fn accounts_filter_sets_losing_bids_list(&self, filter_set_name: &str) -> BidderAccountFilterSetLosingBidListCall<'a, C, A> {
+        BidderAccountFilterSetLosingBidListCall {
+            hub: self.hub,
+            _filter_set_name: filter_set_name.to_string(),
+            _page_token: Default::default(),
+            _page_size: Default::default(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// List all reasons for which winning bids were not billable, with the number
+    /// of bids not billed for each reason.
+    /// 
+    /// # Arguments
+    ///
+    /// * `filterSetName` - Name of the filter set that should be applied to the requested metrics.
+    ///                     For example:
+    ///                     - For a bidder-level filter set for bidder 123:
+    ///                       `bidders/123/filterSets/abc`
+    ///                     - For an account-level filter set for the buyer account representing bidder
+    ///                       123: `bidders/123/accounts/123/filterSets/abc`
+    ///                     - For an account-level filter set for the child seat buyer account 456
+    ///                       whose bidder is 123: `bidders/123/accounts/456/filterSets/abc`
+    pub fn filter_sets_non_billable_winning_bids_list(&self, filter_set_name: &str) -> BidderFilterSetNonBillableWinningBidListCall<'a, C, A> {
+        BidderFilterSetNonBillableWinningBidListCall {
+            hub: self.hub,
+            _filter_set_name: filter_set_name.to_string(),
+            _page_token: Default::default(),
+            _page_size: Default::default(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Lists all metrics that are measured in terms of number of impressions.
+    /// 
+    /// # Arguments
+    ///
+    /// * `filterSetName` - Name of the filter set that should be applied to the requested metrics.
+    ///                     For example:
+    ///                     - For a bidder-level filter set for bidder 123:
+    ///                       `bidders/123/filterSets/abc`
+    ///                     - For an account-level filter set for the buyer account representing bidder
+    ///                       123: `bidders/123/accounts/123/filterSets/abc`
+    ///                     - For an account-level filter set for the child seat buyer account 456
+    ///                       whose bidder is 123: `bidders/123/accounts/456/filterSets/abc`
+    pub fn filter_sets_impression_metrics_list(&self, filter_set_name: &str) -> BidderFilterSetImpressionMetricListCall<'a, C, A> {
+        BidderFilterSetImpressionMetricListCall {
+            hub: self.hub,
+            _filter_set_name: filter_set_name.to_string(),
+            _page_token: Default::default(),
+            _page_size: Default::default(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// List all details associated with a specific reason for which bids were
+    /// filtered, with the number of bids filtered for each detail.
+    /// 
+    /// # Arguments
+    ///
+    /// * `filterSetName` - Name of the filter set that should be applied to the requested metrics.
+    ///                     For example:
+    ///                     - For a bidder-level filter set for bidder 123:
+    ///                       `bidders/123/filterSets/abc`
+    ///                     - For an account-level filter set for the buyer account representing bidder
+    ///                       123: `bidders/123/accounts/123/filterSets/abc`
+    ///                     - For an account-level filter set for the child seat buyer account 456
+    ///                       whose bidder is 123: `bidders/123/accounts/456/filterSets/abc`
+    /// * `creativeStatusId` - The ID of the creative status for which to retrieve a breakdown by detail.
+    ///                        See
+    ///                        [creative-status-codes](https://developers.google.com/ad-exchange/rtb/downloads/creative-status-codes).
+    ///                        Details are only available for statuses 10, 14, 15, 17, 18, 19, 86, and 87.
+    pub fn filter_sets_filtered_bids_details_list(&self, filter_set_name: &str, creative_status_id: i32) -> BidderFilterSetFilteredBidDetailListCall<'a, C, A> {
+        BidderFilterSetFilteredBidDetailListCall {
+            hub: self.hub,
+            _filter_set_name: filter_set_name.to_string(),
+            _creative_status_id: creative_status_id,
+            _page_token: Default::default(),
+            _page_size: Default::default(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// List all errors that occurred in bid responses, with the number of bid
+    /// responses affected for each reason.
+    /// 
+    /// # Arguments
+    ///
+    /// * `filterSetName` - Name of the filter set that should be applied to the requested metrics.
+    ///                     For example:
+    ///                     - For a bidder-level filter set for bidder 123:
+    ///                       `bidders/123/filterSets/abc`
+    ///                     - For an account-level filter set for the buyer account representing bidder
+    ///                       123: `bidders/123/accounts/123/filterSets/abc`
+    ///                     - For an account-level filter set for the child seat buyer account 456
+    ///                       whose bidder is 123: `bidders/123/accounts/456/filterSets/abc`
+    pub fn filter_sets_bid_response_errors_list(&self, filter_set_name: &str) -> BidderFilterSetBidResponseErrorListCall<'a, C, A> {
+        BidderFilterSetBidResponseErrorListCall {
+            hub: self.hub,
+            _filter_set_name: filter_set_name.to_string(),
+            _page_token: Default::default(),
+            _page_size: Default::default(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// List all reasons for which winning bids were not billable, with the number
+    /// of bids not billed for each reason.
+    /// 
+    /// # Arguments
+    ///
+    /// * `filterSetName` - Name of the filter set that should be applied to the requested metrics.
+    ///                     For example:
+    ///                     - For a bidder-level filter set for bidder 123:
+    ///                       `bidders/123/filterSets/abc`
+    ///                     - For an account-level filter set for the buyer account representing bidder
+    ///                       123: `bidders/123/accounts/123/filterSets/abc`
+    ///                     - For an account-level filter set for the child seat buyer account 456
+    ///                       whose bidder is 123: `bidders/123/accounts/456/filterSets/abc`
+    pub fn accounts_filter_sets_non_billable_winning_bids_list(&self, filter_set_name: &str) -> BidderAccountFilterSetNonBillableWinningBidListCall<'a, C, A> {
+        BidderAccountFilterSetNonBillableWinningBidListCall {
+            hub: self.hub,
+            _filter_set_name: filter_set_name.to_string(),
+            _page_token: Default::default(),
+            _page_size: Default::default(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Lists all metrics that are measured in terms of number of bids.
+    /// 
+    /// # Arguments
+    ///
+    /// * `filterSetName` - Name of the filter set that should be applied to the requested metrics.
+    ///                     For example:
+    ///                     - For a bidder-level filter set for bidder 123:
+    ///                       `bidders/123/filterSets/abc`
+    ///                     - For an account-level filter set for the buyer account representing bidder
+    ///                       123: `bidders/123/accounts/123/filterSets/abc`
+    ///                     - For an account-level filter set for the child seat buyer account 456
+    ///                       whose bidder is 123: `bidders/123/accounts/456/filterSets/abc`
+    pub fn filter_sets_bid_metrics_list(&self, filter_set_name: &str) -> BidderFilterSetBidMetricListCall<'a, C, A> {
+        BidderFilterSetBidMetricListCall {
+            hub: self.hub,
+            _filter_set_name: filter_set_name.to_string(),
+            _page_token: Default::default(),
+            _page_size: Default::default(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// List all reasons for which bid responses were considered to have no
+    /// applicable bids, with the number of bid responses affected for each reason.
+    /// 
+    /// # Arguments
+    ///
+    /// * `filterSetName` - Name of the filter set that should be applied to the requested metrics.
+    ///                     For example:
+    ///                     - For a bidder-level filter set for bidder 123:
+    ///                       `bidders/123/filterSets/abc`
+    ///                     - For an account-level filter set for the buyer account representing bidder
+    ///                       123: `bidders/123/accounts/123/filterSets/abc`
+    ///                     - For an account-level filter set for the child seat buyer account 456
+    ///                       whose bidder is 123: `bidders/123/accounts/456/filterSets/abc`
+    pub fn filter_sets_bid_responses_without_bids_list(&self, filter_set_name: &str) -> BidderFilterSetBidResponsesWithoutBidListCall<'a, C, A> {
+        BidderFilterSetBidResponsesWithoutBidListCall {
+            hub: self.hub,
+            _filter_set_name: filter_set_name.to_string(),
+            _page_token: Default::default(),
+            _page_size: Default::default(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Creates the specified filter set for the account with the given account ID.
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    /// * `ownerName` - Name of the owner (bidder or account) of the filter set to be created.
+    ///                 For example:
+    ///                 - For a bidder-level filter set for bidder 123: `bidders/123`
+    ///                 - For an account-level filter set for the buyer account representing bidder
+    ///                   123: `bidders/123/accounts/123`
+    ///                 - For an account-level filter set for the child seat buyer account 456
+    ///                   whose bidder is 123: `bidders/123/accounts/456`
+    pub fn filter_sets_create(&self, request: FilterSet, owner_name: &str) -> BidderFilterSetCreateCall<'a, C, A> {
+        BidderFilterSetCreateCall {
+            hub: self.hub,
+            _request: request,
+            _owner_name: owner_name.to_string(),
+            _is_transient: Default::default(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+}
+
+
+
+/// A builder providing access to all methods supported on *account* resources.
+/// It is not used directly, but through the `AdExchangeBuyerII` hub.
+///
+/// # Example
+///
+/// Instantiate a resource builder
+///
+/// ```test_harness,no_run
+/// extern crate hyper;
+/// extern crate hyper_rustls;
+/// extern crate yup_oauth2 as oauth2;
+/// extern crate google_adexchangebuyer2_v2_beta1 as adexchangebuyer2_v2_beta1;
+/// 
+/// # #[test] fn egal() {
+/// use std::default::Default;
+/// use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// use adexchangebuyer2_v2_beta1::AdExchangeBuyerII;
+/// 
+/// let secret: ApplicationSecret = Default::default();
+/// let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+///                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+///                               <MemoryStorage as Default>::default(), None);
+/// let mut hub = AdExchangeBuyerII::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // Usually you wouldn't bind this to a variable, but keep calling *CallBuilders*
+/// // like `clients_create(...)`, `clients_get(...)`, `clients_invitations_create(...)`, `clients_invitations_get(...)`, `clients_invitations_list(...)`, `clients_list(...)`, `clients_update(...)`, `clients_users_get(...)`, `clients_users_list(...)`, `clients_users_update(...)`, `creatives_create(...)`, `creatives_deal_associations_add(...)`, `creatives_deal_associations_list(...)`, `creatives_deal_associations_remove(...)`, `creatives_get(...)`, `creatives_list(...)`, `creatives_stop_watching(...)`, `creatives_update(...)` and `creatives_watch(...)`
+/// // to build up your call.
+/// let rb = hub.accounts();
+/// # }
+/// ```
+pub struct AccountMethods<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a AdExchangeBuyerII<C, A>,
+}
+
+impl<'a, C, A> MethodsBuilder for AccountMethods<'a, C, A> {}
+
+impl<'a, C, A> AccountMethods<'a, C, A> {
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Associate an existing deal with a creative.
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    /// * `accountId` - The account the creative belongs to.
+    /// * `creativeId` - The ID of the creative associated with the deal.
+    pub fn creatives_deal_associations_add(&self, request: AddDealAssociationRequest, account_id: &str, creative_id: &str) -> AccountCreativeDealAssociationAddCall<'a, C, A> {
+        AccountCreativeDealAssociationAddCall {
+            hub: self.hub,
+            _request: request,
+            _account_id: account_id.to_string(),
+            _creative_id: creative_id.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Lists creatives.
+    /// 
+    /// # Arguments
+    ///
+    /// * `accountId` - The account to list the creatives from.
+    ///                 Specify "-" to list all creatives the current user has access to.
+    pub fn creatives_list(&self, account_id: &str) -> AccountCreativeListCall<'a, C, A> {
+        AccountCreativeListCall {
+            hub: self.hub,
+            _account_id: account_id.to_string(),
+            _query: Default::default(),
+            _page_token: Default::default(),
+            _page_size: Default::default(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Watches a creative. Will result in push notifications being sent to the
+    /// topic when the creative changes status.
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    /// * `accountId` - The account of the creative to watch.
+    /// * `creativeId` - The creative ID to watch for status changes.
+    ///                  Specify "-" to watch all creatives under the above account.
+    ///                  If both creative-level and account-level notifications are
+    ///                  sent, only a single notification will be sent to the
+    ///                  creative-level notification topic.
+    pub fn creatives_watch(&self, request: WatchCreativeRequest, account_id: &str, creative_id: &str) -> AccountCreativeWatchCall<'a, C, A> {
+        AccountCreativeWatchCall {
+            hub: self.hub,
+            _request: request,
+            _account_id: account_id.to_string(),
+            _creative_id: creative_id.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Updates an existing client buyer.
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    /// * `accountId` - Unique numerical account ID for the buyer of which the client buyer
+    ///                 is a customer; the sponsor buyer to update a client for. (required)
+    /// * `clientAccountId` - Unique numerical account ID of the client to update. (required)
+    pub fn clients_update(&self, request: Client, account_id: &str, client_account_id: &str) -> AccountClientUpdateCall<'a, C, A> {
+        AccountClientUpdateCall {
+            hub: self.hub,
+            _request: request,
+            _account_id: account_id.to_string(),
+            _client_account_id: client_account_id.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Retrieves an existing client user.
+    /// 
+    /// # Arguments
+    ///
+    /// * `accountId` - Numerical account ID of the client's sponsor buyer. (required)
+    /// * `clientAccountId` - Numerical account ID of the client buyer
+    ///                       that the user to be retrieved is associated with. (required)
+    /// * `userId` - Numerical identifier of the user to retrieve. (required)
+    pub fn clients_users_get(&self, account_id: &str, client_account_id: &str, user_id: &str) -> AccountClientUserGetCall<'a, C, A> {
+        AccountClientUserGetCall {
+            hub: self.hub,
+            _account_id: account_id.to_string(),
+            _client_account_id: client_account_id.to_string(),
+            _user_id: user_id.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Retrieves an existing client user invitation.
+    /// 
+    /// # Arguments
+    ///
+    /// * `accountId` - Numerical account ID of the client's sponsor buyer. (required)
+    /// * `clientAccountId` - Numerical account ID of the client buyer that the user invitation
+    ///                       to be retrieved is associated with. (required)
+    /// * `invitationId` - Numerical identifier of the user invitation to retrieve. (required)
+    pub fn clients_invitations_get(&self, account_id: &str, client_account_id: &str, invitation_id: &str) -> AccountClientInvitationGetCall<'a, C, A> {
+        AccountClientInvitationGetCall {
+            hub: self.hub,
+            _account_id: account_id.to_string(),
+            _client_account_id: client_account_id.to_string(),
+            _invitation_id: invitation_id.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Lists all the clients for the current sponsor buyer.
+    /// 
+    /// # Arguments
+    ///
+    /// * `accountId` - Unique numerical account ID of the sponsor buyer to list the clients for.
+    pub fn clients_list(&self, account_id: &str) -> AccountClientListCall<'a, C, A> {
+        AccountClientListCall {
+            hub: self.hub,
+            _account_id: account_id.to_string(),
+            _partner_client_id: Default::default(),
+            _page_token: Default::default(),
+            _page_size: Default::default(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Gets a creative.
+    /// 
+    /// # Arguments
+    ///
+    /// * `accountId` - The account the creative belongs to.
+    /// * `creativeId` - The ID of the creative to retrieve.
+    pub fn creatives_get(&self, account_id: &str, creative_id: &str) -> AccountCreativeGetCall<'a, C, A> {
+        AccountCreativeGetCall {
+            hub: self.hub,
+            _account_id: account_id.to_string(),
+            _creative_id: creative_id.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Creates a creative.
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    /// * `accountId` - The account that this creative belongs to.
+    ///                 Can be used to filter the response of the
+    ///                 creatives.list
+    ///                 method.
+    pub fn creatives_create(&self, request: Creative, account_id: &str) -> AccountCreativeCreateCall<'a, C, A> {
+        AccountCreativeCreateCall {
+            hub: self.hub,
+            _request: request,
+            _account_id: account_id.to_string(),
+            _duplicate_id_mode: Default::default(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Stops watching a creative. Will stop push notifications being sent to the
+    /// topics when the creative changes status.
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    /// * `accountId` - The account of the creative to stop notifications for.
+    /// * `creativeId` - The creative ID of the creative to stop notifications for.
+    ///                  Specify "-" to specify stopping account level notifications.
+    pub fn creatives_stop_watching(&self, request: StopWatchingCreativeRequest, account_id: &str, creative_id: &str) -> AccountCreativeStopWatchingCall<'a, C, A> {
+        AccountCreativeStopWatchingCall {
+            hub: self.hub,
+            _request: request,
+            _account_id: account_id.to_string(),
+            _creative_id: creative_id.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Updates an existing client user.
+    /// Only the user status can be changed on update.
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    /// * `accountId` - Numerical account ID of the client's sponsor buyer. (required)
+    /// * `clientAccountId` - Numerical account ID of the client buyer that the user to be retrieved
+    ///                       is associated with. (required)
+    /// * `userId` - Numerical identifier of the user to retrieve. (required)
+    pub fn clients_users_update(&self, request: ClientUser, account_id: &str, client_account_id: &str, user_id: &str) -> AccountClientUserUpdateCall<'a, C, A> {
+        AccountClientUserUpdateCall {
+            hub: self.hub,
+            _request: request,
+            _account_id: account_id.to_string(),
+            _client_account_id: client_account_id.to_string(),
+            _user_id: user_id.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Creates and sends out an email invitation to access
+    /// an Ad Exchange client buyer account.
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    /// * `accountId` - Numerical account ID of the client's sponsor buyer. (required)
+    /// * `clientAccountId` - Numerical account ID of the client buyer that the user
+    ///                       should be associated with. (required)
+    pub fn clients_invitations_create(&self, request: ClientUserInvitation, account_id: &str, client_account_id: &str) -> AccountClientInvitationCreateCall<'a, C, A> {
+        AccountClientInvitationCreateCall {
+            hub: self.hub,
+            _request: request,
+            _account_id: account_id.to_string(),
+            _client_account_id: client_account_id.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Lists all the known client users for a specified
+    /// sponsor buyer account ID.
+    /// 
+    /// # Arguments
+    ///
+    /// * `accountId` - Numerical account ID of the sponsor buyer of the client to list users for.
+    ///                 (required)
+    /// * `clientAccountId` - The account ID of the client buyer to list users for. (required)
+    ///                       You must specify either a string representation of a
+    ///                       numerical account identifier or the `-` character
+    ///                       to list all the client users for all the clients
+    ///                       of a given sponsor buyer.
+    pub fn clients_users_list(&self, account_id: &str, client_account_id: &str) -> AccountClientUserListCall<'a, C, A> {
+        AccountClientUserListCall {
+            hub: self.hub,
+            _account_id: account_id.to_string(),
+            _client_account_id: client_account_id.to_string(),
+            _page_token: Default::default(),
+            _page_size: Default::default(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Creates a new client buyer.
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    /// * `accountId` - Unique numerical account ID for the buyer of which the client buyer
+    ///                 is a customer; the sponsor buyer to create a client for. (required)
+    pub fn clients_create(&self, request: Client, account_id: &str) -> AccountClientCreateCall<'a, C, A> {
+        AccountClientCreateCall {
+            hub: self.hub,
+            _request: request,
+            _account_id: account_id.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Gets a client buyer with a given client account ID.
+    /// 
+    /// # Arguments
+    ///
+    /// * `accountId` - Numerical account ID of the client's sponsor buyer. (required)
+    /// * `clientAccountId` - Numerical account ID of the client buyer to retrieve. (required)
+    pub fn clients_get(&self, account_id: &str, client_account_id: &str) -> AccountClientGetCall<'a, C, A> {
+        AccountClientGetCall {
+            hub: self.hub,
+            _account_id: account_id.to_string(),
+            _client_account_id: client_account_id.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// List all creative-deal associations.
+    /// 
+    /// # Arguments
+    ///
+    /// * `accountId` - The account to list the associations from.
+    ///                 Specify "-" to list all creatives the current user has access to.
+    /// * `creativeId` - The creative ID to list the associations from.
+    ///                  Specify "-" to list all creatives under the above account.
+    pub fn creatives_deal_associations_list(&self, account_id: &str, creative_id: &str) -> AccountCreativeDealAssociationListCall<'a, C, A> {
+        AccountCreativeDealAssociationListCall {
+            hub: self.hub,
+            _account_id: account_id.to_string(),
+            _creative_id: creative_id.to_string(),
+            _query: Default::default(),
+            _page_token: Default::default(),
+            _page_size: Default::default(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Updates a creative.
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    /// * `accountId` - The account that this creative belongs to.
+    ///                 Can be used to filter the response of the
+    ///                 creatives.list
+    ///                 method.
+    /// * `creativeId` - The buyer-defined creative ID of this creative.
+    ///                  Can be used to filter the response of the
+    ///                  creatives.list
+    ///                  method.
+    pub fn creatives_update(&self, request: Creative, account_id: &str, creative_id: &str) -> AccountCreativeUpdateCall<'a, C, A> {
+        AccountCreativeUpdateCall {
+            hub: self.hub,
+            _request: request,
+            _account_id: account_id.to_string(),
+            _creative_id: creative_id.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Remove the association between a deal and a creative.
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    /// * `accountId` - The account the creative belongs to.
+    /// * `creativeId` - The ID of the creative associated with the deal.
+    pub fn creatives_deal_associations_remove(&self, request: RemoveDealAssociationRequest, account_id: &str, creative_id: &str) -> AccountCreativeDealAssociationRemoveCall<'a, C, A> {
+        AccountCreativeDealAssociationRemoveCall {
+            hub: self.hub,
+            _request: request,
+            _account_id: account_id.to_string(),
+            _creative_id: creative_id.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Lists all the client users invitations for a client
+    /// with a given account ID.
+    /// 
+    /// # Arguments
+    ///
+    /// * `accountId` - Numerical account ID of the client's sponsor buyer. (required)
+    /// * `clientAccountId` - Numerical account ID of the client buyer to list invitations for.
+    ///                       (required)
+    ///                       You must either specify a string representation of a
+    ///                       numerical account identifier or the `-` character
+    ///                       to list all the invitations for all the clients
+    ///                       of a given sponsor buyer.
+    pub fn clients_invitations_list(&self, account_id: &str, client_account_id: &str) -> AccountClientInvitationListCall<'a, C, A> {
+        AccountClientInvitationListCall {
+            hub: self.hub,
+            _account_id: account_id.to_string(),
+            _client_account_id: client_account_id.to_string(),
+            _page_token: Default::default(),
+            _page_size: Default::default(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+}
+
+
+
+
+
+// ###################
+// CallBuilders   ###
+// #################
+
+/// Retrieves the requested filter set for the account with the given account
+/// ID.
+///
+/// A builder for the *accounts.filterSets.get* method supported by a *bidder* resource.
+/// It is not used directly, but through a `BidderMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_adexchangebuyer2_v2_beta1 as adexchangebuyer2_v2_beta1;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use adexchangebuyer2_v2_beta1::AdExchangeBuyerII;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = AdExchangeBuyerII::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.bidders().accounts_filter_sets_get("name")
+///              .doit();
+/// # }
+/// ```
+pub struct BidderAccountFilterSetGetCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a AdExchangeBuyerII<C, A>,
+    _name: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for BidderAccountFilterSetGetCall<'a, C, A> {}
+
+impl<'a, C, A> BidderAccountFilterSetGetCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, FilterSet)> {
+        use url::percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "adexchangebuyer2.bidders.accounts.filterSets.get",
+                               http_method: hyper::method::Method::Get });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((3 + self._additional_params.len()));
+        params.push(("name", self._name.to_string()));
+        for &field in ["alt", "name"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v2beta1/{+name}";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::AdexchangeBuyer.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{+name}", "name")].iter() {
+            let mut replace_with = String::new();
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = value.to_string();
+                    break;
+                }
+            }
+            if find_this.as_bytes()[1] == '+' as u8 {
+                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET);
+            }
+            url = url.replace(find_this, &replace_with);
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["name"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Get, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    /// Full name of the resource being requested.
+    /// For example:
+    /// 
+    /// - For a bidder-level filter set for bidder 123:
+    ///   `bidders/123/filterSets/abc`
+    /// 
+    /// - For an account-level filter set for the buyer account representing bidder
+    ///   123: `bidders/123/accounts/123/filterSets/abc`
+    /// 
+    /// - For an account-level filter set for the child seat buyer account 456
+    ///   whose bidder is 123: `bidders/123/accounts/456/filterSets/abc`
+    ///
+    /// Sets the *name* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn name(mut self, new_value: &str) -> BidderAccountFilterSetGetCall<'a, C, A> {
+        self._name = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> BidderAccountFilterSetGetCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> BidderAccountFilterSetGetCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::AdexchangeBuyer`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> BidderAccountFilterSetGetCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// List all reasons for which bids were filtered, with the number of bids
+/// filtered for each reason.
+///
+/// A builder for the *filterSets.filteredBids.list* method supported by a *bidder* resource.
+/// It is not used directly, but through a `BidderMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_adexchangebuyer2_v2_beta1 as adexchangebuyer2_v2_beta1;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use adexchangebuyer2_v2_beta1::AdExchangeBuyerII;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = AdExchangeBuyerII::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.bidders().filter_sets_filtered_bids_list("filterSetName")
+///              .page_token("takimata")
+///              .page_size(-70)
+///              .doit();
+/// # }
+/// ```
+pub struct BidderFilterSetFilteredBidListCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a AdExchangeBuyerII<C, A>,
+    _filter_set_name: String,
+    _page_token: Option<String>,
+    _page_size: Option<i32>,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for BidderFilterSetFilteredBidListCall<'a, C, A> {}
+
+impl<'a, C, A> BidderFilterSetFilteredBidListCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, ListFilteredBidsResponse)> {
+        use url::percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "adexchangebuyer2.bidders.filterSets.filteredBids.list",
+                               http_method: hyper::method::Method::Get });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((5 + self._additional_params.len()));
+        params.push(("filterSetName", self._filter_set_name.to_string()));
+        if let Some(value) = self._page_token {
+            params.push(("pageToken", value.to_string()));
+        }
+        if let Some(value) = self._page_size {
+            params.push(("pageSize", value.to_string()));
+        }
+        for &field in ["alt", "filterSetName", "pageToken", "pageSize"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v2beta1/{+filterSetName}/filteredBids";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::AdexchangeBuyer.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{+filterSetName}", "filterSetName")].iter() {
+            let mut replace_with = String::new();
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = value.to_string();
+                    break;
+                }
+            }
+            if find_this.as_bytes()[1] == '+' as u8 {
+                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET);
+            }
+            url = url.replace(find_this, &replace_with);
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["filterSetName"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Get, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    /// Name of the filter set that should be applied to the requested metrics.
+    /// For example:
+    /// 
+    /// - For a bidder-level filter set for bidder 123:
+    ///   `bidders/123/filterSets/abc`
+    /// 
+    /// - For an account-level filter set for the buyer account representing bidder
+    ///   123: `bidders/123/accounts/123/filterSets/abc`
+    /// 
+    /// - For an account-level filter set for the child seat buyer account 456
+    ///   whose bidder is 123: `bidders/123/accounts/456/filterSets/abc`
+    ///
+    /// Sets the *filter set name* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn filter_set_name(mut self, new_value: &str) -> BidderFilterSetFilteredBidListCall<'a, C, A> {
+        self._filter_set_name = new_value.to_string();
+        self
+    }
+    /// A token identifying a page of results the server should return.
+    /// Typically, this is the value of
+    /// ListFilteredBidsResponse.nextPageToken
+    /// returned from the previous call to the filteredBids.list
+    /// method.
+    ///
+    /// Sets the *page token* query property to the given value.
+    pub fn page_token(mut self, new_value: &str) -> BidderFilterSetFilteredBidListCall<'a, C, A> {
+        self._page_token = Some(new_value.to_string());
+        self
+    }
+    /// Requested page size. The server may return fewer results than requested.
+    /// If unspecified, the server will pick an appropriate default.
+    ///
+    /// Sets the *page size* query property to the given value.
+    pub fn page_size(mut self, new_value: i32) -> BidderFilterSetFilteredBidListCall<'a, C, A> {
+        self._page_size = Some(new_value);
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> BidderFilterSetFilteredBidListCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> BidderFilterSetFilteredBidListCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::AdexchangeBuyer`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> BidderFilterSetFilteredBidListCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Lists all filter sets for the account with the given account ID.
+///
+/// A builder for the *filterSets.list* method supported by a *bidder* resource.
+/// It is not used directly, but through a `BidderMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_adexchangebuyer2_v2_beta1 as adexchangebuyer2_v2_beta1;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use adexchangebuyer2_v2_beta1::AdExchangeBuyerII;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = AdExchangeBuyerII::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.bidders().filter_sets_list("ownerName")
+///              .page_token("erat")
+///              .page_size(-35)
+///              .doit();
+/// # }
+/// ```
+pub struct BidderFilterSetListCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a AdExchangeBuyerII<C, A>,
+    _owner_name: String,
+    _page_token: Option<String>,
+    _page_size: Option<i32>,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for BidderFilterSetListCall<'a, C, A> {}
+
+impl<'a, C, A> BidderFilterSetListCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, ListFilterSetsResponse)> {
+        use url::percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "adexchangebuyer2.bidders.filterSets.list",
+                               http_method: hyper::method::Method::Get });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((5 + self._additional_params.len()));
+        params.push(("ownerName", self._owner_name.to_string()));
+        if let Some(value) = self._page_token {
+            params.push(("pageToken", value.to_string()));
+        }
+        if let Some(value) = self._page_size {
+            params.push(("pageSize", value.to_string()));
+        }
+        for &field in ["alt", "ownerName", "pageToken", "pageSize"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v2beta1/{+ownerName}/filterSets";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::AdexchangeBuyer.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{+ownerName}", "ownerName")].iter() {
+            let mut replace_with = String::new();
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = value.to_string();
+                    break;
+                }
+            }
+            if find_this.as_bytes()[1] == '+' as u8 {
+                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET);
+            }
+            url = url.replace(find_this, &replace_with);
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["ownerName"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Get, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    /// Name of the owner (bidder or account) of the filter sets to be listed.
+    /// For example:
+    /// 
+    /// - For a bidder-level filter set for bidder 123: `bidders/123`
+    /// 
+    /// - For an account-level filter set for the buyer account representing bidder
+    ///   123: `bidders/123/accounts/123`
+    /// 
+    /// - For an account-level filter set for the child seat buyer account 456
+    ///   whose bidder is 123: `bidders/123/accounts/456`
+    ///
+    /// Sets the *owner name* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn owner_name(mut self, new_value: &str) -> BidderFilterSetListCall<'a, C, A> {
+        self._owner_name = new_value.to_string();
+        self
+    }
+    /// A token identifying a page of results the server should return.
+    /// Typically, this is the value of
+    /// ListFilterSetsResponse.nextPageToken
+    /// returned from the previous call to the
+    /// accounts.filterSets.list
+    /// method.
+    ///
+    /// Sets the *page token* query property to the given value.
+    pub fn page_token(mut self, new_value: &str) -> BidderFilterSetListCall<'a, C, A> {
+        self._page_token = Some(new_value.to_string());
+        self
+    }
+    /// Requested page size. The server may return fewer results than requested.
+    /// If unspecified, the server will pick an appropriate default.
+    ///
+    /// Sets the *page size* query property to the given value.
+    pub fn page_size(mut self, new_value: i32) -> BidderFilterSetListCall<'a, C, A> {
+        self._page_size = Some(new_value);
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> BidderFilterSetListCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> BidderFilterSetListCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::AdexchangeBuyer`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> BidderFilterSetListCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Creates the specified filter set for the account with the given account ID.
+///
+/// A builder for the *accounts.filterSets.create* method supported by a *bidder* resource.
+/// It is not used directly, but through a `BidderMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_adexchangebuyer2_v2_beta1 as adexchangebuyer2_v2_beta1;
+/// use adexchangebuyer2_v2_beta1::FilterSet;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use adexchangebuyer2_v2_beta1::AdExchangeBuyerII;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = AdExchangeBuyerII::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = FilterSet::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.bidders().accounts_filter_sets_create(req, "ownerName")
+///              .is_transient(false)
+///              .doit();
+/// # }
+/// ```
+pub struct BidderAccountFilterSetCreateCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a AdExchangeBuyerII<C, A>,
+    _request: FilterSet,
+    _owner_name: String,
+    _is_transient: Option<bool>,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for BidderAccountFilterSetCreateCall<'a, C, A> {}
+
+impl<'a, C, A> BidderAccountFilterSetCreateCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, FilterSet)> {
+        use url::percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "adexchangebuyer2.bidders.accounts.filterSets.create",
+                               http_method: hyper::method::Method::Post });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((5 + self._additional_params.len()));
+        params.push(("ownerName", self._owner_name.to_string()));
+        if let Some(value) = self._is_transient {
+            params.push(("isTransient", value.to_string()));
+        }
+        for &field in ["alt", "ownerName", "isTransient"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v2beta1/{+ownerName}/filterSets";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::AdexchangeBuyer.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{+ownerName}", "ownerName")].iter() {
+            let mut replace_with = String::new();
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = value.to_string();
+                    break;
+                }
+            }
+            if find_this.as_bytes()[1] == '+' as u8 {
+                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET);
+            }
+            url = url.replace(find_this, &replace_with);
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["ownerName"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Post, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: FilterSet) -> BidderAccountFilterSetCreateCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// Name of the owner (bidder or account) of the filter set to be created.
+    /// For example:
+    /// 
+    /// - For a bidder-level filter set for bidder 123: `bidders/123`
+    /// 
+    /// - For an account-level filter set for the buyer account representing bidder
+    ///   123: `bidders/123/accounts/123`
+    /// 
+    /// - For an account-level filter set for the child seat buyer account 456
+    ///   whose bidder is 123: `bidders/123/accounts/456`
+    ///
+    /// Sets the *owner name* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn owner_name(mut self, new_value: &str) -> BidderAccountFilterSetCreateCall<'a, C, A> {
+        self._owner_name = new_value.to_string();
+        self
+    }
+    /// Whether the filter set is transient, or should be persisted indefinitely.
+    /// By default, filter sets are not transient.
+    /// If transient, it will be available for at least 1 hour after creation.
+    ///
+    /// Sets the *is transient* query property to the given value.
+    pub fn is_transient(mut self, new_value: bool) -> BidderAccountFilterSetCreateCall<'a, C, A> {
+        self._is_transient = Some(new_value);
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> BidderAccountFilterSetCreateCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> BidderAccountFilterSetCreateCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::AdexchangeBuyer`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> BidderAccountFilterSetCreateCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Lists all metrics that are measured in terms of number of bids.
+///
+/// A builder for the *accounts.filterSets.bidMetrics.list* method supported by a *bidder* resource.
+/// It is not used directly, but through a `BidderMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_adexchangebuyer2_v2_beta1 as adexchangebuyer2_v2_beta1;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use adexchangebuyer2_v2_beta1::AdExchangeBuyerII;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = AdExchangeBuyerII::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.bidders().accounts_filter_sets_bid_metrics_list("filterSetName")
+///              .page_token("gubergren")
+///              .page_size(-95)
+///              .doit();
+/// # }
+/// ```
+pub struct BidderAccountFilterSetBidMetricListCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a AdExchangeBuyerII<C, A>,
+    _filter_set_name: String,
+    _page_token: Option<String>,
+    _page_size: Option<i32>,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for BidderAccountFilterSetBidMetricListCall<'a, C, A> {}
+
+impl<'a, C, A> BidderAccountFilterSetBidMetricListCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, ListBidMetricsResponse)> {
+        use url::percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "adexchangebuyer2.bidders.accounts.filterSets.bidMetrics.list",
+                               http_method: hyper::method::Method::Get });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((5 + self._additional_params.len()));
+        params.push(("filterSetName", self._filter_set_name.to_string()));
+        if let Some(value) = self._page_token {
+            params.push(("pageToken", value.to_string()));
+        }
+        if let Some(value) = self._page_size {
+            params.push(("pageSize", value.to_string()));
+        }
+        for &field in ["alt", "filterSetName", "pageToken", "pageSize"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v2beta1/{+filterSetName}/bidMetrics";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::AdexchangeBuyer.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{+filterSetName}", "filterSetName")].iter() {
+            let mut replace_with = String::new();
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = value.to_string();
+                    break;
+                }
+            }
+            if find_this.as_bytes()[1] == '+' as u8 {
+                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET);
+            }
+            url = url.replace(find_this, &replace_with);
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["filterSetName"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Get, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    /// Name of the filter set that should be applied to the requested metrics.
+    /// For example:
+    /// 
+    /// - For a bidder-level filter set for bidder 123:
+    ///   `bidders/123/filterSets/abc`
+    /// 
+    /// - For an account-level filter set for the buyer account representing bidder
+    ///   123: `bidders/123/accounts/123/filterSets/abc`
+    /// 
+    /// - For an account-level filter set for the child seat buyer account 456
+    ///   whose bidder is 123: `bidders/123/accounts/456/filterSets/abc`
+    ///
+    /// Sets the *filter set name* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn filter_set_name(mut self, new_value: &str) -> BidderAccountFilterSetBidMetricListCall<'a, C, A> {
+        self._filter_set_name = new_value.to_string();
+        self
+    }
+    /// A token identifying a page of results the server should return.
+    /// Typically, this is the value of
+    /// ListBidMetricsResponse.nextPageToken
+    /// returned from the previous call to the bidMetrics.list
+    /// method.
+    ///
+    /// Sets the *page token* query property to the given value.
+    pub fn page_token(mut self, new_value: &str) -> BidderAccountFilterSetBidMetricListCall<'a, C, A> {
+        self._page_token = Some(new_value.to_string());
+        self
+    }
+    /// Requested page size. The server may return fewer results than requested.
+    /// If unspecified, the server will pick an appropriate default.
+    ///
+    /// Sets the *page size* query property to the given value.
+    pub fn page_size(mut self, new_value: i32) -> BidderAccountFilterSetBidMetricListCall<'a, C, A> {
+        self._page_size = Some(new_value);
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> BidderAccountFilterSetBidMetricListCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> BidderAccountFilterSetBidMetricListCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::AdexchangeBuyer`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> BidderAccountFilterSetBidMetricListCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// List all creatives associated with a specific reason for which bids were
+/// filtered, with the number of bids filtered for each creative.
+///
+/// A builder for the *accounts.filterSets.filteredBids.creatives.list* method supported by a *bidder* resource.
+/// It is not used directly, but through a `BidderMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_adexchangebuyer2_v2_beta1 as adexchangebuyer2_v2_beta1;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use adexchangebuyer2_v2_beta1::AdExchangeBuyerII;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = AdExchangeBuyerII::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.bidders().accounts_filter_sets_filtered_bids_creatives_list("filterSetName", -66)
+///              .page_token("no")
+///              .page_size(-21)
+///              .doit();
+/// # }
+/// ```
+pub struct BidderAccountFilterSetFilteredBidCreativeListCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a AdExchangeBuyerII<C, A>,
+    _filter_set_name: String,
+    _creative_status_id: i32,
+    _page_token: Option<String>,
+    _page_size: Option<i32>,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for BidderAccountFilterSetFilteredBidCreativeListCall<'a, C, A> {}
+
+impl<'a, C, A> BidderAccountFilterSetFilteredBidCreativeListCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, ListCreativeStatusBreakdownByCreativeResponse)> {
+        use url::percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "adexchangebuyer2.bidders.accounts.filterSets.filteredBids.creatives.list",
+                               http_method: hyper::method::Method::Get });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((6 + self._additional_params.len()));
+        params.push(("filterSetName", self._filter_set_name.to_string()));
+        params.push(("creativeStatusId", self._creative_status_id.to_string()));
+        if let Some(value) = self._page_token {
+            params.push(("pageToken", value.to_string()));
+        }
+        if let Some(value) = self._page_size {
+            params.push(("pageSize", value.to_string()));
+        }
+        for &field in ["alt", "filterSetName", "creativeStatusId", "pageToken", "pageSize"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v2beta1/{+filterSetName}/filteredBids/{creativeStatusId}/creatives";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::AdexchangeBuyer.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{+filterSetName}", "filterSetName"), ("{creativeStatusId}", "creativeStatusId")].iter() {
+            let mut replace_with = String::new();
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = value.to_string();
+                    break;
+                }
+            }
+            if find_this.as_bytes()[1] == '+' as u8 {
+                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET);
+            }
+            url = url.replace(find_this, &replace_with);
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(2);
+            for param_name in ["creativeStatusId", "filterSetName"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Get, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    /// Name of the filter set that should be applied to the requested metrics.
+    /// For example:
+    /// 
+    /// - For a bidder-level filter set for bidder 123:
+    ///   `bidders/123/filterSets/abc`
+    /// 
+    /// - For an account-level filter set for the buyer account representing bidder
+    ///   123: `bidders/123/accounts/123/filterSets/abc`
+    /// 
+    /// - For an account-level filter set for the child seat buyer account 456
+    ///   whose bidder is 123: `bidders/123/accounts/456/filterSets/abc`
+    ///
+    /// Sets the *filter set name* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn filter_set_name(mut self, new_value: &str) -> BidderAccountFilterSetFilteredBidCreativeListCall<'a, C, A> {
+        self._filter_set_name = new_value.to_string();
+        self
+    }
+    /// The ID of the creative status for which to retrieve a breakdown by
+    /// creative.
+    /// See
+    /// [creative-status-codes](https://developers.google.com/ad-exchange/rtb/downloads/creative-status-codes).
+    ///
+    /// Sets the *creative status id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn creative_status_id(mut self, new_value: i32) -> BidderAccountFilterSetFilteredBidCreativeListCall<'a, C, A> {
+        self._creative_status_id = new_value;
+        self
+    }
+    /// A token identifying a page of results the server should return.
+    /// Typically, this is the value of
+    /// ListCreativeStatusBreakdownByCreativeResponse.nextPageToken
+    /// returned from the previous call to the filteredBids.creatives.list
+    /// method.
+    ///
+    /// Sets the *page token* query property to the given value.
+    pub fn page_token(mut self, new_value: &str) -> BidderAccountFilterSetFilteredBidCreativeListCall<'a, C, A> {
+        self._page_token = Some(new_value.to_string());
+        self
+    }
+    /// Requested page size. The server may return fewer results than requested.
+    /// If unspecified, the server will pick an appropriate default.
+    ///
+    /// Sets the *page size* query property to the given value.
+    pub fn page_size(mut self, new_value: i32) -> BidderAccountFilterSetFilteredBidCreativeListCall<'a, C, A> {
+        self._page_size = Some(new_value);
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> BidderAccountFilterSetFilteredBidCreativeListCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> BidderAccountFilterSetFilteredBidCreativeListCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::AdexchangeBuyer`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> BidderAccountFilterSetFilteredBidCreativeListCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Deletes the requested filter set from the account with the given account
+/// ID.
+///
+/// A builder for the *accounts.filterSets.delete* method supported by a *bidder* resource.
+/// It is not used directly, but through a `BidderMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_adexchangebuyer2_v2_beta1 as adexchangebuyer2_v2_beta1;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use adexchangebuyer2_v2_beta1::AdExchangeBuyerII;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = AdExchangeBuyerII::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.bidders().accounts_filter_sets_delete("name")
+///              .doit();
+/// # }
+/// ```
+pub struct BidderAccountFilterSetDeleteCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a AdExchangeBuyerII<C, A>,
+    _name: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for BidderAccountFilterSetDeleteCall<'a, C, A> {}
+
+impl<'a, C, A> BidderAccountFilterSetDeleteCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, Empty)> {
+        use url::percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "adexchangebuyer2.bidders.accounts.filterSets.delete",
+                               http_method: hyper::method::Method::Delete });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((3 + self._additional_params.len()));
+        params.push(("name", self._name.to_string()));
+        for &field in ["alt", "name"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v2beta1/{+name}";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::AdexchangeBuyer.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{+name}", "name")].iter() {
+            let mut replace_with = String::new();
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = value.to_string();
+                    break;
+                }
+            }
+            if find_this.as_bytes()[1] == '+' as u8 {
+                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET);
+            }
+            url = url.replace(find_this, &replace_with);
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["name"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Delete, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    /// Full name of the resource to delete.
+    /// For example:
+    /// 
+    /// - For a bidder-level filter set for bidder 123:
+    ///   `bidders/123/filterSets/abc`
+    /// 
+    /// - For an account-level filter set for the buyer account representing bidder
+    ///   123: `bidders/123/accounts/123/filterSets/abc`
+    /// 
+    /// - For an account-level filter set for the child seat buyer account 456
+    ///   whose bidder is 123: `bidders/123/accounts/456/filterSets/abc`
+    ///
+    /// Sets the *name* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn name(mut self, new_value: &str) -> BidderAccountFilterSetDeleteCall<'a, C, A> {
+        self._name = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> BidderAccountFilterSetDeleteCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> BidderAccountFilterSetDeleteCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::AdexchangeBuyer`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> BidderAccountFilterSetDeleteCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// List all reasons that caused a bid request not to be sent for an
+/// impression, with the number of bid requests not sent for each reason.
+///
+/// A builder for the *accounts.filterSets.filteredBidRequests.list* method supported by a *bidder* resource.
+/// It is not used directly, but through a `BidderMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_adexchangebuyer2_v2_beta1 as adexchangebuyer2_v2_beta1;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use adexchangebuyer2_v2_beta1::AdExchangeBuyerII;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = AdExchangeBuyerII::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.bidders().accounts_filter_sets_filtered_bid_requests_list("filterSetName")
+///              .page_token("et")
+///              .page_size(-41)
+///              .doit();
+/// # }
+/// ```
+pub struct BidderAccountFilterSetFilteredBidRequestListCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a AdExchangeBuyerII<C, A>,
+    _filter_set_name: String,
+    _page_token: Option<String>,
+    _page_size: Option<i32>,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for BidderAccountFilterSetFilteredBidRequestListCall<'a, C, A> {}
+
+impl<'a, C, A> BidderAccountFilterSetFilteredBidRequestListCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, ListFilteredBidRequestsResponse)> {
+        use url::percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "adexchangebuyer2.bidders.accounts.filterSets.filteredBidRequests.list",
+                               http_method: hyper::method::Method::Get });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((5 + self._additional_params.len()));
+        params.push(("filterSetName", self._filter_set_name.to_string()));
+        if let Some(value) = self._page_token {
+            params.push(("pageToken", value.to_string()));
+        }
+        if let Some(value) = self._page_size {
+            params.push(("pageSize", value.to_string()));
+        }
+        for &field in ["alt", "filterSetName", "pageToken", "pageSize"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v2beta1/{+filterSetName}/filteredBidRequests";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::AdexchangeBuyer.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{+filterSetName}", "filterSetName")].iter() {
+            let mut replace_with = String::new();
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = value.to_string();
+                    break;
+                }
+            }
+            if find_this.as_bytes()[1] == '+' as u8 {
+                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET);
+            }
+            url = url.replace(find_this, &replace_with);
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["filterSetName"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Get, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    /// Name of the filter set that should be applied to the requested metrics.
+    /// For example:
+    /// 
+    /// - For a bidder-level filter set for bidder 123:
+    ///   `bidders/123/filterSets/abc`
+    /// 
+    /// - For an account-level filter set for the buyer account representing bidder
+    ///   123: `bidders/123/accounts/123/filterSets/abc`
+    /// 
+    /// - For an account-level filter set for the child seat buyer account 456
+    ///   whose bidder is 123: `bidders/123/accounts/456/filterSets/abc`
+    ///
+    /// Sets the *filter set name* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn filter_set_name(mut self, new_value: &str) -> BidderAccountFilterSetFilteredBidRequestListCall<'a, C, A> {
+        self._filter_set_name = new_value.to_string();
+        self
+    }
+    /// A token identifying a page of results the server should return.
+    /// Typically, this is the value of
+    /// ListFilteredBidRequestsResponse.nextPageToken
+    /// returned from the previous call to the filteredBidRequests.list
+    /// method.
+    ///
+    /// Sets the *page token* query property to the given value.
+    pub fn page_token(mut self, new_value: &str) -> BidderAccountFilterSetFilteredBidRequestListCall<'a, C, A> {
+        self._page_token = Some(new_value.to_string());
+        self
+    }
+    /// Requested page size. The server may return fewer results than requested.
+    /// If unspecified, the server will pick an appropriate default.
+    ///
+    /// Sets the *page size* query property to the given value.
+    pub fn page_size(mut self, new_value: i32) -> BidderAccountFilterSetFilteredBidRequestListCall<'a, C, A> {
+        self._page_size = Some(new_value);
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> BidderAccountFilterSetFilteredBidRequestListCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> BidderAccountFilterSetFilteredBidRequestListCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::AdexchangeBuyer`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> BidderAccountFilterSetFilteredBidRequestListCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// List all creatives associated with a specific reason for which bids were
+/// filtered, with the number of bids filtered for each creative.
+///
+/// A builder for the *filterSets.filteredBids.creatives.list* method supported by a *bidder* resource.
+/// It is not used directly, but through a `BidderMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_adexchangebuyer2_v2_beta1 as adexchangebuyer2_v2_beta1;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use adexchangebuyer2_v2_beta1::AdExchangeBuyerII;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = AdExchangeBuyerII::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.bidders().filter_sets_filtered_bids_creatives_list("filterSetName", -5)
+///              .page_token("et")
+///              .page_size(-70)
+///              .doit();
+/// # }
+/// ```
+pub struct BidderFilterSetFilteredBidCreativeListCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a AdExchangeBuyerII<C, A>,
+    _filter_set_name: String,
+    _creative_status_id: i32,
+    _page_token: Option<String>,
+    _page_size: Option<i32>,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for BidderFilterSetFilteredBidCreativeListCall<'a, C, A> {}
+
+impl<'a, C, A> BidderFilterSetFilteredBidCreativeListCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, ListCreativeStatusBreakdownByCreativeResponse)> {
+        use url::percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "adexchangebuyer2.bidders.filterSets.filteredBids.creatives.list",
+                               http_method: hyper::method::Method::Get });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((6 + self._additional_params.len()));
+        params.push(("filterSetName", self._filter_set_name.to_string()));
+        params.push(("creativeStatusId", self._creative_status_id.to_string()));
+        if let Some(value) = self._page_token {
+            params.push(("pageToken", value.to_string()));
+        }
+        if let Some(value) = self._page_size {
+            params.push(("pageSize", value.to_string()));
+        }
+        for &field in ["alt", "filterSetName", "creativeStatusId", "pageToken", "pageSize"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v2beta1/{+filterSetName}/filteredBids/{creativeStatusId}/creatives";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::AdexchangeBuyer.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{+filterSetName}", "filterSetName"), ("{creativeStatusId}", "creativeStatusId")].iter() {
+            let mut replace_with = String::new();
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = value.to_string();
+                    break;
+                }
+            }
+            if find_this.as_bytes()[1] == '+' as u8 {
+                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET);
+            }
+            url = url.replace(find_this, &replace_with);
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(2);
+            for param_name in ["creativeStatusId", "filterSetName"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Get, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    /// Name of the filter set that should be applied to the requested metrics.
+    /// For example:
+    /// 
+    /// - For a bidder-level filter set for bidder 123:
+    ///   `bidders/123/filterSets/abc`
+    /// 
+    /// - For an account-level filter set for the buyer account representing bidder
+    ///   123: `bidders/123/accounts/123/filterSets/abc`
+    /// 
+    /// - For an account-level filter set for the child seat buyer account 456
+    ///   whose bidder is 123: `bidders/123/accounts/456/filterSets/abc`
+    ///
+    /// Sets the *filter set name* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn filter_set_name(mut self, new_value: &str) -> BidderFilterSetFilteredBidCreativeListCall<'a, C, A> {
+        self._filter_set_name = new_value.to_string();
+        self
+    }
+    /// The ID of the creative status for which to retrieve a breakdown by
+    /// creative.
+    /// See
+    /// [creative-status-codes](https://developers.google.com/ad-exchange/rtb/downloads/creative-status-codes).
+    ///
+    /// Sets the *creative status id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn creative_status_id(mut self, new_value: i32) -> BidderFilterSetFilteredBidCreativeListCall<'a, C, A> {
+        self._creative_status_id = new_value;
+        self
+    }
+    /// A token identifying a page of results the server should return.
+    /// Typically, this is the value of
+    /// ListCreativeStatusBreakdownByCreativeResponse.nextPageToken
+    /// returned from the previous call to the filteredBids.creatives.list
+    /// method.
+    ///
+    /// Sets the *page token* query property to the given value.
+    pub fn page_token(mut self, new_value: &str) -> BidderFilterSetFilteredBidCreativeListCall<'a, C, A> {
+        self._page_token = Some(new_value.to_string());
+        self
+    }
+    /// Requested page size. The server may return fewer results than requested.
+    /// If unspecified, the server will pick an appropriate default.
+    ///
+    /// Sets the *page size* query property to the given value.
+    pub fn page_size(mut self, new_value: i32) -> BidderFilterSetFilteredBidCreativeListCall<'a, C, A> {
+        self._page_size = Some(new_value);
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> BidderFilterSetFilteredBidCreativeListCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> BidderFilterSetFilteredBidCreativeListCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::AdexchangeBuyer`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> BidderFilterSetFilteredBidCreativeListCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Retrieves the requested filter set for the account with the given account
+/// ID.
+///
+/// A builder for the *filterSets.get* method supported by a *bidder* resource.
+/// It is not used directly, but through a `BidderMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_adexchangebuyer2_v2_beta1 as adexchangebuyer2_v2_beta1;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use adexchangebuyer2_v2_beta1::AdExchangeBuyerII;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = AdExchangeBuyerII::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.bidders().filter_sets_get("name")
+///              .doit();
+/// # }
+/// ```
+pub struct BidderFilterSetGetCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a AdExchangeBuyerII<C, A>,
+    _name: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for BidderFilterSetGetCall<'a, C, A> {}
+
+impl<'a, C, A> BidderFilterSetGetCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, FilterSet)> {
+        use url::percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "adexchangebuyer2.bidders.filterSets.get",
+                               http_method: hyper::method::Method::Get });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((3 + self._additional_params.len()));
+        params.push(("name", self._name.to_string()));
+        for &field in ["alt", "name"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v2beta1/{+name}";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::AdexchangeBuyer.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{+name}", "name")].iter() {
+            let mut replace_with = String::new();
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = value.to_string();
+                    break;
+                }
+            }
+            if find_this.as_bytes()[1] == '+' as u8 {
+                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET);
+            }
+            url = url.replace(find_this, &replace_with);
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["name"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Get, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    /// Full name of the resource being requested.
+    /// For example:
+    /// 
+    /// - For a bidder-level filter set for bidder 123:
+    ///   `bidders/123/filterSets/abc`
+    /// 
+    /// - For an account-level filter set for the buyer account representing bidder
+    ///   123: `bidders/123/accounts/123/filterSets/abc`
+    /// 
+    /// - For an account-level filter set for the child seat buyer account 456
+    ///   whose bidder is 123: `bidders/123/accounts/456/filterSets/abc`
+    ///
+    /// Sets the *name* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn name(mut self, new_value: &str) -> BidderFilterSetGetCall<'a, C, A> {
+        self._name = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> BidderFilterSetGetCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> BidderFilterSetGetCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::AdexchangeBuyer`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> BidderFilterSetGetCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Lists all filter sets for the account with the given account ID.
+///
+/// A builder for the *accounts.filterSets.list* method supported by a *bidder* resource.
+/// It is not used directly, but through a `BidderMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_adexchangebuyer2_v2_beta1 as adexchangebuyer2_v2_beta1;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use adexchangebuyer2_v2_beta1::AdExchangeBuyerII;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = AdExchangeBuyerII::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.bidders().accounts_filter_sets_list("ownerName")
+///              .page_token("Lorem")
+///              .page_size(-75)
+///              .doit();
+/// # }
+/// ```
+pub struct BidderAccountFilterSetListCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a AdExchangeBuyerII<C, A>,
+    _owner_name: String,
+    _page_token: Option<String>,
+    _page_size: Option<i32>,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for BidderAccountFilterSetListCall<'a, C, A> {}
+
+impl<'a, C, A> BidderAccountFilterSetListCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, ListFilterSetsResponse)> {
+        use url::percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "adexchangebuyer2.bidders.accounts.filterSets.list",
+                               http_method: hyper::method::Method::Get });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((5 + self._additional_params.len()));
+        params.push(("ownerName", self._owner_name.to_string()));
+        if let Some(value) = self._page_token {
+            params.push(("pageToken", value.to_string()));
+        }
+        if let Some(value) = self._page_size {
+            params.push(("pageSize", value.to_string()));
+        }
+        for &field in ["alt", "ownerName", "pageToken", "pageSize"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v2beta1/{+ownerName}/filterSets";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::AdexchangeBuyer.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{+ownerName}", "ownerName")].iter() {
+            let mut replace_with = String::new();
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = value.to_string();
+                    break;
+                }
+            }
+            if find_this.as_bytes()[1] == '+' as u8 {
+                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET);
+            }
+            url = url.replace(find_this, &replace_with);
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["ownerName"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Get, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    /// Name of the owner (bidder or account) of the filter sets to be listed.
+    /// For example:
+    /// 
+    /// - For a bidder-level filter set for bidder 123: `bidders/123`
+    /// 
+    /// - For an account-level filter set for the buyer account representing bidder
+    ///   123: `bidders/123/accounts/123`
+    /// 
+    /// - For an account-level filter set for the child seat buyer account 456
+    ///   whose bidder is 123: `bidders/123/accounts/456`
+    ///
+    /// Sets the *owner name* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn owner_name(mut self, new_value: &str) -> BidderAccountFilterSetListCall<'a, C, A> {
+        self._owner_name = new_value.to_string();
+        self
+    }
+    /// A token identifying a page of results the server should return.
+    /// Typically, this is the value of
+    /// ListFilterSetsResponse.nextPageToken
+    /// returned from the previous call to the
+    /// accounts.filterSets.list
+    /// method.
+    ///
+    /// Sets the *page token* query property to the given value.
+    pub fn page_token(mut self, new_value: &str) -> BidderAccountFilterSetListCall<'a, C, A> {
+        self._page_token = Some(new_value.to_string());
+        self
+    }
+    /// Requested page size. The server may return fewer results than requested.
+    /// If unspecified, the server will pick an appropriate default.
+    ///
+    /// Sets the *page size* query property to the given value.
+    pub fn page_size(mut self, new_value: i32) -> BidderAccountFilterSetListCall<'a, C, A> {
+        self._page_size = Some(new_value);
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> BidderAccountFilterSetListCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> BidderAccountFilterSetListCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::AdexchangeBuyer`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> BidderAccountFilterSetListCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// List all errors that occurred in bid responses, with the number of bid
+/// responses affected for each reason.
+///
+/// A builder for the *accounts.filterSets.bidResponseErrors.list* method supported by a *bidder* resource.
+/// It is not used directly, but through a `BidderMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_adexchangebuyer2_v2_beta1 as adexchangebuyer2_v2_beta1;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use adexchangebuyer2_v2_beta1::AdExchangeBuyerII;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = AdExchangeBuyerII::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.bidders().accounts_filter_sets_bid_response_errors_list("filterSetName")
+///              .page_token("sadipscing")
+///              .page_size(-48)
+///              .doit();
+/// # }
+/// ```
+pub struct BidderAccountFilterSetBidResponseErrorListCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a AdExchangeBuyerII<C, A>,
+    _filter_set_name: String,
+    _page_token: Option<String>,
+    _page_size: Option<i32>,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for BidderAccountFilterSetBidResponseErrorListCall<'a, C, A> {}
+
+impl<'a, C, A> BidderAccountFilterSetBidResponseErrorListCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, ListBidResponseErrorsResponse)> {
+        use url::percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "adexchangebuyer2.bidders.accounts.filterSets.bidResponseErrors.list",
+                               http_method: hyper::method::Method::Get });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((5 + self._additional_params.len()));
+        params.push(("filterSetName", self._filter_set_name.to_string()));
+        if let Some(value) = self._page_token {
+            params.push(("pageToken", value.to_string()));
+        }
+        if let Some(value) = self._page_size {
+            params.push(("pageSize", value.to_string()));
+        }
+        for &field in ["alt", "filterSetName", "pageToken", "pageSize"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v2beta1/{+filterSetName}/bidResponseErrors";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::AdexchangeBuyer.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{+filterSetName}", "filterSetName")].iter() {
+            let mut replace_with = String::new();
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = value.to_string();
+                    break;
+                }
+            }
+            if find_this.as_bytes()[1] == '+' as u8 {
+                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET);
+            }
+            url = url.replace(find_this, &replace_with);
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["filterSetName"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Get, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    /// Name of the filter set that should be applied to the requested metrics.
+    /// For example:
+    /// 
+    /// - For a bidder-level filter set for bidder 123:
+    ///   `bidders/123/filterSets/abc`
+    /// 
+    /// - For an account-level filter set for the buyer account representing bidder
+    ///   123: `bidders/123/accounts/123/filterSets/abc`
+    /// 
+    /// - For an account-level filter set for the child seat buyer account 456
+    ///   whose bidder is 123: `bidders/123/accounts/456/filterSets/abc`
+    ///
+    /// Sets the *filter set name* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn filter_set_name(mut self, new_value: &str) -> BidderAccountFilterSetBidResponseErrorListCall<'a, C, A> {
+        self._filter_set_name = new_value.to_string();
+        self
+    }
+    /// A token identifying a page of results the server should return.
+    /// Typically, this is the value of
+    /// ListBidResponseErrorsResponse.nextPageToken
+    /// returned from the previous call to the bidResponseErrors.list
+    /// method.
+    ///
+    /// Sets the *page token* query property to the given value.
+    pub fn page_token(mut self, new_value: &str) -> BidderAccountFilterSetBidResponseErrorListCall<'a, C, A> {
+        self._page_token = Some(new_value.to_string());
+        self
+    }
+    /// Requested page size. The server may return fewer results than requested.
+    /// If unspecified, the server will pick an appropriate default.
+    ///
+    /// Sets the *page size* query property to the given value.
+    pub fn page_size(mut self, new_value: i32) -> BidderAccountFilterSetBidResponseErrorListCall<'a, C, A> {
+        self._page_size = Some(new_value);
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> BidderAccountFilterSetBidResponseErrorListCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> BidderAccountFilterSetBidResponseErrorListCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::AdexchangeBuyer`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> BidderAccountFilterSetBidResponseErrorListCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Deletes the requested filter set from the account with the given account
+/// ID.
+///
+/// A builder for the *filterSets.delete* method supported by a *bidder* resource.
+/// It is not used directly, but through a `BidderMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_adexchangebuyer2_v2_beta1 as adexchangebuyer2_v2_beta1;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use adexchangebuyer2_v2_beta1::AdExchangeBuyerII;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = AdExchangeBuyerII::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.bidders().filter_sets_delete("name")
+///              .doit();
+/// # }
+/// ```
+pub struct BidderFilterSetDeleteCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a AdExchangeBuyerII<C, A>,
+    _name: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for BidderFilterSetDeleteCall<'a, C, A> {}
+
+impl<'a, C, A> BidderFilterSetDeleteCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, Empty)> {
+        use url::percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "adexchangebuyer2.bidders.filterSets.delete",
+                               http_method: hyper::method::Method::Delete });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((3 + self._additional_params.len()));
+        params.push(("name", self._name.to_string()));
+        for &field in ["alt", "name"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v2beta1/{+name}";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::AdexchangeBuyer.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{+name}", "name")].iter() {
+            let mut replace_with = String::new();
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = value.to_string();
+                    break;
+                }
+            }
+            if find_this.as_bytes()[1] == '+' as u8 {
+                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET);
+            }
+            url = url.replace(find_this, &replace_with);
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["name"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Delete, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    /// Full name of the resource to delete.
+    /// For example:
+    /// 
+    /// - For a bidder-level filter set for bidder 123:
+    ///   `bidders/123/filterSets/abc`
+    /// 
+    /// - For an account-level filter set for the buyer account representing bidder
+    ///   123: `bidders/123/accounts/123/filterSets/abc`
+    /// 
+    /// - For an account-level filter set for the child seat buyer account 456
+    ///   whose bidder is 123: `bidders/123/accounts/456/filterSets/abc`
+    ///
+    /// Sets the *name* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn name(mut self, new_value: &str) -> BidderFilterSetDeleteCall<'a, C, A> {
+        self._name = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> BidderFilterSetDeleteCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> BidderFilterSetDeleteCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::AdexchangeBuyer`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> BidderFilterSetDeleteCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Lists all metrics that are measured in terms of number of impressions.
+///
+/// A builder for the *accounts.filterSets.impressionMetrics.list* method supported by a *bidder* resource.
+/// It is not used directly, but through a `BidderMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_adexchangebuyer2_v2_beta1 as adexchangebuyer2_v2_beta1;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use adexchangebuyer2_v2_beta1::AdExchangeBuyerII;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = AdExchangeBuyerII::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.bidders().accounts_filter_sets_impression_metrics_list("filterSetName")
+///              .page_token("amet")
+///              .page_size(-60)
+///              .doit();
+/// # }
+/// ```
+pub struct BidderAccountFilterSetImpressionMetricListCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a AdExchangeBuyerII<C, A>,
+    _filter_set_name: String,
+    _page_token: Option<String>,
+    _page_size: Option<i32>,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for BidderAccountFilterSetImpressionMetricListCall<'a, C, A> {}
+
+impl<'a, C, A> BidderAccountFilterSetImpressionMetricListCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, ListImpressionMetricsResponse)> {
+        use url::percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "adexchangebuyer2.bidders.accounts.filterSets.impressionMetrics.list",
+                               http_method: hyper::method::Method::Get });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((5 + self._additional_params.len()));
+        params.push(("filterSetName", self._filter_set_name.to_string()));
+        if let Some(value) = self._page_token {
+            params.push(("pageToken", value.to_string()));
+        }
+        if let Some(value) = self._page_size {
+            params.push(("pageSize", value.to_string()));
+        }
+        for &field in ["alt", "filterSetName", "pageToken", "pageSize"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v2beta1/{+filterSetName}/impressionMetrics";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::AdexchangeBuyer.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{+filterSetName}", "filterSetName")].iter() {
+            let mut replace_with = String::new();
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = value.to_string();
+                    break;
+                }
+            }
+            if find_this.as_bytes()[1] == '+' as u8 {
+                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET);
+            }
+            url = url.replace(find_this, &replace_with);
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["filterSetName"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Get, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    /// Name of the filter set that should be applied to the requested metrics.
+    /// For example:
+    /// 
+    /// - For a bidder-level filter set for bidder 123:
+    ///   `bidders/123/filterSets/abc`
+    /// 
+    /// - For an account-level filter set for the buyer account representing bidder
+    ///   123: `bidders/123/accounts/123/filterSets/abc`
+    /// 
+    /// - For an account-level filter set for the child seat buyer account 456
+    ///   whose bidder is 123: `bidders/123/accounts/456/filterSets/abc`
+    ///
+    /// Sets the *filter set name* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn filter_set_name(mut self, new_value: &str) -> BidderAccountFilterSetImpressionMetricListCall<'a, C, A> {
+        self._filter_set_name = new_value.to_string();
+        self
+    }
+    /// A token identifying a page of results the server should return.
+    /// Typically, this is the value of
+    /// ListImpressionMetricsResponse.nextPageToken
+    /// returned from the previous call to the impressionMetrics.list
+    /// method.
+    ///
+    /// Sets the *page token* query property to the given value.
+    pub fn page_token(mut self, new_value: &str) -> BidderAccountFilterSetImpressionMetricListCall<'a, C, A> {
+        self._page_token = Some(new_value.to_string());
+        self
+    }
+    /// Requested page size. The server may return fewer results than requested.
+    /// If unspecified, the server will pick an appropriate default.
+    ///
+    /// Sets the *page size* query property to the given value.
+    pub fn page_size(mut self, new_value: i32) -> BidderAccountFilterSetImpressionMetricListCall<'a, C, A> {
+        self._page_size = Some(new_value);
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> BidderAccountFilterSetImpressionMetricListCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> BidderAccountFilterSetImpressionMetricListCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::AdexchangeBuyer`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> BidderAccountFilterSetImpressionMetricListCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// List all reasons for which bids lost in the auction, with the number of
+/// bids that lost for each reason.
+///
+/// A builder for the *filterSets.losingBids.list* method supported by a *bidder* resource.
+/// It is not used directly, but through a `BidderMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_adexchangebuyer2_v2_beta1 as adexchangebuyer2_v2_beta1;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use adexchangebuyer2_v2_beta1::AdExchangeBuyerII;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = AdExchangeBuyerII::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.bidders().filter_sets_losing_bids_list("filterSetName")
+///              .page_token("eirmod")
+///              .page_size(-33)
+///              .doit();
+/// # }
+/// ```
+pub struct BidderFilterSetLosingBidListCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a AdExchangeBuyerII<C, A>,
+    _filter_set_name: String,
+    _page_token: Option<String>,
+    _page_size: Option<i32>,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for BidderFilterSetLosingBidListCall<'a, C, A> {}
+
+impl<'a, C, A> BidderFilterSetLosingBidListCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, ListLosingBidsResponse)> {
+        use url::percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "adexchangebuyer2.bidders.filterSets.losingBids.list",
+                               http_method: hyper::method::Method::Get });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((5 + self._additional_params.len()));
+        params.push(("filterSetName", self._filter_set_name.to_string()));
+        if let Some(value) = self._page_token {
+            params.push(("pageToken", value.to_string()));
+        }
+        if let Some(value) = self._page_size {
+            params.push(("pageSize", value.to_string()));
+        }
+        for &field in ["alt", "filterSetName", "pageToken", "pageSize"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v2beta1/{+filterSetName}/losingBids";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::AdexchangeBuyer.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{+filterSetName}", "filterSetName")].iter() {
+            let mut replace_with = String::new();
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = value.to_string();
+                    break;
+                }
+            }
+            if find_this.as_bytes()[1] == '+' as u8 {
+                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET);
+            }
+            url = url.replace(find_this, &replace_with);
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["filterSetName"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Get, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    /// Name of the filter set that should be applied to the requested metrics.
+    /// For example:
+    /// 
+    /// - For a bidder-level filter set for bidder 123:
+    ///   `bidders/123/filterSets/abc`
+    /// 
+    /// - For an account-level filter set for the buyer account representing bidder
+    ///   123: `bidders/123/accounts/123/filterSets/abc`
+    /// 
+    /// - For an account-level filter set for the child seat buyer account 456
+    ///   whose bidder is 123: `bidders/123/accounts/456/filterSets/abc`
+    ///
+    /// Sets the *filter set name* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn filter_set_name(mut self, new_value: &str) -> BidderFilterSetLosingBidListCall<'a, C, A> {
+        self._filter_set_name = new_value.to_string();
+        self
+    }
+    /// A token identifying a page of results the server should return.
+    /// Typically, this is the value of
+    /// ListLosingBidsResponse.nextPageToken
+    /// returned from the previous call to the losingBids.list
+    /// method.
+    ///
+    /// Sets the *page token* query property to the given value.
+    pub fn page_token(mut self, new_value: &str) -> BidderFilterSetLosingBidListCall<'a, C, A> {
+        self._page_token = Some(new_value.to_string());
+        self
+    }
+    /// Requested page size. The server may return fewer results than requested.
+    /// If unspecified, the server will pick an appropriate default.
+    ///
+    /// Sets the *page size* query property to the given value.
+    pub fn page_size(mut self, new_value: i32) -> BidderFilterSetLosingBidListCall<'a, C, A> {
+        self._page_size = Some(new_value);
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> BidderFilterSetLosingBidListCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> BidderFilterSetLosingBidListCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::AdexchangeBuyer`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> BidderFilterSetLosingBidListCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// List all details associated with a specific reason for which bids were
+/// filtered, with the number of bids filtered for each detail.
+///
+/// A builder for the *accounts.filterSets.filteredBids.details.list* method supported by a *bidder* resource.
+/// It is not used directly, but through a `BidderMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_adexchangebuyer2_v2_beta1 as adexchangebuyer2_v2_beta1;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use adexchangebuyer2_v2_beta1::AdExchangeBuyerII;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = AdExchangeBuyerII::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.bidders().accounts_filter_sets_filtered_bids_details_list("filterSetName", -82)
+///              .page_token("accusam")
+///              .page_size(-56)
+///              .doit();
+/// # }
+/// ```
+pub struct BidderAccountFilterSetFilteredBidDetailListCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a AdExchangeBuyerII<C, A>,
+    _filter_set_name: String,
+    _creative_status_id: i32,
+    _page_token: Option<String>,
+    _page_size: Option<i32>,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for BidderAccountFilterSetFilteredBidDetailListCall<'a, C, A> {}
+
+impl<'a, C, A> BidderAccountFilterSetFilteredBidDetailListCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, ListCreativeStatusBreakdownByDetailResponse)> {
+        use url::percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "adexchangebuyer2.bidders.accounts.filterSets.filteredBids.details.list",
+                               http_method: hyper::method::Method::Get });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((6 + self._additional_params.len()));
+        params.push(("filterSetName", self._filter_set_name.to_string()));
+        params.push(("creativeStatusId", self._creative_status_id.to_string()));
+        if let Some(value) = self._page_token {
+            params.push(("pageToken", value.to_string()));
+        }
+        if let Some(value) = self._page_size {
+            params.push(("pageSize", value.to_string()));
+        }
+        for &field in ["alt", "filterSetName", "creativeStatusId", "pageToken", "pageSize"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v2beta1/{+filterSetName}/filteredBids/{creativeStatusId}/details";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::AdexchangeBuyer.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{+filterSetName}", "filterSetName"), ("{creativeStatusId}", "creativeStatusId")].iter() {
+            let mut replace_with = String::new();
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = value.to_string();
+                    break;
+                }
+            }
+            if find_this.as_bytes()[1] == '+' as u8 {
+                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET);
+            }
+            url = url.replace(find_this, &replace_with);
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(2);
+            for param_name in ["creativeStatusId", "filterSetName"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Get, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    /// Name of the filter set that should be applied to the requested metrics.
+    /// For example:
+    /// 
+    /// - For a bidder-level filter set for bidder 123:
+    ///   `bidders/123/filterSets/abc`
+    /// 
+    /// - For an account-level filter set for the buyer account representing bidder
+    ///   123: `bidders/123/accounts/123/filterSets/abc`
+    /// 
+    /// - For an account-level filter set for the child seat buyer account 456
+    ///   whose bidder is 123: `bidders/123/accounts/456/filterSets/abc`
+    ///
+    /// Sets the *filter set name* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn filter_set_name(mut self, new_value: &str) -> BidderAccountFilterSetFilteredBidDetailListCall<'a, C, A> {
+        self._filter_set_name = new_value.to_string();
+        self
+    }
+    /// The ID of the creative status for which to retrieve a breakdown by detail.
+    /// See
+    /// [creative-status-codes](https://developers.google.com/ad-exchange/rtb/downloads/creative-status-codes).
+    /// Details are only available for statuses 10, 14, 15, 17, 18, 19, 86, and 87.
+    ///
+    /// Sets the *creative status id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn creative_status_id(mut self, new_value: i32) -> BidderAccountFilterSetFilteredBidDetailListCall<'a, C, A> {
+        self._creative_status_id = new_value;
+        self
+    }
+    /// A token identifying a page of results the server should return.
+    /// Typically, this is the value of
+    /// ListCreativeStatusBreakdownByDetailResponse.nextPageToken
+    /// returned from the previous call to the filteredBids.details.list
+    /// method.
+    ///
+    /// Sets the *page token* query property to the given value.
+    pub fn page_token(mut self, new_value: &str) -> BidderAccountFilterSetFilteredBidDetailListCall<'a, C, A> {
+        self._page_token = Some(new_value.to_string());
+        self
+    }
+    /// Requested page size. The server may return fewer results than requested.
+    /// If unspecified, the server will pick an appropriate default.
+    ///
+    /// Sets the *page size* query property to the given value.
+    pub fn page_size(mut self, new_value: i32) -> BidderAccountFilterSetFilteredBidDetailListCall<'a, C, A> {
+        self._page_size = Some(new_value);
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> BidderAccountFilterSetFilteredBidDetailListCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> BidderAccountFilterSetFilteredBidDetailListCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::AdexchangeBuyer`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> BidderAccountFilterSetFilteredBidDetailListCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// List all reasons for which bids were filtered, with the number of bids
+/// filtered for each reason.
+///
+/// A builder for the *accounts.filterSets.filteredBids.list* method supported by a *bidder* resource.
+/// It is not used directly, but through a `BidderMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_adexchangebuyer2_v2_beta1 as adexchangebuyer2_v2_beta1;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use adexchangebuyer2_v2_beta1::AdExchangeBuyerII;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = AdExchangeBuyerII::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.bidders().accounts_filter_sets_filtered_bids_list("filterSetName")
+///              .page_token("et")
+///              .page_size(-70)
+///              .doit();
+/// # }
+/// ```
+pub struct BidderAccountFilterSetFilteredBidListCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a AdExchangeBuyerII<C, A>,
+    _filter_set_name: String,
+    _page_token: Option<String>,
+    _page_size: Option<i32>,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for BidderAccountFilterSetFilteredBidListCall<'a, C, A> {}
+
+impl<'a, C, A> BidderAccountFilterSetFilteredBidListCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, ListFilteredBidsResponse)> {
+        use url::percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "adexchangebuyer2.bidders.accounts.filterSets.filteredBids.list",
+                               http_method: hyper::method::Method::Get });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((5 + self._additional_params.len()));
+        params.push(("filterSetName", self._filter_set_name.to_string()));
+        if let Some(value) = self._page_token {
+            params.push(("pageToken", value.to_string()));
+        }
+        if let Some(value) = self._page_size {
+            params.push(("pageSize", value.to_string()));
+        }
+        for &field in ["alt", "filterSetName", "pageToken", "pageSize"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v2beta1/{+filterSetName}/filteredBids";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::AdexchangeBuyer.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{+filterSetName}", "filterSetName")].iter() {
+            let mut replace_with = String::new();
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = value.to_string();
+                    break;
+                }
+            }
+            if find_this.as_bytes()[1] == '+' as u8 {
+                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET);
+            }
+            url = url.replace(find_this, &replace_with);
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["filterSetName"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Get, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    /// Name of the filter set that should be applied to the requested metrics.
+    /// For example:
+    /// 
+    /// - For a bidder-level filter set for bidder 123:
+    ///   `bidders/123/filterSets/abc`
+    /// 
+    /// - For an account-level filter set for the buyer account representing bidder
+    ///   123: `bidders/123/accounts/123/filterSets/abc`
+    /// 
+    /// - For an account-level filter set for the child seat buyer account 456
+    ///   whose bidder is 123: `bidders/123/accounts/456/filterSets/abc`
+    ///
+    /// Sets the *filter set name* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn filter_set_name(mut self, new_value: &str) -> BidderAccountFilterSetFilteredBidListCall<'a, C, A> {
+        self._filter_set_name = new_value.to_string();
+        self
+    }
+    /// A token identifying a page of results the server should return.
+    /// Typically, this is the value of
+    /// ListFilteredBidsResponse.nextPageToken
+    /// returned from the previous call to the filteredBids.list
+    /// method.
+    ///
+    /// Sets the *page token* query property to the given value.
+    pub fn page_token(mut self, new_value: &str) -> BidderAccountFilterSetFilteredBidListCall<'a, C, A> {
+        self._page_token = Some(new_value.to_string());
+        self
+    }
+    /// Requested page size. The server may return fewer results than requested.
+    /// If unspecified, the server will pick an appropriate default.
+    ///
+    /// Sets the *page size* query property to the given value.
+    pub fn page_size(mut self, new_value: i32) -> BidderAccountFilterSetFilteredBidListCall<'a, C, A> {
+        self._page_size = Some(new_value);
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> BidderAccountFilterSetFilteredBidListCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> BidderAccountFilterSetFilteredBidListCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::AdexchangeBuyer`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> BidderAccountFilterSetFilteredBidListCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// List all reasons that caused a bid request not to be sent for an
+/// impression, with the number of bid requests not sent for each reason.
+///
+/// A builder for the *filterSets.filteredBidRequests.list* method supported by a *bidder* resource.
+/// It is not used directly, but through a `BidderMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_adexchangebuyer2_v2_beta1 as adexchangebuyer2_v2_beta1;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use adexchangebuyer2_v2_beta1::AdExchangeBuyerII;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = AdExchangeBuyerII::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.bidders().filter_sets_filtered_bid_requests_list("filterSetName")
+///              .page_token("eirmod")
+///              .page_size(-58)
+///              .doit();
+/// # }
+/// ```
+pub struct BidderFilterSetFilteredBidRequestListCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a AdExchangeBuyerII<C, A>,
+    _filter_set_name: String,
+    _page_token: Option<String>,
+    _page_size: Option<i32>,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for BidderFilterSetFilteredBidRequestListCall<'a, C, A> {}
+
+impl<'a, C, A> BidderFilterSetFilteredBidRequestListCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, ListFilteredBidRequestsResponse)> {
+        use url::percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "adexchangebuyer2.bidders.filterSets.filteredBidRequests.list",
+                               http_method: hyper::method::Method::Get });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((5 + self._additional_params.len()));
+        params.push(("filterSetName", self._filter_set_name.to_string()));
+        if let Some(value) = self._page_token {
+            params.push(("pageToken", value.to_string()));
+        }
+        if let Some(value) = self._page_size {
+            params.push(("pageSize", value.to_string()));
+        }
+        for &field in ["alt", "filterSetName", "pageToken", "pageSize"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v2beta1/{+filterSetName}/filteredBidRequests";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::AdexchangeBuyer.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{+filterSetName}", "filterSetName")].iter() {
+            let mut replace_with = String::new();
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = value.to_string();
+                    break;
+                }
+            }
+            if find_this.as_bytes()[1] == '+' as u8 {
+                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET);
+            }
+            url = url.replace(find_this, &replace_with);
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["filterSetName"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Get, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    /// Name of the filter set that should be applied to the requested metrics.
+    /// For example:
+    /// 
+    /// - For a bidder-level filter set for bidder 123:
+    ///   `bidders/123/filterSets/abc`
+    /// 
+    /// - For an account-level filter set for the buyer account representing bidder
+    ///   123: `bidders/123/accounts/123/filterSets/abc`
+    /// 
+    /// - For an account-level filter set for the child seat buyer account 456
+    ///   whose bidder is 123: `bidders/123/accounts/456/filterSets/abc`
+    ///
+    /// Sets the *filter set name* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn filter_set_name(mut self, new_value: &str) -> BidderFilterSetFilteredBidRequestListCall<'a, C, A> {
+        self._filter_set_name = new_value.to_string();
+        self
+    }
+    /// A token identifying a page of results the server should return.
+    /// Typically, this is the value of
+    /// ListFilteredBidRequestsResponse.nextPageToken
+    /// returned from the previous call to the filteredBidRequests.list
+    /// method.
+    ///
+    /// Sets the *page token* query property to the given value.
+    pub fn page_token(mut self, new_value: &str) -> BidderFilterSetFilteredBidRequestListCall<'a, C, A> {
+        self._page_token = Some(new_value.to_string());
+        self
+    }
+    /// Requested page size. The server may return fewer results than requested.
+    /// If unspecified, the server will pick an appropriate default.
+    ///
+    /// Sets the *page size* query property to the given value.
+    pub fn page_size(mut self, new_value: i32) -> BidderFilterSetFilteredBidRequestListCall<'a, C, A> {
+        self._page_size = Some(new_value);
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> BidderFilterSetFilteredBidRequestListCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> BidderFilterSetFilteredBidRequestListCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::AdexchangeBuyer`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> BidderFilterSetFilteredBidRequestListCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// List all reasons for which bid responses were considered to have no
+/// applicable bids, with the number of bid responses affected for each reason.
+///
+/// A builder for the *accounts.filterSets.bidResponsesWithoutBids.list* method supported by a *bidder* resource.
+/// It is not used directly, but through a `BidderMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_adexchangebuyer2_v2_beta1 as adexchangebuyer2_v2_beta1;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use adexchangebuyer2_v2_beta1::AdExchangeBuyerII;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = AdExchangeBuyerII::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.bidders().accounts_filter_sets_bid_responses_without_bids_list("filterSetName")
+///              .page_token("amet")
+///              .page_size(-23)
+///              .doit();
+/// # }
+/// ```
+pub struct BidderAccountFilterSetBidResponsesWithoutBidListCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a AdExchangeBuyerII<C, A>,
+    _filter_set_name: String,
+    _page_token: Option<String>,
+    _page_size: Option<i32>,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for BidderAccountFilterSetBidResponsesWithoutBidListCall<'a, C, A> {}
+
+impl<'a, C, A> BidderAccountFilterSetBidResponsesWithoutBidListCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, ListBidResponsesWithoutBidsResponse)> {
+        use url::percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "adexchangebuyer2.bidders.accounts.filterSets.bidResponsesWithoutBids.list",
+                               http_method: hyper::method::Method::Get });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((5 + self._additional_params.len()));
+        params.push(("filterSetName", self._filter_set_name.to_string()));
+        if let Some(value) = self._page_token {
+            params.push(("pageToken", value.to_string()));
+        }
+        if let Some(value) = self._page_size {
+            params.push(("pageSize", value.to_string()));
+        }
+        for &field in ["alt", "filterSetName", "pageToken", "pageSize"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v2beta1/{+filterSetName}/bidResponsesWithoutBids";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::AdexchangeBuyer.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{+filterSetName}", "filterSetName")].iter() {
+            let mut replace_with = String::new();
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = value.to_string();
+                    break;
+                }
+            }
+            if find_this.as_bytes()[1] == '+' as u8 {
+                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET);
+            }
+            url = url.replace(find_this, &replace_with);
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["filterSetName"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Get, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    /// Name of the filter set that should be applied to the requested metrics.
+    /// For example:
+    /// 
+    /// - For a bidder-level filter set for bidder 123:
+    ///   `bidders/123/filterSets/abc`
+    /// 
+    /// - For an account-level filter set for the buyer account representing bidder
+    ///   123: `bidders/123/accounts/123/filterSets/abc`
+    /// 
+    /// - For an account-level filter set for the child seat buyer account 456
+    ///   whose bidder is 123: `bidders/123/accounts/456/filterSets/abc`
+    ///
+    /// Sets the *filter set name* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn filter_set_name(mut self, new_value: &str) -> BidderAccountFilterSetBidResponsesWithoutBidListCall<'a, C, A> {
+        self._filter_set_name = new_value.to_string();
+        self
+    }
+    /// A token identifying a page of results the server should return.
+    /// Typically, this is the value of
+    /// ListBidResponsesWithoutBidsResponse.nextPageToken
+    /// returned from the previous call to the bidResponsesWithoutBids.list
+    /// method.
+    ///
+    /// Sets the *page token* query property to the given value.
+    pub fn page_token(mut self, new_value: &str) -> BidderAccountFilterSetBidResponsesWithoutBidListCall<'a, C, A> {
+        self._page_token = Some(new_value.to_string());
+        self
+    }
+    /// Requested page size. The server may return fewer results than requested.
+    /// If unspecified, the server will pick an appropriate default.
+    ///
+    /// Sets the *page size* query property to the given value.
+    pub fn page_size(mut self, new_value: i32) -> BidderAccountFilterSetBidResponsesWithoutBidListCall<'a, C, A> {
+        self._page_size = Some(new_value);
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> BidderAccountFilterSetBidResponsesWithoutBidListCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> BidderAccountFilterSetBidResponsesWithoutBidListCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::AdexchangeBuyer`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> BidderAccountFilterSetBidResponsesWithoutBidListCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// List all reasons for which bids lost in the auction, with the number of
+/// bids that lost for each reason.
+///
+/// A builder for the *accounts.filterSets.losingBids.list* method supported by a *bidder* resource.
+/// It is not used directly, but through a `BidderMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_adexchangebuyer2_v2_beta1 as adexchangebuyer2_v2_beta1;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use adexchangebuyer2_v2_beta1::AdExchangeBuyerII;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = AdExchangeBuyerII::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.bidders().accounts_filter_sets_losing_bids_list("filterSetName")
+///              .page_token("ut")
+///              .page_size(-16)
+///              .doit();
+/// # }
+/// ```
+pub struct BidderAccountFilterSetLosingBidListCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a AdExchangeBuyerII<C, A>,
+    _filter_set_name: String,
+    _page_token: Option<String>,
+    _page_size: Option<i32>,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for BidderAccountFilterSetLosingBidListCall<'a, C, A> {}
+
+impl<'a, C, A> BidderAccountFilterSetLosingBidListCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, ListLosingBidsResponse)> {
+        use url::percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "adexchangebuyer2.bidders.accounts.filterSets.losingBids.list",
+                               http_method: hyper::method::Method::Get });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((5 + self._additional_params.len()));
+        params.push(("filterSetName", self._filter_set_name.to_string()));
+        if let Some(value) = self._page_token {
+            params.push(("pageToken", value.to_string()));
+        }
+        if let Some(value) = self._page_size {
+            params.push(("pageSize", value.to_string()));
+        }
+        for &field in ["alt", "filterSetName", "pageToken", "pageSize"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v2beta1/{+filterSetName}/losingBids";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::AdexchangeBuyer.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{+filterSetName}", "filterSetName")].iter() {
+            let mut replace_with = String::new();
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = value.to_string();
+                    break;
+                }
+            }
+            if find_this.as_bytes()[1] == '+' as u8 {
+                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET);
+            }
+            url = url.replace(find_this, &replace_with);
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["filterSetName"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Get, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    /// Name of the filter set that should be applied to the requested metrics.
+    /// For example:
+    /// 
+    /// - For a bidder-level filter set for bidder 123:
+    ///   `bidders/123/filterSets/abc`
+    /// 
+    /// - For an account-level filter set for the buyer account representing bidder
+    ///   123: `bidders/123/accounts/123/filterSets/abc`
+    /// 
+    /// - For an account-level filter set for the child seat buyer account 456
+    ///   whose bidder is 123: `bidders/123/accounts/456/filterSets/abc`
+    ///
+    /// Sets the *filter set name* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn filter_set_name(mut self, new_value: &str) -> BidderAccountFilterSetLosingBidListCall<'a, C, A> {
+        self._filter_set_name = new_value.to_string();
+        self
+    }
+    /// A token identifying a page of results the server should return.
+    /// Typically, this is the value of
+    /// ListLosingBidsResponse.nextPageToken
+    /// returned from the previous call to the losingBids.list
+    /// method.
+    ///
+    /// Sets the *page token* query property to the given value.
+    pub fn page_token(mut self, new_value: &str) -> BidderAccountFilterSetLosingBidListCall<'a, C, A> {
+        self._page_token = Some(new_value.to_string());
+        self
+    }
+    /// Requested page size. The server may return fewer results than requested.
+    /// If unspecified, the server will pick an appropriate default.
+    ///
+    /// Sets the *page size* query property to the given value.
+    pub fn page_size(mut self, new_value: i32) -> BidderAccountFilterSetLosingBidListCall<'a, C, A> {
+        self._page_size = Some(new_value);
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> BidderAccountFilterSetLosingBidListCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> BidderAccountFilterSetLosingBidListCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::AdexchangeBuyer`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> BidderAccountFilterSetLosingBidListCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// List all reasons for which winning bids were not billable, with the number
+/// of bids not billed for each reason.
+///
+/// A builder for the *filterSets.nonBillableWinningBids.list* method supported by a *bidder* resource.
+/// It is not used directly, but through a `BidderMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_adexchangebuyer2_v2_beta1 as adexchangebuyer2_v2_beta1;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use adexchangebuyer2_v2_beta1::AdExchangeBuyerII;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = AdExchangeBuyerII::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.bidders().filter_sets_non_billable_winning_bids_list("filterSetName")
+///              .page_token("dolor")
+///              .page_size(-48)
+///              .doit();
+/// # }
+/// ```
+pub struct BidderFilterSetNonBillableWinningBidListCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a AdExchangeBuyerII<C, A>,
+    _filter_set_name: String,
+    _page_token: Option<String>,
+    _page_size: Option<i32>,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for BidderFilterSetNonBillableWinningBidListCall<'a, C, A> {}
+
+impl<'a, C, A> BidderFilterSetNonBillableWinningBidListCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, ListNonBillableWinningBidsResponse)> {
+        use url::percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "adexchangebuyer2.bidders.filterSets.nonBillableWinningBids.list",
+                               http_method: hyper::method::Method::Get });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((5 + self._additional_params.len()));
+        params.push(("filterSetName", self._filter_set_name.to_string()));
+        if let Some(value) = self._page_token {
+            params.push(("pageToken", value.to_string()));
+        }
+        if let Some(value) = self._page_size {
+            params.push(("pageSize", value.to_string()));
+        }
+        for &field in ["alt", "filterSetName", "pageToken", "pageSize"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v2beta1/{+filterSetName}/nonBillableWinningBids";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::AdexchangeBuyer.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{+filterSetName}", "filterSetName")].iter() {
+            let mut replace_with = String::new();
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = value.to_string();
+                    break;
+                }
+            }
+            if find_this.as_bytes()[1] == '+' as u8 {
+                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET);
+            }
+            url = url.replace(find_this, &replace_with);
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["filterSetName"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Get, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    /// Name of the filter set that should be applied to the requested metrics.
+    /// For example:
+    /// 
+    /// - For a bidder-level filter set for bidder 123:
+    ///   `bidders/123/filterSets/abc`
+    /// 
+    /// - For an account-level filter set for the buyer account representing bidder
+    ///   123: `bidders/123/accounts/123/filterSets/abc`
+    /// 
+    /// - For an account-level filter set for the child seat buyer account 456
+    ///   whose bidder is 123: `bidders/123/accounts/456/filterSets/abc`
+    ///
+    /// Sets the *filter set name* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn filter_set_name(mut self, new_value: &str) -> BidderFilterSetNonBillableWinningBidListCall<'a, C, A> {
+        self._filter_set_name = new_value.to_string();
+        self
+    }
+    /// A token identifying a page of results the server should return.
+    /// Typically, this is the value of
+    /// ListNonBillableWinningBidsResponse.nextPageToken
+    /// returned from the previous call to the nonBillableWinningBids.list
+    /// method.
+    ///
+    /// Sets the *page token* query property to the given value.
+    pub fn page_token(mut self, new_value: &str) -> BidderFilterSetNonBillableWinningBidListCall<'a, C, A> {
+        self._page_token = Some(new_value.to_string());
+        self
+    }
+    /// Requested page size. The server may return fewer results than requested.
+    /// If unspecified, the server will pick an appropriate default.
+    ///
+    /// Sets the *page size* query property to the given value.
+    pub fn page_size(mut self, new_value: i32) -> BidderFilterSetNonBillableWinningBidListCall<'a, C, A> {
+        self._page_size = Some(new_value);
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> BidderFilterSetNonBillableWinningBidListCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> BidderFilterSetNonBillableWinningBidListCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::AdexchangeBuyer`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> BidderFilterSetNonBillableWinningBidListCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Lists all metrics that are measured in terms of number of impressions.
+///
+/// A builder for the *filterSets.impressionMetrics.list* method supported by a *bidder* resource.
+/// It is not used directly, but through a `BidderMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_adexchangebuyer2_v2_beta1 as adexchangebuyer2_v2_beta1;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use adexchangebuyer2_v2_beta1::AdExchangeBuyerII;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = AdExchangeBuyerII::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.bidders().filter_sets_impression_metrics_list("filterSetName")
+///              .page_token("et")
+///              .page_size(-96)
+///              .doit();
+/// # }
+/// ```
+pub struct BidderFilterSetImpressionMetricListCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a AdExchangeBuyerII<C, A>,
+    _filter_set_name: String,
+    _page_token: Option<String>,
+    _page_size: Option<i32>,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for BidderFilterSetImpressionMetricListCall<'a, C, A> {}
+
+impl<'a, C, A> BidderFilterSetImpressionMetricListCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, ListImpressionMetricsResponse)> {
+        use url::percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "adexchangebuyer2.bidders.filterSets.impressionMetrics.list",
+                               http_method: hyper::method::Method::Get });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((5 + self._additional_params.len()));
+        params.push(("filterSetName", self._filter_set_name.to_string()));
+        if let Some(value) = self._page_token {
+            params.push(("pageToken", value.to_string()));
+        }
+        if let Some(value) = self._page_size {
+            params.push(("pageSize", value.to_string()));
+        }
+        for &field in ["alt", "filterSetName", "pageToken", "pageSize"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v2beta1/{+filterSetName}/impressionMetrics";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::AdexchangeBuyer.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{+filterSetName}", "filterSetName")].iter() {
+            let mut replace_with = String::new();
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = value.to_string();
+                    break;
+                }
+            }
+            if find_this.as_bytes()[1] == '+' as u8 {
+                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET);
+            }
+            url = url.replace(find_this, &replace_with);
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["filterSetName"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Get, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    /// Name of the filter set that should be applied to the requested metrics.
+    /// For example:
+    /// 
+    /// - For a bidder-level filter set for bidder 123:
+    ///   `bidders/123/filterSets/abc`
+    /// 
+    /// - For an account-level filter set for the buyer account representing bidder
+    ///   123: `bidders/123/accounts/123/filterSets/abc`
+    /// 
+    /// - For an account-level filter set for the child seat buyer account 456
+    ///   whose bidder is 123: `bidders/123/accounts/456/filterSets/abc`
+    ///
+    /// Sets the *filter set name* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn filter_set_name(mut self, new_value: &str) -> BidderFilterSetImpressionMetricListCall<'a, C, A> {
+        self._filter_set_name = new_value.to_string();
+        self
+    }
+    /// A token identifying a page of results the server should return.
+    /// Typically, this is the value of
+    /// ListImpressionMetricsResponse.nextPageToken
+    /// returned from the previous call to the impressionMetrics.list
+    /// method.
+    ///
+    /// Sets the *page token* query property to the given value.
+    pub fn page_token(mut self, new_value: &str) -> BidderFilterSetImpressionMetricListCall<'a, C, A> {
+        self._page_token = Some(new_value.to_string());
+        self
+    }
+    /// Requested page size. The server may return fewer results than requested.
+    /// If unspecified, the server will pick an appropriate default.
+    ///
+    /// Sets the *page size* query property to the given value.
+    pub fn page_size(mut self, new_value: i32) -> BidderFilterSetImpressionMetricListCall<'a, C, A> {
+        self._page_size = Some(new_value);
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> BidderFilterSetImpressionMetricListCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> BidderFilterSetImpressionMetricListCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::AdexchangeBuyer`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> BidderFilterSetImpressionMetricListCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// List all details associated with a specific reason for which bids were
+/// filtered, with the number of bids filtered for each detail.
+///
+/// A builder for the *filterSets.filteredBids.details.list* method supported by a *bidder* resource.
+/// It is not used directly, but through a `BidderMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_adexchangebuyer2_v2_beta1 as adexchangebuyer2_v2_beta1;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use adexchangebuyer2_v2_beta1::AdExchangeBuyerII;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = AdExchangeBuyerII::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.bidders().filter_sets_filtered_bids_details_list("filterSetName", -27)
+///              .page_token("Lorem")
+///              .page_size(-11)
+///              .doit();
+/// # }
+/// ```
+pub struct BidderFilterSetFilteredBidDetailListCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a AdExchangeBuyerII<C, A>,
+    _filter_set_name: String,
+    _creative_status_id: i32,
+    _page_token: Option<String>,
+    _page_size: Option<i32>,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for BidderFilterSetFilteredBidDetailListCall<'a, C, A> {}
+
+impl<'a, C, A> BidderFilterSetFilteredBidDetailListCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, ListCreativeStatusBreakdownByDetailResponse)> {
+        use url::percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "adexchangebuyer2.bidders.filterSets.filteredBids.details.list",
+                               http_method: hyper::method::Method::Get });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((6 + self._additional_params.len()));
+        params.push(("filterSetName", self._filter_set_name.to_string()));
+        params.push(("creativeStatusId", self._creative_status_id.to_string()));
+        if let Some(value) = self._page_token {
+            params.push(("pageToken", value.to_string()));
+        }
+        if let Some(value) = self._page_size {
+            params.push(("pageSize", value.to_string()));
+        }
+        for &field in ["alt", "filterSetName", "creativeStatusId", "pageToken", "pageSize"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v2beta1/{+filterSetName}/filteredBids/{creativeStatusId}/details";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::AdexchangeBuyer.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{+filterSetName}", "filterSetName"), ("{creativeStatusId}", "creativeStatusId")].iter() {
+            let mut replace_with = String::new();
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = value.to_string();
+                    break;
+                }
+            }
+            if find_this.as_bytes()[1] == '+' as u8 {
+                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET);
+            }
+            url = url.replace(find_this, &replace_with);
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(2);
+            for param_name in ["creativeStatusId", "filterSetName"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Get, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    /// Name of the filter set that should be applied to the requested metrics.
+    /// For example:
+    /// 
+    /// - For a bidder-level filter set for bidder 123:
+    ///   `bidders/123/filterSets/abc`
+    /// 
+    /// - For an account-level filter set for the buyer account representing bidder
+    ///   123: `bidders/123/accounts/123/filterSets/abc`
+    /// 
+    /// - For an account-level filter set for the child seat buyer account 456
+    ///   whose bidder is 123: `bidders/123/accounts/456/filterSets/abc`
+    ///
+    /// Sets the *filter set name* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn filter_set_name(mut self, new_value: &str) -> BidderFilterSetFilteredBidDetailListCall<'a, C, A> {
+        self._filter_set_name = new_value.to_string();
+        self
+    }
+    /// The ID of the creative status for which to retrieve a breakdown by detail.
+    /// See
+    /// [creative-status-codes](https://developers.google.com/ad-exchange/rtb/downloads/creative-status-codes).
+    /// Details are only available for statuses 10, 14, 15, 17, 18, 19, 86, and 87.
+    ///
+    /// Sets the *creative status id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn creative_status_id(mut self, new_value: i32) -> BidderFilterSetFilteredBidDetailListCall<'a, C, A> {
+        self._creative_status_id = new_value;
+        self
+    }
+    /// A token identifying a page of results the server should return.
+    /// Typically, this is the value of
+    /// ListCreativeStatusBreakdownByDetailResponse.nextPageToken
+    /// returned from the previous call to the filteredBids.details.list
+    /// method.
+    ///
+    /// Sets the *page token* query property to the given value.
+    pub fn page_token(mut self, new_value: &str) -> BidderFilterSetFilteredBidDetailListCall<'a, C, A> {
+        self._page_token = Some(new_value.to_string());
+        self
+    }
+    /// Requested page size. The server may return fewer results than requested.
+    /// If unspecified, the server will pick an appropriate default.
+    ///
+    /// Sets the *page size* query property to the given value.
+    pub fn page_size(mut self, new_value: i32) -> BidderFilterSetFilteredBidDetailListCall<'a, C, A> {
+        self._page_size = Some(new_value);
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> BidderFilterSetFilteredBidDetailListCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> BidderFilterSetFilteredBidDetailListCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::AdexchangeBuyer`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> BidderFilterSetFilteredBidDetailListCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// List all errors that occurred in bid responses, with the number of bid
+/// responses affected for each reason.
+///
+/// A builder for the *filterSets.bidResponseErrors.list* method supported by a *bidder* resource.
+/// It is not used directly, but through a `BidderMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_adexchangebuyer2_v2_beta1 as adexchangebuyer2_v2_beta1;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use adexchangebuyer2_v2_beta1::AdExchangeBuyerII;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = AdExchangeBuyerII::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.bidders().filter_sets_bid_response_errors_list("filterSetName")
+///              .page_token("sit")
+///              .page_size(-26)
+///              .doit();
+/// # }
+/// ```
+pub struct BidderFilterSetBidResponseErrorListCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a AdExchangeBuyerII<C, A>,
+    _filter_set_name: String,
+    _page_token: Option<String>,
+    _page_size: Option<i32>,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for BidderFilterSetBidResponseErrorListCall<'a, C, A> {}
+
+impl<'a, C, A> BidderFilterSetBidResponseErrorListCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, ListBidResponseErrorsResponse)> {
+        use url::percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "adexchangebuyer2.bidders.filterSets.bidResponseErrors.list",
+                               http_method: hyper::method::Method::Get });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((5 + self._additional_params.len()));
+        params.push(("filterSetName", self._filter_set_name.to_string()));
+        if let Some(value) = self._page_token {
+            params.push(("pageToken", value.to_string()));
+        }
+        if let Some(value) = self._page_size {
+            params.push(("pageSize", value.to_string()));
+        }
+        for &field in ["alt", "filterSetName", "pageToken", "pageSize"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v2beta1/{+filterSetName}/bidResponseErrors";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::AdexchangeBuyer.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{+filterSetName}", "filterSetName")].iter() {
+            let mut replace_with = String::new();
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = value.to_string();
+                    break;
+                }
+            }
+            if find_this.as_bytes()[1] == '+' as u8 {
+                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET);
+            }
+            url = url.replace(find_this, &replace_with);
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["filterSetName"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Get, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    /// Name of the filter set that should be applied to the requested metrics.
+    /// For example:
+    /// 
+    /// - For a bidder-level filter set for bidder 123:
+    ///   `bidders/123/filterSets/abc`
+    /// 
+    /// - For an account-level filter set for the buyer account representing bidder
+    ///   123: `bidders/123/accounts/123/filterSets/abc`
+    /// 
+    /// - For an account-level filter set for the child seat buyer account 456
+    ///   whose bidder is 123: `bidders/123/accounts/456/filterSets/abc`
+    ///
+    /// Sets the *filter set name* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn filter_set_name(mut self, new_value: &str) -> BidderFilterSetBidResponseErrorListCall<'a, C, A> {
+        self._filter_set_name = new_value.to_string();
+        self
+    }
+    /// A token identifying a page of results the server should return.
+    /// Typically, this is the value of
+    /// ListBidResponseErrorsResponse.nextPageToken
+    /// returned from the previous call to the bidResponseErrors.list
+    /// method.
+    ///
+    /// Sets the *page token* query property to the given value.
+    pub fn page_token(mut self, new_value: &str) -> BidderFilterSetBidResponseErrorListCall<'a, C, A> {
+        self._page_token = Some(new_value.to_string());
+        self
+    }
+    /// Requested page size. The server may return fewer results than requested.
+    /// If unspecified, the server will pick an appropriate default.
+    ///
+    /// Sets the *page size* query property to the given value.
+    pub fn page_size(mut self, new_value: i32) -> BidderFilterSetBidResponseErrorListCall<'a, C, A> {
+        self._page_size = Some(new_value);
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> BidderFilterSetBidResponseErrorListCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> BidderFilterSetBidResponseErrorListCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::AdexchangeBuyer`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> BidderFilterSetBidResponseErrorListCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// List all reasons for which winning bids were not billable, with the number
+/// of bids not billed for each reason.
+///
+/// A builder for the *accounts.filterSets.nonBillableWinningBids.list* method supported by a *bidder* resource.
+/// It is not used directly, but through a `BidderMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_adexchangebuyer2_v2_beta1 as adexchangebuyer2_v2_beta1;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use adexchangebuyer2_v2_beta1::AdExchangeBuyerII;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = AdExchangeBuyerII::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.bidders().accounts_filter_sets_non_billable_winning_bids_list("filterSetName")
+///              .page_token("rebum.")
+///              .page_size(-45)
+///              .doit();
+/// # }
+/// ```
+pub struct BidderAccountFilterSetNonBillableWinningBidListCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a AdExchangeBuyerII<C, A>,
+    _filter_set_name: String,
+    _page_token: Option<String>,
+    _page_size: Option<i32>,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for BidderAccountFilterSetNonBillableWinningBidListCall<'a, C, A> {}
+
+impl<'a, C, A> BidderAccountFilterSetNonBillableWinningBidListCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, ListNonBillableWinningBidsResponse)> {
+        use url::percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "adexchangebuyer2.bidders.accounts.filterSets.nonBillableWinningBids.list",
+                               http_method: hyper::method::Method::Get });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((5 + self._additional_params.len()));
+        params.push(("filterSetName", self._filter_set_name.to_string()));
+        if let Some(value) = self._page_token {
+            params.push(("pageToken", value.to_string()));
+        }
+        if let Some(value) = self._page_size {
+            params.push(("pageSize", value.to_string()));
+        }
+        for &field in ["alt", "filterSetName", "pageToken", "pageSize"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v2beta1/{+filterSetName}/nonBillableWinningBids";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::AdexchangeBuyer.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{+filterSetName}", "filterSetName")].iter() {
+            let mut replace_with = String::new();
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = value.to_string();
+                    break;
+                }
+            }
+            if find_this.as_bytes()[1] == '+' as u8 {
+                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET);
+            }
+            url = url.replace(find_this, &replace_with);
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["filterSetName"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Get, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    /// Name of the filter set that should be applied to the requested metrics.
+    /// For example:
+    /// 
+    /// - For a bidder-level filter set for bidder 123:
+    ///   `bidders/123/filterSets/abc`
+    /// 
+    /// - For an account-level filter set for the buyer account representing bidder
+    ///   123: `bidders/123/accounts/123/filterSets/abc`
+    /// 
+    /// - For an account-level filter set for the child seat buyer account 456
+    ///   whose bidder is 123: `bidders/123/accounts/456/filterSets/abc`
+    ///
+    /// Sets the *filter set name* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn filter_set_name(mut self, new_value: &str) -> BidderAccountFilterSetNonBillableWinningBidListCall<'a, C, A> {
+        self._filter_set_name = new_value.to_string();
+        self
+    }
+    /// A token identifying a page of results the server should return.
+    /// Typically, this is the value of
+    /// ListNonBillableWinningBidsResponse.nextPageToken
+    /// returned from the previous call to the nonBillableWinningBids.list
+    /// method.
+    ///
+    /// Sets the *page token* query property to the given value.
+    pub fn page_token(mut self, new_value: &str) -> BidderAccountFilterSetNonBillableWinningBidListCall<'a, C, A> {
+        self._page_token = Some(new_value.to_string());
+        self
+    }
+    /// Requested page size. The server may return fewer results than requested.
+    /// If unspecified, the server will pick an appropriate default.
+    ///
+    /// Sets the *page size* query property to the given value.
+    pub fn page_size(mut self, new_value: i32) -> BidderAccountFilterSetNonBillableWinningBidListCall<'a, C, A> {
+        self._page_size = Some(new_value);
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> BidderAccountFilterSetNonBillableWinningBidListCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> BidderAccountFilterSetNonBillableWinningBidListCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::AdexchangeBuyer`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> BidderAccountFilterSetNonBillableWinningBidListCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Lists all metrics that are measured in terms of number of bids.
+///
+/// A builder for the *filterSets.bidMetrics.list* method supported by a *bidder* resource.
+/// It is not used directly, but through a `BidderMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_adexchangebuyer2_v2_beta1 as adexchangebuyer2_v2_beta1;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use adexchangebuyer2_v2_beta1::AdExchangeBuyerII;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = AdExchangeBuyerII::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.bidders().filter_sets_bid_metrics_list("filterSetName")
+///              .page_token("vero")
+///              .page_size(-95)
+///              .doit();
+/// # }
+/// ```
+pub struct BidderFilterSetBidMetricListCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a AdExchangeBuyerII<C, A>,
+    _filter_set_name: String,
+    _page_token: Option<String>,
+    _page_size: Option<i32>,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for BidderFilterSetBidMetricListCall<'a, C, A> {}
+
+impl<'a, C, A> BidderFilterSetBidMetricListCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, ListBidMetricsResponse)> {
+        use url::percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "adexchangebuyer2.bidders.filterSets.bidMetrics.list",
+                               http_method: hyper::method::Method::Get });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((5 + self._additional_params.len()));
+        params.push(("filterSetName", self._filter_set_name.to_string()));
+        if let Some(value) = self._page_token {
+            params.push(("pageToken", value.to_string()));
+        }
+        if let Some(value) = self._page_size {
+            params.push(("pageSize", value.to_string()));
+        }
+        for &field in ["alt", "filterSetName", "pageToken", "pageSize"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v2beta1/{+filterSetName}/bidMetrics";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::AdexchangeBuyer.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{+filterSetName}", "filterSetName")].iter() {
+            let mut replace_with = String::new();
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = value.to_string();
+                    break;
+                }
+            }
+            if find_this.as_bytes()[1] == '+' as u8 {
+                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET);
+            }
+            url = url.replace(find_this, &replace_with);
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["filterSetName"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Get, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    /// Name of the filter set that should be applied to the requested metrics.
+    /// For example:
+    /// 
+    /// - For a bidder-level filter set for bidder 123:
+    ///   `bidders/123/filterSets/abc`
+    /// 
+    /// - For an account-level filter set for the buyer account representing bidder
+    ///   123: `bidders/123/accounts/123/filterSets/abc`
+    /// 
+    /// - For an account-level filter set for the child seat buyer account 456
+    ///   whose bidder is 123: `bidders/123/accounts/456/filterSets/abc`
+    ///
+    /// Sets the *filter set name* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn filter_set_name(mut self, new_value: &str) -> BidderFilterSetBidMetricListCall<'a, C, A> {
+        self._filter_set_name = new_value.to_string();
+        self
+    }
+    /// A token identifying a page of results the server should return.
+    /// Typically, this is the value of
+    /// ListBidMetricsResponse.nextPageToken
+    /// returned from the previous call to the bidMetrics.list
+    /// method.
+    ///
+    /// Sets the *page token* query property to the given value.
+    pub fn page_token(mut self, new_value: &str) -> BidderFilterSetBidMetricListCall<'a, C, A> {
+        self._page_token = Some(new_value.to_string());
+        self
+    }
+    /// Requested page size. The server may return fewer results than requested.
+    /// If unspecified, the server will pick an appropriate default.
+    ///
+    /// Sets the *page size* query property to the given value.
+    pub fn page_size(mut self, new_value: i32) -> BidderFilterSetBidMetricListCall<'a, C, A> {
+        self._page_size = Some(new_value);
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> BidderFilterSetBidMetricListCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> BidderFilterSetBidMetricListCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::AdexchangeBuyer`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> BidderFilterSetBidMetricListCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// List all reasons for which bid responses were considered to have no
+/// applicable bids, with the number of bid responses affected for each reason.
+///
+/// A builder for the *filterSets.bidResponsesWithoutBids.list* method supported by a *bidder* resource.
+/// It is not used directly, but through a `BidderMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_adexchangebuyer2_v2_beta1 as adexchangebuyer2_v2_beta1;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use adexchangebuyer2_v2_beta1::AdExchangeBuyerII;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = AdExchangeBuyerII::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.bidders().filter_sets_bid_responses_without_bids_list("filterSetName")
+///              .page_token("consetetur")
+///              .page_size(-84)
+///              .doit();
+/// # }
+/// ```
+pub struct BidderFilterSetBidResponsesWithoutBidListCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a AdExchangeBuyerII<C, A>,
+    _filter_set_name: String,
+    _page_token: Option<String>,
+    _page_size: Option<i32>,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for BidderFilterSetBidResponsesWithoutBidListCall<'a, C, A> {}
+
+impl<'a, C, A> BidderFilterSetBidResponsesWithoutBidListCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, ListBidResponsesWithoutBidsResponse)> {
+        use url::percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "adexchangebuyer2.bidders.filterSets.bidResponsesWithoutBids.list",
+                               http_method: hyper::method::Method::Get });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((5 + self._additional_params.len()));
+        params.push(("filterSetName", self._filter_set_name.to_string()));
+        if let Some(value) = self._page_token {
+            params.push(("pageToken", value.to_string()));
+        }
+        if let Some(value) = self._page_size {
+            params.push(("pageSize", value.to_string()));
+        }
+        for &field in ["alt", "filterSetName", "pageToken", "pageSize"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v2beta1/{+filterSetName}/bidResponsesWithoutBids";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::AdexchangeBuyer.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{+filterSetName}", "filterSetName")].iter() {
+            let mut replace_with = String::new();
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = value.to_string();
+                    break;
+                }
+            }
+            if find_this.as_bytes()[1] == '+' as u8 {
+                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET);
+            }
+            url = url.replace(find_this, &replace_with);
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["filterSetName"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Get, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    /// Name of the filter set that should be applied to the requested metrics.
+    /// For example:
+    /// 
+    /// - For a bidder-level filter set for bidder 123:
+    ///   `bidders/123/filterSets/abc`
+    /// 
+    /// - For an account-level filter set for the buyer account representing bidder
+    ///   123: `bidders/123/accounts/123/filterSets/abc`
+    /// 
+    /// - For an account-level filter set for the child seat buyer account 456
+    ///   whose bidder is 123: `bidders/123/accounts/456/filterSets/abc`
+    ///
+    /// Sets the *filter set name* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn filter_set_name(mut self, new_value: &str) -> BidderFilterSetBidResponsesWithoutBidListCall<'a, C, A> {
+        self._filter_set_name = new_value.to_string();
+        self
+    }
+    /// A token identifying a page of results the server should return.
+    /// Typically, this is the value of
+    /// ListBidResponsesWithoutBidsResponse.nextPageToken
+    /// returned from the previous call to the bidResponsesWithoutBids.list
+    /// method.
+    ///
+    /// Sets the *page token* query property to the given value.
+    pub fn page_token(mut self, new_value: &str) -> BidderFilterSetBidResponsesWithoutBidListCall<'a, C, A> {
+        self._page_token = Some(new_value.to_string());
+        self
+    }
+    /// Requested page size. The server may return fewer results than requested.
+    /// If unspecified, the server will pick an appropriate default.
+    ///
+    /// Sets the *page size* query property to the given value.
+    pub fn page_size(mut self, new_value: i32) -> BidderFilterSetBidResponsesWithoutBidListCall<'a, C, A> {
+        self._page_size = Some(new_value);
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> BidderFilterSetBidResponsesWithoutBidListCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> BidderFilterSetBidResponsesWithoutBidListCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::AdexchangeBuyer`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> BidderFilterSetBidResponsesWithoutBidListCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Creates the specified filter set for the account with the given account ID.
+///
+/// A builder for the *filterSets.create* method supported by a *bidder* resource.
+/// It is not used directly, but through a `BidderMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_adexchangebuyer2_v2_beta1 as adexchangebuyer2_v2_beta1;
+/// use adexchangebuyer2_v2_beta1::FilterSet;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use adexchangebuyer2_v2_beta1::AdExchangeBuyerII;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = AdExchangeBuyerII::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = FilterSet::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.bidders().filter_sets_create(req, "ownerName")
+///              .is_transient(false)
+///              .doit();
+/// # }
+/// ```
+pub struct BidderFilterSetCreateCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a AdExchangeBuyerII<C, A>,
+    _request: FilterSet,
+    _owner_name: String,
+    _is_transient: Option<bool>,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for BidderFilterSetCreateCall<'a, C, A> {}
+
+impl<'a, C, A> BidderFilterSetCreateCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, FilterSet)> {
+        use url::percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "adexchangebuyer2.bidders.filterSets.create",
+                               http_method: hyper::method::Method::Post });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((5 + self._additional_params.len()));
+        params.push(("ownerName", self._owner_name.to_string()));
+        if let Some(value) = self._is_transient {
+            params.push(("isTransient", value.to_string()));
+        }
+        for &field in ["alt", "ownerName", "isTransient"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v2beta1/{+ownerName}/filterSets";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::AdexchangeBuyer.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{+ownerName}", "ownerName")].iter() {
+            let mut replace_with = String::new();
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = value.to_string();
+                    break;
+                }
+            }
+            if find_this.as_bytes()[1] == '+' as u8 {
+                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET);
+            }
+            url = url.replace(find_this, &replace_with);
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["ownerName"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Post, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: FilterSet) -> BidderFilterSetCreateCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// Name of the owner (bidder or account) of the filter set to be created.
+    /// For example:
+    /// 
+    /// - For a bidder-level filter set for bidder 123: `bidders/123`
+    /// 
+    /// - For an account-level filter set for the buyer account representing bidder
+    ///   123: `bidders/123/accounts/123`
+    /// 
+    /// - For an account-level filter set for the child seat buyer account 456
+    ///   whose bidder is 123: `bidders/123/accounts/456`
+    ///
+    /// Sets the *owner name* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn owner_name(mut self, new_value: &str) -> BidderFilterSetCreateCall<'a, C, A> {
+        self._owner_name = new_value.to_string();
+        self
+    }
+    /// Whether the filter set is transient, or should be persisted indefinitely.
+    /// By default, filter sets are not transient.
+    /// If transient, it will be available for at least 1 hour after creation.
+    ///
+    /// Sets the *is transient* query property to the given value.
+    pub fn is_transient(mut self, new_value: bool) -> BidderFilterSetCreateCall<'a, C, A> {
+        self._is_transient = Some(new_value);
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> BidderFilterSetCreateCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> BidderFilterSetCreateCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::AdexchangeBuyer`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> BidderFilterSetCreateCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Associate an existing deal with a creative.
+///
+/// A builder for the *creatives.dealAssociations.add* method supported by a *account* resource.
+/// It is not used directly, but through a `AccountMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_adexchangebuyer2_v2_beta1 as adexchangebuyer2_v2_beta1;
+/// use adexchangebuyer2_v2_beta1::AddDealAssociationRequest;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use adexchangebuyer2_v2_beta1::AdExchangeBuyerII;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = AdExchangeBuyerII::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = AddDealAssociationRequest::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.accounts().creatives_deal_associations_add(req, "accountId", "creativeId")
+///              .doit();
+/// # }
+/// ```
+pub struct AccountCreativeDealAssociationAddCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a AdExchangeBuyerII<C, A>,
+    _request: AddDealAssociationRequest,
+    _account_id: String,
+    _creative_id: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for AccountCreativeDealAssociationAddCall<'a, C, A> {}
+
+impl<'a, C, A> AccountCreativeDealAssociationAddCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, Empty)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "adexchangebuyer2.accounts.creatives.dealAssociations.add",
+                               http_method: hyper::method::Method::Post });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((5 + self._additional_params.len()));
+        params.push(("accountId", self._account_id.to_string()));
+        params.push(("creativeId", self._creative_id.to_string()));
+        for &field in ["alt", "accountId", "creativeId"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v2beta1/accounts/{accountId}/creatives/{creativeId}/dealAssociations:add";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::AdexchangeBuyer.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{accountId}", "accountId"), ("{creativeId}", "creativeId")].iter() {
+            let mut replace_with: Option<&str> = None;
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = Some(value);
+                    break;
+                }
+            }
+            url = url.replace(find_this, replace_with.expect("to find substitution value in params"));
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(2);
+            for param_name in ["creativeId", "accountId"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Post, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: AddDealAssociationRequest) -> AccountCreativeDealAssociationAddCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// The account the creative belongs to.
+    ///
+    /// Sets the *account id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn account_id(mut self, new_value: &str) -> AccountCreativeDealAssociationAddCall<'a, C, A> {
+        self._account_id = new_value.to_string();
+        self
+    }
+    /// The ID of the creative associated with the deal.
+    ///
+    /// Sets the *creative id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn creative_id(mut self, new_value: &str) -> AccountCreativeDealAssociationAddCall<'a, C, A> {
+        self._creative_id = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> AccountCreativeDealAssociationAddCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> AccountCreativeDealAssociationAddCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::AdexchangeBuyer`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> AccountCreativeDealAssociationAddCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Lists creatives.
+///
+/// A builder for the *creatives.list* method supported by a *account* resource.
+/// It is not used directly, but through a `AccountMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_adexchangebuyer2_v2_beta1 as adexchangebuyer2_v2_beta1;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use adexchangebuyer2_v2_beta1::AdExchangeBuyerII;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = AdExchangeBuyerII::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.accounts().creatives_list("accountId")
+///              .query("consetetur")
+///              .page_token("takimata")
+///              .page_size(-40)
+///              .doit();
+/// # }
+/// ```
+pub struct AccountCreativeListCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a AdExchangeBuyerII<C, A>,
+    _account_id: String,
+    _query: Option<String>,
+    _page_token: Option<String>,
+    _page_size: Option<i32>,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for AccountCreativeListCall<'a, C, A> {}
+
+impl<'a, C, A> AccountCreativeListCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, ListCreativesResponse)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "adexchangebuyer2.accounts.creatives.list",
+                               http_method: hyper::method::Method::Get });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((6 + self._additional_params.len()));
+        params.push(("accountId", self._account_id.to_string()));
+        if let Some(value) = self._query {
+            params.push(("query", value.to_string()));
+        }
+        if let Some(value) = self._page_token {
+            params.push(("pageToken", value.to_string()));
+        }
+        if let Some(value) = self._page_size {
+            params.push(("pageSize", value.to_string()));
+        }
+        for &field in ["alt", "accountId", "query", "pageToken", "pageSize"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v2beta1/accounts/{accountId}/creatives";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::AdexchangeBuyer.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{accountId}", "accountId")].iter() {
+            let mut replace_with: Option<&str> = None;
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = Some(value);
+                    break;
+                }
+            }
+            url = url.replace(find_this, replace_with.expect("to find substitution value in params"));
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["accountId"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Get, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    /// The account to list the creatives from.
+    /// Specify "-" to list all creatives the current user has access to.
+    ///
+    /// Sets the *account id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn account_id(mut self, new_value: &str) -> AccountCreativeListCall<'a, C, A> {
+        self._account_id = new_value.to_string();
+        self
+    }
+    /// An optional query string to filter creatives. If no filter is specified,
+    /// all active creatives will be returned.
+    /// Supported queries are:
+    /// <ul>
+    /// <li>accountId=<i>account_id_string</i>
+    /// <li>creativeId=<i>creative_id_string</i>
+    /// <li>dealsStatus: {approved, conditionally_approved, disapproved,
+    ///                    not_checked}
+    /// <li>openAuctionStatus: {approved, conditionally_approved, disapproved,
+    ///                           not_checked}
+    /// <li>attribute: {a numeric attribute from the list of attributes}
+    /// <li>disapprovalReason: {a reason from
+    /// DisapprovalReason
+    /// </ul>
+    /// Example: 'accountId=12345 AND (dealsStatus:disapproved AND
+    /// disapprovalReason:unacceptable_content) OR attribute:47'
+    ///
+    /// Sets the *query* query property to the given value.
+    pub fn query(mut self, new_value: &str) -> AccountCreativeListCall<'a, C, A> {
+        self._query = Some(new_value.to_string());
+        self
+    }
+    /// A token identifying a page of results the server should return.
+    /// Typically, this is the value of
+    /// ListCreativesResponse.next_page_token
+    /// returned from the previous call to 'ListCreatives' method.
+    ///
+    /// Sets the *page token* query property to the given value.
+    pub fn page_token(mut self, new_value: &str) -> AccountCreativeListCall<'a, C, A> {
+        self._page_token = Some(new_value.to_string());
+        self
+    }
+    /// Requested page size. The server may return fewer creatives than requested
+    /// (due to timeout constraint) even if more are available via another call.
+    /// If unspecified, server will pick an appropriate default.
+    /// Acceptable values are 1 to 1000, inclusive.
+    ///
+    /// Sets the *page size* query property to the given value.
+    pub fn page_size(mut self, new_value: i32) -> AccountCreativeListCall<'a, C, A> {
+        self._page_size = Some(new_value);
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> AccountCreativeListCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> AccountCreativeListCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::AdexchangeBuyer`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> AccountCreativeListCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Watches a creative. Will result in push notifications being sent to the
+/// topic when the creative changes status.
+///
+/// A builder for the *creatives.watch* method supported by a *account* resource.
+/// It is not used directly, but through a `AccountMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_adexchangebuyer2_v2_beta1 as adexchangebuyer2_v2_beta1;
+/// use adexchangebuyer2_v2_beta1::WatchCreativeRequest;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use adexchangebuyer2_v2_beta1::AdExchangeBuyerII;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = AdExchangeBuyerII::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = WatchCreativeRequest::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.accounts().creatives_watch(req, "accountId", "creativeId")
+///              .doit();
+/// # }
+/// ```
+pub struct AccountCreativeWatchCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a AdExchangeBuyerII<C, A>,
+    _request: WatchCreativeRequest,
+    _account_id: String,
+    _creative_id: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for AccountCreativeWatchCall<'a, C, A> {}
+
+impl<'a, C, A> AccountCreativeWatchCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, Empty)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "adexchangebuyer2.accounts.creatives.watch",
+                               http_method: hyper::method::Method::Post });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((5 + self._additional_params.len()));
+        params.push(("accountId", self._account_id.to_string()));
+        params.push(("creativeId", self._creative_id.to_string()));
+        for &field in ["alt", "accountId", "creativeId"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v2beta1/accounts/{accountId}/creatives/{creativeId}:watch";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::AdexchangeBuyer.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{accountId}", "accountId"), ("{creativeId}", "creativeId")].iter() {
+            let mut replace_with: Option<&str> = None;
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = Some(value);
+                    break;
+                }
+            }
+            url = url.replace(find_this, replace_with.expect("to find substitution value in params"));
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(2);
+            for param_name in ["creativeId", "accountId"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Post, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: WatchCreativeRequest) -> AccountCreativeWatchCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// The account of the creative to watch.
+    ///
+    /// Sets the *account id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn account_id(mut self, new_value: &str) -> AccountCreativeWatchCall<'a, C, A> {
+        self._account_id = new_value.to_string();
+        self
+    }
+    /// The creative ID to watch for status changes.
+    /// Specify "-" to watch all creatives under the above account.
+    /// If both creative-level and account-level notifications are
+    /// sent, only a single notification will be sent to the
+    /// creative-level notification topic.
+    ///
+    /// Sets the *creative id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn creative_id(mut self, new_value: &str) -> AccountCreativeWatchCall<'a, C, A> {
+        self._creative_id = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> AccountCreativeWatchCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> AccountCreativeWatchCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::AdexchangeBuyer`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> AccountCreativeWatchCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Updates an existing client buyer.
+///
+/// A builder for the *clients.update* method supported by a *account* resource.
+/// It is not used directly, but through a `AccountMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_adexchangebuyer2_v2_beta1 as adexchangebuyer2_v2_beta1;
+/// use adexchangebuyer2_v2_beta1::Client;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use adexchangebuyer2_v2_beta1::AdExchangeBuyerII;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = AdExchangeBuyerII::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = Client::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.accounts().clients_update(req, "accountId", "clientAccountId")
+///              .doit();
+/// # }
+/// ```
+pub struct AccountClientUpdateCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a AdExchangeBuyerII<C, A>,
+    _request: Client,
+    _account_id: String,
+    _client_account_id: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for AccountClientUpdateCall<'a, C, A> {}
+
+impl<'a, C, A> AccountClientUpdateCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, Client)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "adexchangebuyer2.accounts.clients.update",
+                               http_method: hyper::method::Method::Put });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((5 + self._additional_params.len()));
+        params.push(("accountId", self._account_id.to_string()));
+        params.push(("clientAccountId", self._client_account_id.to_string()));
+        for &field in ["alt", "accountId", "clientAccountId"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v2beta1/accounts/{accountId}/clients/{clientAccountId}";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::AdexchangeBuyer.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{accountId}", "accountId"), ("{clientAccountId}", "clientAccountId")].iter() {
+            let mut replace_with: Option<&str> = None;
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = Some(value);
+                    break;
+                }
+            }
+            url = url.replace(find_this, replace_with.expect("to find substitution value in params"));
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(2);
+            for param_name in ["clientAccountId", "accountId"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Put, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: Client) -> AccountClientUpdateCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// Unique numerical account ID for the buyer of which the client buyer
+    /// is a customer; the sponsor buyer to update a client for. (required)
+    ///
+    /// Sets the *account id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn account_id(mut self, new_value: &str) -> AccountClientUpdateCall<'a, C, A> {
+        self._account_id = new_value.to_string();
+        self
+    }
+    /// Unique numerical account ID of the client to update. (required)
+    ///
+    /// Sets the *client account id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn client_account_id(mut self, new_value: &str) -> AccountClientUpdateCall<'a, C, A> {
+        self._client_account_id = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> AccountClientUpdateCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> AccountClientUpdateCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::AdexchangeBuyer`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> AccountClientUpdateCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Retrieves an existing client user.
+///
+/// A builder for the *clients.users.get* method supported by a *account* resource.
+/// It is not used directly, but through a `AccountMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_adexchangebuyer2_v2_beta1 as adexchangebuyer2_v2_beta1;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use adexchangebuyer2_v2_beta1::AdExchangeBuyerII;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = AdExchangeBuyerII::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.accounts().clients_users_get("accountId", "clientAccountId", "userId")
+///              .doit();
+/// # }
+/// ```
+pub struct AccountClientUserGetCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a AdExchangeBuyerII<C, A>,
+    _account_id: String,
+    _client_account_id: String,
+    _user_id: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for AccountClientUserGetCall<'a, C, A> {}
+
+impl<'a, C, A> AccountClientUserGetCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, ClientUser)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "adexchangebuyer2.accounts.clients.users.get",
+                               http_method: hyper::method::Method::Get });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((5 + self._additional_params.len()));
+        params.push(("accountId", self._account_id.to_string()));
+        params.push(("clientAccountId", self._client_account_id.to_string()));
+        params.push(("userId", self._user_id.to_string()));
+        for &field in ["alt", "accountId", "clientAccountId", "userId"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v2beta1/accounts/{accountId}/clients/{clientAccountId}/users/{userId}";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::AdexchangeBuyer.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{accountId}", "accountId"), ("{clientAccountId}", "clientAccountId"), ("{userId}", "userId")].iter() {
+            let mut replace_with: Option<&str> = None;
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = Some(value);
+                    break;
+                }
+            }
+            url = url.replace(find_this, replace_with.expect("to find substitution value in params"));
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(3);
+            for param_name in ["userId", "clientAccountId", "accountId"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Get, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    /// Numerical account ID of the client's sponsor buyer. (required)
+    ///
+    /// Sets the *account id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn account_id(mut self, new_value: &str) -> AccountClientUserGetCall<'a, C, A> {
+        self._account_id = new_value.to_string();
+        self
+    }
+    /// Numerical account ID of the client buyer
+    /// that the user to be retrieved is associated with. (required)
+    ///
+    /// Sets the *client account id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn client_account_id(mut self, new_value: &str) -> AccountClientUserGetCall<'a, C, A> {
+        self._client_account_id = new_value.to_string();
+        self
+    }
+    /// Numerical identifier of the user to retrieve. (required)
+    ///
+    /// Sets the *user id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn user_id(mut self, new_value: &str) -> AccountClientUserGetCall<'a, C, A> {
+        self._user_id = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> AccountClientUserGetCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> AccountClientUserGetCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::AdexchangeBuyer`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> AccountClientUserGetCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Retrieves an existing client user invitation.
+///
+/// A builder for the *clients.invitations.get* method supported by a *account* resource.
+/// It is not used directly, but through a `AccountMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_adexchangebuyer2_v2_beta1 as adexchangebuyer2_v2_beta1;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use adexchangebuyer2_v2_beta1::AdExchangeBuyerII;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = AdExchangeBuyerII::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.accounts().clients_invitations_get("accountId", "clientAccountId", "invitationId")
+///              .doit();
+/// # }
+/// ```
+pub struct AccountClientInvitationGetCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a AdExchangeBuyerII<C, A>,
+    _account_id: String,
+    _client_account_id: String,
+    _invitation_id: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for AccountClientInvitationGetCall<'a, C, A> {}
+
+impl<'a, C, A> AccountClientInvitationGetCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, ClientUserInvitation)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "adexchangebuyer2.accounts.clients.invitations.get",
+                               http_method: hyper::method::Method::Get });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((5 + self._additional_params.len()));
+        params.push(("accountId", self._account_id.to_string()));
+        params.push(("clientAccountId", self._client_account_id.to_string()));
+        params.push(("invitationId", self._invitation_id.to_string()));
+        for &field in ["alt", "accountId", "clientAccountId", "invitationId"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v2beta1/accounts/{accountId}/clients/{clientAccountId}/invitations/{invitationId}";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::AdexchangeBuyer.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{accountId}", "accountId"), ("{clientAccountId}", "clientAccountId"), ("{invitationId}", "invitationId")].iter() {
+            let mut replace_with: Option<&str> = None;
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = Some(value);
+                    break;
+                }
+            }
+            url = url.replace(find_this, replace_with.expect("to find substitution value in params"));
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(3);
+            for param_name in ["invitationId", "clientAccountId", "accountId"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Get, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    /// Numerical account ID of the client's sponsor buyer. (required)
+    ///
+    /// Sets the *account id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn account_id(mut self, new_value: &str) -> AccountClientInvitationGetCall<'a, C, A> {
+        self._account_id = new_value.to_string();
+        self
+    }
+    /// Numerical account ID of the client buyer that the user invitation
+    /// to be retrieved is associated with. (required)
+    ///
+    /// Sets the *client account id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn client_account_id(mut self, new_value: &str) -> AccountClientInvitationGetCall<'a, C, A> {
+        self._client_account_id = new_value.to_string();
+        self
+    }
+    /// Numerical identifier of the user invitation to retrieve. (required)
+    ///
+    /// Sets the *invitation id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn invitation_id(mut self, new_value: &str) -> AccountClientInvitationGetCall<'a, C, A> {
+        self._invitation_id = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> AccountClientInvitationGetCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> AccountClientInvitationGetCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::AdexchangeBuyer`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> AccountClientInvitationGetCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Lists all the clients for the current sponsor buyer.
+///
+/// A builder for the *clients.list* method supported by a *account* resource.
+/// It is not used directly, but through a `AccountMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_adexchangebuyer2_v2_beta1 as adexchangebuyer2_v2_beta1;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use adexchangebuyer2_v2_beta1::AdExchangeBuyerII;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = AdExchangeBuyerII::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.accounts().clients_list("accountId")
+///              .partner_client_id("sed")
+///              .page_token("aliquyam")
+///              .page_size(-53)
+///              .doit();
+/// # }
+/// ```
+pub struct AccountClientListCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a AdExchangeBuyerII<C, A>,
+    _account_id: String,
+    _partner_client_id: Option<String>,
+    _page_token: Option<String>,
+    _page_size: Option<i32>,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for AccountClientListCall<'a, C, A> {}
+
+impl<'a, C, A> AccountClientListCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, ListClientsResponse)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "adexchangebuyer2.accounts.clients.list",
+                               http_method: hyper::method::Method::Get });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((6 + self._additional_params.len()));
+        params.push(("accountId", self._account_id.to_string()));
+        if let Some(value) = self._partner_client_id {
+            params.push(("partnerClientId", value.to_string()));
+        }
+        if let Some(value) = self._page_token {
+            params.push(("pageToken", value.to_string()));
+        }
+        if let Some(value) = self._page_size {
+            params.push(("pageSize", value.to_string()));
+        }
+        for &field in ["alt", "accountId", "partnerClientId", "pageToken", "pageSize"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v2beta1/accounts/{accountId}/clients";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::AdexchangeBuyer.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{accountId}", "accountId")].iter() {
+            let mut replace_with: Option<&str> = None;
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = Some(value);
+                    break;
+                }
+            }
+            url = url.replace(find_this, replace_with.expect("to find substitution value in params"));
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["accountId"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Get, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    /// Unique numerical account ID of the sponsor buyer to list the clients for.
+    ///
+    /// Sets the *account id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn account_id(mut self, new_value: &str) -> AccountClientListCall<'a, C, A> {
+        self._account_id = new_value.to_string();
+        self
+    }
+    /// Optional unique identifier (from the standpoint of an Ad Exchange sponsor
+    /// buyer partner) of the client to return.
+    /// If specified, at most one client will be returned in the response.
+    ///
+    /// Sets the *partner client id* query property to the given value.
+    pub fn partner_client_id(mut self, new_value: &str) -> AccountClientListCall<'a, C, A> {
+        self._partner_client_id = Some(new_value.to_string());
+        self
+    }
+    /// A token identifying a page of results the server should return.
+    /// Typically, this is the value of
+    /// ListClientsResponse.nextPageToken
+    /// returned from the previous call to the
+    /// accounts.clients.list method.
+    ///
+    /// Sets the *page token* query property to the given value.
+    pub fn page_token(mut self, new_value: &str) -> AccountClientListCall<'a, C, A> {
+        self._page_token = Some(new_value.to_string());
+        self
+    }
+    /// Requested page size. The server may return fewer clients than requested.
+    /// If unspecified, the server will pick an appropriate default.
+    ///
+    /// Sets the *page size* query property to the given value.
+    pub fn page_size(mut self, new_value: i32) -> AccountClientListCall<'a, C, A> {
+        self._page_size = Some(new_value);
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> AccountClientListCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> AccountClientListCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::AdexchangeBuyer`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> AccountClientListCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Gets a creative.
+///
+/// A builder for the *creatives.get* method supported by a *account* resource.
+/// It is not used directly, but through a `AccountMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_adexchangebuyer2_v2_beta1 as adexchangebuyer2_v2_beta1;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use adexchangebuyer2_v2_beta1::AdExchangeBuyerII;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = AdExchangeBuyerII::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.accounts().creatives_get("accountId", "creativeId")
+///              .doit();
+/// # }
+/// ```
+pub struct AccountCreativeGetCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a AdExchangeBuyerII<C, A>,
+    _account_id: String,
+    _creative_id: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for AccountCreativeGetCall<'a, C, A> {}
+
+impl<'a, C, A> AccountCreativeGetCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, Creative)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "adexchangebuyer2.accounts.creatives.get",
+                               http_method: hyper::method::Method::Get });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((4 + self._additional_params.len()));
+        params.push(("accountId", self._account_id.to_string()));
+        params.push(("creativeId", self._creative_id.to_string()));
+        for &field in ["alt", "accountId", "creativeId"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v2beta1/accounts/{accountId}/creatives/{creativeId}";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::AdexchangeBuyer.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{accountId}", "accountId"), ("{creativeId}", "creativeId")].iter() {
+            let mut replace_with: Option<&str> = None;
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = Some(value);
+                    break;
+                }
+            }
+            url = url.replace(find_this, replace_with.expect("to find substitution value in params"));
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(2);
+            for param_name in ["creativeId", "accountId"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Get, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    /// The account the creative belongs to.
+    ///
+    /// Sets the *account id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn account_id(mut self, new_value: &str) -> AccountCreativeGetCall<'a, C, A> {
+        self._account_id = new_value.to_string();
+        self
+    }
+    /// The ID of the creative to retrieve.
+    ///
+    /// Sets the *creative id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn creative_id(mut self, new_value: &str) -> AccountCreativeGetCall<'a, C, A> {
+        self._creative_id = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> AccountCreativeGetCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> AccountCreativeGetCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::AdexchangeBuyer`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> AccountCreativeGetCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Creates a creative.
+///
+/// A builder for the *creatives.create* method supported by a *account* resource.
+/// It is not used directly, but through a `AccountMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_adexchangebuyer2_v2_beta1 as adexchangebuyer2_v2_beta1;
+/// use adexchangebuyer2_v2_beta1::Creative;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use adexchangebuyer2_v2_beta1::AdExchangeBuyerII;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = AdExchangeBuyerII::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = Creative::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.accounts().creatives_create(req, "accountId")
+///              .duplicate_id_mode("sed")
+///              .doit();
+/// # }
+/// ```
+pub struct AccountCreativeCreateCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a AdExchangeBuyerII<C, A>,
+    _request: Creative,
+    _account_id: String,
+    _duplicate_id_mode: Option<String>,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for AccountCreativeCreateCall<'a, C, A> {}
+
+impl<'a, C, A> AccountCreativeCreateCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, Creative)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "adexchangebuyer2.accounts.creatives.create",
+                               http_method: hyper::method::Method::Post });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((5 + self._additional_params.len()));
+        params.push(("accountId", self._account_id.to_string()));
+        if let Some(value) = self._duplicate_id_mode {
+            params.push(("duplicateIdMode", value.to_string()));
+        }
+        for &field in ["alt", "accountId", "duplicateIdMode"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v2beta1/accounts/{accountId}/creatives";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::AdexchangeBuyer.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{accountId}", "accountId")].iter() {
+            let mut replace_with: Option<&str> = None;
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = Some(value);
+                    break;
+                }
+            }
+            url = url.replace(find_this, replace_with.expect("to find substitution value in params"));
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["accountId"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Post, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: Creative) -> AccountCreativeCreateCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// The account that this creative belongs to.
+    /// Can be used to filter the response of the
+    /// creatives.list
+    /// method.
+    ///
+    /// Sets the *account id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn account_id(mut self, new_value: &str) -> AccountCreativeCreateCall<'a, C, A> {
+        self._account_id = new_value.to_string();
+        self
+    }
+    /// Indicates if multiple creatives can share an ID or not. Default is
+    /// NO_DUPLICATES (one ID per creative).
+    ///
+    /// Sets the *duplicate id mode* query property to the given value.
+    pub fn duplicate_id_mode(mut self, new_value: &str) -> AccountCreativeCreateCall<'a, C, A> {
+        self._duplicate_id_mode = Some(new_value.to_string());
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> AccountCreativeCreateCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> AccountCreativeCreateCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::AdexchangeBuyer`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> AccountCreativeCreateCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Stops watching a creative. Will stop push notifications being sent to the
+/// topics when the creative changes status.
+///
+/// A builder for the *creatives.stopWatching* method supported by a *account* resource.
+/// It is not used directly, but through a `AccountMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_adexchangebuyer2_v2_beta1 as adexchangebuyer2_v2_beta1;
+/// use adexchangebuyer2_v2_beta1::StopWatchingCreativeRequest;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use adexchangebuyer2_v2_beta1::AdExchangeBuyerII;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = AdExchangeBuyerII::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = StopWatchingCreativeRequest::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.accounts().creatives_stop_watching(req, "accountId", "creativeId")
+///              .doit();
+/// # }
+/// ```
+pub struct AccountCreativeStopWatchingCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a AdExchangeBuyerII<C, A>,
+    _request: StopWatchingCreativeRequest,
+    _account_id: String,
+    _creative_id: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for AccountCreativeStopWatchingCall<'a, C, A> {}
+
+impl<'a, C, A> AccountCreativeStopWatchingCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, Empty)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "adexchangebuyer2.accounts.creatives.stopWatching",
+                               http_method: hyper::method::Method::Post });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((5 + self._additional_params.len()));
+        params.push(("accountId", self._account_id.to_string()));
+        params.push(("creativeId", self._creative_id.to_string()));
+        for &field in ["alt", "accountId", "creativeId"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v2beta1/accounts/{accountId}/creatives/{creativeId}:stopWatching";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::AdexchangeBuyer.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{accountId}", "accountId"), ("{creativeId}", "creativeId")].iter() {
+            let mut replace_with: Option<&str> = None;
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = Some(value);
+                    break;
+                }
+            }
+            url = url.replace(find_this, replace_with.expect("to find substitution value in params"));
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(2);
+            for param_name in ["creativeId", "accountId"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Post, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: StopWatchingCreativeRequest) -> AccountCreativeStopWatchingCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// The account of the creative to stop notifications for.
+    ///
+    /// Sets the *account id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn account_id(mut self, new_value: &str) -> AccountCreativeStopWatchingCall<'a, C, A> {
+        self._account_id = new_value.to_string();
+        self
+    }
+    /// The creative ID of the creative to stop notifications for.
+    /// Specify "-" to specify stopping account level notifications.
+    ///
+    /// Sets the *creative id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn creative_id(mut self, new_value: &str) -> AccountCreativeStopWatchingCall<'a, C, A> {
+        self._creative_id = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> AccountCreativeStopWatchingCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> AccountCreativeStopWatchingCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::AdexchangeBuyer`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> AccountCreativeStopWatchingCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Updates an existing client user.
+/// Only the user status can be changed on update.
+///
+/// A builder for the *clients.users.update* method supported by a *account* resource.
+/// It is not used directly, but through a `AccountMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_adexchangebuyer2_v2_beta1 as adexchangebuyer2_v2_beta1;
+/// use adexchangebuyer2_v2_beta1::ClientUser;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use adexchangebuyer2_v2_beta1::AdExchangeBuyerII;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = AdExchangeBuyerII::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = ClientUser::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.accounts().clients_users_update(req, "accountId", "clientAccountId", "userId")
+///              .doit();
+/// # }
+/// ```
+pub struct AccountClientUserUpdateCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a AdExchangeBuyerII<C, A>,
+    _request: ClientUser,
+    _account_id: String,
+    _client_account_id: String,
+    _user_id: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for AccountClientUserUpdateCall<'a, C, A> {}
+
+impl<'a, C, A> AccountClientUserUpdateCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, ClientUser)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "adexchangebuyer2.accounts.clients.users.update",
+                               http_method: hyper::method::Method::Put });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((6 + self._additional_params.len()));
+        params.push(("accountId", self._account_id.to_string()));
+        params.push(("clientAccountId", self._client_account_id.to_string()));
+        params.push(("userId", self._user_id.to_string()));
+        for &field in ["alt", "accountId", "clientAccountId", "userId"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v2beta1/accounts/{accountId}/clients/{clientAccountId}/users/{userId}";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::AdexchangeBuyer.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{accountId}", "accountId"), ("{clientAccountId}", "clientAccountId"), ("{userId}", "userId")].iter() {
+            let mut replace_with: Option<&str> = None;
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = Some(value);
+                    break;
+                }
+            }
+            url = url.replace(find_this, replace_with.expect("to find substitution value in params"));
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(3);
+            for param_name in ["userId", "clientAccountId", "accountId"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Put, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: ClientUser) -> AccountClientUserUpdateCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// Numerical account ID of the client's sponsor buyer. (required)
+    ///
+    /// Sets the *account id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn account_id(mut self, new_value: &str) -> AccountClientUserUpdateCall<'a, C, A> {
+        self._account_id = new_value.to_string();
+        self
+    }
+    /// Numerical account ID of the client buyer that the user to be retrieved
+    /// is associated with. (required)
+    ///
+    /// Sets the *client account id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn client_account_id(mut self, new_value: &str) -> AccountClientUserUpdateCall<'a, C, A> {
+        self._client_account_id = new_value.to_string();
+        self
+    }
+    /// Numerical identifier of the user to retrieve. (required)
+    ///
+    /// Sets the *user id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn user_id(mut self, new_value: &str) -> AccountClientUserUpdateCall<'a, C, A> {
+        self._user_id = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> AccountClientUserUpdateCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> AccountClientUserUpdateCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::AdexchangeBuyer`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> AccountClientUserUpdateCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Creates and sends out an email invitation to access
+/// an Ad Exchange client buyer account.
+///
+/// A builder for the *clients.invitations.create* method supported by a *account* resource.
+/// It is not used directly, but through a `AccountMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_adexchangebuyer2_v2_beta1 as adexchangebuyer2_v2_beta1;
+/// use adexchangebuyer2_v2_beta1::ClientUserInvitation;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use adexchangebuyer2_v2_beta1::AdExchangeBuyerII;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = AdExchangeBuyerII::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = ClientUserInvitation::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.accounts().clients_invitations_create(req, "accountId", "clientAccountId")
+///              .doit();
+/// # }
+/// ```
+pub struct AccountClientInvitationCreateCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a AdExchangeBuyerII<C, A>,
+    _request: ClientUserInvitation,
+    _account_id: String,
+    _client_account_id: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for AccountClientInvitationCreateCall<'a, C, A> {}
+
+impl<'a, C, A> AccountClientInvitationCreateCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, ClientUserInvitation)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "adexchangebuyer2.accounts.clients.invitations.create",
+                               http_method: hyper::method::Method::Post });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((5 + self._additional_params.len()));
+        params.push(("accountId", self._account_id.to_string()));
+        params.push(("clientAccountId", self._client_account_id.to_string()));
+        for &field in ["alt", "accountId", "clientAccountId"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v2beta1/accounts/{accountId}/clients/{clientAccountId}/invitations";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::AdexchangeBuyer.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{accountId}", "accountId"), ("{clientAccountId}", "clientAccountId")].iter() {
+            let mut replace_with: Option<&str> = None;
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = Some(value);
+                    break;
+                }
+            }
+            url = url.replace(find_this, replace_with.expect("to find substitution value in params"));
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(2);
+            for param_name in ["clientAccountId", "accountId"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Post, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: ClientUserInvitation) -> AccountClientInvitationCreateCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// Numerical account ID of the client's sponsor buyer. (required)
+    ///
+    /// Sets the *account id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn account_id(mut self, new_value: &str) -> AccountClientInvitationCreateCall<'a, C, A> {
+        self._account_id = new_value.to_string();
+        self
+    }
+    /// Numerical account ID of the client buyer that the user
+    /// should be associated with. (required)
+    ///
+    /// Sets the *client account id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn client_account_id(mut self, new_value: &str) -> AccountClientInvitationCreateCall<'a, C, A> {
+        self._client_account_id = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> AccountClientInvitationCreateCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> AccountClientInvitationCreateCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::AdexchangeBuyer`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> AccountClientInvitationCreateCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Lists all the known client users for a specified
+/// sponsor buyer account ID.
+///
+/// A builder for the *clients.users.list* method supported by a *account* resource.
+/// It is not used directly, but through a `AccountMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_adexchangebuyer2_v2_beta1 as adexchangebuyer2_v2_beta1;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use adexchangebuyer2_v2_beta1::AdExchangeBuyerII;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = AdExchangeBuyerII::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.accounts().clients_users_list("accountId", "clientAccountId")
+///              .page_token("dolores")
+///              .page_size(-98)
+///              .doit();
+/// # }
+/// ```
+pub struct AccountClientUserListCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a AdExchangeBuyerII<C, A>,
+    _account_id: String,
+    _client_account_id: String,
+    _page_token: Option<String>,
+    _page_size: Option<i32>,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for AccountClientUserListCall<'a, C, A> {}
+
+impl<'a, C, A> AccountClientUserListCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, ListClientUsersResponse)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "adexchangebuyer2.accounts.clients.users.list",
+                               http_method: hyper::method::Method::Get });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((6 + self._additional_params.len()));
+        params.push(("accountId", self._account_id.to_string()));
+        params.push(("clientAccountId", self._client_account_id.to_string()));
+        if let Some(value) = self._page_token {
+            params.push(("pageToken", value.to_string()));
+        }
+        if let Some(value) = self._page_size {
+            params.push(("pageSize", value.to_string()));
+        }
+        for &field in ["alt", "accountId", "clientAccountId", "pageToken", "pageSize"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v2beta1/accounts/{accountId}/clients/{clientAccountId}/users";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::AdexchangeBuyer.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{accountId}", "accountId"), ("{clientAccountId}", "clientAccountId")].iter() {
+            let mut replace_with: Option<&str> = None;
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = Some(value);
+                    break;
+                }
+            }
+            url = url.replace(find_this, replace_with.expect("to find substitution value in params"));
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(2);
+            for param_name in ["clientAccountId", "accountId"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Get, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    /// Numerical account ID of the sponsor buyer of the client to list users for.
+    /// (required)
+    ///
+    /// Sets the *account id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn account_id(mut self, new_value: &str) -> AccountClientUserListCall<'a, C, A> {
+        self._account_id = new_value.to_string();
+        self
+    }
+    /// The account ID of the client buyer to list users for. (required)
+    /// You must specify either a string representation of a
+    /// numerical account identifier or the `-` character
+    /// to list all the client users for all the clients
+    /// of a given sponsor buyer.
+    ///
+    /// Sets the *client account id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn client_account_id(mut self, new_value: &str) -> AccountClientUserListCall<'a, C, A> {
+        self._client_account_id = new_value.to_string();
+        self
+    }
+    /// A token identifying a page of results the server should return.
+    /// Typically, this is the value of
+    /// ListClientUsersResponse.nextPageToken
+    /// returned from the previous call to the
+    /// accounts.clients.users.list method.
+    ///
+    /// Sets the *page token* query property to the given value.
+    pub fn page_token(mut self, new_value: &str) -> AccountClientUserListCall<'a, C, A> {
+        self._page_token = Some(new_value.to_string());
+        self
+    }
+    /// Requested page size. The server may return fewer clients than requested.
+    /// If unspecified, the server will pick an appropriate default.
+    ///
+    /// Sets the *page size* query property to the given value.
+    pub fn page_size(mut self, new_value: i32) -> AccountClientUserListCall<'a, C, A> {
+        self._page_size = Some(new_value);
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> AccountClientUserListCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> AccountClientUserListCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::AdexchangeBuyer`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> AccountClientUserListCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Creates a new client buyer.
+///
+/// A builder for the *clients.create* method supported by a *account* resource.
+/// It is not used directly, but through a `AccountMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_adexchangebuyer2_v2_beta1 as adexchangebuyer2_v2_beta1;
+/// use adexchangebuyer2_v2_beta1::Client;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use adexchangebuyer2_v2_beta1::AdExchangeBuyerII;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = AdExchangeBuyerII::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = Client::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.accounts().clients_create(req, "accountId")
+///              .doit();
+/// # }
+/// ```
+pub struct AccountClientCreateCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a AdExchangeBuyerII<C, A>,
+    _request: Client,
+    _account_id: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for AccountClientCreateCall<'a, C, A> {}
+
+impl<'a, C, A> AccountClientCreateCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, Client)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "adexchangebuyer2.accounts.clients.create",
+                               http_method: hyper::method::Method::Post });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((4 + self._additional_params.len()));
+        params.push(("accountId", self._account_id.to_string()));
+        for &field in ["alt", "accountId"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v2beta1/accounts/{accountId}/clients";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::AdexchangeBuyer.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{accountId}", "accountId")].iter() {
+            let mut replace_with: Option<&str> = None;
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = Some(value);
+                    break;
+                }
+            }
+            url = url.replace(find_this, replace_with.expect("to find substitution value in params"));
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["accountId"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Post, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: Client) -> AccountClientCreateCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// Unique numerical account ID for the buyer of which the client buyer
+    /// is a customer; the sponsor buyer to create a client for. (required)
+    ///
+    /// Sets the *account id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn account_id(mut self, new_value: &str) -> AccountClientCreateCall<'a, C, A> {
+        self._account_id = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> AccountClientCreateCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> AccountClientCreateCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::AdexchangeBuyer`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> AccountClientCreateCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Gets a client buyer with a given client account ID.
+///
+/// A builder for the *clients.get* method supported by a *account* resource.
+/// It is not used directly, but through a `AccountMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_adexchangebuyer2_v2_beta1 as adexchangebuyer2_v2_beta1;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use adexchangebuyer2_v2_beta1::AdExchangeBuyerII;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = AdExchangeBuyerII::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.accounts().clients_get("accountId", "clientAccountId")
+///              .doit();
+/// # }
+/// ```
+pub struct AccountClientGetCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a AdExchangeBuyerII<C, A>,
+    _account_id: String,
+    _client_account_id: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for AccountClientGetCall<'a, C, A> {}
+
+impl<'a, C, A> AccountClientGetCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, Client)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "adexchangebuyer2.accounts.clients.get",
+                               http_method: hyper::method::Method::Get });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((4 + self._additional_params.len()));
+        params.push(("accountId", self._account_id.to_string()));
+        params.push(("clientAccountId", self._client_account_id.to_string()));
+        for &field in ["alt", "accountId", "clientAccountId"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v2beta1/accounts/{accountId}/clients/{clientAccountId}";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::AdexchangeBuyer.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{accountId}", "accountId"), ("{clientAccountId}", "clientAccountId")].iter() {
+            let mut replace_with: Option<&str> = None;
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = Some(value);
+                    break;
+                }
+            }
+            url = url.replace(find_this, replace_with.expect("to find substitution value in params"));
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(2);
+            for param_name in ["clientAccountId", "accountId"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Get, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    /// Numerical account ID of the client's sponsor buyer. (required)
+    ///
+    /// Sets the *account id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn account_id(mut self, new_value: &str) -> AccountClientGetCall<'a, C, A> {
+        self._account_id = new_value.to_string();
+        self
+    }
+    /// Numerical account ID of the client buyer to retrieve. (required)
+    ///
+    /// Sets the *client account id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn client_account_id(mut self, new_value: &str) -> AccountClientGetCall<'a, C, A> {
+        self._client_account_id = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> AccountClientGetCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> AccountClientGetCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::AdexchangeBuyer`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> AccountClientGetCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// List all creative-deal associations.
+///
+/// A builder for the *creatives.dealAssociations.list* method supported by a *account* resource.
+/// It is not used directly, but through a `AccountMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_adexchangebuyer2_v2_beta1 as adexchangebuyer2_v2_beta1;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use adexchangebuyer2_v2_beta1::AdExchangeBuyerII;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = AdExchangeBuyerII::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.accounts().creatives_deal_associations_list("accountId", "creativeId")
+///              .query("accusam")
+///              .page_token("clita")
+///              .page_size(-79)
+///              .doit();
+/// # }
+/// ```
+pub struct AccountCreativeDealAssociationListCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a AdExchangeBuyerII<C, A>,
+    _account_id: String,
+    _creative_id: String,
+    _query: Option<String>,
+    _page_token: Option<String>,
+    _page_size: Option<i32>,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for AccountCreativeDealAssociationListCall<'a, C, A> {}
+
+impl<'a, C, A> AccountCreativeDealAssociationListCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, ListDealAssociationsResponse)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "adexchangebuyer2.accounts.creatives.dealAssociations.list",
+                               http_method: hyper::method::Method::Get });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((7 + self._additional_params.len()));
+        params.push(("accountId", self._account_id.to_string()));
+        params.push(("creativeId", self._creative_id.to_string()));
+        if let Some(value) = self._query {
+            params.push(("query", value.to_string()));
+        }
+        if let Some(value) = self._page_token {
+            params.push(("pageToken", value.to_string()));
+        }
+        if let Some(value) = self._page_size {
+            params.push(("pageSize", value.to_string()));
+        }
+        for &field in ["alt", "accountId", "creativeId", "query", "pageToken", "pageSize"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v2beta1/accounts/{accountId}/creatives/{creativeId}/dealAssociations";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::AdexchangeBuyer.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{accountId}", "accountId"), ("{creativeId}", "creativeId")].iter() {
+            let mut replace_with: Option<&str> = None;
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = Some(value);
+                    break;
+                }
+            }
+            url = url.replace(find_this, replace_with.expect("to find substitution value in params"));
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(2);
+            for param_name in ["creativeId", "accountId"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Get, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    /// The account to list the associations from.
+    /// Specify "-" to list all creatives the current user has access to.
+    ///
+    /// Sets the *account id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn account_id(mut self, new_value: &str) -> AccountCreativeDealAssociationListCall<'a, C, A> {
+        self._account_id = new_value.to_string();
+        self
+    }
+    /// The creative ID to list the associations from.
+    /// Specify "-" to list all creatives under the above account.
+    ///
+    /// Sets the *creative id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn creative_id(mut self, new_value: &str) -> AccountCreativeDealAssociationListCall<'a, C, A> {
+        self._creative_id = new_value.to_string();
+        self
+    }
+    /// An optional query string to filter deal associations. If no filter is
+    /// specified, all associations will be returned.
+    /// Supported queries are:
+    /// <ul>
+    /// <li>accountId=<i>account_id_string</i>
+    /// <li>creativeId=<i>creative_id_string</i>
+    /// <li>dealsId=<i>deals_id_string</i>
+    /// <li>dealsStatus:{approved, conditionally_approved, disapproved,
+    ///                   not_checked}
+    /// <li>openAuctionStatus:{approved, conditionally_approved, disapproved,
+    ///                          not_checked}
+    /// </ul>
+    /// Example: 'dealsId=12345 AND dealsStatus:disapproved'
+    ///
+    /// Sets the *query* query property to the given value.
+    pub fn query(mut self, new_value: &str) -> AccountCreativeDealAssociationListCall<'a, C, A> {
+        self._query = Some(new_value.to_string());
+        self
+    }
+    /// A token identifying a page of results the server should return.
+    /// Typically, this is the value of
+    /// ListDealAssociationsResponse.next_page_token
+    /// returned from the previous call to 'ListDealAssociations' method.
+    ///
+    /// Sets the *page token* query property to the given value.
+    pub fn page_token(mut self, new_value: &str) -> AccountCreativeDealAssociationListCall<'a, C, A> {
+        self._page_token = Some(new_value.to_string());
+        self
+    }
+    /// Requested page size. Server may return fewer associations than requested.
+    /// If unspecified, server will pick an appropriate default.
+    ///
+    /// Sets the *page size* query property to the given value.
+    pub fn page_size(mut self, new_value: i32) -> AccountCreativeDealAssociationListCall<'a, C, A> {
+        self._page_size = Some(new_value);
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> AccountCreativeDealAssociationListCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> AccountCreativeDealAssociationListCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::AdexchangeBuyer`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> AccountCreativeDealAssociationListCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Updates a creative.
+///
+/// A builder for the *creatives.update* method supported by a *account* resource.
+/// It is not used directly, but through a `AccountMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_adexchangebuyer2_v2_beta1 as adexchangebuyer2_v2_beta1;
+/// use adexchangebuyer2_v2_beta1::Creative;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use adexchangebuyer2_v2_beta1::AdExchangeBuyerII;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = AdExchangeBuyerII::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = Creative::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.accounts().creatives_update(req, "accountId", "creativeId")
+///              .doit();
+/// # }
+/// ```
+pub struct AccountCreativeUpdateCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a AdExchangeBuyerII<C, A>,
+    _request: Creative,
+    _account_id: String,
+    _creative_id: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for AccountCreativeUpdateCall<'a, C, A> {}
+
+impl<'a, C, A> AccountCreativeUpdateCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, Creative)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "adexchangebuyer2.accounts.creatives.update",
+                               http_method: hyper::method::Method::Put });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((5 + self._additional_params.len()));
+        params.push(("accountId", self._account_id.to_string()));
+        params.push(("creativeId", self._creative_id.to_string()));
+        for &field in ["alt", "accountId", "creativeId"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v2beta1/accounts/{accountId}/creatives/{creativeId}";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::AdexchangeBuyer.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{accountId}", "accountId"), ("{creativeId}", "creativeId")].iter() {
+            let mut replace_with: Option<&str> = None;
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = Some(value);
+                    break;
+                }
+            }
+            url = url.replace(find_this, replace_with.expect("to find substitution value in params"));
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(2);
+            for param_name in ["creativeId", "accountId"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Put, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: Creative) -> AccountCreativeUpdateCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// The account that this creative belongs to.
+    /// Can be used to filter the response of the
+    /// creatives.list
+    /// method.
+    ///
+    /// Sets the *account id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn account_id(mut self, new_value: &str) -> AccountCreativeUpdateCall<'a, C, A> {
+        self._account_id = new_value.to_string();
+        self
+    }
+    /// The buyer-defined creative ID of this creative.
+    /// Can be used to filter the response of the
+    /// creatives.list
+    /// method.
+    ///
+    /// Sets the *creative id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn creative_id(mut self, new_value: &str) -> AccountCreativeUpdateCall<'a, C, A> {
+        self._creative_id = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> AccountCreativeUpdateCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> AccountCreativeUpdateCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::AdexchangeBuyer`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> AccountCreativeUpdateCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Remove the association between a deal and a creative.
+///
+/// A builder for the *creatives.dealAssociations.remove* method supported by a *account* resource.
+/// It is not used directly, but through a `AccountMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_adexchangebuyer2_v2_beta1 as adexchangebuyer2_v2_beta1;
+/// use adexchangebuyer2_v2_beta1::RemoveDealAssociationRequest;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use adexchangebuyer2_v2_beta1::AdExchangeBuyerII;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = AdExchangeBuyerII::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = RemoveDealAssociationRequest::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.accounts().creatives_deal_associations_remove(req, "accountId", "creativeId")
+///              .doit();
+/// # }
+/// ```
+pub struct AccountCreativeDealAssociationRemoveCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a AdExchangeBuyerII<C, A>,
+    _request: RemoveDealAssociationRequest,
+    _account_id: String,
+    _creative_id: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for AccountCreativeDealAssociationRemoveCall<'a, C, A> {}
+
+impl<'a, C, A> AccountCreativeDealAssociationRemoveCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, Empty)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "adexchangebuyer2.accounts.creatives.dealAssociations.remove",
+                               http_method: hyper::method::Method::Post });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((5 + self._additional_params.len()));
+        params.push(("accountId", self._account_id.to_string()));
+        params.push(("creativeId", self._creative_id.to_string()));
+        for &field in ["alt", "accountId", "creativeId"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v2beta1/accounts/{accountId}/creatives/{creativeId}/dealAssociations:remove";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::AdexchangeBuyer.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{accountId}", "accountId"), ("{creativeId}", "creativeId")].iter() {
+            let mut replace_with: Option<&str> = None;
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = Some(value);
+                    break;
+                }
+            }
+            url = url.replace(find_this, replace_with.expect("to find substitution value in params"));
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(2);
+            for param_name in ["creativeId", "accountId"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Post, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: RemoveDealAssociationRequest) -> AccountCreativeDealAssociationRemoveCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// The account the creative belongs to.
+    ///
+    /// Sets the *account id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn account_id(mut self, new_value: &str) -> AccountCreativeDealAssociationRemoveCall<'a, C, A> {
+        self._account_id = new_value.to_string();
+        self
+    }
+    /// The ID of the creative associated with the deal.
+    ///
+    /// Sets the *creative id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn creative_id(mut self, new_value: &str) -> AccountCreativeDealAssociationRemoveCall<'a, C, A> {
+        self._creative_id = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> AccountCreativeDealAssociationRemoveCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> AccountCreativeDealAssociationRemoveCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::AdexchangeBuyer`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> AccountCreativeDealAssociationRemoveCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Lists all the client users invitations for a client
+/// with a given account ID.
+///
+/// A builder for the *clients.invitations.list* method supported by a *account* resource.
+/// It is not used directly, but through a `AccountMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_adexchangebuyer2_v2_beta1 as adexchangebuyer2_v2_beta1;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use adexchangebuyer2_v2_beta1::AdExchangeBuyerII;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = AdExchangeBuyerII::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.accounts().clients_invitations_list("accountId", "clientAccountId")
+///              .page_token("eos")
+///              .page_size(-78)
+///              .doit();
+/// # }
+/// ```
+pub struct AccountClientInvitationListCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a AdExchangeBuyerII<C, A>,
+    _account_id: String,
+    _client_account_id: String,
+    _page_token: Option<String>,
+    _page_size: Option<i32>,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for AccountClientInvitationListCall<'a, C, A> {}
+
+impl<'a, C, A> AccountClientInvitationListCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, ListClientUserInvitationsResponse)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "adexchangebuyer2.accounts.clients.invitations.list",
+                               http_method: hyper::method::Method::Get });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((6 + self._additional_params.len()));
+        params.push(("accountId", self._account_id.to_string()));
+        params.push(("clientAccountId", self._client_account_id.to_string()));
+        if let Some(value) = self._page_token {
+            params.push(("pageToken", value.to_string()));
+        }
+        if let Some(value) = self._page_size {
+            params.push(("pageSize", value.to_string()));
+        }
+        for &field in ["alt", "accountId", "clientAccountId", "pageToken", "pageSize"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v2beta1/accounts/{accountId}/clients/{clientAccountId}/invitations";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::AdexchangeBuyer.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{accountId}", "accountId"), ("{clientAccountId}", "clientAccountId")].iter() {
+            let mut replace_with: Option<&str> = None;
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = Some(value);
+                    break;
+                }
+            }
+            url = url.replace(find_this, replace_with.expect("to find substitution value in params"));
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(2);
+            for param_name in ["clientAccountId", "accountId"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Get, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    /// Numerical account ID of the client's sponsor buyer. (required)
+    ///
+    /// Sets the *account id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn account_id(mut self, new_value: &str) -> AccountClientInvitationListCall<'a, C, A> {
+        self._account_id = new_value.to_string();
+        self
+    }
+    /// Numerical account ID of the client buyer to list invitations for.
+    /// (required)
+    /// You must either specify a string representation of a
+    /// numerical account identifier or the `-` character
+    /// to list all the invitations for all the clients
+    /// of a given sponsor buyer.
+    ///
+    /// Sets the *client account id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn client_account_id(mut self, new_value: &str) -> AccountClientInvitationListCall<'a, C, A> {
+        self._client_account_id = new_value.to_string();
+        self
+    }
+    /// A token identifying a page of results the server should return.
+    /// Typically, this is the value of
+    /// ListClientUserInvitationsResponse.nextPageToken
+    /// returned from the previous call to the
+    /// clients.invitations.list
+    /// method.
+    ///
+    /// Sets the *page token* query property to the given value.
+    pub fn page_token(mut self, new_value: &str) -> AccountClientInvitationListCall<'a, C, A> {
+        self._page_token = Some(new_value.to_string());
+        self
+    }
+    /// Requested page size. Server may return fewer clients than requested.
+    /// If unspecified, server will pick an appropriate default.
+    ///
+    /// Sets the *page size* query property to the given value.
+    pub fn page_size(mut self, new_value: i32) -> AccountClientInvitationListCall<'a, C, A> {
+        self._page_size = Some(new_value);
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> AccountClientInvitationListCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> AccountClientInvitationListCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::AdexchangeBuyer`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> AccountClientInvitationListCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+

--- a/gen/analyticsreporting4-cli/Cargo.toml
+++ b/gen/analyticsreporting4-cli/Cargo.toml
@@ -1,0 +1,40 @@
+# DO NOT EDIT !
+# This file was generated automatically from 'src/mako/Cargo.toml.mako'
+# DO NOT EDIT !
+[package]
+
+name = "google-analyticsreporting4-cli"
+version = "1.0.7+20171108"
+authors = ["Sebastian Thiel <byronimo@gmail.com>"]
+description = "A complete library to interact with AnalyticsReporting (protocol v4)"
+repository = "https://github.com/Byron/google-apis-rs/tree/master/gen/analyticsreporting4-cli"
+homepage = "https://developers.google.com/analytics/devguides/reporting/core/v4/"
+documentation = "http://byron.github.io/google-apis-rs/google_analyticsreporting4_cli"
+license = "MIT"
+keywords = ["analyticsreporting", "google", "cli"]
+
+[[bin]]
+name = "analyticsreporting4"
+
+[dev-dependencies]
+hyper-rustls = "^0.6"
+
+[dependencies]
+hyper = "^ 0.10"
+mime = "^ 0.2.0"
+serde = "^ 1.0"
+serde_json = "^ 1.0"
+serde_derive = "^ 1.0"
+yup-oauth2 = "^ 1.0"
+strsim = "^0.5"
+hyper-rustls = "^0.6"
+yup-hyper-mock = "^2.0"
+clap = "^2.0"
+
+[features]
+
+
+
+[dependencies.google-analyticsreporting4]
+path = "../analyticsreporting4"
+version = "1.0.7+20171108"

--- a/gen/analyticsreporting4-cli/LICENSE.md
+++ b/gen/analyticsreporting4-cli/LICENSE.md
@@ -1,0 +1,30 @@
+<!---
+DO NOT EDIT !
+This file was generated automatically from 'src/mako/LICENSE.md.mako'
+DO NOT EDIT !
+-->
+The MIT License (MIT)
+=====================
+
+Copyright © `2015-2016` `Sebastian Thiel`
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the “Software”), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.

--- a/gen/analyticsreporting4-cli/README.md
+++ b/gen/analyticsreporting4-cli/README.md
@@ -1,0 +1,114 @@
+<!---
+DO NOT EDIT !
+This file was generated automatically from 'src/mako/cli/README.md.mako'
+DO NOT EDIT !
+-->
+The `analyticsreporting4` command-line interface *(CLI)* allows to use most features of the *Google AnalyticsReporting* service from the comfort of your terminal.
+
+By default all output is printed to standard out, but flags can be set to direct it into a file independent of your shell's
+capabilities. Errors will be printed to standard error, and cause the program's exit code to be non-zero.
+
+If data-structures are requested, these will be returned as pretty-printed JSON, to be useful as input to other tools.
+
+Everything else about the *AnalyticsReporting* API can be found at the
+[official documentation site](https://developers.google.com/analytics/devguides/reporting/core/v4/).
+
+# Installation and Source Code
+
+Install the command-line interface with cargo using:
+
+```bash
+cargo install google-analyticsreporting4-cli
+```
+
+Find the source code [on github](https://github.com/Byron/google-apis-rs/tree/master/gen/analyticsreporting4-cli).
+
+# Usage
+
+This documentation was generated from the *AnalyticsReporting* API at revision *20171108*. The CLI is at version *1.0.7*.
+
+```bash
+analyticsreporting4 [options]
+        reports
+                batch-get (-r <kv>)... [-p <v>]... [-o <out>]
+  analyticsreporting4 --help
+
+Configuration:
+  [--scope <url>]...
+            Specify the authentication a method should be executed in. Each scope
+            requires the user to grant this application permission to use it.
+            If unset, it defaults to the shortest scope url for a particular method.
+  --config-dir <folder>
+            A directory into which we will store our persistent data. Defaults to
+            a user-writable directory that we will create during the first invocation.
+            [default: ~/.google-service-cli]
+  --debug
+            Output all server communication to standard error. `tx` and `rx` are placed
+            into the same stream.
+  --debug-auth
+            Output all communication related to authentication to standard error. `tx`
+            and `rx` are placed into the same stream.
+
+```
+
+# Configuration
+
+The program will store all persistent data in the `~/.google-service-cli` directory in *JSON* files prefixed with `analyticsreporting4-`.  You can change the directory used to store configuration with the `--config-dir` flag on a per-invocation basis.
+
+More information about the various kinds of persistent data are given in the following paragraphs.
+
+# Authentication
+
+Most APIs require a user to authenticate any request. If this is the case, the [scope][scopes] determines the 
+set of permissions granted. The granularity of these is usually no more than *read-only* or *full-access*.
+
+If not set, the system will automatically select the smallest feasible scope, e.g. when invoking a
+method that is read-only, it will ask only for a read-only scope. 
+You may use the `--scope` flag to specify a scope directly. 
+All applicable scopes are documented in the respective method's CLI documentation.
+
+The first time a scope is used, the user is asked for permission. Follow the instructions given 
+by the CLI to grant permissions, or to decline.
+
+If a scope was authenticated by the user, the respective information will be stored as *JSON* in the configuration
+directory, e.g. `~/.google-service-cli/analyticsreporting4-token-<scope-hash>.json`. No manual management of these tokens
+is necessary.
+
+To revoke granted authentication, please refer to the [official documentation][revoke-access].
+
+# Application Secrets
+
+In order to allow any application to use Google services, it will need to be registered using the 
+[Google Developer Console][google-dev-console]. APIs the application may use are then enabled for it
+one by one. Most APIs can be used for free and have a daily quota.
+
+To allow more comfortable usage of the CLI without forcing anyone to register an own application, the CLI
+comes with a default application secret that is configured accordingly. This also means that heavy usage
+all around the world may deplete the daily quota.
+
+You can workaround this limitation by putting your own secrets file at this location: 
+`~/.google-service-cli/analyticsreporting4-secret.json`, assuming that the required *analyticsreporting* API 
+was enabled for it. Such a secret file can be downloaded in the *Google Developer Console* at 
+*APIs & auth -> Credentials -> Download JSON* and used as is.
+
+Learn more about how to setup Google projects and enable APIs using the [official documentation][google-project-new].
+
+
+# Debugging
+
+Even though the CLI does its best to provide usable error messages, sometimes it might be desirable to know
+what exactly led to a particular issue. This is done by allowing all client-server communication to be 
+output to standard error *as-is*.
+
+The `--debug` flag will print all client-server communication to standard error, whereas the `--debug-auth` flag
+will cause all communication related to authentication to standard error.
+If the `--debug` flag is set, error-results will be debug-printed, possibly yielding more information about the 
+issue at hand.
+
+You may consider redirecting standard error into a file for ease of use, e.g. `analyticsreporting4 --debug <resource> <method> [options] 2>debug.txt`.
+
+
+[scopes]: https://developers.google.com/+/api/oauth#scopes
+[revoke-access]: http://webapps.stackexchange.com/a/30849
+[google-dev-console]: https://console.developers.google.com/
+[google-project-new]: https://developers.google.com/console/help/new/

--- a/gen/analyticsreporting4-cli/mkdocs.yml
+++ b/gen/analyticsreporting4-cli/mkdocs.yml
@@ -1,0 +1,17 @@
+site_name: AnalyticsReporting v1.0.7+20171108
+site_url: http://byron.github.io/google-apis-rs/google-analyticsreporting4-cli
+site_description: A complete library to interact with AnalyticsReporting (protocol v4)
+
+repo_url: https://github.com/Byron/google-apis-rs/tree/master/gen/analyticsreporting4-cli
+
+docs_dir: docs
+site_dir: build_html
+
+pages:
+- ['index.md', 'Home']
+- ['reports_batch-get.md', 'Reports', 'Batch Get']
+
+theme: readthedocs
+
+copyright: Copyright &copy; 2015-2016, `Sebastian Thiel`
+

--- a/gen/analyticsreporting4-cli/src/cmn.rs
+++ b/gen/analyticsreporting4-cli/src/cmn.rs
@@ -1,0 +1,799 @@
+// COPY OF 'src/rust/cli/cmn.rs'
+// DO NOT EDIT
+use oauth2::{ApplicationSecret, ConsoleApplicationSecret, TokenStorage, Token};
+use serde_json as json;
+use serde_json::value::Value;
+use mime::Mime;
+use clap::{App, SubCommand};
+use strsim;
+
+use std::fs;
+use std::env;
+use std::io;
+use std::error::Error as StdError;
+use std::fmt;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+use std::string::ToString;
+use std::io::{Write, Read, stdout};
+
+use std::default::Default;
+
+const FIELD_SEP: char = '.';
+
+
+pub enum ComplexType {
+    Pod,
+    Vec,
+    Map,
+}
+
+// Null,
+// Bool(bool),
+// I64(i64),
+// U64(u64),
+// F64(f64),
+// String(String),
+
+pub enum JsonType {
+    Boolean,
+    Int,
+    Uint,
+    Float,
+    String,
+}
+
+pub struct JsonTypeInfo {
+    pub jtype: JsonType,
+    pub ctype: ComplexType,
+}
+
+// Based on @erickt user comment. Thanks for the idea !
+// Remove all keys whose values are null from given value (changed in place)
+pub fn remove_json_null_values(value: &mut Value) {
+    match *value {
+        Value::Object(ref mut map) => {
+            let mut for_removal = Vec::new();
+
+            for (key, mut value) in map.iter_mut() {
+                if value.is_null() {
+                    for_removal.push(key.clone());
+                } else {
+                    remove_json_null_values(&mut value);
+                }
+            }
+
+            for key in &for_removal {
+                map.remove(key);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn did_you_mean<'a>(v: &str, possible_values: &[&'a str]) -> Option<&'a str> {
+
+    let mut candidate: Option<(f64, &str)> = None;
+    for pv in possible_values {
+        let confidence = strsim::jaro_winkler(v, pv);
+        if confidence > 0.8 &&
+           (candidate.is_none() || (candidate.as_ref().unwrap().0 < confidence)) {
+            candidate = Some((confidence, pv));
+        }
+    }
+    match candidate {
+        None => None,
+        Some((_, candidate)) => Some(candidate),
+    }
+}
+
+pub enum CallType {
+    Upload(UploadProtocol),
+    Standard,
+}
+
+arg_enum!{
+    pub enum UploadProtocol {
+        Simple,
+        Resumable
+    }
+}
+
+impl AsRef<str> for UploadProtocol {
+    fn as_ref(&self) -> &str {
+        match *self {
+            UploadProtocol::Simple => "simple",
+            UploadProtocol::Resumable => "resumable",
+        }
+    }
+}
+
+impl AsRef<str> for CallType {
+    fn as_ref(&self) -> &str {
+        match *self {
+            CallType::Upload(ref proto) => proto.as_ref(),
+            CallType::Standard => "standard-request",
+        }
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct FieldCursor(Vec<String>);
+
+impl ToString for  FieldCursor {
+    fn to_string(&self) -> String {
+        self.0.join(".")
+    }
+}
+
+impl From<&'static str> for FieldCursor {
+    fn from(value: &'static str) -> FieldCursor {
+        let mut res = FieldCursor::default();
+        res.set(value).unwrap();
+        res
+    }
+}
+
+fn assure_entry<'a, 'b>(m: &'a mut json::Map<String, Value>, k: &'b String) -> &'a mut Value {
+    if m.contains_key(k) {
+        return m.get_mut(k).expect("value to exist");
+    }
+    m.insert(k.to_owned(), Value::Object(Default::default()));
+    m.get_mut(k).expect("value to exist")
+}
+
+impl FieldCursor {
+    pub fn set(&mut self, value: &str) -> Result<(), CLIError> {
+        if value.len() == 0 {
+            return Err(CLIError::Field(FieldError::Empty));
+        }
+
+        let mut first_is_field_sep = false;
+        let mut char_count: usize = 0;
+        let mut last_c = FIELD_SEP;
+        let mut num_conscutive_field_seps = 0;
+
+        let mut field = String::new();
+        let mut fields = self.0.clone();
+
+        let push_field = |fs: &mut Vec<String>, f: &mut String| {
+            if f.len() > 0 {
+                fs.push(f.clone());
+                f.truncate(0);
+            }
+        };
+
+        for (cid, c) in value.chars().enumerate() {
+            char_count += 1;
+
+            if c == FIELD_SEP {
+                if cid == 0 {
+                    first_is_field_sep = true;
+                }
+                num_conscutive_field_seps += 1;
+                if cid > 0 && last_c == FIELD_SEP {
+                    if fields.pop().is_none() {
+                        return Err(CLIError::Field(FieldError::PopOnEmpty(value.to_string())));
+                    }
+                } else {
+                    push_field(&mut fields, &mut field);
+                }
+            } else {
+                num_conscutive_field_seps = 0;
+                if cid == 1 {
+                    if first_is_field_sep {
+                        fields.truncate(0);
+                    }
+                }
+                field.push(c);
+            }
+
+            last_c = c;
+        }
+
+        push_field(&mut fields, &mut field);
+
+        if char_count == 1 && first_is_field_sep {
+            fields.truncate(0);
+        }
+        if char_count > 1 && num_conscutive_field_seps == 1 {
+            return Err(CLIError::Field(FieldError::TrailingFieldSep(value.to_string())));
+        }
+
+        self.0 = fields;
+        Ok(())
+    }
+
+    pub fn did_you_mean(value: &str, possible_values: &[&str]) -> Option<String> {
+        if value.len() == 0 {
+            return None;
+        }
+
+        let mut last_c = FIELD_SEP;
+
+        let mut field = String::new();
+        let mut output = String::new();
+
+        let push_field = |fs: &mut String, f: &mut String| {
+            if f.len() > 0 {
+                fs.push_str(match did_you_mean(&f, possible_values) {
+                    Some(candidate) => candidate,
+                    None => &f,
+                });
+                f.truncate(0);
+            }
+        };
+
+        for (cid, c) in value.chars().enumerate() {
+            if c == FIELD_SEP {
+                if last_c != FIELD_SEP {
+                    push_field(&mut output, &mut field);
+                }
+                output.push(c);
+            } else {
+                field.push(c);
+            }
+
+            last_c = c;
+        }
+
+        push_field(&mut output, &mut field);
+
+        if &output == value {
+            None
+        } else {
+            Some(output)
+        }
+    }
+
+    pub fn set_json_value(&self,
+                          mut object: &mut Value,
+                          value: &str,
+                          type_info: JsonTypeInfo,
+                          err: &mut InvalidOptionsError,
+                          orig_cursor: &FieldCursor) {
+        assert!(self.0.len() > 0);
+
+        for field in &self.0[..self.0.len() - 1] {
+            let tmp = object;
+            object = match *tmp {
+                Value::Object(ref mut mapping) => {
+                    assure_entry(mapping, &field)
+                }
+                _ => panic!("We don't expect non-object Values here ..."),
+            };
+        }
+
+        match *object {
+            Value::Object(ref mut mapping) => {
+                let field = &self.0[self.0.len() - 1];
+                let to_jval = |value: &str,
+                               jtype: JsonType,
+                               err: &mut InvalidOptionsError|
+                               -> Value {
+                    match jtype {
+                        JsonType::Boolean =>
+                            Value::Bool(arg_from_str(value, err, &field, "boolean")),
+                        JsonType::Int =>
+                            Value::Number(json::Number::from_f64(arg_from_str(value,
+                                                                              err,
+                                                                              &field,
+                                                                              "int"))
+                                              .expect("valid f64")),
+                        JsonType::Uint =>
+                            Value::Number(json::Number::from_f64(arg_from_str(value,
+                                                                              err,
+                                                                              &field,
+                                                                              "uint"))
+                                              .expect("valid f64")),
+                        JsonType::Float =>
+                            Value::Number(json::Number::from_f64(arg_from_str(value,
+                                                                              err,
+                                                                              &field,
+                                                                              "float"))
+                                              .expect("valid f64")),
+                        JsonType::String => Value::String(value.to_owned()),
+                    }
+                };
+
+                match type_info.ctype {
+                    ComplexType::Pod => {
+                        if mapping.insert(field.to_owned(), to_jval(value, type_info.jtype, err))
+                                  .is_some() {
+                            err.issues.push(CLIError::Field(FieldError::Duplicate(orig_cursor.to_string())));
+                        }
+                    }
+                    ComplexType::Vec => {
+                        match *assure_entry(mapping, field) {
+                            Value::Array(ref mut values) =>
+                                values.push(to_jval(value, type_info.jtype, err)),
+                            _ => unreachable!(),
+                        }
+                    }
+                    ComplexType::Map => {
+                        let (key, value) = parse_kv_arg(value, err, true);
+                        let jval = to_jval(value.unwrap_or(""), type_info.jtype, err);
+
+                        match *assure_entry(mapping, &field) {
+
+                            Value::Object(ref mut value_map) => {
+                                if value_map.insert(key.to_owned(), jval).is_some() {
+                                    err.issues.push(CLIError::Field(FieldError::Duplicate(orig_cursor.to_string())));
+                                }
+                            }
+                            _ => unreachable!(),
+                        }
+                    }
+                }
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    pub fn num_fields(&self) -> usize {
+        self.0.len()
+    }
+}
+
+pub fn parse_kv_arg<'a>(kv: &'a str,
+                        err: &mut InvalidOptionsError,
+                        for_hashmap: bool)
+                        -> (&'a str, Option<&'a str>) {
+    let mut add_err = || {
+        err.issues.push(CLIError::InvalidKeyValueSyntax(kv.to_string(), for_hashmap))
+    };
+    match kv.find('=') {
+        None => {
+            add_err();
+            return (kv, None);
+        }
+        Some(pos) => {
+            let key = &kv[..pos];
+            if kv.len() <= pos + 1 {
+                add_err();
+                return (key, Some(""));
+            }
+            (key, Some(&kv[pos + 1..]))
+        }
+    }
+}
+
+pub fn calltype_from_str(name: &str,
+                         valid_protocols: Vec<String>,
+                         err: &mut InvalidOptionsError)
+                         -> CallType {
+    CallType::Upload(match UploadProtocol::from_str(name) {
+        Ok(up) => up,
+        Err(msg) => {
+            err.issues.push(CLIError::InvalidUploadProtocol(name.to_string(), valid_protocols));
+            UploadProtocol::Simple
+        }
+    })
+}
+
+pub fn input_file_from_opts(file_path: &str, err: &mut InvalidOptionsError) -> Option<fs::File> {
+    match fs::File::open(file_path) {
+        Ok(f) => Some(f),
+        Err(io_err) => {
+            err.issues.push(CLIError::Input(InputError::Io((file_path.to_string(), io_err))));
+            None
+        }
+    }
+}
+
+pub fn input_mime_from_opts(mime: &str, err: &mut InvalidOptionsError) -> Option<Mime> {
+    match mime.parse() {
+        Ok(m) => Some(m),
+        Err(_) => {
+            err.issues.push(CLIError::Input(InputError::Mime(mime.to_string())));
+            None
+        }
+    }
+}
+
+pub fn writer_from_opts(arg: Option<&str>) -> Result<Box<Write>, io::Error> {
+    let f = arg.unwrap_or("-");
+    match f {
+        "-" => Ok(Box::new(stdout())),
+        _ => match fs::OpenOptions::new().create(true).write(true).open(f) {
+            Ok(f) => Ok(Box::new(f)),
+            Err(io_err) => Err(io_err),
+        },
+    }
+}
+
+
+pub fn arg_from_str<'a, T>(arg: &str,
+                           err: &mut InvalidOptionsError,
+                           arg_name: &'a str,
+                           arg_type: &'a str)
+                           -> T
+    where T: FromStr + Default,
+          <T as FromStr>::Err: fmt::Display
+{
+    match FromStr::from_str(arg) {
+        Err(perr) => {
+            err.issues.push(CLIError::ParseError(arg_name.to_owned(),
+                                                 arg_type.to_owned(),
+                                                 arg.to_string(),
+                                                 format!("{}", perr)));
+            Default::default()
+        }
+        Ok(v) => v,
+    }
+}
+
+pub struct JsonTokenStorage {
+    pub program_name: &'static str,
+    pub db_dir: String,
+}
+
+impl JsonTokenStorage {
+    fn path(&self, scope_hash: u64) -> PathBuf {
+        Path::new(&self.db_dir).join(&format!("{}-token-{}.json", self.program_name, scope_hash))
+    }
+}
+
+
+#[derive(Debug)]
+pub enum TokenStorageError {
+    Json(json::Error),
+    Io(io::Error),
+}
+
+impl fmt::Display for TokenStorageError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            TokenStorageError::Json(ref err) => writeln!(f, "Could not serialize secrets: {}", err),
+            TokenStorageError::Io(ref err) => writeln!(f, "Failed to write secret token: {}", err),
+        }
+    }
+}
+
+impl StdError for TokenStorageError {
+    fn description(&self) -> &str {
+        "Failure when getting or setting the token storage"
+    }
+}
+
+
+impl TokenStorage for JsonTokenStorage {
+    type Error = TokenStorageError;
+
+    // NOTE: logging might be interesting, currently we swallow all errors
+    fn set(&mut self,
+           scope_hash: u64,
+           _: &Vec<&str>,
+           token: Option<Token>)
+           -> Result<(), TokenStorageError> {
+        match token {
+            None => {
+                match fs::remove_file(self.path(scope_hash)) {
+                    Err(err) => match err.kind() {
+                        io::ErrorKind::NotFound => Ok(()),
+                        _ => Err(TokenStorageError::Io(err)),
+                    },
+                    Ok(_) => Ok(()),
+                }
+            }
+            Some(token) => {
+                match fs::OpenOptions::new().create(true).write(true).open(&self.path(scope_hash)) {
+                    Ok(mut f) => {
+                        match json::to_writer_pretty(&mut f, &token) {
+                            Ok(_) => Ok(()),
+                            Err(serde_err) => Err(TokenStorageError::Json(serde_err)),
+                        }
+                    }
+                    Err(io_err) => Err(TokenStorageError::Io(io_err)),
+                }
+            }
+        }
+    }
+
+    fn get(&self, scope_hash: u64, _: &Vec<&str>) -> Result<Option<Token>, TokenStorageError> {
+        match fs::File::open(&self.path(scope_hash)) {
+            Ok(f) => {
+                match json::de::from_reader(f) {
+                    Ok(token) => Ok(Some(token)),
+                    Err(err) => Err(TokenStorageError::Json(err)),
+                }
+            }
+            Err(io_err) => {
+                match io_err.kind() {
+                    io::ErrorKind::NotFound => Ok(None),
+                    _ => Err(TokenStorageError::Io(io_err)),
+                }
+            }
+        }
+    }
+}
+
+
+#[derive(Debug)]
+pub enum ApplicationSecretError {
+    DecoderError((String, json::Error)),
+    FormatError(String),
+}
+
+impl fmt::Display for ApplicationSecretError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            ApplicationSecretError::DecoderError((ref path, ref err)) =>
+                writeln!(f,
+                         "Could not decode file at '{}' with error: {}.",
+                         path,
+                         err),
+            ApplicationSecretError::FormatError(ref path) =>
+                writeln!(f,
+                         "'installed' field is unset in secret file at '{}'.",
+                         path),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum ConfigurationError {
+    DirectoryCreationFailed((String, io::Error)),
+    DirectoryUnset,
+    HomeExpansionFailed(String),
+    Secret(ApplicationSecretError),
+    Io((String, io::Error)),
+}
+
+impl fmt::Display for ConfigurationError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            ConfigurationError::DirectoryCreationFailed((ref dir, ref err)) =>
+                writeln!(f,
+                         "Directory '{}' could not be created with error: {}.",
+                         dir,
+                         err),
+            ConfigurationError::DirectoryUnset => writeln!(f, "--config-dir was unset or empty."),
+            ConfigurationError::HomeExpansionFailed(ref dir) =>
+                writeln!(f,
+                         "Couldn't find HOME directory of current user, failed to expand '{}'.",
+                         dir),
+            ConfigurationError::Secret(ref err) => writeln!(f, "Secret -> {}", err),
+            ConfigurationError::Io((ref path, ref err)) =>
+                writeln!(f,
+                         "IO operation failed on path '{}' with error: {}.",
+                         path,
+                         err),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum InputError {
+    Io((String, io::Error)),
+    Mime(String),
+}
+
+impl fmt::Display for InputError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            InputError::Io((ref file_path, ref io_err)) =>
+                writeln!(f,
+                         "Failed to open '{}' for reading with error: {}.",
+                         file_path,
+                         io_err),
+            InputError::Mime(ref mime) => writeln!(f, "'{}' is not a known mime-type.", mime),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum FieldError {
+    PopOnEmpty(String),
+    TrailingFieldSep(String),
+    Unknown(String, Option<String>, Option<String>),
+    Duplicate(String),
+    Empty,
+}
+
+
+impl fmt::Display for FieldError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            FieldError::PopOnEmpty(ref field) =>
+                writeln!(f, "'{}': Cannot move up on empty field cursor.", field),
+            FieldError::TrailingFieldSep(ref field) =>
+                writeln!(f,
+                         "'{}': Single field separator may not be last character.",
+                         field),
+            FieldError::Unknown(ref field, ref suggestion, ref value) => {
+                let suffix = match *suggestion {
+                    Some(ref s) => {
+                        let kv = match *value {
+                            Some(ref v) => format!("{}={}", s, v),
+                            None => s.clone(),
+                        };
+                        format!(" Did you mean '{}' ?", kv)
+                    }
+                    None => String::new(),
+                };
+                writeln!(f, "Field '{}' does not exist.{}", field, suffix)
+            }
+            FieldError::Duplicate(ref cursor) =>
+                writeln!(f, "Value at '{}' was already set", cursor),
+            FieldError::Empty => writeln!(f, "Field names must not be empty."),
+        }
+    }
+}
+
+
+#[derive(Debug)]
+pub enum CLIError {
+    Configuration(ConfigurationError),
+    ParseError(String, String, String, String),
+    UnknownParameter(String, Vec<&'static str>),
+    InvalidUploadProtocol(String, Vec<String>),
+    InvalidKeyValueSyntax(String, bool),
+    Input(InputError),
+    Field(FieldError),
+    MissingCommandError,
+    MissingMethodError(String),
+}
+
+impl fmt::Display for CLIError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            CLIError::Configuration(ref err) => write!(f, "Configuration -> {}", err),
+            CLIError::Input(ref err) => write!(f, "Input -> {}", err),
+            CLIError::Field(ref err) => write!(f, "Field -> {}", err),
+            CLIError::InvalidUploadProtocol(ref proto_name, ref valid_names) =>
+                writeln!(f,
+                         "'{}' is not a valid upload protocol. Choose from one of {}.",
+                         proto_name,
+                         valid_names.join(", ")),
+            CLIError::ParseError(ref arg_name, ref type_name, ref value, ref err_desc) =>
+                writeln!(f,
+                         "Failed to parse argument '{}' with value '{}' as {} with error: {}.",
+                         arg_name,
+                         value,
+                         type_name,
+                         err_desc),
+            CLIError::UnknownParameter(ref param_name, ref possible_values) => {
+                let suffix = match did_you_mean(param_name, &possible_values) {
+                    Some(v) => format!(" Did you mean '{}' ?", v),
+                    None => String::new(),
+                };
+                write!(f, "Parameter '{}' is unknown.{}\n", param_name, suffix)
+            }
+            CLIError::InvalidKeyValueSyntax(ref kv, is_hashmap) => {
+                let hashmap_info = if is_hashmap {
+                    "hashmap "
+                } else {
+                    ""
+                };
+                writeln!(f,
+                         "'{}' does not match {}pattern <key>=<value>.",
+                         kv,
+                         hashmap_info)
+            }
+            CLIError::MissingCommandError => writeln!(f, "Please specify the main sub-command."),
+            CLIError::MissingMethodError(ref cmd) =>
+                writeln!(f,
+                         "Please specify the method to call on the '{}' command.",
+                         cmd),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct InvalidOptionsError {
+    pub issues: Vec<CLIError>,
+    pub exit_code: i32,
+}
+
+impl fmt::Display for InvalidOptionsError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        for issue in &self.issues {
+            try!(issue.fmt(f));
+        }
+        Ok(())
+    }
+}
+
+impl InvalidOptionsError {
+    pub fn single(err: CLIError, exit_code: i32) -> InvalidOptionsError {
+        InvalidOptionsError {
+            issues: vec![err],
+            exit_code: exit_code,
+        }
+    }
+
+    pub fn new() -> InvalidOptionsError {
+        InvalidOptionsError {
+            issues: Vec::new(),
+            exit_code: 1,
+        }
+    }
+}
+
+pub fn assure_config_dir_exists(dir: &str) -> Result<String, CLIError> {
+    let trdir = dir.trim();
+    if trdir.len() == 0 {
+        return Err(CLIError::Configuration(ConfigurationError::DirectoryUnset));
+    }
+
+    let expanded_config_dir = if trdir.as_bytes()[0] == b'~' {
+        match env::var("HOME").ok().or(env::var("UserProfile").ok()) {
+            None => return Err(CLIError::Configuration(ConfigurationError::HomeExpansionFailed(trdir.to_string()))),
+            Some(mut user) => {
+                user.push_str(&trdir[1..]);
+                user
+            }
+        }
+    } else {
+        trdir.to_string()
+    };
+
+    if let Err(err) = fs::create_dir(&expanded_config_dir) {
+        if err.kind() != io::ErrorKind::AlreadyExists {
+            return Err(CLIError::Configuration(
+                    ConfigurationError::DirectoryCreationFailed((expanded_config_dir, err))));
+        }
+    }
+
+    Ok(expanded_config_dir)
+}
+
+pub fn application_secret_from_directory(dir: &str,
+                                         secret_basename: &str,
+                                         json_console_secret: &str)
+                                         -> Result<ApplicationSecret, CLIError> {
+    let secret_path = Path::new(dir).join(secret_basename);
+    let secret_str = || secret_path.as_path().to_str().unwrap().to_string();
+    let secret_io_error = |io_err: io::Error| {
+        Err(CLIError::Configuration(ConfigurationError::Io((secret_str(), io_err))))
+    };
+
+    for _ in 0..2 {
+        match fs::File::open(&secret_path) {
+            Err(mut err) => {
+                if err.kind() == io::ErrorKind::NotFound {
+                    // Write our built-in one - user may adjust the written file at will
+
+                    err = match fs::OpenOptions::new()
+                                    .create(true)
+                                    .write(true)
+                                    .open(&secret_path) {
+                        Err(cfe) => cfe,
+                        Ok(mut f) => {
+                            // Assure we convert 'ugly' json string into pretty one
+                            let console_secret: ConsoleApplicationSecret =
+                                json::from_str(json_console_secret).unwrap();
+                            match json::to_writer_pretty(&mut f, &console_secret) {
+                                Err(serde_err) =>
+                                    panic!("Unexpected serde error: {:#?}", serde_err),
+                                Ok(_) => continue,
+                            }
+                        }
+                    };
+                    // fall through to IO error handling
+                }
+                return secret_io_error(err);
+            }
+            Ok(f) => {
+                match json::de::from_reader::<_, ConsoleApplicationSecret>(f) {
+                    Err(json_err) =>
+                        return Err(CLIError::Configuration(
+                            ConfigurationError::Secret(
+                                ApplicationSecretError::DecoderError(
+                                                (secret_str(), json_err)
+                                              )))),
+                    Ok(console_secret) => match console_secret.installed {
+                        Some(secret) => return Ok(secret),
+                        None => return Err(
+                                        CLIError::Configuration(
+                                        ConfigurationError::Secret(
+                                        ApplicationSecretError::FormatError(secret_str())
+                                        ))),
+                    },
+                }
+            }
+        }
+    }
+    unreachable!();
+}

--- a/gen/analyticsreporting4-cli/src/main.rs
+++ b/gen/analyticsreporting4-cli/src/main.rs
@@ -1,0 +1,358 @@
+// DO NOT EDIT !
+// This file was generated automatically from 'src/mako/cli/main.rs.mako'
+// DO NOT EDIT !
+#![allow(unused_variables, unused_imports, dead_code, unused_mut)]
+
+#[macro_use]
+extern crate clap;
+extern crate yup_oauth2 as oauth2;
+extern crate yup_hyper_mock as mock;
+extern crate hyper_rustls;
+extern crate serde;
+extern crate serde_json;
+extern crate hyper;
+extern crate mime;
+extern crate strsim;
+extern crate google_analyticsreporting4 as api;
+
+use std::env;
+use std::io::{self, Write};
+use clap::{App, SubCommand, Arg};
+
+mod cmn;
+
+use cmn::{InvalidOptionsError, CLIError, JsonTokenStorage, arg_from_str, writer_from_opts, parse_kv_arg,
+          input_file_from_opts, input_mime_from_opts, FieldCursor, FieldError, CallType, UploadProtocol,
+          calltype_from_str, remove_json_null_values, ComplexType, JsonType, JsonTypeInfo};
+
+use std::default::Default;
+use std::str::FromStr;
+
+use oauth2::{Authenticator, DefaultAuthenticatorDelegate, FlowType};
+use serde_json as json;
+use clap::ArgMatches;
+
+enum DoitError {
+    IoError(String, io::Error),
+    ApiError(api::Error),
+}
+
+struct Engine<'n> {
+    opt: ArgMatches<'n>,
+    hub: api::AnalyticsReporting<hyper::Client, Authenticator<DefaultAuthenticatorDelegate, JsonTokenStorage, hyper::Client>>,
+    gp: Vec<&'static str>,
+    gpm: Vec<(&'static str, &'static str)>,
+}
+
+
+impl<'n> Engine<'n> {
+    fn _reports_batch_get(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    "use-resource-quotas" => Some(("useResourceQuotas", JsonTypeInfo { jtype: JsonType::Boolean, ctype: ComplexType::Pod })),
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec!["use-resource-quotas"]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::GetReportsRequest = json::value::from_value(object).unwrap();
+        let mut call = self.hub.reports().batch_get(request);
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _doit(&self, dry_run: bool) -> Result<Result<(), DoitError>, Option<InvalidOptionsError>> {
+        let mut err = InvalidOptionsError::new();
+        let mut call_result: Result<(), DoitError> = Ok(());
+        let mut err_opt: Option<InvalidOptionsError> = None;
+        match self.opt.subcommand() {
+            ("reports", Some(opt)) => {
+                match opt.subcommand() {
+                    ("batch-get", Some(opt)) => {
+                        call_result = self._reports_batch_get(opt, dry_run, &mut err);
+                    },
+                    _ => {
+                        err.issues.push(CLIError::MissingMethodError("reports".to_string()));
+                        writeln!(io::stderr(), "{}\n", opt.usage()).ok();
+                    }
+                }
+            },
+            _ => {
+                err.issues.push(CLIError::MissingCommandError);
+                writeln!(io::stderr(), "{}\n", self.opt.usage()).ok();
+            }
+        }
+
+        if dry_run {
+            if err.issues.len() > 0 {
+                err_opt = Some(err);
+            }
+            Err(err_opt)
+        } else {
+            Ok(call_result)
+        }
+    }
+
+    // Please note that this call will fail if any part of the opt can't be handled
+    fn new(opt: ArgMatches<'n>) -> Result<Engine<'n>, InvalidOptionsError> {
+        let (config_dir, secret) = {
+            let config_dir = match cmn::assure_config_dir_exists(opt.value_of("folder").unwrap_or("~/.google-service-cli")) {
+                Err(e) => return Err(InvalidOptionsError::single(e, 3)),
+                Ok(p) => p,
+            };
+
+            match cmn::application_secret_from_directory(&config_dir, "analyticsreporting4-secret.json",
+                                                         "{\"installed\":{\"auth_uri\":\"https://accounts.google.com/o/oauth2/auth\",\"client_secret\":\"hCsslbCUyfehWMmbkG8vTYxG\",\"token_uri\":\"https://accounts.google.com/o/oauth2/token\",\"client_email\":\"\",\"redirect_uris\":[\"urn:ietf:wg:oauth:2.0:oob\",\"oob\"],\"client_x509_cert_url\":\"\",\"client_id\":\"620010449518-9ngf7o4dhs0dka470npqvor6dc5lqb9b.apps.googleusercontent.com\",\"auth_provider_x509_cert_url\":\"https://www.googleapis.com/oauth2/v1/certs\"}}") {
+                Ok(secret) => (config_dir, secret),
+                Err(e) => return Err(InvalidOptionsError::single(e, 4))
+            }
+        };
+
+        let auth = Authenticator::new(  &secret, DefaultAuthenticatorDelegate,
+                                        if opt.is_present("debug-auth") {
+                                            hyper::Client::with_connector(mock::TeeConnector {
+                                                    connector: hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())
+                                                })
+                                        } else {
+                                            hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new()))
+                                        },
+                                        JsonTokenStorage {
+                                          program_name: "analyticsreporting4",
+                                          db_dir: config_dir.clone(),
+                                        }, Some(FlowType::InstalledRedirect(54324)));
+
+        let client =
+            if opt.is_present("debug") {
+                hyper::Client::with_connector(mock::TeeConnector {
+                        connector: hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())
+                    })
+            } else {
+                hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new()))
+            };
+        let engine = Engine {
+            opt: opt,
+            hub: api::AnalyticsReporting::new(client, auth),
+            gp: vec!["$-xgafv", "access-token", "alt", "bearer-token", "callback", "fields", "key", "oauth-token", "pp", "pretty-print", "quota-user", "upload-type", "upload-protocol"],
+            gpm: vec![
+                    ("$-xgafv", "$.xgafv"),
+                    ("access-token", "access_token"),
+                    ("bearer-token", "bearer_token"),
+                    ("oauth-token", "oauth_token"),
+                    ("pretty-print", "prettyPrint"),
+                    ("quota-user", "quotaUser"),
+                    ("upload-type", "uploadType"),
+                    ("upload-protocol", "upload_protocol"),
+                ]
+        };
+
+        match engine._doit(true) {
+            Err(Some(err)) => Err(err),
+            Err(None)      => Ok(engine),
+            Ok(_)          => unreachable!(),
+        }
+    }
+
+    fn doit(&self) -> Result<(), DoitError> {
+        match self._doit(false) {
+            Ok(res) => res,
+            Err(_) => unreachable!(),
+        }
+    }
+}
+
+fn main() {
+    let mut exit_status = 0i32;
+    let arg_data = [
+        ("reports", "methods: 'batch-get'", vec![
+            ("batch-get",
+                    Some(r##"Returns the Analytics data."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_analyticsreporting4_cli/reports_batch-get",
+                  vec![
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ]),
+        
+    ];
+    
+    let mut app = App::new("analyticsreporting4")
+           .author("Sebastian Thiel <byronimo@gmail.com>")
+           .version("1.0.7+20171108")
+           .about("Accesses Analytics report data.")
+           .after_help("All documentation details can be found at http://byron.github.io/google-apis-rs/google_analyticsreporting4_cli")
+           .arg(Arg::with_name("url")
+                   .long("scope")
+                   .help("Specify the authentication a method should be executed in. Each scope requires the user to grant this application permission to use it.If unset, it defaults to the shortest scope url for a particular method.")
+                   .multiple(true)
+                   .takes_value(true))
+           .arg(Arg::with_name("folder")
+                   .long("config-dir")
+                   .help("A directory into which we will store our persistent data. Defaults to a user-writable directory that we will create during the first invocation.[default: ~/.google-service-cli")
+                   .multiple(false)
+                   .takes_value(true))
+           .arg(Arg::with_name("debug")
+                   .long("debug")
+                   .help("Output all server communication to standard error. `tx` and `rx` are placed into the same stream.")
+                   .multiple(false)
+                   .takes_value(false))
+           .arg(Arg::with_name("debug-auth")
+                   .long("debug-auth")
+                   .help("Output all communication related to authentication to standard error. `tx` and `rx` are placed into the same stream.")
+                   .multiple(false)
+                   .takes_value(false));
+           
+           for &(main_command_name, about, ref subcommands) in arg_data.iter() {
+               let mut mcmd = SubCommand::with_name(main_command_name).about(about);
+           
+               for &(sub_command_name, ref desc, url_info, ref args) in subcommands {
+                   let mut scmd = SubCommand::with_name(sub_command_name);
+                   if let &Some(desc) = desc {
+                       scmd = scmd.about(desc);
+                   }
+                   scmd = scmd.after_help(url_info);
+           
+                   for &(ref arg_name, ref flag, ref desc, ref required, ref multi) in args {
+                       let arg_name_str =
+                           match (arg_name, flag) {
+                                   (&Some(an), _       ) => an,
+                                   (_        , &Some(f)) => f,
+                                    _                    => unreachable!(),
+                            };
+                       let mut arg = Arg::with_name(arg_name_str)
+                                         .empty_values(false);
+                       if let &Some(short_flag) = flag {
+                           arg = arg.short(short_flag);
+                       }
+                       if let &Some(desc) = desc {
+                           arg = arg.help(desc);
+                       }
+                       if arg_name.is_some() && flag.is_some() {
+                           arg = arg.takes_value(true);
+                       }
+                       if let &Some(required) = required {
+                           arg = arg.required(required);
+                       }
+                       if let &Some(multi) = multi {
+                           arg = arg.multiple(multi);
+                       }
+                       scmd = scmd.arg(arg);
+                   }
+                   mcmd = mcmd.subcommand(scmd);
+               }
+               app = app.subcommand(mcmd);
+           }
+           
+        let matches = app.get_matches();
+
+    let debug = matches.is_present("debug");
+    match Engine::new(matches) {
+        Err(err) => {
+            exit_status = err.exit_code;
+            writeln!(io::stderr(), "{}", err).ok();
+        },
+        Ok(engine) => {
+            if let Err(doit_err) = engine.doit() {
+                exit_status = 1;
+                match doit_err {
+                    DoitError::IoError(path, err) => {
+                        writeln!(io::stderr(), "Failed to open output file '{}': {}", path, err).ok();
+                    },
+                    DoitError::ApiError(err) => {
+                        if debug {
+                            writeln!(io::stderr(), "{:#?}", err).ok();
+                        } else {
+                            writeln!(io::stderr(), "{}", err).ok();
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    std::process::exit(exit_status);
+}

--- a/gen/analyticsreporting4/Cargo.toml
+++ b/gen/analyticsreporting4/Cargo.toml
@@ -1,0 +1,31 @@
+# DO NOT EDIT !
+# This file was generated automatically from 'src/mako/Cargo.toml.mako'
+# DO NOT EDIT !
+[package]
+
+name = "google-analyticsreporting4"
+version = "1.0.7+20171108"
+authors = ["Sebastian Thiel <byronimo@gmail.com>"]
+description = "A complete library to interact with AnalyticsReporting (protocol v4)"
+repository = "https://github.com/Byron/google-apis-rs/tree/master/gen/analyticsreporting4"
+homepage = "https://developers.google.com/analytics/devguides/reporting/core/v4/"
+documentation = "https://docs.rs/google-analyticsreporting4/1.0.7+20171108"
+license = "MIT"
+keywords = ["analyticsreporting", "google", "protocol", "web", "api"]
+
+
+[dev-dependencies]
+hyper-rustls = "^0.6"
+
+[dependencies]
+hyper = "^ 0.10"
+mime = "^ 0.2.0"
+serde = "^ 1.0"
+serde_json = "^ 1.0"
+serde_derive = "^ 1.0"
+yup-oauth2 = "^ 1.0"
+url = "= 0.5"
+
+[features]
+
+

--- a/gen/analyticsreporting4/LICENSE.md
+++ b/gen/analyticsreporting4/LICENSE.md
@@ -1,0 +1,30 @@
+<!---
+DO NOT EDIT !
+This file was generated automatically from 'src/mako/LICENSE.md.mako'
+DO NOT EDIT !
+-->
+The MIT License (MIT)
+=====================
+
+Copyright © `2015-2016` `Sebastian Thiel`
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the “Software”), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.

--- a/gen/analyticsreporting4/README.md
+++ b/gen/analyticsreporting4/README.md
@@ -1,0 +1,180 @@
+<!---
+DO NOT EDIT !
+This file was generated automatically from 'src/mako/api/README.md.mako'
+DO NOT EDIT !
+-->
+The `google-analyticsreporting4` library allows access to all features of the *Google AnalyticsReporting* service.
+
+This documentation was generated from *AnalyticsReporting* crate version *1.0.7+20171108*, where *20171108* is the exact revision of the *analyticsreporting:v4* schema built by the [mako](http://www.makotemplates.org/) code generator *v1.0.7*.
+
+Everything else about the *AnalyticsReporting* *v4* API can be found at the
+[official documentation site](https://developers.google.com/analytics/devguides/reporting/core/v4/).
+# Features
+
+Handle the following *Resources* with ease from the central [hub](https://docs.rs/google-analyticsreporting4/1.0.7+20171108/google_analyticsreporting4/struct.AnalyticsReporting.html) ... 
+
+* [reports](https://docs.rs/google-analyticsreporting4/1.0.7+20171108/google_analyticsreporting4/struct.Report.html)
+ * [*batch get*](https://docs.rs/google-analyticsreporting4/1.0.7+20171108/google_analyticsreporting4/struct.ReportBatchGetCall.html)
+
+
+
+
+# Structure of this Library
+
+The API is structured into the following primary items:
+
+* **[Hub](https://docs.rs/google-analyticsreporting4/1.0.7+20171108/google_analyticsreporting4/struct.AnalyticsReporting.html)**
+    * a central object to maintain state and allow accessing all *Activities*
+    * creates [*Method Builders*](https://docs.rs/google-analyticsreporting4/1.0.7+20171108/google_analyticsreporting4/trait.MethodsBuilder.html) which in turn
+      allow access to individual [*Call Builders*](https://docs.rs/google-analyticsreporting4/1.0.7+20171108/google_analyticsreporting4/trait.CallBuilder.html)
+* **[Resources](https://docs.rs/google-analyticsreporting4/1.0.7+20171108/google_analyticsreporting4/trait.Resource.html)**
+    * primary types that you can apply *Activities* to
+    * a collection of properties and *Parts*
+    * **[Parts](https://docs.rs/google-analyticsreporting4/1.0.7+20171108/google_analyticsreporting4/trait.Part.html)**
+        * a collection of properties
+        * never directly used in *Activities*
+* **[Activities](https://docs.rs/google-analyticsreporting4/1.0.7+20171108/google_analyticsreporting4/trait.CallBuilder.html)**
+    * operations to apply to *Resources*
+
+All *structures* are marked with applicable traits to further categorize them and ease browsing.
+
+Generally speaking, you can invoke *Activities* like this:
+
+```Rust,ignore
+let r = hub.resource().activity(...).doit()
+```
+
+Or specifically ...
+
+```ignore
+let r = hub.reports().batch_get(...).doit()
+```
+
+The `resource()` and `activity(...)` calls create [builders][builder-pattern]. The second one dealing with `Activities` 
+supports various methods to configure the impending operation (not shown here). It is made such that all required arguments have to be 
+specified right away (i.e. `(...)`), whereas all optional ones can be [build up][builder-pattern] as desired.
+The `doit()` method performs the actual communication with the server and returns the respective result.
+
+# Usage
+
+## Setting up your Project
+
+To use this library, you would put the following lines into your `Cargo.toml` file:
+
+```toml
+[dependencies]
+google-analyticsreporting4 = "*"
+```
+
+## A complete example
+
+```Rust
+extern crate hyper;
+extern crate hyper_rustls;
+extern crate yup_oauth2 as oauth2;
+extern crate google_analyticsreporting4 as analyticsreporting4;
+use analyticsreporting4::GetReportsRequest;
+use analyticsreporting4::{Result, Error};
+use std::default::Default;
+use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+use analyticsreporting4::AnalyticsReporting;
+
+// Get an ApplicationSecret instance by some means. It contains the `client_id` and 
+// `client_secret`, among other things.
+let secret: ApplicationSecret = Default::default();
+// Instantiate the authenticator. It will choose a suitable authentication flow for you, 
+// unless you replace  `None` with the desired Flow.
+// Provide your own `AuthenticatorDelegate` to adjust the way it operates and get feedback about 
+// what's going on. You probably want to bring in your own `TokenStorage` to persist tokens and
+// retrieve them from storage.
+let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+                              hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+                              <MemoryStorage as Default>::default(), None);
+let mut hub = AnalyticsReporting::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+// As the method needs a request, you would usually fill it with the desired information
+// into the respective structure. Some of the parts shown here might not be applicable !
+// Values shown here are possibly random and not representative !
+let mut req = GetReportsRequest::default();
+
+// You can configure optional parameters by calling the respective setters at will, and
+// execute the final call using `doit()`.
+// Values shown here are possibly random and not representative !
+let result = hub.reports().batch_get(req)
+             .doit();
+
+match result {
+    Err(e) => match e {
+        // The Error enum provides details about what exactly happened.
+        // You can also just use its `Debug`, `Display` or `Error` traits
+         Error::HttpError(_)
+        |Error::MissingAPIKey
+        |Error::MissingToken(_)
+        |Error::Cancelled
+        |Error::UploadSizeLimitExceeded(_, _)
+        |Error::Failure(_)
+        |Error::BadRequest(_)
+        |Error::FieldClash(_)
+        |Error::JsonDecodeError(_, _) => println!("{}", e),
+    },
+    Ok(res) => println!("Success: {:?}", res),
+}
+
+```
+## Handling Errors
+
+All errors produced by the system are provided either as [Result](https://docs.rs/google-analyticsreporting4/1.0.7+20171108/google_analyticsreporting4/enum.Result.html) enumeration as return value of 
+the doit() methods, or handed as possibly intermediate results to either the 
+[Hub Delegate](https://docs.rs/google-analyticsreporting4/1.0.7+20171108/google_analyticsreporting4/trait.Delegate.html), or the [Authenticator Delegate](https://docs.rs/yup-oauth2/*/yup_oauth2/trait.AuthenticatorDelegate.html).
+
+When delegates handle errors or intermediate values, they may have a chance to instruct the system to retry. This 
+makes the system potentially resilient to all kinds of errors.
+
+## Uploads and Downloads
+If a method supports downloads, the response body, which is part of the [Result](https://docs.rs/google-analyticsreporting4/1.0.7+20171108/google_analyticsreporting4/enum.Result.html), should be
+read by you to obtain the media.
+If such a method also supports a [Response Result](https://docs.rs/google-analyticsreporting4/1.0.7+20171108/google_analyticsreporting4/trait.ResponseResult.html), it will return that by default.
+You can see it as meta-data for the actual media. To trigger a media download, you will have to set up the builder by making
+this call: `.param("alt", "media")`.
+
+Methods supporting uploads can do so using up to 2 different protocols: 
+*simple* and *resumable*. The distinctiveness of each is represented by customized 
+`doit(...)` methods, which are then named `upload(...)` and `upload_resumable(...)` respectively.
+
+## Customization and Callbacks
+
+You may alter the way an `doit()` method is called by providing a [delegate](https://docs.rs/google-analyticsreporting4/1.0.7+20171108/google_analyticsreporting4/trait.Delegate.html) to the 
+[Method Builder](https://docs.rs/google-analyticsreporting4/1.0.7+20171108/google_analyticsreporting4/trait.CallBuilder.html) before making the final `doit()` call. 
+Respective methods will be called to provide progress information, as well as determine whether the system should 
+retry on failure.
+
+The [delegate trait](https://docs.rs/google-analyticsreporting4/1.0.7+20171108/google_analyticsreporting4/trait.Delegate.html) is default-implemented, allowing you to customize it with minimal effort.
+
+## Optional Parts in Server-Requests
+
+All structures provided by this library are made to be [enocodable](https://docs.rs/google-analyticsreporting4/1.0.7+20171108/google_analyticsreporting4/trait.RequestValue.html) and 
+[decodable](https://docs.rs/google-analyticsreporting4/1.0.7+20171108/google_analyticsreporting4/trait.ResponseResult.html) via *json*. Optionals are used to indicate that partial requests are responses 
+are valid.
+Most optionals are are considered [Parts](https://docs.rs/google-analyticsreporting4/1.0.7+20171108/google_analyticsreporting4/trait.Part.html) which are identifiable by name, which will be sent to 
+the server to indicate either the set parts of the request or the desired parts in the response.
+
+## Builder Arguments
+
+Using [method builders](https://docs.rs/google-analyticsreporting4/1.0.7+20171108/google_analyticsreporting4/trait.CallBuilder.html), you are able to prepare an action call by repeatedly calling it's methods.
+These will always take a single argument, for which the following statements are true.
+
+* [PODs][wiki-pod] are handed by copy
+* strings are passed as `&str`
+* [request values](https://docs.rs/google-analyticsreporting4/1.0.7+20171108/google_analyticsreporting4/trait.RequestValue.html) are moved
+
+Arguments will always be copied or cloned into the builder, to make them independent of their original life times.
+
+[wiki-pod]: http://en.wikipedia.org/wiki/Plain_old_data_structure
+[builder-pattern]: http://en.wikipedia.org/wiki/Builder_pattern
+[google-go-api]: https://github.com/google/google-api-go-client
+
+# License
+The **analyticsreporting4** library was generated by Sebastian Thiel, and is placed 
+under the *MIT* license.
+You can read the full text at the repository's [license file][repo-license].
+
+[repo-license]: https://github.com/Byron/google-apis-rsblob/master/LICENSE.md

--- a/gen/analyticsreporting4/src/cmn.rs
+++ b/gen/analyticsreporting4/src/cmn.rs
@@ -1,0 +1,753 @@
+// COPY OF 'src/rust/api/cmn.rs'
+// DO NOT EDIT
+use std::io::{self, Read, Seek, Cursor, Write, SeekFrom};
+use std;
+use std::fmt::{self, Display};
+use std::str::FromStr;
+use std::error;
+use std::thread::sleep;
+use std::time::Duration;
+
+use mime::{Mime, TopLevel, SubLevel, Attr, Value};
+use oauth2::{TokenType, Retry, self};
+use hyper;
+use hyper::header::{ContentType, ContentLength, Headers, UserAgent, Authorization, Header,
+                    HeaderFormat, Bearer};
+use hyper::http::h1::LINE_ENDING;
+use hyper::method::Method;
+use hyper::status::StatusCode;
+
+use serde_json as json;
+
+/// Identifies the Hub. There is only one per library, this trait is supposed
+/// to make intended use more explicit.
+/// The hub allows to access all resource methods more easily.
+pub trait Hub {}
+
+/// Identifies types for building methods of a particular resource type
+pub trait MethodsBuilder {}
+
+/// Identifies types which represent builders for a particular resource method
+pub trait CallBuilder {}
+
+/// Identifies types which can be inserted and deleted.
+/// Types with this trait are most commonly used by clients of this API.
+pub trait Resource {}
+
+/// Identifies types which are used in API responses.
+pub trait ResponseResult {}
+
+/// Identifies types which are used in API requests.
+pub trait RequestValue {}
+
+/// Identifies types which are not actually used by the API
+/// This might be a bug within the google API schema.
+pub trait UnusedType {}
+
+/// Identifies types which are only used as part of other types, which
+/// usually are carrying the `Resource` trait.
+pub trait Part {}
+
+/// Identifies types which are only used by other types internally.
+/// They have no special meaning, this trait just marks them for completeness.
+pub trait NestedType {}
+
+/// A utility to specify reader types which provide seeking capabilities too
+pub trait ReadSeek: Seek + Read {}
+impl<T: Seek + Read> ReadSeek for T {}
+
+/// A trait for all types that can convert themselves into a *parts* string
+pub trait ToParts {
+    fn to_parts(&self) -> String;
+}
+
+/// A utility type which can decode a server response that indicates error
+#[derive(Deserialize)]
+pub struct JsonServerError {
+    pub error: String,
+    pub error_description: Option<String>
+}
+
+/// A utility to represent detailed errors we might see in case there are BadRequests.
+/// The latter happen if the sent parameters or request structures are unsound
+#[derive(Deserialize, Serialize, Debug)]
+pub struct ErrorResponse {
+    error: ServerError,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct ServerError {
+    errors: Vec<ServerMessage>,
+    code: u16,
+    message: String,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct ServerMessage {
+    domain: String,
+    reason: String,
+    message: String,
+    #[serde(rename="locationType")]
+    location_type: Option<String>,
+    location: Option<String>
+}
+
+#[derive(Copy, Clone)]
+pub struct DummyNetworkStream;
+
+impl Read for DummyNetworkStream {
+    fn read(&mut self, _: &mut [u8]) -> io::Result<usize> {
+        Ok(0)
+    }
+}
+
+impl Write for DummyNetworkStream {
+    fn write(&mut self, _: &[u8]) -> io::Result<usize> {
+        Ok(0)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl hyper::net::NetworkStream for DummyNetworkStream {
+    fn peer_addr(&mut self) -> io::Result<std::net::SocketAddr> {
+        Ok("127.0.0.1:1337".parse().unwrap())
+    }
+
+    fn set_read_timeout(&self, _dur: Option<Duration>) -> io::Result<()> {
+        Ok(())
+    }
+
+    fn set_write_timeout(&self, _dur: Option<Duration>) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+
+/// A trait specifying functionality to help controlling any request performed by the API.
+/// The trait has a conservative default implementation.
+///
+/// It contains methods to deal with all common issues, as well with the ones related to
+/// uploading media
+pub trait Delegate {
+
+    /// Called at the beginning of any API request. The delegate should store the method
+    /// information if he is interesting in knowing more context when further calls to it
+    /// are made.
+    /// The matching `finished()` call will always be made, no matter whether or not the API
+    /// request was successful. That way, the delegate may easily maintain a clean state
+    /// between various API calls.
+    fn begin(&mut self, MethodInfo) {}
+
+    /// Called whenever there is an [HttpError](http://hyperium.github.io/hyper/hyper/error/enum.HttpError.html), usually if there are network problems.
+    ///
+    /// If you choose to retry after a duration, the duration should be chosen using the
+    /// [exponential backoff algorithm](http://en.wikipedia.org/wiki/Exponential_backoff).
+    ///
+    /// Return retry information.
+    fn http_error(&mut self, &hyper::Error) -> Retry {
+        Retry::Abort
+    }
+
+    /// Called whenever there is the need for your applications API key after
+    /// the official authenticator implementation didn't provide one, for some reason.
+    /// If this method returns None as well, the underlying operation will fail
+    fn api_key(&mut self) -> Option<String> {
+        None
+    }
+
+    /// Called whenever the Authenticator didn't yield a token. The delegate
+    /// may attempt to provide one, or just take it as a general information about the
+    /// impending failure.
+    /// The given Error provides information about why the token couldn't be acquired in the
+    /// first place
+    fn token(&mut self, err: &error::Error) -> Option<oauth2::Token> {
+        let _ = err;
+        None
+    }
+
+    /// Called during resumable uploads to provide a URL for the impending upload.
+    /// It was saved after a previous call to `store_upload_url(...)`, and if not None,
+    /// will be used instead of asking the server for a new upload URL.
+    /// This is useful in case a previous resumable upload was aborted/canceled, but should now
+    /// be resumed.
+    /// The returned URL will be used exactly once - if it fails again and the delegate allows
+    /// to retry, we will ask the server for a new upload URL.
+    fn upload_url(&mut self) -> Option<String> {
+        None
+    }
+
+    /// Called after we have retrieved a new upload URL for a resumable upload to store it
+    /// in case we fail or cancel. That way, we can attempt to resume the upload later,
+    /// see `upload_url()`.
+    /// It will also be called with None after a successful upload, which allows the delegate
+    /// to forget the URL. That way, we will not attempt to resume an upload that has already
+    /// finished.
+    fn store_upload_url(&mut self, url: Option<&str>) {
+        let _ = url;
+    }
+
+    /// Called whenever a server response could not be decoded from json.
+    /// It's for informational purposes only, the caller will return with an error
+    /// accordingly.
+    ///
+    /// # Arguments
+    ///
+    /// * `json_encoded_value` - The json-encoded value which failed to decode.
+    /// * `json_decode_error`  - The decoder error
+    fn response_json_decode_error(&mut self, json_encoded_value: &str, json_decode_error: &json::Error) {
+        let _ = json_encoded_value;
+        let _ = json_decode_error;
+    }
+
+    /// Called whenever the http request returns with a non-success status code.
+    /// This can involve authentication issues, or anything else that very much
+    /// depends on the used API method.
+    /// The delegate should check the status, header and decoded json error to decide
+    /// whether to retry or not. In the latter case, the underlying call will fail.
+    ///
+    /// If you choose to retry after a duration, the duration should be chosen using the
+    /// [exponential backoff algorithm](http://en.wikipedia.org/wiki/Exponential_backoff).
+    fn http_failure(&mut self, _: &hyper::client::Response, Option<JsonServerError>, _: Option<ServerError>) -> Retry {
+        Retry::Abort
+    }
+
+    /// Called prior to sending the main request of the given method. It can be used to time
+    /// the call or to print progress information.
+    /// It's also useful as you can be sure that a request will definitely be made.
+    fn pre_request(&mut self) { }
+
+    /// Return the size of each chunk of a resumable upload.
+    /// Must be a power of two, with 1<<18 being the smallest allowed chunk size.
+    /// Will be called once before starting any resumable upload.
+    fn chunk_size(&mut self) -> u64 {
+        1 << 23
+    }
+
+    /// Called before the given chunk is uploaded to the server.
+    /// If true is returned, the upload will be interrupted.
+    /// However, it may be resumable if you stored the upload URL in a previous call
+    /// to `store_upload_url()`
+    fn cancel_chunk_upload(&mut self, chunk: &ContentRange) -> bool {
+        let _ = chunk;
+        false
+    }
+
+    /// Called before the API request method returns, in every case. It can be used to clean up
+    /// internal state between calls to the API.
+    /// This call always has a matching call to `begin(...)`.
+    ///
+    /// # Arguments
+    ///
+    /// * `is_success` - a true value indicates the operation was successful. If false, you should
+    ///                  discard all values stored during `store_upload_url`.
+    fn finished(&mut self, is_success: bool) {
+        let _ = is_success;
+    }
+}
+
+/// A delegate with a conservative default implementation, which is used if no other delegate is
+/// set.
+#[derive(Default)]
+pub struct DefaultDelegate;
+
+impl Delegate for DefaultDelegate {}
+
+
+#[derive(Debug)]
+pub enum Error {
+    /// The http connection failed
+    HttpError(hyper::Error),
+
+    /// An attempt was made to upload a resource with size stored in field `.0`
+    /// even though the maximum upload size is what is stored in field `.1`.
+    UploadSizeLimitExceeded(u64, u64),
+
+    /// Represents information about a request that was not understood by the server.
+    /// Details are included.
+    BadRequest(ErrorResponse),
+
+    /// We needed an API key for authentication, but didn't obtain one.
+    /// Neither through the authenticator, nor through the Delegate.
+    MissingAPIKey,
+
+    /// We required a Token, but didn't get one from the Authenticator
+    MissingToken(Box<error::Error>),
+
+    /// The delgate instructed to cancel the operation
+    Cancelled,
+
+    /// An additional, free form field clashed with one of the built-in optional ones
+    FieldClash(&'static str),
+
+    /// Shows that we failed to decode the server response.
+    /// This can happen if the protocol changes in conjunction with strict json decoding.
+    JsonDecodeError(String, json::Error),
+
+    /// Indicates an HTTP repsonse with a non-success status code
+    Failure(hyper::client::Response),
+}
+
+
+impl Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Error::HttpError(ref err) => err.fmt(f),
+            Error::UploadSizeLimitExceeded(ref resource_size, ref max_size) =>
+                writeln!(f, "The media size {} exceeds the maximum allowed upload size of {}"
+                         , resource_size, max_size),
+            Error::MissingAPIKey => {
+                (writeln!(f, "The application's API key was not found in the configuration")).ok();
+                writeln!(f, "It is used as there are no Scopes defined for this method.")
+            },
+            Error::BadRequest(ref err) => {
+                try!(writeln!(f, "Bad Request ({}): {}", err.error.code, err.error.message));
+                for err in err.error.errors.iter() {
+                    try!(writeln!(f, "    {}: {}, {}{}",
+                                            err.domain,
+                                            err.message,
+                                            err.reason,
+                                            match &err.location {
+                                                &Some(ref loc) => format!("@{}", loc),
+                                                &None => String::new(),
+                                            }));
+                }
+                Ok(())
+            },
+            Error::MissingToken(ref err) =>
+                writeln!(f, "Token retrieval failed with error: {}", err),
+            Error::Cancelled =>
+                writeln!(f, "Operation cancelled by delegate"),
+            Error::FieldClash(field) =>
+                writeln!(f, "The custom parameter '{}' is already provided natively by the CallBuilder.", field),
+            Error::JsonDecodeError(ref json_str, ref err)
+                => writeln!(f, "{}: {}", err, json_str),
+            Error::Failure(ref response) =>
+                writeln!(f, "Http status indicates failure: {:?}", response),
+        }
+    }
+}
+
+impl error::Error for Error {
+    fn description(&self) -> &str {
+        match *self {
+            Error::HttpError(ref err) => err.description(),
+            Error::JsonDecodeError(_, ref err) => err.description(),
+            _ => "NO DESCRIPTION POSSIBLE - use `Display.fmt()` instead"
+        }
+    }
+
+    fn cause(&self) -> Option<&error::Error> {
+        match *self {
+            Error::HttpError(ref err) => err.cause(),
+            Error::JsonDecodeError(_, ref err) => err.cause(),
+            _ => None
+        }
+    }
+}
+
+/// A universal result type used as return for all calls.
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Contains information about an API request.
+pub struct MethodInfo {
+    pub id: &'static str,
+    pub http_method: Method,
+}
+
+const BOUNDARY: &'static str = "MDuXWGyeE33QFXGchb2VFWc4Z7945d";
+
+/// Provides a `Read` interface that converts multiple parts into the protocol
+/// identified by [RFC2387](https://tools.ietf.org/html/rfc2387).
+/// **Note**: This implementation is just as rich as it needs to be to perform uploads
+/// to google APIs, and might not be a fully-featured implementation.
+#[derive(Default)]
+pub struct MultiPartReader<'a> {
+    raw_parts: Vec<(Headers, &'a mut Read)>,
+    current_part: Option<(Cursor<Vec<u8>>, &'a mut Read)>,
+    last_part_boundary: Option<Cursor<Vec<u8>>>,
+}
+
+impl<'a> MultiPartReader<'a> {
+
+    /// Reserve memory for exactly the given amount of parts
+    pub fn reserve_exact(&mut self, cap: usize) {
+        self.raw_parts.reserve_exact(cap);
+    }
+
+    /// Add a new part to the queue of parts to be read on the first `read` call.
+    ///
+    /// # Arguments
+    ///
+    /// `headers` - identifying the body of the part. It's similar to the header
+    ///             in an ordinary single-part call, and should thus contain the
+    ///             same information.
+    /// `reader`  - a reader providing the part's body
+    /// `size`    - the amount of bytes provided by the reader. It will be put onto the header as
+    ///             content-size.
+    /// `mime`    - It will be put onto the content type
+    pub fn add_part(&mut self, reader: &'a mut Read, size: u64, mime_type: Mime) -> &mut MultiPartReader<'a> {
+        let mut headers = Headers::new();
+        headers.set(ContentType(mime_type));
+        headers.set(ContentLength(size));
+        self.raw_parts.push((headers, reader));
+        self
+    }
+
+    /// Returns the mime-type representing our multi-part message.
+    /// Use it with the ContentType header.
+    pub fn mime_type(&self) -> Mime {
+        Mime(
+            TopLevel::Multipart,
+            SubLevel::Ext("Related".to_string()),
+            vec![(Attr::Ext("boundary".to_string()), Value::Ext(BOUNDARY.to_string()))],
+        )
+    }
+
+    /// Returns true if we are totally used
+    fn is_depleted(&self) -> bool {
+        self.raw_parts.len() == 0 && self.current_part.is_none() && self.last_part_boundary.is_none()
+    }
+
+    /// Returns true if we are handling our last part
+    fn is_last_part(&self) -> bool {
+        self.raw_parts.len() == 0 && self.current_part.is_some()
+    }
+}
+
+impl<'a> Read for MultiPartReader<'a> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        match (self.raw_parts.len(),
+               self.current_part.is_none(),
+               self.last_part_boundary.is_none()) {
+            (_, _, false) => {
+                let br = self.last_part_boundary.as_mut().unwrap().read(buf).unwrap_or(0);
+                if br < buf.len() {
+                    self.last_part_boundary = None;
+                }
+                return Ok(br)
+            },
+            (0, true, true) => return Ok(0),
+            (n, true, _) if n > 0 => {
+                let (headers, reader) = self.raw_parts.remove(0);
+                let mut c = Cursor::new(Vec::<u8>::new());
+                (write!(&mut c, "{}--{}{}{}{}", LINE_ENDING, BOUNDARY, LINE_ENDING,
+                                                headers, LINE_ENDING)).unwrap();
+                c.seek(SeekFrom::Start(0)).unwrap();
+                self.current_part = Some((c, reader));
+            }
+            _ => {},
+        }
+
+        // read headers as long as possible
+        let (hb, rr) = {
+            let &mut (ref mut c, ref mut reader) = self.current_part.as_mut().unwrap();
+            let b = c.read(buf).unwrap_or(0);
+            (b, reader.read(&mut buf[b..]))
+        };
+
+        match rr {
+            Ok(bytes_read) => {
+                if hb < buf.len() && bytes_read == 0 {
+                    if self.is_last_part() {
+                        // before clearing the last part, we will add the boundary that
+                        // will be written last
+                        self.last_part_boundary = Some(Cursor::new(
+                                                        format!("{}--{}--", LINE_ENDING, BOUNDARY).into_bytes()))
+                    }
+                    // We are depleted - this can trigger the next part to come in
+                    self.current_part = None;
+                }
+                let mut total_bytes_read = hb + bytes_read;
+                while total_bytes_read < buf.len() && !self.is_depleted() {
+                    match self.read(&mut buf[total_bytes_read ..]) {
+                        Ok(br) => total_bytes_read += br,
+                        Err(err) => return Err(err),
+                    }
+                }
+                Ok(total_bytes_read)
+            }
+            Err(err) => {
+                // fail permanently
+                self.current_part = None;
+                self.last_part_boundary = None;
+                self.raw_parts.clear();
+                Err(err)
+            }
+        }
+    }
+}
+
+/// The `X-Upload-Content-Type` header.
+///
+/// Generated via rustc --pretty expanded -Z unstable-options, and manually
+/// processed to be more readable.
+#[derive(PartialEq, Debug, Clone)]
+pub struct XUploadContentType(pub Mime);
+
+impl ::std::ops::Deref for XUploadContentType {
+    type Target = Mime;
+    fn deref<'a>(&'a self) -> &'a Mime { &self.0 }
+}
+impl ::std::ops::DerefMut for XUploadContentType {
+    fn deref_mut<'a>(&'a mut self) -> &'a mut Mime { &mut self.0 }
+}
+impl Header for XUploadContentType {
+    fn header_name() -> &'static str { "X-Upload-Content-Type" }
+    fn parse_header(raw: &[Vec<u8>]) -> hyper::error::Result<Self> {
+        hyper::header::parsing::from_one_raw_str(raw).map(XUploadContentType)
+    }
+}
+impl HeaderFormat for XUploadContentType {
+    fn fmt_header(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        Display::fmt(&**self, f)
+    }
+}
+impl Display for XUploadContentType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(&**self, f)
+    }
+}
+
+#[derive(Clone, PartialEq, Debug)]
+pub struct Chunk {
+    pub first: u64,
+    pub last: u64
+}
+
+impl fmt::Display for Chunk {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        (write!(fmt, "{}-{}", self.first, self.last)).ok();
+        Ok(())
+    }
+}
+
+impl FromStr for Chunk {
+    type Err = &'static str;
+
+    /// NOTE: only implements `%i-%i`, not `*`
+    fn from_str(s: &str) -> std::result::Result<Chunk, &'static str> {
+        let parts: Vec<&str> = s.split('-').collect();
+        if parts.len() != 2 {
+            return Err("Expected two parts: %i-%i")
+        }
+        Ok(
+            Chunk {
+                first: match FromStr::from_str(parts[0]) {
+                    Ok(d) => d,
+                    _ => return Err("Couldn't parse 'first' as digit")
+                },
+                last: match FromStr::from_str(parts[1]) {
+                    Ok(d) => d,
+                    _ => return Err("Couldn't parse 'last' as digit")
+                }
+            }
+        )
+    }
+}
+
+/// Implements the Content-Range header, for serialization only
+#[derive(Clone, PartialEq, Debug)]
+pub struct ContentRange {
+    pub range: Option<Chunk>,
+    pub total_length: u64,
+}
+
+impl Header for ContentRange {
+    fn header_name() -> &'static str {
+        "Content-Range"
+    }
+
+    /// We are not parsable, as parsing is done by the `Range` header
+    fn parse_header(_: &[Vec<u8>]) -> hyper::error::Result<Self> {
+        Err(hyper::error::Error::Method)
+    }
+}
+
+
+impl HeaderFormat for ContentRange {
+    fn fmt_header(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        try!(fmt.write_str("bytes "));
+        match self.range {
+            Some(ref c) => try!(c.fmt(fmt)),
+            None => try!(fmt.write_str("*"))
+        }
+        (write!(fmt, "/{}", self.total_length)).ok();
+        Ok(())
+    }
+}
+
+#[derive(Clone, PartialEq, Debug)]
+pub struct RangeResponseHeader(pub Chunk);
+
+impl Header for RangeResponseHeader {
+    fn header_name() -> &'static str {
+        "Range"
+    }
+
+    fn parse_header(raw: &[Vec<u8>]) -> hyper::error::Result<Self> {
+        if raw.len() > 0 {
+            let v = &raw[0];
+            if let Ok(s) = std::str::from_utf8(v) {
+                const PREFIX: &'static str = "bytes ";
+                if s.starts_with(PREFIX) {
+                    if let Ok(c) = <Chunk as FromStr>::from_str(&s[PREFIX.len()..]) {
+                        return  Ok(RangeResponseHeader(c))
+                    }
+                }
+            }
+        }
+        Err(hyper::error::Error::Method)
+    }
+}
+
+impl HeaderFormat for RangeResponseHeader {
+    /// No implmentation necessary, we just need to parse
+    fn fmt_header(&self, _: &mut fmt::Formatter) -> fmt::Result {
+        Err(fmt::Error)
+    }
+}
+
+/// A utility type to perform a resumable upload from start to end.
+pub struct ResumableUploadHelper<'a, A: 'a> {
+    pub client: &'a mut hyper::client::Client,
+    pub delegate: &'a mut Delegate,
+    pub start_at: Option<u64>,
+    pub auth: &'a mut A,
+    pub user_agent: &'a str,
+    pub auth_header: Authorization<Bearer>,
+    pub url: &'a str,
+    pub reader: &'a mut ReadSeek,
+    pub media_type: Mime,
+    pub content_length: u64
+}
+
+impl<'a, A> ResumableUploadHelper<'a, A>
+    where A: oauth2::GetToken {
+
+    fn query_transfer_status(&mut self) -> std::result::Result<u64, hyper::Result<hyper::client::Response>> {
+        loop {
+            match self.client.post(self.url)
+                .header(UserAgent(self.user_agent.to_string()))
+                .header(ContentRange { range: None, total_length: self.content_length })
+                .header(self.auth_header.clone())
+                .send() {
+                Ok(r) => {
+                    // 308 = resume-incomplete == PermanentRedirect
+                    let headers = r.headers.clone();
+                    let h: &RangeResponseHeader = match headers.get() {
+                        Some(hh) if r.status == StatusCode::PermanentRedirect => hh,
+                        None|Some(_) => {
+                            if let Retry::After(d) = self.delegate.http_failure(&r, None, None) {
+                                sleep(d);
+                                continue;
+                            }
+                            return Err(Ok(r))
+                        }
+                    };
+                    return Ok(h.0.last)
+                }
+                Err(err) => {
+                    if let Retry::After(d) = self.delegate.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    return Err(Err(err))
+                }
+            }
+        }
+    }
+
+    /// returns None if operation was cancelled by delegate, or the HttpResult.
+    /// It can be that we return the result just because we didn't understand the status code -
+    /// caller should check for status himself before assuming it's OK to use
+    pub fn upload(&mut self) -> Option<hyper::Result<hyper::client::Response>> {
+        let mut start = match self.start_at {
+            Some(s) => s,
+            None => match self.query_transfer_status() {
+                Ok(s) => s,
+                Err(result) => return Some(result)
+            }
+        };
+
+        const MIN_CHUNK_SIZE: u64 = 1 << 18;
+        let chunk_size = match self.delegate.chunk_size() {
+            cs if cs > MIN_CHUNK_SIZE => cs,
+            _ => MIN_CHUNK_SIZE
+        };
+
+        self.reader.seek(SeekFrom::Start(start)).unwrap();
+        loop {
+            let request_size = match self.content_length - start {
+                rs if rs > chunk_size => chunk_size,
+                rs => rs
+            };
+
+            let mut section_reader = self.reader.take(request_size);
+            let range_header = ContentRange {
+                range: Some(Chunk {first: start, last: start + request_size - 1}),
+                total_length: self.content_length
+            };
+            start += request_size;
+            if self.delegate.cancel_chunk_upload(&range_header) {
+                return None
+            }
+            let res = self.client.post(self.url)
+                                 .header(range_header)
+                                 .header(ContentType(self.media_type.clone()))
+                                 .header(UserAgent(self.user_agent.to_string()))
+                                 .body(&mut section_reader)
+                                 .send();
+            match res {
+                Ok(mut res) => {
+                    if res.status == StatusCode::PermanentRedirect  {
+                        continue
+                    }
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let Retry::After(d) = self.delegate.http_failure(&res,
+                                                        json::from_str(&json_err).ok(),
+                                                        json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                    }
+                    return Some(Ok(res))
+                },
+                Err(err) => {
+                    if let Retry::After(d) = self.delegate.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    return Some(Err(err))
+                }
+            }
+        }
+    }
+}
+
+// Copy of src/rust/cli/cmn.rs
+// TODO(ST): Allow sharing common code between program types
+pub fn remove_json_null_values(value: &mut json::value::Value) {
+    match *value {
+        json::value::Value::Object(ref mut map) => {
+            let mut for_removal = Vec::new();
+
+            for (key, mut value) in map.iter_mut() {
+                if value.is_null() {
+                    for_removal.push(key.clone());
+                } else {
+                    remove_json_null_values(&mut value);
+                }
+            }
+
+            for key in &for_removal {
+                map.remove(key);
+            }
+        }
+        _ => {}
+    }
+}

--- a/gen/analyticsreporting4/src/lib.rs
+++ b/gen/analyticsreporting4/src/lib.rs
@@ -1,0 +1,1686 @@
+// DO NOT EDIT !
+// This file was generated automatically from 'src/mako/api/lib.rs.mako'
+// DO NOT EDIT !
+
+//! This documentation was generated from *AnalyticsReporting* crate version *1.0.7+20171108*, where *20171108* is the exact revision of the *analyticsreporting:v4* schema built by the [mako](http://www.makotemplates.org/) code generator *v1.0.7*.
+//! 
+//! Everything else about the *AnalyticsReporting* *v4* API can be found at the
+//! [official documentation site](https://developers.google.com/analytics/devguides/reporting/core/v4/).
+//! The original source code is [on github](https://github.com/Byron/google-apis-rs/tree/master/gen/analyticsreporting4).
+//! # Features
+//! 
+//! Handle the following *Resources* with ease from the central [hub](struct.AnalyticsReporting.html) ... 
+//! 
+//! * [reports](struct.Report.html)
+//!  * [*batch get*](struct.ReportBatchGetCall.html)
+//! 
+//! 
+//! 
+//! 
+//! Not what you are looking for ? Find all other Google APIs in their Rust [documentation index](http://byron.github.io/google-apis-rs).
+//! 
+//! # Structure of this Library
+//! 
+//! The API is structured into the following primary items:
+//! 
+//! * **[Hub](struct.AnalyticsReporting.html)**
+//!     * a central object to maintain state and allow accessing all *Activities*
+//!     * creates [*Method Builders*](trait.MethodsBuilder.html) which in turn
+//!       allow access to individual [*Call Builders*](trait.CallBuilder.html)
+//! * **[Resources](trait.Resource.html)**
+//!     * primary types that you can apply *Activities* to
+//!     * a collection of properties and *Parts*
+//!     * **[Parts](trait.Part.html)**
+//!         * a collection of properties
+//!         * never directly used in *Activities*
+//! * **[Activities](trait.CallBuilder.html)**
+//!     * operations to apply to *Resources*
+//! 
+//! All *structures* are marked with applicable traits to further categorize them and ease browsing.
+//! 
+//! Generally speaking, you can invoke *Activities* like this:
+//! 
+//! ```Rust,ignore
+//! let r = hub.resource().activity(...).doit()
+//! ```
+//! 
+//! Or specifically ...
+//! 
+//! ```ignore
+//! let r = hub.reports().batch_get(...).doit()
+//! ```
+//! 
+//! The `resource()` and `activity(...)` calls create [builders][builder-pattern]. The second one dealing with `Activities` 
+//! supports various methods to configure the impending operation (not shown here). It is made such that all required arguments have to be 
+//! specified right away (i.e. `(...)`), whereas all optional ones can be [build up][builder-pattern] as desired.
+//! The `doit()` method performs the actual communication with the server and returns the respective result.
+//! 
+//! # Usage
+//! 
+//! ## Setting up your Project
+//! 
+//! To use this library, you would put the following lines into your `Cargo.toml` file:
+//! 
+//! ```toml
+//! [dependencies]
+//! google-analyticsreporting4 = "*"
+//! ```
+//! 
+//! ## A complete example
+//! 
+//! ```test_harness,no_run
+//! extern crate hyper;
+//! extern crate hyper_rustls;
+//! extern crate yup_oauth2 as oauth2;
+//! extern crate google_analyticsreporting4 as analyticsreporting4;
+//! use analyticsreporting4::GetReportsRequest;
+//! use analyticsreporting4::{Result, Error};
+//! # #[test] fn egal() {
+//! use std::default::Default;
+//! use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+//! use analyticsreporting4::AnalyticsReporting;
+//! 
+//! // Get an ApplicationSecret instance by some means. It contains the `client_id` and 
+//! // `client_secret`, among other things.
+//! let secret: ApplicationSecret = Default::default();
+//! // Instantiate the authenticator. It will choose a suitable authentication flow for you, 
+//! // unless you replace  `None` with the desired Flow.
+//! // Provide your own `AuthenticatorDelegate` to adjust the way it operates and get feedback about 
+//! // what's going on. You probably want to bring in your own `TokenStorage` to persist tokens and
+//! // retrieve them from storage.
+//! let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+//!                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+//!                               <MemoryStorage as Default>::default(), None);
+//! let mut hub = AnalyticsReporting::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+//! // As the method needs a request, you would usually fill it with the desired information
+//! // into the respective structure. Some of the parts shown here might not be applicable !
+//! // Values shown here are possibly random and not representative !
+//! let mut req = GetReportsRequest::default();
+//! 
+//! // You can configure optional parameters by calling the respective setters at will, and
+//! // execute the final call using `doit()`.
+//! // Values shown here are possibly random and not representative !
+//! let result = hub.reports().batch_get(req)
+//!              .doit();
+//! 
+//! match result {
+//!     Err(e) => match e {
+//!         // The Error enum provides details about what exactly happened.
+//!         // You can also just use its `Debug`, `Display` or `Error` traits
+//!          Error::HttpError(_)
+//!         |Error::MissingAPIKey
+//!         |Error::MissingToken(_)
+//!         |Error::Cancelled
+//!         |Error::UploadSizeLimitExceeded(_, _)
+//!         |Error::Failure(_)
+//!         |Error::BadRequest(_)
+//!         |Error::FieldClash(_)
+//!         |Error::JsonDecodeError(_, _) => println!("{}", e),
+//!     },
+//!     Ok(res) => println!("Success: {:?}", res),
+//! }
+//! # }
+//! ```
+//! ## Handling Errors
+//! 
+//! All errors produced by the system are provided either as [Result](enum.Result.html) enumeration as return value of 
+//! the doit() methods, or handed as possibly intermediate results to either the 
+//! [Hub Delegate](trait.Delegate.html), or the [Authenticator Delegate](https://docs.rs/yup-oauth2/*/yup_oauth2/trait.AuthenticatorDelegate.html).
+//! 
+//! When delegates handle errors or intermediate values, they may have a chance to instruct the system to retry. This 
+//! makes the system potentially resilient to all kinds of errors.
+//! 
+//! ## Uploads and Downloads
+//! If a method supports downloads, the response body, which is part of the [Result](enum.Result.html), should be
+//! read by you to obtain the media.
+//! If such a method also supports a [Response Result](trait.ResponseResult.html), it will return that by default.
+//! You can see it as meta-data for the actual media. To trigger a media download, you will have to set up the builder by making
+//! this call: `.param("alt", "media")`.
+//! 
+//! Methods supporting uploads can do so using up to 2 different protocols: 
+//! *simple* and *resumable*. The distinctiveness of each is represented by customized 
+//! `doit(...)` methods, which are then named `upload(...)` and `upload_resumable(...)` respectively.
+//! 
+//! ## Customization and Callbacks
+//! 
+//! You may alter the way an `doit()` method is called by providing a [delegate](trait.Delegate.html) to the 
+//! [Method Builder](trait.CallBuilder.html) before making the final `doit()` call. 
+//! Respective methods will be called to provide progress information, as well as determine whether the system should 
+//! retry on failure.
+//! 
+//! The [delegate trait](trait.Delegate.html) is default-implemented, allowing you to customize it with minimal effort.
+//! 
+//! ## Optional Parts in Server-Requests
+//! 
+//! All structures provided by this library are made to be [enocodable](trait.RequestValue.html) and 
+//! [decodable](trait.ResponseResult.html) via *json*. Optionals are used to indicate that partial requests are responses 
+//! are valid.
+//! Most optionals are are considered [Parts](trait.Part.html) which are identifiable by name, which will be sent to 
+//! the server to indicate either the set parts of the request or the desired parts in the response.
+//! 
+//! ## Builder Arguments
+//! 
+//! Using [method builders](trait.CallBuilder.html), you are able to prepare an action call by repeatedly calling it's methods.
+//! These will always take a single argument, for which the following statements are true.
+//! 
+//! * [PODs][wiki-pod] are handed by copy
+//! * strings are passed as `&str`
+//! * [request values](trait.RequestValue.html) are moved
+//! 
+//! Arguments will always be copied or cloned into the builder, to make them independent of their original life times.
+//! 
+//! [wiki-pod]: http://en.wikipedia.org/wiki/Plain_old_data_structure
+//! [builder-pattern]: http://en.wikipedia.org/wiki/Builder_pattern
+//! [google-go-api]: https://github.com/google/google-api-go-client
+//! 
+//! 
+
+// Unused attributes happen thanks to defined, but unused structures
+// We don't warn about this, as depending on the API, some data structures or facilities are never used.
+// Instead of pre-determining this, we just disable the lint. It's manually tuned to not have any
+// unused imports in fully featured APIs. Same with unused_mut ... .
+#![allow(unused_imports, unused_mut, dead_code)]
+
+// DO NOT EDIT !
+// This file was generated automatically from 'src/mako/api/lib.rs.mako'
+// DO NOT EDIT !
+
+#[macro_use]
+extern crate serde_derive;
+
+extern crate hyper;
+extern crate serde;
+extern crate serde_json;
+extern crate yup_oauth2 as oauth2;
+extern crate mime;
+extern crate url;
+
+mod cmn;
+
+use std::collections::HashMap;
+use std::cell::RefCell;
+use std::borrow::BorrowMut;
+use std::default::Default;
+use std::collections::BTreeMap;
+use serde_json as json;
+use std::io;
+use std::fs;
+use std::mem;
+use std::thread::sleep;
+use std::time::Duration;
+
+pub use cmn::{MultiPartReader, ToParts, MethodInfo, Result, Error, CallBuilder, Hub, ReadSeek, Part,
+              ResponseResult, RequestValue, NestedType, Delegate, DefaultDelegate, MethodsBuilder,
+              Resource, ErrorResponse, remove_json_null_values};
+
+
+// ##############
+// UTILITIES ###
+// ############
+
+/// Identifies the an OAuth2 authorization scope.
+/// A scope is needed when requesting an
+/// [authorization token](https://developers.google.com/youtube/v3/guides/authentication).
+#[derive(PartialEq, Eq, Hash)]
+pub enum Scope {
+    /// View and manage your Google Analytics data
+    Analytic,
+
+    /// View your Google Analytics data
+    AnalyticReadonly,
+}
+
+impl AsRef<str> for Scope {
+    fn as_ref(&self) -> &str {
+        match *self {
+            Scope::Analytic => "https://www.googleapis.com/auth/analytics",
+            Scope::AnalyticReadonly => "https://www.googleapis.com/auth/analytics.readonly",
+        }
+    }
+}
+
+impl Default for Scope {
+    fn default() -> Scope {
+        Scope::AnalyticReadonly
+    }
+}
+
+
+
+// ########
+// HUB ###
+// ######
+
+/// Central instance to access all AnalyticsReporting related resource activities
+///
+/// # Examples
+///
+/// Instantiate a new hub
+///
+/// ```test_harness,no_run
+/// extern crate hyper;
+/// extern crate hyper_rustls;
+/// extern crate yup_oauth2 as oauth2;
+/// extern crate google_analyticsreporting4 as analyticsreporting4;
+/// use analyticsreporting4::GetReportsRequest;
+/// use analyticsreporting4::{Result, Error};
+/// # #[test] fn egal() {
+/// use std::default::Default;
+/// use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// use analyticsreporting4::AnalyticsReporting;
+/// 
+/// // Get an ApplicationSecret instance by some means. It contains the `client_id` and 
+/// // `client_secret`, among other things.
+/// let secret: ApplicationSecret = Default::default();
+/// // Instantiate the authenticator. It will choose a suitable authentication flow for you, 
+/// // unless you replace  `None` with the desired Flow.
+/// // Provide your own `AuthenticatorDelegate` to adjust the way it operates and get feedback about 
+/// // what's going on. You probably want to bring in your own `TokenStorage` to persist tokens and
+/// // retrieve them from storage.
+/// let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+///                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+///                               <MemoryStorage as Default>::default(), None);
+/// let mut hub = AnalyticsReporting::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = GetReportsRequest::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.reports().batch_get(req)
+///              .doit();
+/// 
+/// match result {
+///     Err(e) => match e {
+///         // The Error enum provides details about what exactly happened.
+///         // You can also just use its `Debug`, `Display` or `Error` traits
+///          Error::HttpError(_)
+///         |Error::MissingAPIKey
+///         |Error::MissingToken(_)
+///         |Error::Cancelled
+///         |Error::UploadSizeLimitExceeded(_, _)
+///         |Error::Failure(_)
+///         |Error::BadRequest(_)
+///         |Error::FieldClash(_)
+///         |Error::JsonDecodeError(_, _) => println!("{}", e),
+///     },
+///     Ok(res) => println!("Success: {:?}", res),
+/// }
+/// # }
+/// ```
+pub struct AnalyticsReporting<C, A> {
+    client: RefCell<C>,
+    auth: RefCell<A>,
+    _user_agent: String,
+    _base_url: String,
+    _root_url: String,
+}
+
+impl<'a, C, A> Hub for AnalyticsReporting<C, A> {}
+
+impl<'a, C, A> AnalyticsReporting<C, A>
+    where  C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+    pub fn new(client: C, authenticator: A) -> AnalyticsReporting<C, A> {
+        AnalyticsReporting {
+            client: RefCell::new(client),
+            auth: RefCell::new(authenticator),
+            _user_agent: "google-api-rust-client/1.0.7".to_string(),
+            _base_url: "https://analyticsreporting.googleapis.com/".to_string(),
+            _root_url: "https://analyticsreporting.googleapis.com/".to_string(),
+        }
+    }
+
+    pub fn reports(&'a self) -> ReportMethods<'a, C, A> {
+        ReportMethods { hub: &self }
+    }
+
+    /// Set the user-agent header field to use in all requests to the server.
+    /// It defaults to `google-api-rust-client/1.0.7`.
+    ///
+    /// Returns the previously set user-agent.
+    pub fn user_agent(&mut self, agent_name: String) -> String {
+        mem::replace(&mut self._user_agent, agent_name)
+    }
+
+    /// Set the base url to use in all requests to the server.
+    /// It defaults to `https://analyticsreporting.googleapis.com/`.
+    ///
+    /// Returns the previously set base url.
+    pub fn base_url(&mut self, new_base_url: String) -> String {
+        mem::replace(&mut self._base_url, new_base_url)
+    }
+
+    /// Set the root url to use in all requests to the server.
+    /// It defaults to `https://analyticsreporting.googleapis.com/`.
+    ///
+    /// Returns the previously set root url.
+    pub fn root_url(&mut self, new_root_url: String) -> String {
+        mem::replace(&mut self._root_url, new_root_url)
+    }
+}
+
+
+// ############
+// SCHEMAS ###
+// ##########
+/// Defines a cohort. A cohort is a group of users who share a common
+/// characteristic. For example, all users with the same acquisition date
+/// belong to the same cohort.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Cohort {
+    /// This is used for `FIRST_VISIT_DATE` cohort, the cohort selects users
+    /// whose first visit date is between start date and end date defined in the
+    /// DateRange. The date ranges should be aligned for cohort requests. If the
+    /// request contains `ga:cohortNthDay` it should be exactly one day long,
+    /// if `ga:cohortNthWeek` it should be aligned to the week boundary (starting
+    /// at Sunday and ending Saturday), and for `ga:cohortNthMonth` the date range
+    /// should be aligned to the month (starting at the first and ending on the
+    /// last day of the month).
+    /// For LTV requests there are no such restrictions.
+    /// You do not need to supply a date range for the
+    /// `reportsRequest.dateRanges` field.
+    #[serde(rename="dateRange")]
+    pub date_range: Option<DateRange>,
+    /// Type of the cohort. The only supported type as of now is
+    /// `FIRST_VISIT_DATE`. If this field is unspecified the cohort is treated
+    /// as `FIRST_VISIT_DATE` type cohort.
+    #[serde(rename="type")]
+    pub type_: Option<String>,
+    /// A unique name for the cohort. If not defined name will be auto-generated
+    /// with values cohort_[1234...].
+    pub name: Option<String>,
+}
+
+impl Part for Cohort {}
+
+
+/// The data part of the report.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct ReportData {
+    /// There's one ReportRow for every unique combination of dimensions.
+    pub rows: Option<Vec<ReportRow>>,
+    /// Minimum and maximum values seen over all matching rows. These are both
+    /// empty when `hideValueRanges` in the request is false, or when
+    /// rowCount is zero.
+    pub maximums: Option<Vec<DateRangeValues>>,
+    /// Minimum and maximum values seen over all matching rows. These are both
+    /// empty when `hideValueRanges` in the request is false, or when
+    /// rowCount is zero.
+    pub minimums: Option<Vec<DateRangeValues>>,
+    /// Indicates if response to this request is golden or not. Data is
+    /// golden when the exact same request will not produce any new results if
+    /// asked at a later point in time.
+    #[serde(rename="isDataGolden")]
+    pub is_data_golden: Option<bool>,
+    /// If the results are
+    /// [sampled](https://support.google.com/analytics/answer/2637192),
+    /// this returns the total number of
+    /// samples present, one entry per date range. If the results are not sampled
+    /// this field will not be defined. See
+    /// [developer guide](/analytics/devguides/reporting/core/v4/basics#sampling)
+    /// for details.
+    #[serde(rename="samplingSpaceSizes")]
+    pub sampling_space_sizes: Option<Vec<String>>,
+    /// For each requested date range, for the set of all rows that match
+    /// the query, every requested value format gets a total. The total
+    /// for a value format is computed by first totaling the metrics
+    /// mentioned in the value format and then evaluating the value
+    /// format as a scalar expression.  E.g., The "totals" for
+    /// `3 / (ga:sessions + 2)` we compute
+    /// `3 / ((sum of all relevant ga:sessions) + 2)`.
+    /// Totals are computed before pagination.
+    pub totals: Option<Vec<DateRangeValues>>,
+    /// Total number of matching rows for this query.
+    #[serde(rename="rowCount")]
+    pub row_count: Option<i32>,
+    /// The last time the data in the report was refreshed. All the hits received
+    /// before this timestamp are included in the calculation of the report.
+    #[serde(rename="dataLastRefreshed")]
+    pub data_last_refreshed: Option<String>,
+    /// If the results are
+    /// [sampled](https://support.google.com/analytics/answer/2637192),
+    /// this returns the total number of samples read, one entry per date range.
+    /// If the results are not sampled this field will not be defined. See
+    /// [developer guide](/analytics/devguides/reporting/core/v4/basics#sampling)
+    /// for details.
+    #[serde(rename="samplesReadCounts")]
+    pub samples_read_counts: Option<Vec<i64>>,
+}
+
+impl Part for ReportData {}
+
+
+/// The batch request containing multiple report request.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [batch get reports](struct.ReportBatchGetCall.html) (request)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct GetReportsRequest {
+    /// Requests, each request will have a separate response.
+    /// There can be a maximum of 5 requests. All requests should have the same
+    /// `dateRanges`, `viewId`, `segments`, `samplingLevel`, and `cohortGroup`.
+    #[serde(rename="reportRequests")]
+    pub report_requests: Option<Vec<ReportRequest>>,
+    /// Enables
+    /// [resource based quotas](/analytics/devguides/reporting/core/v4/limits-quotas#analytics_reporting_api_v4),
+    /// (defaults to `False`). If this field is set to `True` the
+    /// per view (profile) quotas are governed by the computational
+    /// cost of the request. Note that using cost based quotas will
+    /// higher enable sampling rates. (10 Million for `SMALL`,
+    /// 100M for `LARGE`. See the
+    /// [limits and quotas documentation](/analytics/devguides/reporting/core/v4/limits-quotas#analytics_reporting_api_v4) for details.
+    #[serde(rename="useResourceQuotas")]
+    pub use_resource_quotas: Option<bool>,
+}
+
+impl RequestValue for GetReportsRequest {}
+
+
+/// A contiguous set of days: startDate, startDate + 1 day, ..., endDate.
+/// The start and end dates are specified in
+/// [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) date format `YYYY-MM-DD`.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct DateRange {
+    /// The start date for the query in the format `YYYY-MM-DD`.
+    #[serde(rename="startDate")]
+    pub start_date: Option<String>,
+    /// The end date for the query in the format `YYYY-MM-DD`.
+    #[serde(rename="endDate")]
+    pub end_date: Option<String>,
+}
+
+impl Part for DateRange {}
+
+
+/// The main response class which holds the reports from the Reporting API
+/// `batchGet` call.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [batch get reports](struct.ReportBatchGetCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct GetReportsResponse {
+    /// The amount of resource quota tokens deducted to execute the query. Includes
+    /// all responses.
+    #[serde(rename="queryCost")]
+    pub query_cost: Option<i32>,
+    /// The amount of resource quota remaining for the property.
+    #[serde(rename="resourceQuotasRemaining")]
+    pub resource_quotas_remaining: Option<ResourceQuotasRemaining>,
+    /// Responses corresponding to each of the request.
+    pub reports: Option<Vec<Report>>,
+}
+
+impl ResponseResult for GetReportsResponse {}
+
+
+/// SegmentDefinition defines the segment to be a set of SegmentFilters which
+/// are combined together with a logical `AND` operation.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct SegmentDefinition {
+    /// A segment is defined by a set of segment filters which are combined
+    /// together with a logical `AND` operation.
+    #[serde(rename="segmentFilters")]
+    pub segment_filters: Option<Vec<SegmentFilter>>,
+}
+
+impl Part for SegmentDefinition {}
+
+
+/// The main request class which specifies the Reporting API request.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct ReportRequest {
+    /// The metrics requested.
+    /// Requests must specify at least one metric. Requests can have a
+    /// total of 10 metrics.
+    pub metrics: Option<Vec<Metric>>,
+    /// Page size is for paging and specifies the maximum number of returned rows.
+    /// Page size should be >= 0. A query returns the default of 1,000 rows.
+    /// The Analytics Core Reporting API returns a maximum of 10,000 rows per
+    /// request, no matter how many you ask for. It can also return fewer rows
+    /// than requested, if there aren't as many dimension segments as you expect.
+    /// For instance, there are fewer than 300 possible values for `ga:country`,
+    /// so when segmenting only by country, you can't get more than 300 rows,
+    /// even if you set `pageSize` to a higher value.
+    #[serde(rename="pageSize")]
+    pub page_size: Option<i32>,
+    /// The Analytics
+    /// [view ID](https://support.google.com/analytics/answer/1009618)
+    /// from which to retrieve data. Every [ReportRequest](#ReportRequest)
+    /// within a `batchGet` method must contain the same `viewId`.
+    #[serde(rename="viewId")]
+    pub view_id: Option<String>,
+    /// Cohort group associated with this request. If there is a cohort group
+    /// in the request the `ga:cohort` dimension must be present.
+    /// Every [ReportRequest](#ReportRequest) within a `batchGet` method must
+    /// contain the same `cohortGroup` definition.
+    #[serde(rename="cohortGroup")]
+    pub cohort_group: Option<CohortGroup>,
+    /// Date ranges in the request. The request can have a maximum of 2 date
+    /// ranges. The response will contain a set of metric values for each
+    /// combination of the dimensions for each date range in the request. So, if
+    /// there are two date ranges, there will be two set of metric values, one for
+    /// the original date range and one for the second date range.
+    /// The `reportRequest.dateRanges` field should not be specified for cohorts
+    /// or Lifetime value requests.
+    /// If a date range is not provided, the default date range is (startDate:
+    /// current date - 7 days, endDate: current date - 1 day). Every
+    /// [ReportRequest](#ReportRequest) within a `batchGet` method must
+    /// contain the same `dateRanges` definition.
+    #[serde(rename="dateRanges")]
+    pub date_ranges: Option<Vec<DateRange>>,
+    /// The desired report
+    /// [sample](https://support.google.com/analytics/answer/2637192) size.
+    /// If the the `samplingLevel` field is unspecified the `DEFAULT` sampling
+    /// level is used. Every [ReportRequest](#ReportRequest) within a
+    /// `batchGet` method must contain the same `samplingLevel` definition. See
+    /// [developer guide](/analytics/devguides/reporting/core/v4/basics#sampling)
+    ///  for details.
+    #[serde(rename="samplingLevel")]
+    pub sampling_level: Option<String>,
+    /// The metric filter clauses. They are logically combined with the `AND`
+    /// operator.  Metric filters look at only the first date range and not the
+    /// comparing date range. Note that filtering on metrics occurs after the
+    /// metrics are aggregated.
+    #[serde(rename="metricFilterClauses")]
+    pub metric_filter_clauses: Option<Vec<MetricFilterClause>>,
+    /// The pivot definitions. Requests can have a maximum of 2 pivots.
+    pub pivots: Option<Vec<Pivot>>,
+    /// If set to true, hides the total of all metrics for all the matching rows,
+    /// for every date range. The default false and will return the totals.
+    #[serde(rename="hideTotals")]
+    pub hide_totals: Option<bool>,
+    /// The dimensions requested.
+    /// Requests can have a total of 7 dimensions.
+    pub dimensions: Option<Vec<Dimension>>,
+    /// The dimension filter clauses for filtering Dimension Values. They are
+    /// logically combined with the `AND` operator. Note that filtering occurs
+    /// before any dimensions are aggregated, so that the returned metrics
+    /// represent the total for only the relevant dimensions.
+    #[serde(rename="dimensionFilterClauses")]
+    pub dimension_filter_clauses: Option<Vec<DimensionFilterClause>>,
+    /// If set to false, the response does not include rows if all the retrieved
+    /// metrics are equal to zero. The default is false which will exclude these
+    /// rows.
+    #[serde(rename="includeEmptyRows")]
+    pub include_empty_rows: Option<bool>,
+    /// Segment the data returned for the request. A segment definition helps look
+    /// at a subset of the segment request. A request can contain up to four
+    /// segments. Every [ReportRequest](#ReportRequest) within a
+    /// `batchGet` method must contain the same `segments` definition. Requests
+    /// with segments must have the `ga:segment` dimension.
+    pub segments: Option<Vec<Segment>>,
+    /// Sort order on output rows. To compare two rows, the elements of the
+    /// following are applied in order until a difference is found.  All date
+    /// ranges in the output get the same row order.
+    #[serde(rename="orderBys")]
+    pub order_bys: Option<Vec<OrderBy>>,
+    /// Dimension or metric filters that restrict the data returned for your
+    /// request. To use the `filtersExpression`, supply a dimension or metric on
+    /// which to filter, followed by the filter expression. For example, the
+    /// following expression selects `ga:browser` dimension which starts with
+    /// Firefox; `ga:browser=~^Firefox`. For more information on dimensions
+    /// and metric filters, see
+    /// [Filters reference](https://developers.google.com/analytics/devguides/reporting/core/v3/reference#filters).
+    #[serde(rename="filtersExpression")]
+    pub filters_expression: Option<String>,
+    /// A continuation token to get the next page of the results. Adding this to
+    /// the request will return the rows after the pageToken. The pageToken should
+    /// be the value returned in the nextPageToken parameter in the response to
+    /// the GetReports request.
+    #[serde(rename="pageToken")]
+    pub page_token: Option<String>,
+    /// If set to true, hides the minimum and maximum across all matching rows.
+    /// The default is false and the value ranges are returned.
+    #[serde(rename="hideValueRanges")]
+    pub hide_value_ranges: Option<bool>,
+}
+
+impl Part for ReportRequest {}
+
+
+/// Represents a group of metric filters.
+/// Set the operator value to specify how the filters are logically combined.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct MetricFilterClause {
+    /// The operator for combining multiple metric filters. If unspecified, it is
+    /// treated as an `OR`.
+    pub operator: Option<String>,
+    /// The repeated set of filters. They are logically combined based on the
+    /// operator specified.
+    pub filters: Option<Vec<MetricFilter>>,
+}
+
+impl Part for MetricFilterClause {}
+
+
+/// SegmentFilter defines the segment to be either a simple or a sequence
+/// segment. A simple segment condition contains dimension and metric conditions
+/// to select the sessions or users. A sequence segment condition can be used to
+/// select users or sessions based on sequential conditions.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct SegmentFilter {
+    /// If true, match the complement of simple or sequence segment.
+    /// For example, to match all visits not from "New York", we can define the
+    /// segment as follows:
+    /// 
+    ///       "sessionSegment": {
+    ///         "segmentFilters": [{
+    ///           "simpleSegment" :{
+    ///             "orFiltersForSegment": [{
+    ///               "segmentFilterClauses":[{
+    ///                 "dimensionFilter": {
+    ///                   "dimensionName": "ga:city",
+    ///                   "expressions": ["New York"]
+    ///                 }
+    ///               }]
+    ///             }]
+    ///           },
+    ///           "not": "True"
+    ///         }]
+    ///       },
+    pub not: Option<bool>,
+    /// A Simple segment conditions consist of one or more dimension/metric
+    /// conditions that can be combined
+    #[serde(rename="simpleSegment")]
+    pub simple_segment: Option<SimpleSegment>,
+    /// Sequence conditions consist of one or more steps, where each step is
+    /// defined by one or more dimension/metric conditions. Multiple steps can
+    /// be combined with special sequence operators.
+    #[serde(rename="sequenceSegment")]
+    pub sequence_segment: Option<SequenceSegment>,
+}
+
+impl Part for SegmentFilter {}
+
+
+/// Specifies the sorting options.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct OrderBy {
+    /// The order type. The default orderType is `VALUE`.
+    #[serde(rename="orderType")]
+    pub order_type: Option<String>,
+    /// The field which to sort by. The default sort order is ascending. Example:
+    /// `ga:browser`.
+    /// Note, that you can only specify one field for sort here. For example,
+    /// `ga:browser, ga:city` is not valid.
+    #[serde(rename="fieldName")]
+    pub field_name: Option<String>,
+    /// The sorting order for the field.
+    #[serde(rename="sortOrder")]
+    pub sort_order: Option<String>,
+}
+
+impl Part for OrderBy {}
+
+
+/// Sequence conditions consist of one or more steps, where each step is defined
+/// by one or more dimension/metric conditions. Multiple steps can be combined
+/// with special sequence operators.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct SequenceSegment {
+    /// If set, first step condition must match the first hit of the visitor (in
+    /// the date range).
+    #[serde(rename="firstStepShouldMatchFirstHit")]
+    pub first_step_should_match_first_hit: Option<bool>,
+    /// The list of steps in the sequence.
+    #[serde(rename="segmentSequenceSteps")]
+    pub segment_sequence_steps: Option<Vec<SegmentSequenceStep>>,
+}
+
+impl Part for SequenceSegment {}
+
+
+/// The metric values in the pivot region.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct PivotValueRegion {
+    /// The values of the metrics in each of the pivot regions.
+    pub values: Option<Vec<String>>,
+}
+
+impl Part for PivotValueRegion {}
+
+
+/// Column headers.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct ColumnHeader {
+    /// The dimension names in the response.
+    pub dimensions: Option<Vec<String>>,
+    /// Metric headers for the metrics in the response.
+    #[serde(rename="metricHeader")]
+    pub metric_header: Option<MetricHeader>,
+}
+
+impl Part for ColumnHeader {}
+
+
+/// Dynamic segment definition for defining the segment within the request.
+/// A segment can select users, sessions or both.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct DynamicSegment {
+    /// Session Segment to select sessions to include in the segment.
+    #[serde(rename="sessionSegment")]
+    pub session_segment: Option<SegmentDefinition>,
+    /// The name of the dynamic segment.
+    pub name: Option<String>,
+    /// User Segment to select users to include in the segment.
+    #[serde(rename="userSegment")]
+    pub user_segment: Option<SegmentDefinition>,
+}
+
+impl Part for DynamicSegment {}
+
+
+/// Header for the metrics.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct MetricHeaderEntry {
+    /// The type of the metric, for example `INTEGER`.
+    #[serde(rename="type")]
+    pub type_: Option<String>,
+    /// The name of the header.
+    pub name: Option<String>,
+}
+
+impl Part for MetricHeaderEntry {}
+
+
+/// The data response corresponding to the request.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [batch get reports](struct.ReportBatchGetCall.html) (none)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Report {
+    /// Page token to retrieve the next page of results in the list.
+    #[serde(rename="nextPageToken")]
+    pub next_page_token: Option<String>,
+    /// Response data.
+    pub data: Option<ReportData>,
+    /// The column headers.
+    #[serde(rename="columnHeader")]
+    pub column_header: Option<ColumnHeader>,
+}
+
+impl Resource for Report {}
+
+
+/// A row in the report.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct ReportRow {
+    /// List of metrics for each requested DateRange.
+    pub metrics: Option<Vec<DateRangeValues>>,
+    /// List of requested dimensions.
+    pub dimensions: Option<Vec<String>>,
+}
+
+impl Part for ReportRow {}
+
+
+/// The segment definition, if the report needs to be segmented.
+/// A Segment is a subset of the Analytics data. For example, of the entire
+/// set of users, one Segment might be users from a particular country or city.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Segment {
+    /// A dynamic segment definition in the request.
+    #[serde(rename="dynamicSegment")]
+    pub dynamic_segment: Option<DynamicSegment>,
+    /// The segment ID of a built-in or custom segment, for example `gaid::-3`.
+    #[serde(rename="segmentId")]
+    pub segment_id: Option<String>,
+}
+
+impl Part for Segment {}
+
+
+/// The resource quota tokens remaining for the property after the request is
+/// completed.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct ResourceQuotasRemaining {
+    /// Daily resource quota remaining remaining.
+    #[serde(rename="dailyQuotaTokensRemaining")]
+    pub daily_quota_tokens_remaining: Option<i32>,
+    /// Hourly resource quota tokens remaining.
+    #[serde(rename="hourlyQuotaTokensRemaining")]
+    pub hourly_quota_tokens_remaining: Option<i32>,
+}
+
+impl Part for ResourceQuotasRemaining {}
+
+
+/// The headers for each of the pivot sections defined in the request.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct PivotHeader {
+    /// The total number of groups for this pivot.
+    #[serde(rename="totalPivotGroupsCount")]
+    pub total_pivot_groups_count: Option<i32>,
+    /// A single pivot section header.
+    #[serde(rename="pivotHeaderEntries")]
+    pub pivot_header_entries: Option<Vec<PivotHeaderEntry>>,
+}
+
+impl Part for PivotHeader {}
+
+
+/// A Simple segment conditions consist of one or more dimension/metric
+/// conditions that can be combined.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct SimpleSegment {
+    /// A list of segment filters groups which are combined with logical `AND`
+    /// operator.
+    #[serde(rename="orFiltersForSegment")]
+    pub or_filters_for_segment: Option<Vec<OrFiltersForSegment>>,
+}
+
+impl Part for SimpleSegment {}
+
+
+/// The headers for the each of the metric column corresponding to the metrics
+/// requested in the pivots section of the response.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct PivotHeaderEntry {
+    /// The values for the dimensions in the pivot.
+    #[serde(rename="dimensionValues")]
+    pub dimension_values: Option<Vec<String>>,
+    /// The name of the dimensions in the pivot response.
+    #[serde(rename="dimensionNames")]
+    pub dimension_names: Option<Vec<String>>,
+    /// The metric header for the metric in the pivot.
+    pub metric: Option<MetricHeaderEntry>,
+}
+
+impl Part for PivotHeaderEntry {}
+
+
+/// Used to return a list of metrics for a single DateRange / dimension
+/// combination
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct DateRangeValues {
+    /// Each value corresponds to each Metric in the request.
+    pub values: Option<Vec<String>>,
+    /// The values of each pivot region.
+    #[serde(rename="pivotValueRegions")]
+    pub pivot_value_regions: Option<Vec<PivotValueRegion>>,
+}
+
+impl Part for DateRangeValues {}
+
+
+/// Defines a cohort group.
+/// For example:
+/// 
+///     "cohortGroup": {
+///       "cohorts": [{
+///         "name": "cohort 1",
+///         "type": "FIRST_VISIT_DATE",
+///         "dateRange": { "startDate": "2015-08-01", "endDate": "2015-08-01" }
+///       },{
+///         "name": "cohort 2"
+///          "type": "FIRST_VISIT_DATE"
+///          "dateRange": { "startDate": "2015-07-01", "endDate": "2015-07-01" }
+///       }]
+///     }
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct CohortGroup {
+    /// The definition for the cohort.
+    pub cohorts: Option<Vec<Cohort>>,
+    /// Enable Life Time Value (LTV).  LTV measures lifetime value for users
+    /// acquired through different channels.
+    /// Please see:
+    /// [Cohort Analysis](https://support.google.com/analytics/answer/6074676) and
+    /// [Lifetime Value](https://support.google.com/analytics/answer/6182550)
+    /// If the value of lifetimeValue is false:
+    /// 
+    /// - The metric values are similar to the values in the web interface cohort
+    ///   report.
+    /// - The cohort definition date ranges must be aligned to the calendar week
+    ///   and month. i.e. while requesting `ga:cohortNthWeek` the `startDate` in
+    ///   the cohort definition should be a Sunday and the `endDate` should be the
+    ///   following Saturday, and for `ga:cohortNthMonth`, the `startDate`
+    ///   should be the 1st of the month and `endDate` should be the last day
+    ///   of the month.
+    /// 
+    /// When the lifetimeValue is true:
+    /// 
+    /// - The metric values will correspond to the values in the web interface
+    ///   LifeTime value report.
+    /// - The Lifetime Value report shows you how user value (Revenue) and
+    ///   engagement (Appviews, Goal Completions, Sessions, and Session Duration)
+    ///   grow during the 90 days after a user is acquired.
+    /// - The metrics are calculated as a cumulative average per user per the time
+    ///   increment.
+    /// - The cohort definition date ranges need not be aligned to the calendar
+    ///   week and month boundaries.
+    /// - The `viewId` must be an
+    ///   [app view ID](https://support.google.com/analytics/answer/2649553#WebVersusAppViews)
+    #[serde(rename="lifetimeValue")]
+    pub lifetime_value: Option<bool>,
+}
+
+impl Part for CohortGroup {}
+
+
+/// Dimension filter specifies the filtering options on a dimension.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct DimensionFilter {
+    /// The dimension to filter on. A DimensionFilter must contain a dimension.
+    #[serde(rename="dimensionName")]
+    pub dimension_name: Option<String>,
+    /// Should the match be case sensitive? Default is false.
+    #[serde(rename="caseSensitive")]
+    pub case_sensitive: Option<bool>,
+    /// Strings or regular expression to match against. Only the first value of
+    /// the list is used for comparison unless the operator is `IN_LIST`.
+    /// If `IN_LIST` operator, then the entire list is used to filter the
+    /// dimensions as explained in the description of the `IN_LIST` operator.
+    pub expressions: Option<Vec<String>>,
+    /// Logical `NOT` operator. If this boolean is set to true, then the matching
+    /// dimension values will be excluded in the report. The default is false.
+    pub not: Option<bool>,
+    /// How to match the dimension to the expression. The default is REGEXP.
+    pub operator: Option<String>,
+}
+
+impl Part for DimensionFilter {}
+
+
+/// The headers for the metrics.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct MetricHeader {
+    /// Headers for the pivots in the response.
+    #[serde(rename="pivotHeaders")]
+    pub pivot_headers: Option<Vec<PivotHeader>>,
+    /// Headers for the metrics in the response.
+    #[serde(rename="metricHeaderEntries")]
+    pub metric_header_entries: Option<Vec<MetricHeaderEntry>>,
+}
+
+impl Part for MetricHeader {}
+
+
+/// A segment sequence definition.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct SegmentSequenceStep {
+    /// Specifies if the step immediately precedes or can be any time before the
+    /// next step.
+    #[serde(rename="matchType")]
+    pub match_type: Option<String>,
+    /// A sequence is specified with a list of Or grouped filters which are
+    /// combined with `AND` operator.
+    #[serde(rename="orFiltersForSegment")]
+    pub or_filters_for_segment: Option<Vec<OrFiltersForSegment>>,
+}
+
+impl Part for SegmentSequenceStep {}
+
+
+/// [Dimensions](https://support.google.com/analytics/answer/1033861)
+/// are attributes of your data. For example, the dimension `ga:city`
+/// indicates the city, for example, "Paris" or "New York", from which
+/// a session originates.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Dimension {
+    /// Name of the dimension to fetch, for example `ga:browser`.
+    pub name: Option<String>,
+    /// If non-empty, we place dimension values into buckets after string to
+    /// int64. Dimension values that are not the string representation of an
+    /// integral value will be converted to zero.  The bucket values have to be in
+    /// increasing order.  Each bucket is closed on the lower end, and open on the
+    /// upper end. The "first" bucket includes all values less than the first
+    /// boundary, the "last" bucket includes all values up to infinity. Dimension
+    /// values that fall in a bucket get transformed to a new dimension value. For
+    /// example, if one gives a list of "0, 1, 3, 4, 7", then we return the
+    /// following buckets:
+    /// 
+    /// - bucket #1: values < 0, dimension value "<0"
+    /// - bucket #2: values in [0,1), dimension value "0"
+    /// - bucket #3: values in [1,3), dimension value "1-2"
+    /// - bucket #4: values in [3,4), dimension value "3"
+    /// - bucket #5: values in [4,7), dimension value "4-6"
+    /// - bucket #6: values >= 7, dimension value "7+"
+    /// 
+    /// NOTE: If you are applying histogram mutation on any dimension, and using
+    /// that dimension in sort, you will want to use the sort type
+    /// `HISTOGRAM_BUCKET` for that purpose. Without that the dimension values
+    /// will be sorted according to dictionary
+    /// (lexicographic) order. For example the ascending dictionary order is:
+    /// 
+    ///    "<50", "1001+", "121-1000", "50-120"
+    /// 
+    /// And the ascending `HISTOGRAM_BUCKET` order is:
+    /// 
+    ///    "<50", "50-120", "121-1000", "1001+"
+    /// 
+    /// The client has to explicitly request `"orderType": "HISTOGRAM_BUCKET"`
+    /// for a histogram-mutated dimension.
+    #[serde(rename="histogramBuckets")]
+    pub histogram_buckets: Option<Vec<String>>,
+}
+
+impl Part for Dimension {}
+
+
+/// MetricFilter specifies the filter on a metric.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct MetricFilter {
+    /// Is the metric `EQUAL`, `LESS_THAN` or `GREATER_THAN` the
+    /// comparisonValue, the default is `EQUAL`. If the operator is
+    /// `IS_MISSING`, checks if the metric is missing and would ignore the
+    /// comparisonValue.
+    pub operator: Option<String>,
+    /// Logical `NOT` operator. If this boolean is set to true, then the matching
+    /// metric values will be excluded in the report. The default is false.
+    pub not: Option<bool>,
+    /// The value to compare against.
+    #[serde(rename="comparisonValue")]
+    pub comparison_value: Option<String>,
+    /// The metric that will be filtered on. A metricFilter must contain a metric
+    /// name. A metric name can be an alias earlier defined as a metric or it can
+    /// also be a metric expression.
+    #[serde(rename="metricName")]
+    pub metric_name: Option<String>,
+}
+
+impl Part for MetricFilter {}
+
+
+/// [Metrics](https://support.google.com/analytics/answer/1033861)
+/// are the quantitative measurements. For example, the metric `ga:users`
+/// indicates the total number of users for the requested time period.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Metric {
+    /// An alias for the metric expression is an alternate name for the
+    /// expression. The alias can be used for filtering and sorting. This field
+    /// is optional and is useful if the expression is not a single metric but
+    /// a complex expression which cannot be used in filtering and sorting.
+    /// The alias is also used in the response column header.
+    pub alias: Option<String>,
+    /// A metric expression in the request. An expression is constructed from one
+    /// or more metrics and numbers. Accepted operators include: Plus (+), Minus
+    /// (-), Negation (Unary -), Divided by (/), Multiplied by (*), Parenthesis,
+    /// Positive cardinal numbers (0-9), can include decimals and is limited to
+    /// 1024 characters. Example `ga:totalRefunds/ga:users`, in most cases the
+    /// metric expression is just a single metric name like `ga:users`.
+    /// Adding mixed `MetricType` (E.g., `CURRENCY` + `PERCENTAGE`) metrics
+    /// will result in unexpected results.
+    pub expression: Option<String>,
+    /// Specifies how the metric expression should be formatted, for example
+    /// `INTEGER`.
+    #[serde(rename="formattingType")]
+    pub formatting_type: Option<String>,
+}
+
+impl Part for Metric {}
+
+
+/// Dimension filter specifies the filtering options on a dimension.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct SegmentDimensionFilter {
+    /// Name of the dimension for which the filter is being applied.
+    #[serde(rename="dimensionName")]
+    pub dimension_name: Option<String>,
+    /// Should the match be case sensitive, ignored for `IN_LIST` operator.
+    #[serde(rename="caseSensitive")]
+    pub case_sensitive: Option<bool>,
+    /// Minimum comparison values for `BETWEEN` match type.
+    #[serde(rename="minComparisonValue")]
+    pub min_comparison_value: Option<String>,
+    /// The operator to use to match the dimension with the expressions.
+    pub operator: Option<String>,
+    /// The list of expressions, only the first element is used for all operators
+    pub expressions: Option<Vec<String>>,
+    /// Maximum comparison values for `BETWEEN` match type.
+    #[serde(rename="maxComparisonValue")]
+    pub max_comparison_value: Option<String>,
+}
+
+impl Part for SegmentDimensionFilter {}
+
+
+/// A list of segment filters in the `OR` group are combined with the logical OR
+/// operator.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct OrFiltersForSegment {
+    /// List of segment filters to be combined with a `OR` operator.
+    #[serde(rename="segmentFilterClauses")]
+    pub segment_filter_clauses: Option<Vec<SegmentFilterClause>>,
+}
+
+impl Part for OrFiltersForSegment {}
+
+
+/// Filter Clause to be used in a segment definition, can be wither a metric or
+/// a dimension filter.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct SegmentFilterClause {
+    /// Matches the complement (`!`) of the filter.
+    pub not: Option<bool>,
+    /// Dimension Filter for the segment definition.
+    #[serde(rename="dimensionFilter")]
+    pub dimension_filter: Option<SegmentDimensionFilter>,
+    /// Metric Filter for the segment definition.
+    #[serde(rename="metricFilter")]
+    pub metric_filter: Option<SegmentMetricFilter>,
+}
+
+impl Part for SegmentFilterClause {}
+
+
+/// A group of dimension filters. Set the operator value to specify how
+/// the filters are logically combined.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct DimensionFilterClause {
+    /// The operator for combining multiple dimension filters. If unspecified, it
+    /// is treated as an `OR`.
+    pub operator: Option<String>,
+    /// The repeated set of filters. They are logically combined based on the
+    /// operator specified.
+    pub filters: Option<Vec<DimensionFilter>>,
+}
+
+impl Part for DimensionFilterClause {}
+
+
+/// Metric filter to be used in a segment filter clause.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct SegmentMetricFilter {
+    /// Specifies is the operation to perform to compare the metric. The default
+    /// is `EQUAL`.
+    pub operator: Option<String>,
+    /// Scope for a metric defines the level at which that metric is defined.  The
+    /// specified metric scope must be equal to or greater than its primary scope
+    /// as defined in the data model. The primary scope is defined by if the
+    /// segment is selecting users or sessions.
+    pub scope: Option<String>,
+    /// The value to compare against. If the operator is `BETWEEN`, this value is
+    /// treated as minimum comparison value.
+    #[serde(rename="comparisonValue")]
+    pub comparison_value: Option<String>,
+    /// Max comparison value is only used for `BETWEEN` operator.
+    #[serde(rename="maxComparisonValue")]
+    pub max_comparison_value: Option<String>,
+    /// The metric that will be filtered on. A `metricFilter` must contain a
+    /// metric name.
+    #[serde(rename="metricName")]
+    pub metric_name: Option<String>,
+}
+
+impl Part for SegmentMetricFilter {}
+
+
+/// The Pivot describes the pivot section in the request.
+/// The Pivot helps rearrange the information in the table for certain reports
+/// by pivoting your data on a second dimension.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Pivot {
+    /// The pivot metrics. Pivot metrics are part of the
+    /// restriction on total number of metrics allowed in the request.
+    pub metrics: Option<Vec<Metric>>,
+    /// If k metrics were requested, then the response will contain some
+    /// data-dependent multiple of k columns in the report.  E.g., if you pivoted
+    /// on the dimension `ga:browser` then you'd get k columns for "Firefox", k
+    /// columns for "IE", k columns for "Chrome", etc. The ordering of the groups
+    /// of columns is determined by descending order of "total" for the first of
+    /// the k values.  Ties are broken by lexicographic ordering of the first
+    /// pivot dimension, then lexicographic ordering of the second pivot
+    /// dimension, and so on.  E.g., if the totals for the first value for
+    /// Firefox, IE, and Chrome were 8, 2, 8, respectively, the order of columns
+    /// would be Chrome, Firefox, IE.
+    /// 
+    /// The following let you choose which of the groups of k columns are
+    /// included in the response.
+    #[serde(rename="startGroup")]
+    pub start_group: Option<i32>,
+    /// Specifies the maximum number of groups to return.
+    /// The default value is 10, also the maximum value is 1,000.
+    #[serde(rename="maxGroupCount")]
+    pub max_group_count: Option<i32>,
+    /// DimensionFilterClauses are logically combined with an `AND` operator: only
+    /// data that is included by all these DimensionFilterClauses contributes to
+    /// the values in this pivot region. Dimension filters can be used to restrict
+    /// the columns shown in the pivot region. For example if you have
+    /// `ga:browser` as the requested dimension in the pivot region, and you
+    /// specify key filters to restrict `ga:browser` to only "IE" or "Firefox",
+    /// then only those two browsers would show up as columns.
+    #[serde(rename="dimensionFilterClauses")]
+    pub dimension_filter_clauses: Option<Vec<DimensionFilterClause>>,
+    /// A list of dimensions to show as pivot columns. A Pivot can have a maximum
+    /// of 4 dimensions. Pivot dimensions are part of the restriction on the
+    /// total number of dimensions allowed in the request.
+    pub dimensions: Option<Vec<Dimension>>,
+}
+
+impl Part for Pivot {}
+
+
+
+// ###################
+// MethodBuilders ###
+// #################
+
+/// A builder providing access to all methods supported on *report* resources.
+/// It is not used directly, but through the `AnalyticsReporting` hub.
+///
+/// # Example
+///
+/// Instantiate a resource builder
+///
+/// ```test_harness,no_run
+/// extern crate hyper;
+/// extern crate hyper_rustls;
+/// extern crate yup_oauth2 as oauth2;
+/// extern crate google_analyticsreporting4 as analyticsreporting4;
+/// 
+/// # #[test] fn egal() {
+/// use std::default::Default;
+/// use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// use analyticsreporting4::AnalyticsReporting;
+/// 
+/// let secret: ApplicationSecret = Default::default();
+/// let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+///                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+///                               <MemoryStorage as Default>::default(), None);
+/// let mut hub = AnalyticsReporting::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // Usually you wouldn't bind this to a variable, but keep calling *CallBuilders*
+/// // like `batch_get(...)`
+/// // to build up your call.
+/// let rb = hub.reports();
+/// # }
+/// ```
+pub struct ReportMethods<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a AnalyticsReporting<C, A>,
+}
+
+impl<'a, C, A> MethodsBuilder for ReportMethods<'a, C, A> {}
+
+impl<'a, C, A> ReportMethods<'a, C, A> {
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Returns the Analytics data.
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    pub fn batch_get(&self, request: GetReportsRequest) -> ReportBatchGetCall<'a, C, A> {
+        ReportBatchGetCall {
+            hub: self.hub,
+            _request: request,
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+}
+
+
+
+
+
+// ###################
+// CallBuilders   ###
+// #################
+
+/// Returns the Analytics data.
+///
+/// A builder for the *batchGet* method supported by a *report* resource.
+/// It is not used directly, but through a `ReportMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_analyticsreporting4 as analyticsreporting4;
+/// use analyticsreporting4::GetReportsRequest;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use analyticsreporting4::AnalyticsReporting;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = AnalyticsReporting::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = GetReportsRequest::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.reports().batch_get(req)
+///              .doit();
+/// # }
+/// ```
+pub struct ReportBatchGetCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a AnalyticsReporting<C, A>,
+    _request: GetReportsRequest,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for ReportBatchGetCall<'a, C, A> {}
+
+impl<'a, C, A> ReportBatchGetCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, GetReportsResponse)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "analyticsreporting.reports.batchGet",
+                               http_method: hyper::method::Method::Post });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((3 + self._additional_params.len()));
+        for &field in ["alt"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v4/reports:batchGet";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::Analytic.as_ref().to_string(), ());
+        }
+
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Post, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: GetReportsRequest) -> ReportBatchGetCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> ReportBatchGetCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> ReportBatchGetCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::Analytic`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> ReportBatchGetCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+

--- a/gen/cloudbuild1-cli/Cargo.toml
+++ b/gen/cloudbuild1-cli/Cargo.toml
@@ -1,0 +1,40 @@
+# DO NOT EDIT !
+# This file was generated automatically from 'src/mako/Cargo.toml.mako'
+# DO NOT EDIT !
+[package]
+
+name = "google-cloudbuild1-cli"
+version = "1.0.7+20171205"
+authors = ["Sebastian Thiel <byronimo@gmail.com>"]
+description = "A complete library to interact with Cloud Build (protocol v1)"
+repository = "https://github.com/Byron/google-apis-rs/tree/master/gen/cloudbuild1-cli"
+homepage = "https://cloud.google.com/container-builder/docs/"
+documentation = "http://byron.github.io/google-apis-rs/google_cloudbuild1_cli"
+license = "MIT"
+keywords = ["cloudbuild", "google", "cli"]
+
+[[bin]]
+name = "cloudbuild1"
+
+[dev-dependencies]
+hyper-rustls = "^0.6"
+
+[dependencies]
+hyper = "^ 0.10"
+mime = "^ 0.2.0"
+serde = "^ 1.0"
+serde_json = "^ 1.0"
+serde_derive = "^ 1.0"
+yup-oauth2 = "^ 1.0"
+strsim = "^0.5"
+hyper-rustls = "^0.6"
+yup-hyper-mock = "^2.0"
+clap = "^2.0"
+
+[features]
+
+
+
+[dependencies.google-cloudbuild1]
+path = "../cloudbuild1"
+version = "1.0.7+20171205"

--- a/gen/cloudbuild1-cli/LICENSE.md
+++ b/gen/cloudbuild1-cli/LICENSE.md
@@ -1,0 +1,30 @@
+<!---
+DO NOT EDIT !
+This file was generated automatically from 'src/mako/LICENSE.md.mako'
+DO NOT EDIT !
+-->
+The MIT License (MIT)
+=====================
+
+Copyright © `2015-2016` `Sebastian Thiel`
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the “Software”), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.

--- a/gen/cloudbuild1-cli/README.md
+++ b/gen/cloudbuild1-cli/README.md
@@ -1,0 +1,128 @@
+<!---
+DO NOT EDIT !
+This file was generated automatically from 'src/mako/cli/README.md.mako'
+DO NOT EDIT !
+-->
+The `cloudbuild1` command-line interface *(CLI)* allows to use most features of the *Google Cloud Build* service from the comfort of your terminal.
+
+By default all output is printed to standard out, but flags can be set to direct it into a file independent of your shell's
+capabilities. Errors will be printed to standard error, and cause the program's exit code to be non-zero.
+
+If data-structures are requested, these will be returned as pretty-printed JSON, to be useful as input to other tools.
+
+Everything else about the *Cloud Build* API can be found at the
+[official documentation site](https://cloud.google.com/container-builder/docs/).
+
+# Installation and Source Code
+
+Install the command-line interface with cargo using:
+
+```bash
+cargo install google-cloudbuild1-cli
+```
+
+Find the source code [on github](https://github.com/Byron/google-apis-rs/tree/master/gen/cloudbuild1-cli).
+
+# Usage
+
+This documentation was generated from the *Cloud Build* API at revision *20171205*. The CLI is at version *1.0.7*.
+
+```bash
+cloudbuild1 [options]
+        operations
+                cancel <name> (-r <kv>)... [-p <v>]... [-o <out>]
+                get <name> [-p <v>]... [-o <out>]
+                list <name> [-p <v>]... [-o <out>]
+        projects
+                builds-cancel <project-id> <id> (-r <kv>)... [-p <v>]... [-o <out>]
+                builds-create <project-id> (-r <kv>)... [-p <v>]... [-o <out>]
+                builds-get <project-id> <id> [-p <v>]... [-o <out>]
+                builds-list <project-id> [-p <v>]... [-o <out>]
+                builds-retry <project-id> <id> (-r <kv>)... [-p <v>]... [-o <out>]
+                triggers-create <project-id> (-r <kv>)... [-p <v>]... [-o <out>]
+                triggers-delete <project-id> <trigger-id> [-p <v>]... [-o <out>]
+                triggers-get <project-id> <trigger-id> [-p <v>]... [-o <out>]
+                triggers-list <project-id> [-p <v>]... [-o <out>]
+                triggers-patch <project-id> <trigger-id> (-r <kv>)... [-p <v>]... [-o <out>]
+                triggers-run <project-id> <trigger-id> (-r <kv>)... [-p <v>]... [-o <out>]
+  cloudbuild1 --help
+
+Configuration:
+  [--scope <url>]...
+            Specify the authentication a method should be executed in. Each scope
+            requires the user to grant this application permission to use it.
+            If unset, it defaults to the shortest scope url for a particular method.
+  --config-dir <folder>
+            A directory into which we will store our persistent data. Defaults to
+            a user-writable directory that we will create during the first invocation.
+            [default: ~/.google-service-cli]
+  --debug
+            Output all server communication to standard error. `tx` and `rx` are placed
+            into the same stream.
+  --debug-auth
+            Output all communication related to authentication to standard error. `tx`
+            and `rx` are placed into the same stream.
+
+```
+
+# Configuration
+
+The program will store all persistent data in the `~/.google-service-cli` directory in *JSON* files prefixed with `cloudbuild1-`.  You can change the directory used to store configuration with the `--config-dir` flag on a per-invocation basis.
+
+More information about the various kinds of persistent data are given in the following paragraphs.
+
+# Authentication
+
+Most APIs require a user to authenticate any request. If this is the case, the [scope][scopes] determines the 
+set of permissions granted. The granularity of these is usually no more than *read-only* or *full-access*.
+
+If not set, the system will automatically select the smallest feasible scope, e.g. when invoking a
+method that is read-only, it will ask only for a read-only scope. 
+You may use the `--scope` flag to specify a scope directly. 
+All applicable scopes are documented in the respective method's CLI documentation.
+
+The first time a scope is used, the user is asked for permission. Follow the instructions given 
+by the CLI to grant permissions, or to decline.
+
+If a scope was authenticated by the user, the respective information will be stored as *JSON* in the configuration
+directory, e.g. `~/.google-service-cli/cloudbuild1-token-<scope-hash>.json`. No manual management of these tokens
+is necessary.
+
+To revoke granted authentication, please refer to the [official documentation][revoke-access].
+
+# Application Secrets
+
+In order to allow any application to use Google services, it will need to be registered using the 
+[Google Developer Console][google-dev-console]. APIs the application may use are then enabled for it
+one by one. Most APIs can be used for free and have a daily quota.
+
+To allow more comfortable usage of the CLI without forcing anyone to register an own application, the CLI
+comes with a default application secret that is configured accordingly. This also means that heavy usage
+all around the world may deplete the daily quota.
+
+You can workaround this limitation by putting your own secrets file at this location: 
+`~/.google-service-cli/cloudbuild1-secret.json`, assuming that the required *cloudbuild* API 
+was enabled for it. Such a secret file can be downloaded in the *Google Developer Console* at 
+*APIs & auth -> Credentials -> Download JSON* and used as is.
+
+Learn more about how to setup Google projects and enable APIs using the [official documentation][google-project-new].
+
+
+# Debugging
+
+Even though the CLI does its best to provide usable error messages, sometimes it might be desirable to know
+what exactly led to a particular issue. This is done by allowing all client-server communication to be 
+output to standard error *as-is*.
+
+The `--debug` flag will print all client-server communication to standard error, whereas the `--debug-auth` flag
+will cause all communication related to authentication to standard error.
+If the `--debug` flag is set, error-results will be debug-printed, possibly yielding more information about the 
+issue at hand.
+
+You may consider redirecting standard error into a file for ease of use, e.g. `cloudbuild1 --debug <resource> <method> [options] 2>debug.txt`.
+
+
+[scopes]: https://developers.google.com/+/api/oauth#scopes
+[revoke-access]: http://webapps.stackexchange.com/a/30849
+[google-dev-console]: https://console.developers.google.com/
+[google-project-new]: https://developers.google.com/console/help/new/

--- a/gen/cloudbuild1-cli/mkdocs.yml
+++ b/gen/cloudbuild1-cli/mkdocs.yml
@@ -1,0 +1,30 @@
+site_name: Cloud Build v1.0.7+20171205
+site_url: http://byron.github.io/google-apis-rs/google-cloudbuild1-cli
+site_description: A complete library to interact with Cloud Build (protocol v1)
+
+repo_url: https://github.com/Byron/google-apis-rs/tree/master/gen/cloudbuild1-cli
+
+docs_dir: docs
+site_dir: build_html
+
+pages:
+- ['index.md', 'Home']
+- ['operations_cancel.md', 'Operations', 'Cancel']
+- ['operations_get.md', 'Operations', 'Get']
+- ['operations_list.md', 'Operations', 'List']
+- ['projects_builds-cancel.md', 'Projects', 'Builds Cancel']
+- ['projects_builds-create.md', 'Projects', 'Builds Create']
+- ['projects_builds-get.md', 'Projects', 'Builds Get']
+- ['projects_builds-list.md', 'Projects', 'Builds List']
+- ['projects_builds-retry.md', 'Projects', 'Builds Retry']
+- ['projects_triggers-create.md', 'Projects', 'Triggers Create']
+- ['projects_triggers-delete.md', 'Projects', 'Triggers Delete']
+- ['projects_triggers-get.md', 'Projects', 'Triggers Get']
+- ['projects_triggers-list.md', 'Projects', 'Triggers List']
+- ['projects_triggers-patch.md', 'Projects', 'Triggers Patch']
+- ['projects_triggers-run.md', 'Projects', 'Triggers Run']
+
+theme: readthedocs
+
+copyright: Copyright &copy; 2015-2016, `Sebastian Thiel`
+

--- a/gen/cloudbuild1-cli/src/cmn.rs
+++ b/gen/cloudbuild1-cli/src/cmn.rs
@@ -1,0 +1,799 @@
+// COPY OF 'src/rust/cli/cmn.rs'
+// DO NOT EDIT
+use oauth2::{ApplicationSecret, ConsoleApplicationSecret, TokenStorage, Token};
+use serde_json as json;
+use serde_json::value::Value;
+use mime::Mime;
+use clap::{App, SubCommand};
+use strsim;
+
+use std::fs;
+use std::env;
+use std::io;
+use std::error::Error as StdError;
+use std::fmt;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+use std::string::ToString;
+use std::io::{Write, Read, stdout};
+
+use std::default::Default;
+
+const FIELD_SEP: char = '.';
+
+
+pub enum ComplexType {
+    Pod,
+    Vec,
+    Map,
+}
+
+// Null,
+// Bool(bool),
+// I64(i64),
+// U64(u64),
+// F64(f64),
+// String(String),
+
+pub enum JsonType {
+    Boolean,
+    Int,
+    Uint,
+    Float,
+    String,
+}
+
+pub struct JsonTypeInfo {
+    pub jtype: JsonType,
+    pub ctype: ComplexType,
+}
+
+// Based on @erickt user comment. Thanks for the idea !
+// Remove all keys whose values are null from given value (changed in place)
+pub fn remove_json_null_values(value: &mut Value) {
+    match *value {
+        Value::Object(ref mut map) => {
+            let mut for_removal = Vec::new();
+
+            for (key, mut value) in map.iter_mut() {
+                if value.is_null() {
+                    for_removal.push(key.clone());
+                } else {
+                    remove_json_null_values(&mut value);
+                }
+            }
+
+            for key in &for_removal {
+                map.remove(key);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn did_you_mean<'a>(v: &str, possible_values: &[&'a str]) -> Option<&'a str> {
+
+    let mut candidate: Option<(f64, &str)> = None;
+    for pv in possible_values {
+        let confidence = strsim::jaro_winkler(v, pv);
+        if confidence > 0.8 &&
+           (candidate.is_none() || (candidate.as_ref().unwrap().0 < confidence)) {
+            candidate = Some((confidence, pv));
+        }
+    }
+    match candidate {
+        None => None,
+        Some((_, candidate)) => Some(candidate),
+    }
+}
+
+pub enum CallType {
+    Upload(UploadProtocol),
+    Standard,
+}
+
+arg_enum!{
+    pub enum UploadProtocol {
+        Simple,
+        Resumable
+    }
+}
+
+impl AsRef<str> for UploadProtocol {
+    fn as_ref(&self) -> &str {
+        match *self {
+            UploadProtocol::Simple => "simple",
+            UploadProtocol::Resumable => "resumable",
+        }
+    }
+}
+
+impl AsRef<str> for CallType {
+    fn as_ref(&self) -> &str {
+        match *self {
+            CallType::Upload(ref proto) => proto.as_ref(),
+            CallType::Standard => "standard-request",
+        }
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct FieldCursor(Vec<String>);
+
+impl ToString for  FieldCursor {
+    fn to_string(&self) -> String {
+        self.0.join(".")
+    }
+}
+
+impl From<&'static str> for FieldCursor {
+    fn from(value: &'static str) -> FieldCursor {
+        let mut res = FieldCursor::default();
+        res.set(value).unwrap();
+        res
+    }
+}
+
+fn assure_entry<'a, 'b>(m: &'a mut json::Map<String, Value>, k: &'b String) -> &'a mut Value {
+    if m.contains_key(k) {
+        return m.get_mut(k).expect("value to exist");
+    }
+    m.insert(k.to_owned(), Value::Object(Default::default()));
+    m.get_mut(k).expect("value to exist")
+}
+
+impl FieldCursor {
+    pub fn set(&mut self, value: &str) -> Result<(), CLIError> {
+        if value.len() == 0 {
+            return Err(CLIError::Field(FieldError::Empty));
+        }
+
+        let mut first_is_field_sep = false;
+        let mut char_count: usize = 0;
+        let mut last_c = FIELD_SEP;
+        let mut num_conscutive_field_seps = 0;
+
+        let mut field = String::new();
+        let mut fields = self.0.clone();
+
+        let push_field = |fs: &mut Vec<String>, f: &mut String| {
+            if f.len() > 0 {
+                fs.push(f.clone());
+                f.truncate(0);
+            }
+        };
+
+        for (cid, c) in value.chars().enumerate() {
+            char_count += 1;
+
+            if c == FIELD_SEP {
+                if cid == 0 {
+                    first_is_field_sep = true;
+                }
+                num_conscutive_field_seps += 1;
+                if cid > 0 && last_c == FIELD_SEP {
+                    if fields.pop().is_none() {
+                        return Err(CLIError::Field(FieldError::PopOnEmpty(value.to_string())));
+                    }
+                } else {
+                    push_field(&mut fields, &mut field);
+                }
+            } else {
+                num_conscutive_field_seps = 0;
+                if cid == 1 {
+                    if first_is_field_sep {
+                        fields.truncate(0);
+                    }
+                }
+                field.push(c);
+            }
+
+            last_c = c;
+        }
+
+        push_field(&mut fields, &mut field);
+
+        if char_count == 1 && first_is_field_sep {
+            fields.truncate(0);
+        }
+        if char_count > 1 && num_conscutive_field_seps == 1 {
+            return Err(CLIError::Field(FieldError::TrailingFieldSep(value.to_string())));
+        }
+
+        self.0 = fields;
+        Ok(())
+    }
+
+    pub fn did_you_mean(value: &str, possible_values: &[&str]) -> Option<String> {
+        if value.len() == 0 {
+            return None;
+        }
+
+        let mut last_c = FIELD_SEP;
+
+        let mut field = String::new();
+        let mut output = String::new();
+
+        let push_field = |fs: &mut String, f: &mut String| {
+            if f.len() > 0 {
+                fs.push_str(match did_you_mean(&f, possible_values) {
+                    Some(candidate) => candidate,
+                    None => &f,
+                });
+                f.truncate(0);
+            }
+        };
+
+        for (cid, c) in value.chars().enumerate() {
+            if c == FIELD_SEP {
+                if last_c != FIELD_SEP {
+                    push_field(&mut output, &mut field);
+                }
+                output.push(c);
+            } else {
+                field.push(c);
+            }
+
+            last_c = c;
+        }
+
+        push_field(&mut output, &mut field);
+
+        if &output == value {
+            None
+        } else {
+            Some(output)
+        }
+    }
+
+    pub fn set_json_value(&self,
+                          mut object: &mut Value,
+                          value: &str,
+                          type_info: JsonTypeInfo,
+                          err: &mut InvalidOptionsError,
+                          orig_cursor: &FieldCursor) {
+        assert!(self.0.len() > 0);
+
+        for field in &self.0[..self.0.len() - 1] {
+            let tmp = object;
+            object = match *tmp {
+                Value::Object(ref mut mapping) => {
+                    assure_entry(mapping, &field)
+                }
+                _ => panic!("We don't expect non-object Values here ..."),
+            };
+        }
+
+        match *object {
+            Value::Object(ref mut mapping) => {
+                let field = &self.0[self.0.len() - 1];
+                let to_jval = |value: &str,
+                               jtype: JsonType,
+                               err: &mut InvalidOptionsError|
+                               -> Value {
+                    match jtype {
+                        JsonType::Boolean =>
+                            Value::Bool(arg_from_str(value, err, &field, "boolean")),
+                        JsonType::Int =>
+                            Value::Number(json::Number::from_f64(arg_from_str(value,
+                                                                              err,
+                                                                              &field,
+                                                                              "int"))
+                                              .expect("valid f64")),
+                        JsonType::Uint =>
+                            Value::Number(json::Number::from_f64(arg_from_str(value,
+                                                                              err,
+                                                                              &field,
+                                                                              "uint"))
+                                              .expect("valid f64")),
+                        JsonType::Float =>
+                            Value::Number(json::Number::from_f64(arg_from_str(value,
+                                                                              err,
+                                                                              &field,
+                                                                              "float"))
+                                              .expect("valid f64")),
+                        JsonType::String => Value::String(value.to_owned()),
+                    }
+                };
+
+                match type_info.ctype {
+                    ComplexType::Pod => {
+                        if mapping.insert(field.to_owned(), to_jval(value, type_info.jtype, err))
+                                  .is_some() {
+                            err.issues.push(CLIError::Field(FieldError::Duplicate(orig_cursor.to_string())));
+                        }
+                    }
+                    ComplexType::Vec => {
+                        match *assure_entry(mapping, field) {
+                            Value::Array(ref mut values) =>
+                                values.push(to_jval(value, type_info.jtype, err)),
+                            _ => unreachable!(),
+                        }
+                    }
+                    ComplexType::Map => {
+                        let (key, value) = parse_kv_arg(value, err, true);
+                        let jval = to_jval(value.unwrap_or(""), type_info.jtype, err);
+
+                        match *assure_entry(mapping, &field) {
+
+                            Value::Object(ref mut value_map) => {
+                                if value_map.insert(key.to_owned(), jval).is_some() {
+                                    err.issues.push(CLIError::Field(FieldError::Duplicate(orig_cursor.to_string())));
+                                }
+                            }
+                            _ => unreachable!(),
+                        }
+                    }
+                }
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    pub fn num_fields(&self) -> usize {
+        self.0.len()
+    }
+}
+
+pub fn parse_kv_arg<'a>(kv: &'a str,
+                        err: &mut InvalidOptionsError,
+                        for_hashmap: bool)
+                        -> (&'a str, Option<&'a str>) {
+    let mut add_err = || {
+        err.issues.push(CLIError::InvalidKeyValueSyntax(kv.to_string(), for_hashmap))
+    };
+    match kv.find('=') {
+        None => {
+            add_err();
+            return (kv, None);
+        }
+        Some(pos) => {
+            let key = &kv[..pos];
+            if kv.len() <= pos + 1 {
+                add_err();
+                return (key, Some(""));
+            }
+            (key, Some(&kv[pos + 1..]))
+        }
+    }
+}
+
+pub fn calltype_from_str(name: &str,
+                         valid_protocols: Vec<String>,
+                         err: &mut InvalidOptionsError)
+                         -> CallType {
+    CallType::Upload(match UploadProtocol::from_str(name) {
+        Ok(up) => up,
+        Err(msg) => {
+            err.issues.push(CLIError::InvalidUploadProtocol(name.to_string(), valid_protocols));
+            UploadProtocol::Simple
+        }
+    })
+}
+
+pub fn input_file_from_opts(file_path: &str, err: &mut InvalidOptionsError) -> Option<fs::File> {
+    match fs::File::open(file_path) {
+        Ok(f) => Some(f),
+        Err(io_err) => {
+            err.issues.push(CLIError::Input(InputError::Io((file_path.to_string(), io_err))));
+            None
+        }
+    }
+}
+
+pub fn input_mime_from_opts(mime: &str, err: &mut InvalidOptionsError) -> Option<Mime> {
+    match mime.parse() {
+        Ok(m) => Some(m),
+        Err(_) => {
+            err.issues.push(CLIError::Input(InputError::Mime(mime.to_string())));
+            None
+        }
+    }
+}
+
+pub fn writer_from_opts(arg: Option<&str>) -> Result<Box<Write>, io::Error> {
+    let f = arg.unwrap_or("-");
+    match f {
+        "-" => Ok(Box::new(stdout())),
+        _ => match fs::OpenOptions::new().create(true).write(true).open(f) {
+            Ok(f) => Ok(Box::new(f)),
+            Err(io_err) => Err(io_err),
+        },
+    }
+}
+
+
+pub fn arg_from_str<'a, T>(arg: &str,
+                           err: &mut InvalidOptionsError,
+                           arg_name: &'a str,
+                           arg_type: &'a str)
+                           -> T
+    where T: FromStr + Default,
+          <T as FromStr>::Err: fmt::Display
+{
+    match FromStr::from_str(arg) {
+        Err(perr) => {
+            err.issues.push(CLIError::ParseError(arg_name.to_owned(),
+                                                 arg_type.to_owned(),
+                                                 arg.to_string(),
+                                                 format!("{}", perr)));
+            Default::default()
+        }
+        Ok(v) => v,
+    }
+}
+
+pub struct JsonTokenStorage {
+    pub program_name: &'static str,
+    pub db_dir: String,
+}
+
+impl JsonTokenStorage {
+    fn path(&self, scope_hash: u64) -> PathBuf {
+        Path::new(&self.db_dir).join(&format!("{}-token-{}.json", self.program_name, scope_hash))
+    }
+}
+
+
+#[derive(Debug)]
+pub enum TokenStorageError {
+    Json(json::Error),
+    Io(io::Error),
+}
+
+impl fmt::Display for TokenStorageError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            TokenStorageError::Json(ref err) => writeln!(f, "Could not serialize secrets: {}", err),
+            TokenStorageError::Io(ref err) => writeln!(f, "Failed to write secret token: {}", err),
+        }
+    }
+}
+
+impl StdError for TokenStorageError {
+    fn description(&self) -> &str {
+        "Failure when getting or setting the token storage"
+    }
+}
+
+
+impl TokenStorage for JsonTokenStorage {
+    type Error = TokenStorageError;
+
+    // NOTE: logging might be interesting, currently we swallow all errors
+    fn set(&mut self,
+           scope_hash: u64,
+           _: &Vec<&str>,
+           token: Option<Token>)
+           -> Result<(), TokenStorageError> {
+        match token {
+            None => {
+                match fs::remove_file(self.path(scope_hash)) {
+                    Err(err) => match err.kind() {
+                        io::ErrorKind::NotFound => Ok(()),
+                        _ => Err(TokenStorageError::Io(err)),
+                    },
+                    Ok(_) => Ok(()),
+                }
+            }
+            Some(token) => {
+                match fs::OpenOptions::new().create(true).write(true).open(&self.path(scope_hash)) {
+                    Ok(mut f) => {
+                        match json::to_writer_pretty(&mut f, &token) {
+                            Ok(_) => Ok(()),
+                            Err(serde_err) => Err(TokenStorageError::Json(serde_err)),
+                        }
+                    }
+                    Err(io_err) => Err(TokenStorageError::Io(io_err)),
+                }
+            }
+        }
+    }
+
+    fn get(&self, scope_hash: u64, _: &Vec<&str>) -> Result<Option<Token>, TokenStorageError> {
+        match fs::File::open(&self.path(scope_hash)) {
+            Ok(f) => {
+                match json::de::from_reader(f) {
+                    Ok(token) => Ok(Some(token)),
+                    Err(err) => Err(TokenStorageError::Json(err)),
+                }
+            }
+            Err(io_err) => {
+                match io_err.kind() {
+                    io::ErrorKind::NotFound => Ok(None),
+                    _ => Err(TokenStorageError::Io(io_err)),
+                }
+            }
+        }
+    }
+}
+
+
+#[derive(Debug)]
+pub enum ApplicationSecretError {
+    DecoderError((String, json::Error)),
+    FormatError(String),
+}
+
+impl fmt::Display for ApplicationSecretError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            ApplicationSecretError::DecoderError((ref path, ref err)) =>
+                writeln!(f,
+                         "Could not decode file at '{}' with error: {}.",
+                         path,
+                         err),
+            ApplicationSecretError::FormatError(ref path) =>
+                writeln!(f,
+                         "'installed' field is unset in secret file at '{}'.",
+                         path),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum ConfigurationError {
+    DirectoryCreationFailed((String, io::Error)),
+    DirectoryUnset,
+    HomeExpansionFailed(String),
+    Secret(ApplicationSecretError),
+    Io((String, io::Error)),
+}
+
+impl fmt::Display for ConfigurationError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            ConfigurationError::DirectoryCreationFailed((ref dir, ref err)) =>
+                writeln!(f,
+                         "Directory '{}' could not be created with error: {}.",
+                         dir,
+                         err),
+            ConfigurationError::DirectoryUnset => writeln!(f, "--config-dir was unset or empty."),
+            ConfigurationError::HomeExpansionFailed(ref dir) =>
+                writeln!(f,
+                         "Couldn't find HOME directory of current user, failed to expand '{}'.",
+                         dir),
+            ConfigurationError::Secret(ref err) => writeln!(f, "Secret -> {}", err),
+            ConfigurationError::Io((ref path, ref err)) =>
+                writeln!(f,
+                         "IO operation failed on path '{}' with error: {}.",
+                         path,
+                         err),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum InputError {
+    Io((String, io::Error)),
+    Mime(String),
+}
+
+impl fmt::Display for InputError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            InputError::Io((ref file_path, ref io_err)) =>
+                writeln!(f,
+                         "Failed to open '{}' for reading with error: {}.",
+                         file_path,
+                         io_err),
+            InputError::Mime(ref mime) => writeln!(f, "'{}' is not a known mime-type.", mime),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum FieldError {
+    PopOnEmpty(String),
+    TrailingFieldSep(String),
+    Unknown(String, Option<String>, Option<String>),
+    Duplicate(String),
+    Empty,
+}
+
+
+impl fmt::Display for FieldError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            FieldError::PopOnEmpty(ref field) =>
+                writeln!(f, "'{}': Cannot move up on empty field cursor.", field),
+            FieldError::TrailingFieldSep(ref field) =>
+                writeln!(f,
+                         "'{}': Single field separator may not be last character.",
+                         field),
+            FieldError::Unknown(ref field, ref suggestion, ref value) => {
+                let suffix = match *suggestion {
+                    Some(ref s) => {
+                        let kv = match *value {
+                            Some(ref v) => format!("{}={}", s, v),
+                            None => s.clone(),
+                        };
+                        format!(" Did you mean '{}' ?", kv)
+                    }
+                    None => String::new(),
+                };
+                writeln!(f, "Field '{}' does not exist.{}", field, suffix)
+            }
+            FieldError::Duplicate(ref cursor) =>
+                writeln!(f, "Value at '{}' was already set", cursor),
+            FieldError::Empty => writeln!(f, "Field names must not be empty."),
+        }
+    }
+}
+
+
+#[derive(Debug)]
+pub enum CLIError {
+    Configuration(ConfigurationError),
+    ParseError(String, String, String, String),
+    UnknownParameter(String, Vec<&'static str>),
+    InvalidUploadProtocol(String, Vec<String>),
+    InvalidKeyValueSyntax(String, bool),
+    Input(InputError),
+    Field(FieldError),
+    MissingCommandError,
+    MissingMethodError(String),
+}
+
+impl fmt::Display for CLIError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            CLIError::Configuration(ref err) => write!(f, "Configuration -> {}", err),
+            CLIError::Input(ref err) => write!(f, "Input -> {}", err),
+            CLIError::Field(ref err) => write!(f, "Field -> {}", err),
+            CLIError::InvalidUploadProtocol(ref proto_name, ref valid_names) =>
+                writeln!(f,
+                         "'{}' is not a valid upload protocol. Choose from one of {}.",
+                         proto_name,
+                         valid_names.join(", ")),
+            CLIError::ParseError(ref arg_name, ref type_name, ref value, ref err_desc) =>
+                writeln!(f,
+                         "Failed to parse argument '{}' with value '{}' as {} with error: {}.",
+                         arg_name,
+                         value,
+                         type_name,
+                         err_desc),
+            CLIError::UnknownParameter(ref param_name, ref possible_values) => {
+                let suffix = match did_you_mean(param_name, &possible_values) {
+                    Some(v) => format!(" Did you mean '{}' ?", v),
+                    None => String::new(),
+                };
+                write!(f, "Parameter '{}' is unknown.{}\n", param_name, suffix)
+            }
+            CLIError::InvalidKeyValueSyntax(ref kv, is_hashmap) => {
+                let hashmap_info = if is_hashmap {
+                    "hashmap "
+                } else {
+                    ""
+                };
+                writeln!(f,
+                         "'{}' does not match {}pattern <key>=<value>.",
+                         kv,
+                         hashmap_info)
+            }
+            CLIError::MissingCommandError => writeln!(f, "Please specify the main sub-command."),
+            CLIError::MissingMethodError(ref cmd) =>
+                writeln!(f,
+                         "Please specify the method to call on the '{}' command.",
+                         cmd),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct InvalidOptionsError {
+    pub issues: Vec<CLIError>,
+    pub exit_code: i32,
+}
+
+impl fmt::Display for InvalidOptionsError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        for issue in &self.issues {
+            try!(issue.fmt(f));
+        }
+        Ok(())
+    }
+}
+
+impl InvalidOptionsError {
+    pub fn single(err: CLIError, exit_code: i32) -> InvalidOptionsError {
+        InvalidOptionsError {
+            issues: vec![err],
+            exit_code: exit_code,
+        }
+    }
+
+    pub fn new() -> InvalidOptionsError {
+        InvalidOptionsError {
+            issues: Vec::new(),
+            exit_code: 1,
+        }
+    }
+}
+
+pub fn assure_config_dir_exists(dir: &str) -> Result<String, CLIError> {
+    let trdir = dir.trim();
+    if trdir.len() == 0 {
+        return Err(CLIError::Configuration(ConfigurationError::DirectoryUnset));
+    }
+
+    let expanded_config_dir = if trdir.as_bytes()[0] == b'~' {
+        match env::var("HOME").ok().or(env::var("UserProfile").ok()) {
+            None => return Err(CLIError::Configuration(ConfigurationError::HomeExpansionFailed(trdir.to_string()))),
+            Some(mut user) => {
+                user.push_str(&trdir[1..]);
+                user
+            }
+        }
+    } else {
+        trdir.to_string()
+    };
+
+    if let Err(err) = fs::create_dir(&expanded_config_dir) {
+        if err.kind() != io::ErrorKind::AlreadyExists {
+            return Err(CLIError::Configuration(
+                    ConfigurationError::DirectoryCreationFailed((expanded_config_dir, err))));
+        }
+    }
+
+    Ok(expanded_config_dir)
+}
+
+pub fn application_secret_from_directory(dir: &str,
+                                         secret_basename: &str,
+                                         json_console_secret: &str)
+                                         -> Result<ApplicationSecret, CLIError> {
+    let secret_path = Path::new(dir).join(secret_basename);
+    let secret_str = || secret_path.as_path().to_str().unwrap().to_string();
+    let secret_io_error = |io_err: io::Error| {
+        Err(CLIError::Configuration(ConfigurationError::Io((secret_str(), io_err))))
+    };
+
+    for _ in 0..2 {
+        match fs::File::open(&secret_path) {
+            Err(mut err) => {
+                if err.kind() == io::ErrorKind::NotFound {
+                    // Write our built-in one - user may adjust the written file at will
+
+                    err = match fs::OpenOptions::new()
+                                    .create(true)
+                                    .write(true)
+                                    .open(&secret_path) {
+                        Err(cfe) => cfe,
+                        Ok(mut f) => {
+                            // Assure we convert 'ugly' json string into pretty one
+                            let console_secret: ConsoleApplicationSecret =
+                                json::from_str(json_console_secret).unwrap();
+                            match json::to_writer_pretty(&mut f, &console_secret) {
+                                Err(serde_err) =>
+                                    panic!("Unexpected serde error: {:#?}", serde_err),
+                                Ok(_) => continue,
+                            }
+                        }
+                    };
+                    // fall through to IO error handling
+                }
+                return secret_io_error(err);
+            }
+            Ok(f) => {
+                match json::de::from_reader::<_, ConsoleApplicationSecret>(f) {
+                    Err(json_err) =>
+                        return Err(CLIError::Configuration(
+                            ConfigurationError::Secret(
+                                ApplicationSecretError::DecoderError(
+                                                (secret_str(), json_err)
+                                              )))),
+                    Ok(console_secret) => match console_secret.installed {
+                        Some(secret) => return Ok(secret),
+                        None => return Err(
+                                        CLIError::Configuration(
+                                        ConfigurationError::Secret(
+                                        ApplicationSecretError::FormatError(secret_str())
+                                        ))),
+                    },
+                }
+            }
+        }
+    }
+    unreachable!();
+}

--- a/gen/cloudbuild1-cli/src/main.rs
+++ b/gen/cloudbuild1-cli/src/main.rs
@@ -1,0 +1,1878 @@
+// DO NOT EDIT !
+// This file was generated automatically from 'src/mako/cli/main.rs.mako'
+// DO NOT EDIT !
+#![allow(unused_variables, unused_imports, dead_code, unused_mut)]
+
+#[macro_use]
+extern crate clap;
+extern crate yup_oauth2 as oauth2;
+extern crate yup_hyper_mock as mock;
+extern crate hyper_rustls;
+extern crate serde;
+extern crate serde_json;
+extern crate hyper;
+extern crate mime;
+extern crate strsim;
+extern crate google_cloudbuild1 as api;
+
+use std::env;
+use std::io::{self, Write};
+use clap::{App, SubCommand, Arg};
+
+mod cmn;
+
+use cmn::{InvalidOptionsError, CLIError, JsonTokenStorage, arg_from_str, writer_from_opts, parse_kv_arg,
+          input_file_from_opts, input_mime_from_opts, FieldCursor, FieldError, CallType, UploadProtocol,
+          calltype_from_str, remove_json_null_values, ComplexType, JsonType, JsonTypeInfo};
+
+use std::default::Default;
+use std::str::FromStr;
+
+use oauth2::{Authenticator, DefaultAuthenticatorDelegate, FlowType};
+use serde_json as json;
+use clap::ArgMatches;
+
+enum DoitError {
+    IoError(String, io::Error),
+    ApiError(api::Error),
+}
+
+struct Engine<'n> {
+    opt: ArgMatches<'n>,
+    hub: api::CloudBuild<hyper::Client, Authenticator<DefaultAuthenticatorDelegate, JsonTokenStorage, hyper::Client>>,
+    gp: Vec<&'static str>,
+    gpm: Vec<(&'static str, &'static str)>,
+}
+
+
+impl<'n> Engine<'n> {
+    fn _operations_cancel(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec![]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::CancelOperationRequest = json::value::from_value(object).unwrap();
+        let mut call = self.hub.operations().cancel(request, opt.value_of("name").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _operations_get(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let mut call = self.hub.operations().get(opt.value_of("name").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _operations_list(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let mut call = self.hub.operations().list(opt.value_of("name").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                "page-token" => {
+                    call = call.page_token(value.unwrap_or(""));
+                },
+                "page-size" => {
+                    call = call.page_size(arg_from_str(value.unwrap_or("-0"), err, "page-size", "integer"));
+                },
+                "filter" => {
+                    call = call.filter(value.unwrap_or(""));
+                },
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v.extend(["filter", "page-token", "page-size"].iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _projects_builds_cancel(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec![]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::CancelBuildRequest = json::value::from_value(object).unwrap();
+        let mut call = self.hub.projects().builds_cancel(request, opt.value_of("project-id").unwrap_or(""), opt.value_of("id").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _projects_builds_create(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    "status" => Some(("status", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "finish-time" => Some(("finishTime", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "timeout" => Some(("timeout", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "log-url" => Some(("logUrl", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "start-time" => Some(("startTime", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "tags" => Some(("tags", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Vec })),
+                    "logs-bucket" => Some(("logsBucket", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "id" => Some(("id", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "results.build-step-images" => Some(("results.buildStepImages", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Vec })),
+                    "status-detail" => Some(("statusDetail", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "source.storage-source.generation" => Some(("source.storageSource.generation", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "source.storage-source.object" => Some(("source.storageSource.object", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "source.storage-source.bucket" => Some(("source.storageSource.bucket", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "source.repo-source.project-id" => Some(("source.repoSource.projectId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "source.repo-source.commit-sha" => Some(("source.repoSource.commitSha", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "source.repo-source.repo-name" => Some(("source.repoSource.repoName", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "source.repo-source.tag-name" => Some(("source.repoSource.tagName", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "source.repo-source.branch-name" => Some(("source.repoSource.branchName", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "source.repo-source.dir" => Some(("source.repoSource.dir", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "options.substitution-option" => Some(("options.substitutionOption", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "options.machine-type" => Some(("options.machineType", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "options.source-provenance-hash" => Some(("options.sourceProvenanceHash", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Vec })),
+                    "options.log-streaming-option" => Some(("options.logStreamingOption", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "options.disk-size-gb" => Some(("options.diskSizeGb", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "options.requested-verify-option" => Some(("options.requestedVerifyOption", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "source-provenance.resolved-repo-source.project-id" => Some(("sourceProvenance.resolvedRepoSource.projectId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "source-provenance.resolved-repo-source.commit-sha" => Some(("sourceProvenance.resolvedRepoSource.commitSha", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "source-provenance.resolved-repo-source.repo-name" => Some(("sourceProvenance.resolvedRepoSource.repoName", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "source-provenance.resolved-repo-source.tag-name" => Some(("sourceProvenance.resolvedRepoSource.tagName", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "source-provenance.resolved-repo-source.branch-name" => Some(("sourceProvenance.resolvedRepoSource.branchName", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "source-provenance.resolved-repo-source.dir" => Some(("sourceProvenance.resolvedRepoSource.dir", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "source-provenance.resolved-storage-source.generation" => Some(("sourceProvenance.resolvedStorageSource.generation", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "source-provenance.resolved-storage-source.object" => Some(("sourceProvenance.resolvedStorageSource.object", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "source-provenance.resolved-storage-source.bucket" => Some(("sourceProvenance.resolvedStorageSource.bucket", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "project-id" => Some(("projectId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "images" => Some(("images", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Vec })),
+                    "substitutions" => Some(("substitutions", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Map })),
+                    "create-time" => Some(("createTime", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "build-trigger-id" => Some(("buildTriggerId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec!["branch-name", "bucket", "build-step-images", "build-trigger-id", "commit-sha", "create-time", "dir", "disk-size-gb", "finish-time", "generation", "id", "images", "log-streaming-option", "log-url", "logs-bucket", "machine-type", "object", "options", "project-id", "repo-name", "repo-source", "requested-verify-option", "resolved-repo-source", "resolved-storage-source", "results", "source", "source-provenance", "source-provenance-hash", "start-time", "status", "status-detail", "storage-source", "substitution-option", "substitutions", "tag-name", "tags", "timeout"]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::Build = json::value::from_value(object).unwrap();
+        let mut call = self.hub.projects().builds_create(request, opt.value_of("project-id").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _projects_builds_get(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let mut call = self.hub.projects().builds_get(opt.value_of("project-id").unwrap_or(""), opt.value_of("id").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _projects_builds_list(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let mut call = self.hub.projects().builds_list(opt.value_of("project-id").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                "page-token" => {
+                    call = call.page_token(value.unwrap_or(""));
+                },
+                "page-size" => {
+                    call = call.page_size(arg_from_str(value.unwrap_or("-0"), err, "page-size", "integer"));
+                },
+                "filter" => {
+                    call = call.filter(value.unwrap_or(""));
+                },
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v.extend(["filter", "page-token", "page-size"].iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _projects_builds_retry(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec![]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::RetryBuildRequest = json::value::from_value(object).unwrap();
+        let mut call = self.hub.projects().builds_retry(request, opt.value_of("project-id").unwrap_or(""), opt.value_of("id").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _projects_triggers_create(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    "description" => Some(("description", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "create-time" => Some(("createTime", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "filename" => Some(("filename", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "disabled" => Some(("disabled", JsonTypeInfo { jtype: JsonType::Boolean, ctype: ComplexType::Pod })),
+                    "substitutions" => Some(("substitutions", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Map })),
+                    "build.status" => Some(("build.status", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "build.finish-time" => Some(("build.finishTime", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "build.timeout" => Some(("build.timeout", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "build.log-url" => Some(("build.logUrl", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "build.start-time" => Some(("build.startTime", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "build.tags" => Some(("build.tags", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Vec })),
+                    "build.logs-bucket" => Some(("build.logsBucket", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "build.id" => Some(("build.id", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "build.results.build-step-images" => Some(("build.results.buildStepImages", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Vec })),
+                    "build.status-detail" => Some(("build.statusDetail", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "build.source.storage-source.generation" => Some(("build.source.storageSource.generation", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "build.source.storage-source.object" => Some(("build.source.storageSource.object", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "build.source.storage-source.bucket" => Some(("build.source.storageSource.bucket", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "build.source.repo-source.project-id" => Some(("build.source.repoSource.projectId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "build.source.repo-source.commit-sha" => Some(("build.source.repoSource.commitSha", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "build.source.repo-source.repo-name" => Some(("build.source.repoSource.repoName", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "build.source.repo-source.tag-name" => Some(("build.source.repoSource.tagName", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "build.source.repo-source.branch-name" => Some(("build.source.repoSource.branchName", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "build.source.repo-source.dir" => Some(("build.source.repoSource.dir", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "build.options.substitution-option" => Some(("build.options.substitutionOption", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "build.options.machine-type" => Some(("build.options.machineType", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "build.options.source-provenance-hash" => Some(("build.options.sourceProvenanceHash", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Vec })),
+                    "build.options.log-streaming-option" => Some(("build.options.logStreamingOption", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "build.options.disk-size-gb" => Some(("build.options.diskSizeGb", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "build.options.requested-verify-option" => Some(("build.options.requestedVerifyOption", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "build.source-provenance.resolved-repo-source.project-id" => Some(("build.sourceProvenance.resolvedRepoSource.projectId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "build.source-provenance.resolved-repo-source.commit-sha" => Some(("build.sourceProvenance.resolvedRepoSource.commitSha", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "build.source-provenance.resolved-repo-source.repo-name" => Some(("build.sourceProvenance.resolvedRepoSource.repoName", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "build.source-provenance.resolved-repo-source.tag-name" => Some(("build.sourceProvenance.resolvedRepoSource.tagName", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "build.source-provenance.resolved-repo-source.branch-name" => Some(("build.sourceProvenance.resolvedRepoSource.branchName", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "build.source-provenance.resolved-repo-source.dir" => Some(("build.sourceProvenance.resolvedRepoSource.dir", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "build.source-provenance.resolved-storage-source.generation" => Some(("build.sourceProvenance.resolvedStorageSource.generation", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "build.source-provenance.resolved-storage-source.object" => Some(("build.sourceProvenance.resolvedStorageSource.object", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "build.source-provenance.resolved-storage-source.bucket" => Some(("build.sourceProvenance.resolvedStorageSource.bucket", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "build.project-id" => Some(("build.projectId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "build.images" => Some(("build.images", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Vec })),
+                    "build.substitutions" => Some(("build.substitutions", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Map })),
+                    "build.create-time" => Some(("build.createTime", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "build.build-trigger-id" => Some(("build.buildTriggerId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "trigger-template.project-id" => Some(("triggerTemplate.projectId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "trigger-template.commit-sha" => Some(("triggerTemplate.commitSha", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "trigger-template.repo-name" => Some(("triggerTemplate.repoName", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "trigger-template.tag-name" => Some(("triggerTemplate.tagName", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "trigger-template.branch-name" => Some(("triggerTemplate.branchName", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "trigger-template.dir" => Some(("triggerTemplate.dir", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "id" => Some(("id", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec!["branch-name", "bucket", "build", "build-step-images", "build-trigger-id", "commit-sha", "create-time", "description", "dir", "disabled", "disk-size-gb", "filename", "finish-time", "generation", "id", "images", "log-streaming-option", "log-url", "logs-bucket", "machine-type", "object", "options", "project-id", "repo-name", "repo-source", "requested-verify-option", "resolved-repo-source", "resolved-storage-source", "results", "source", "source-provenance", "source-provenance-hash", "start-time", "status", "status-detail", "storage-source", "substitution-option", "substitutions", "tag-name", "tags", "timeout", "trigger-template"]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::BuildTrigger = json::value::from_value(object).unwrap();
+        let mut call = self.hub.projects().triggers_create(request, opt.value_of("project-id").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _projects_triggers_delete(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let mut call = self.hub.projects().triggers_delete(opt.value_of("project-id").unwrap_or(""), opt.value_of("trigger-id").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _projects_triggers_get(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let mut call = self.hub.projects().triggers_get(opt.value_of("project-id").unwrap_or(""), opt.value_of("trigger-id").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _projects_triggers_list(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let mut call = self.hub.projects().triggers_list(opt.value_of("project-id").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _projects_triggers_patch(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    "description" => Some(("description", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "create-time" => Some(("createTime", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "filename" => Some(("filename", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "disabled" => Some(("disabled", JsonTypeInfo { jtype: JsonType::Boolean, ctype: ComplexType::Pod })),
+                    "substitutions" => Some(("substitutions", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Map })),
+                    "build.status" => Some(("build.status", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "build.finish-time" => Some(("build.finishTime", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "build.timeout" => Some(("build.timeout", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "build.log-url" => Some(("build.logUrl", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "build.start-time" => Some(("build.startTime", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "build.tags" => Some(("build.tags", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Vec })),
+                    "build.logs-bucket" => Some(("build.logsBucket", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "build.id" => Some(("build.id", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "build.results.build-step-images" => Some(("build.results.buildStepImages", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Vec })),
+                    "build.status-detail" => Some(("build.statusDetail", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "build.source.storage-source.generation" => Some(("build.source.storageSource.generation", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "build.source.storage-source.object" => Some(("build.source.storageSource.object", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "build.source.storage-source.bucket" => Some(("build.source.storageSource.bucket", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "build.source.repo-source.project-id" => Some(("build.source.repoSource.projectId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "build.source.repo-source.commit-sha" => Some(("build.source.repoSource.commitSha", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "build.source.repo-source.repo-name" => Some(("build.source.repoSource.repoName", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "build.source.repo-source.tag-name" => Some(("build.source.repoSource.tagName", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "build.source.repo-source.branch-name" => Some(("build.source.repoSource.branchName", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "build.source.repo-source.dir" => Some(("build.source.repoSource.dir", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "build.options.substitution-option" => Some(("build.options.substitutionOption", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "build.options.machine-type" => Some(("build.options.machineType", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "build.options.source-provenance-hash" => Some(("build.options.sourceProvenanceHash", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Vec })),
+                    "build.options.log-streaming-option" => Some(("build.options.logStreamingOption", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "build.options.disk-size-gb" => Some(("build.options.diskSizeGb", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "build.options.requested-verify-option" => Some(("build.options.requestedVerifyOption", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "build.source-provenance.resolved-repo-source.project-id" => Some(("build.sourceProvenance.resolvedRepoSource.projectId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "build.source-provenance.resolved-repo-source.commit-sha" => Some(("build.sourceProvenance.resolvedRepoSource.commitSha", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "build.source-provenance.resolved-repo-source.repo-name" => Some(("build.sourceProvenance.resolvedRepoSource.repoName", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "build.source-provenance.resolved-repo-source.tag-name" => Some(("build.sourceProvenance.resolvedRepoSource.tagName", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "build.source-provenance.resolved-repo-source.branch-name" => Some(("build.sourceProvenance.resolvedRepoSource.branchName", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "build.source-provenance.resolved-repo-source.dir" => Some(("build.sourceProvenance.resolvedRepoSource.dir", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "build.source-provenance.resolved-storage-source.generation" => Some(("build.sourceProvenance.resolvedStorageSource.generation", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "build.source-provenance.resolved-storage-source.object" => Some(("build.sourceProvenance.resolvedStorageSource.object", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "build.source-provenance.resolved-storage-source.bucket" => Some(("build.sourceProvenance.resolvedStorageSource.bucket", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "build.project-id" => Some(("build.projectId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "build.images" => Some(("build.images", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Vec })),
+                    "build.substitutions" => Some(("build.substitutions", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Map })),
+                    "build.create-time" => Some(("build.createTime", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "build.build-trigger-id" => Some(("build.buildTriggerId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "trigger-template.project-id" => Some(("triggerTemplate.projectId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "trigger-template.commit-sha" => Some(("triggerTemplate.commitSha", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "trigger-template.repo-name" => Some(("triggerTemplate.repoName", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "trigger-template.tag-name" => Some(("triggerTemplate.tagName", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "trigger-template.branch-name" => Some(("triggerTemplate.branchName", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "trigger-template.dir" => Some(("triggerTemplate.dir", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "id" => Some(("id", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec!["branch-name", "bucket", "build", "build-step-images", "build-trigger-id", "commit-sha", "create-time", "description", "dir", "disabled", "disk-size-gb", "filename", "finish-time", "generation", "id", "images", "log-streaming-option", "log-url", "logs-bucket", "machine-type", "object", "options", "project-id", "repo-name", "repo-source", "requested-verify-option", "resolved-repo-source", "resolved-storage-source", "results", "source", "source-provenance", "source-provenance-hash", "start-time", "status", "status-detail", "storage-source", "substitution-option", "substitutions", "tag-name", "tags", "timeout", "trigger-template"]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::BuildTrigger = json::value::from_value(object).unwrap();
+        let mut call = self.hub.projects().triggers_patch(request, opt.value_of("project-id").unwrap_or(""), opt.value_of("trigger-id").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _projects_triggers_run(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    "project-id" => Some(("projectId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "commit-sha" => Some(("commitSha", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "repo-name" => Some(("repoName", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "tag-name" => Some(("tagName", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "branch-name" => Some(("branchName", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "dir" => Some(("dir", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec!["branch-name", "commit-sha", "dir", "project-id", "repo-name", "tag-name"]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::RepoSource = json::value::from_value(object).unwrap();
+        let mut call = self.hub.projects().triggers_run(request, opt.value_of("project-id").unwrap_or(""), opt.value_of("trigger-id").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _doit(&self, dry_run: bool) -> Result<Result<(), DoitError>, Option<InvalidOptionsError>> {
+        let mut err = InvalidOptionsError::new();
+        let mut call_result: Result<(), DoitError> = Ok(());
+        let mut err_opt: Option<InvalidOptionsError> = None;
+        match self.opt.subcommand() {
+            ("operations", Some(opt)) => {
+                match opt.subcommand() {
+                    ("cancel", Some(opt)) => {
+                        call_result = self._operations_cancel(opt, dry_run, &mut err);
+                    },
+                    ("get", Some(opt)) => {
+                        call_result = self._operations_get(opt, dry_run, &mut err);
+                    },
+                    ("list", Some(opt)) => {
+                        call_result = self._operations_list(opt, dry_run, &mut err);
+                    },
+                    _ => {
+                        err.issues.push(CLIError::MissingMethodError("operations".to_string()));
+                        writeln!(io::stderr(), "{}\n", opt.usage()).ok();
+                    }
+                }
+            },
+            ("projects", Some(opt)) => {
+                match opt.subcommand() {
+                    ("builds-cancel", Some(opt)) => {
+                        call_result = self._projects_builds_cancel(opt, dry_run, &mut err);
+                    },
+                    ("builds-create", Some(opt)) => {
+                        call_result = self._projects_builds_create(opt, dry_run, &mut err);
+                    },
+                    ("builds-get", Some(opt)) => {
+                        call_result = self._projects_builds_get(opt, dry_run, &mut err);
+                    },
+                    ("builds-list", Some(opt)) => {
+                        call_result = self._projects_builds_list(opt, dry_run, &mut err);
+                    },
+                    ("builds-retry", Some(opt)) => {
+                        call_result = self._projects_builds_retry(opt, dry_run, &mut err);
+                    },
+                    ("triggers-create", Some(opt)) => {
+                        call_result = self._projects_triggers_create(opt, dry_run, &mut err);
+                    },
+                    ("triggers-delete", Some(opt)) => {
+                        call_result = self._projects_triggers_delete(opt, dry_run, &mut err);
+                    },
+                    ("triggers-get", Some(opt)) => {
+                        call_result = self._projects_triggers_get(opt, dry_run, &mut err);
+                    },
+                    ("triggers-list", Some(opt)) => {
+                        call_result = self._projects_triggers_list(opt, dry_run, &mut err);
+                    },
+                    ("triggers-patch", Some(opt)) => {
+                        call_result = self._projects_triggers_patch(opt, dry_run, &mut err);
+                    },
+                    ("triggers-run", Some(opt)) => {
+                        call_result = self._projects_triggers_run(opt, dry_run, &mut err);
+                    },
+                    _ => {
+                        err.issues.push(CLIError::MissingMethodError("projects".to_string()));
+                        writeln!(io::stderr(), "{}\n", opt.usage()).ok();
+                    }
+                }
+            },
+            _ => {
+                err.issues.push(CLIError::MissingCommandError);
+                writeln!(io::stderr(), "{}\n", self.opt.usage()).ok();
+            }
+        }
+
+        if dry_run {
+            if err.issues.len() > 0 {
+                err_opt = Some(err);
+            }
+            Err(err_opt)
+        } else {
+            Ok(call_result)
+        }
+    }
+
+    // Please note that this call will fail if any part of the opt can't be handled
+    fn new(opt: ArgMatches<'n>) -> Result<Engine<'n>, InvalidOptionsError> {
+        let (config_dir, secret) = {
+            let config_dir = match cmn::assure_config_dir_exists(opt.value_of("folder").unwrap_or("~/.google-service-cli")) {
+                Err(e) => return Err(InvalidOptionsError::single(e, 3)),
+                Ok(p) => p,
+            };
+
+            match cmn::application_secret_from_directory(&config_dir, "cloudbuild1-secret.json",
+                                                         "{\"installed\":{\"auth_uri\":\"https://accounts.google.com/o/oauth2/auth\",\"client_secret\":\"hCsslbCUyfehWMmbkG8vTYxG\",\"token_uri\":\"https://accounts.google.com/o/oauth2/token\",\"client_email\":\"\",\"redirect_uris\":[\"urn:ietf:wg:oauth:2.0:oob\",\"oob\"],\"client_x509_cert_url\":\"\",\"client_id\":\"620010449518-9ngf7o4dhs0dka470npqvor6dc5lqb9b.apps.googleusercontent.com\",\"auth_provider_x509_cert_url\":\"https://www.googleapis.com/oauth2/v1/certs\"}}") {
+                Ok(secret) => (config_dir, secret),
+                Err(e) => return Err(InvalidOptionsError::single(e, 4))
+            }
+        };
+
+        let auth = Authenticator::new(  &secret, DefaultAuthenticatorDelegate,
+                                        if opt.is_present("debug-auth") {
+                                            hyper::Client::with_connector(mock::TeeConnector {
+                                                    connector: hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())
+                                                })
+                                        } else {
+                                            hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new()))
+                                        },
+                                        JsonTokenStorage {
+                                          program_name: "cloudbuild1",
+                                          db_dir: config_dir.clone(),
+                                        }, Some(FlowType::InstalledRedirect(54324)));
+
+        let client =
+            if opt.is_present("debug") {
+                hyper::Client::with_connector(mock::TeeConnector {
+                        connector: hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())
+                    })
+            } else {
+                hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new()))
+            };
+        let engine = Engine {
+            opt: opt,
+            hub: api::CloudBuild::new(client, auth),
+            gp: vec!["$-xgafv", "access-token", "alt", "bearer-token", "callback", "fields", "key", "oauth-token", "pp", "pretty-print", "quota-user", "upload-type", "upload-protocol"],
+            gpm: vec![
+                    ("$-xgafv", "$.xgafv"),
+                    ("access-token", "access_token"),
+                    ("bearer-token", "bearer_token"),
+                    ("oauth-token", "oauth_token"),
+                    ("pretty-print", "prettyPrint"),
+                    ("quota-user", "quotaUser"),
+                    ("upload-type", "uploadType"),
+                    ("upload-protocol", "upload_protocol"),
+                ]
+        };
+
+        match engine._doit(true) {
+            Err(Some(err)) => Err(err),
+            Err(None)      => Ok(engine),
+            Ok(_)          => unreachable!(),
+        }
+    }
+
+    fn doit(&self) -> Result<(), DoitError> {
+        match self._doit(false) {
+            Ok(res) => res,
+            Err(_) => unreachable!(),
+        }
+    }
+}
+
+fn main() {
+    let mut exit_status = 0i32;
+    let arg_data = [
+        ("operations", "methods: 'cancel', 'get' and 'list'", vec![
+            ("cancel",
+                    Some(r##"Starts asynchronous cancellation on a long-running operation.  The server
+        makes a best effort to cancel the operation, but success is not
+        guaranteed.  If the server doesn't support this method, it returns
+        `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
+        Operations.GetOperation or
+        other methods to check whether the cancellation succeeded or whether the
+        operation completed despite cancellation. On successful cancellation,
+        the operation is not deleted; instead, it becomes an operation with
+        an Operation.error value with a google.rpc.Status.code of 1,
+        corresponding to `Code.CANCELLED`."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_cloudbuild1_cli/operations_cancel",
+                  vec![
+                    (Some(r##"name"##),
+                     None,
+                     Some(r##"The name of the operation resource to be cancelled."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("get",
+                    Some(r##"Gets the latest state of a long-running operation.  Clients can use this
+        method to poll the operation result at intervals as recommended by the API
+        service."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_cloudbuild1_cli/operations_get",
+                  vec![
+                    (Some(r##"name"##),
+                     None,
+                     Some(r##"The name of the operation resource."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("list",
+                    Some(r##"Lists operations that match the specified filter in the request. If the
+        server doesn't support this method, it returns `UNIMPLEMENTED`.
+        
+        NOTE: the `name` binding allows API services to override the binding
+        to use different resource name schemes, such as `users/*/operations`. To
+        override the binding, API services can add a binding such as
+        `"/v1/{name=users/*}/operations"` to their service configuration.
+        For backwards compatibility, the default name includes the operations
+        collection id, however overriding users must ensure the name binding
+        is the parent resource, without the operations collection id."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_cloudbuild1_cli/operations_list",
+                  vec![
+                    (Some(r##"name"##),
+                     None,
+                     Some(r##"The name of the operation's parent resource."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ]),
+        
+        ("projects", "methods: 'builds-cancel', 'builds-create', 'builds-get', 'builds-list', 'builds-retry', 'triggers-create', 'triggers-delete', 'triggers-get', 'triggers-list', 'triggers-patch' and 'triggers-run'", vec![
+            ("builds-cancel",
+                    Some(r##"Cancels a requested build in progress."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_cloudbuild1_cli/projects_builds-cancel",
+                  vec![
+                    (Some(r##"project-id"##),
+                     None,
+                     Some(r##"ID of the project."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"id"##),
+                     None,
+                     Some(r##"ID of the build."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("builds-create",
+                    Some(r##"Starts a build with the specified configuration.
+        
+        The long-running Operation returned by this method will include the ID of
+        the build, which can be passed to GetBuild to determine its status (e.g.,
+        success or failure)."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_cloudbuild1_cli/projects_builds-create",
+                  vec![
+                    (Some(r##"project-id"##),
+                     None,
+                     Some(r##"ID of the project."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("builds-get",
+                    Some(r##"Returns information about a previously requested build.
+        
+        The Build that is returned includes its status (e.g., success or failure,
+        or in-progress), and timing information."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_cloudbuild1_cli/projects_builds-get",
+                  vec![
+                    (Some(r##"project-id"##),
+                     None,
+                     Some(r##"ID of the project."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"id"##),
+                     None,
+                     Some(r##"ID of the build."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("builds-list",
+                    Some(r##"Lists previously requested builds.
+        
+        Previously requested builds may still be in-progress, or may have finished
+        successfully or unsuccessfully."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_cloudbuild1_cli/projects_builds-list",
+                  vec![
+                    (Some(r##"project-id"##),
+                     None,
+                     Some(r##"ID of the project."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("builds-retry",
+                    Some(r##"Creates a new build based on the given build.
+        
+        This API creates a new build using the original build request,  which may
+        or may not result in an identical build.
+        
+        For triggered builds:
+        
+        * Triggered builds resolve to a precise revision, so a retry of a triggered
+        build will result in a build that uses the same revision.
+        
+        For non-triggered builds that specify RepoSource:
+        
+        * If the original build built from the tip of a branch, the retried build
+        will build from the tip of that branch, which may not be the same revision
+        as the original build.
+        * If the original build specified a commit sha or revision ID, the retried
+        build will use the identical source.
+        
+        For builds that specify StorageSource:
+        
+        * If the original build pulled source from Cloud Storage without specifying
+        the generation of the object, the new build will use the current object,
+        which may be different from the original build source.
+        * If the original build pulled source from Cloud Storage and specified the
+        generation of the object, the new build will attempt to use the same
+        object, which may or may not be available depending on the bucket's
+        lifecycle management settings."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_cloudbuild1_cli/projects_builds-retry",
+                  vec![
+                    (Some(r##"project-id"##),
+                     None,
+                     Some(r##"ID of the project."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"id"##),
+                     None,
+                     Some(r##"Build ID of the original build."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("triggers-create",
+                    Some(r##"Creates a new BuildTrigger.
+        
+        This API is experimental."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_cloudbuild1_cli/projects_triggers-create",
+                  vec![
+                    (Some(r##"project-id"##),
+                     None,
+                     Some(r##"ID of the project for which to configure automatic builds."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("triggers-delete",
+                    Some(r##"Deletes an BuildTrigger by its project ID and trigger ID.
+        
+        This API is experimental."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_cloudbuild1_cli/projects_triggers-delete",
+                  vec![
+                    (Some(r##"project-id"##),
+                     None,
+                     Some(r##"ID of the project that owns the trigger."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"trigger-id"##),
+                     None,
+                     Some(r##"ID of the BuildTrigger to delete."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("triggers-get",
+                    Some(r##"Gets information about a BuildTrigger.
+        
+        This API is experimental."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_cloudbuild1_cli/projects_triggers-get",
+                  vec![
+                    (Some(r##"project-id"##),
+                     None,
+                     Some(r##"ID of the project that owns the trigger."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"trigger-id"##),
+                     None,
+                     Some(r##"ID of the BuildTrigger to get."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("triggers-list",
+                    Some(r##"Lists existing BuildTrigger.
+        
+        This API is experimental."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_cloudbuild1_cli/projects_triggers-list",
+                  vec![
+                    (Some(r##"project-id"##),
+                     None,
+                     Some(r##"ID of the project for which to list BuildTriggers."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("triggers-patch",
+                    Some(r##"Updates an BuildTrigger by its project ID and trigger ID.
+        
+        This API is experimental."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_cloudbuild1_cli/projects_triggers-patch",
+                  vec![
+                    (Some(r##"project-id"##),
+                     None,
+                     Some(r##"ID of the project that owns the trigger."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"trigger-id"##),
+                     None,
+                     Some(r##"ID of the BuildTrigger to update."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("triggers-run",
+                    Some(r##"Runs a BuildTrigger at a particular source revision."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_cloudbuild1_cli/projects_triggers-run",
+                  vec![
+                    (Some(r##"project-id"##),
+                     None,
+                     Some(r##"ID of the project."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"trigger-id"##),
+                     None,
+                     Some(r##"ID of the trigger."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ]),
+        
+    ];
+    
+    let mut app = App::new("cloudbuild1")
+           .author("Sebastian Thiel <byronimo@gmail.com>")
+           .version("1.0.7+20171205")
+           .about("Builds container images in the cloud.")
+           .after_help("All documentation details can be found at http://byron.github.io/google-apis-rs/google_cloudbuild1_cli")
+           .arg(Arg::with_name("url")
+                   .long("scope")
+                   .help("Specify the authentication a method should be executed in. Each scope requires the user to grant this application permission to use it.If unset, it defaults to the shortest scope url for a particular method.")
+                   .multiple(true)
+                   .takes_value(true))
+           .arg(Arg::with_name("folder")
+                   .long("config-dir")
+                   .help("A directory into which we will store our persistent data. Defaults to a user-writable directory that we will create during the first invocation.[default: ~/.google-service-cli")
+                   .multiple(false)
+                   .takes_value(true))
+           .arg(Arg::with_name("debug")
+                   .long("debug")
+                   .help("Output all server communication to standard error. `tx` and `rx` are placed into the same stream.")
+                   .multiple(false)
+                   .takes_value(false))
+           .arg(Arg::with_name("debug-auth")
+                   .long("debug-auth")
+                   .help("Output all communication related to authentication to standard error. `tx` and `rx` are placed into the same stream.")
+                   .multiple(false)
+                   .takes_value(false));
+           
+           for &(main_command_name, about, ref subcommands) in arg_data.iter() {
+               let mut mcmd = SubCommand::with_name(main_command_name).about(about);
+           
+               for &(sub_command_name, ref desc, url_info, ref args) in subcommands {
+                   let mut scmd = SubCommand::with_name(sub_command_name);
+                   if let &Some(desc) = desc {
+                       scmd = scmd.about(desc);
+                   }
+                   scmd = scmd.after_help(url_info);
+           
+                   for &(ref arg_name, ref flag, ref desc, ref required, ref multi) in args {
+                       let arg_name_str =
+                           match (arg_name, flag) {
+                                   (&Some(an), _       ) => an,
+                                   (_        , &Some(f)) => f,
+                                    _                    => unreachable!(),
+                            };
+                       let mut arg = Arg::with_name(arg_name_str)
+                                         .empty_values(false);
+                       if let &Some(short_flag) = flag {
+                           arg = arg.short(short_flag);
+                       }
+                       if let &Some(desc) = desc {
+                           arg = arg.help(desc);
+                       }
+                       if arg_name.is_some() && flag.is_some() {
+                           arg = arg.takes_value(true);
+                       }
+                       if let &Some(required) = required {
+                           arg = arg.required(required);
+                       }
+                       if let &Some(multi) = multi {
+                           arg = arg.multiple(multi);
+                       }
+                       scmd = scmd.arg(arg);
+                   }
+                   mcmd = mcmd.subcommand(scmd);
+               }
+               app = app.subcommand(mcmd);
+           }
+           
+        let matches = app.get_matches();
+
+    let debug = matches.is_present("debug");
+    match Engine::new(matches) {
+        Err(err) => {
+            exit_status = err.exit_code;
+            writeln!(io::stderr(), "{}", err).ok();
+        },
+        Ok(engine) => {
+            if let Err(doit_err) = engine.doit() {
+                exit_status = 1;
+                match doit_err {
+                    DoitError::IoError(path, err) => {
+                        writeln!(io::stderr(), "Failed to open output file '{}': {}", path, err).ok();
+                    },
+                    DoitError::ApiError(err) => {
+                        if debug {
+                            writeln!(io::stderr(), "{:#?}", err).ok();
+                        } else {
+                            writeln!(io::stderr(), "{}", err).ok();
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    std::process::exit(exit_status);
+}

--- a/gen/cloudbuild1/Cargo.toml
+++ b/gen/cloudbuild1/Cargo.toml
@@ -1,0 +1,31 @@
+# DO NOT EDIT !
+# This file was generated automatically from 'src/mako/Cargo.toml.mako'
+# DO NOT EDIT !
+[package]
+
+name = "google-cloudbuild1"
+version = "1.0.7+20171205"
+authors = ["Sebastian Thiel <byronimo@gmail.com>"]
+description = "A complete library to interact with Cloud Build (protocol v1)"
+repository = "https://github.com/Byron/google-apis-rs/tree/master/gen/cloudbuild1"
+homepage = "https://cloud.google.com/container-builder/docs/"
+documentation = "https://docs.rs/google-cloudbuild1/1.0.7+20171205"
+license = "MIT"
+keywords = ["cloudbuild", "google", "protocol", "web", "api"]
+
+
+[dev-dependencies]
+hyper-rustls = "^0.6"
+
+[dependencies]
+hyper = "^ 0.10"
+mime = "^ 0.2.0"
+serde = "^ 1.0"
+serde_json = "^ 1.0"
+serde_derive = "^ 1.0"
+yup-oauth2 = "^ 1.0"
+url = "= 0.5"
+
+[features]
+
+

--- a/gen/cloudbuild1/LICENSE.md
+++ b/gen/cloudbuild1/LICENSE.md
@@ -1,0 +1,30 @@
+<!---
+DO NOT EDIT !
+This file was generated automatically from 'src/mako/LICENSE.md.mako'
+DO NOT EDIT !
+-->
+The MIT License (MIT)
+=====================
+
+Copyright © `2015-2016` `Sebastian Thiel`
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the “Software”), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.

--- a/gen/cloudbuild1/README.md
+++ b/gen/cloudbuild1/README.md
@@ -1,0 +1,184 @@
+<!---
+DO NOT EDIT !
+This file was generated automatically from 'src/mako/api/README.md.mako'
+DO NOT EDIT !
+-->
+The `google-cloudbuild1` library allows access to all features of the *Google Cloud Build* service.
+
+This documentation was generated from *Cloud Build* crate version *1.0.7+20171205*, where *20171205* is the exact revision of the *cloudbuild:v1* schema built by the [mako](http://www.makotemplates.org/) code generator *v1.0.7*.
+
+Everything else about the *Cloud Build* *v1* API can be found at the
+[official documentation site](https://cloud.google.com/container-builder/docs/).
+# Features
+
+Handle the following *Resources* with ease from the central [hub](https://docs.rs/google-cloudbuild1/1.0.7+20171205/google_cloudbuild1/struct.CloudBuild.html) ... 
+
+* [operations](https://docs.rs/google-cloudbuild1/1.0.7+20171205/google_cloudbuild1/struct.Operation.html)
+ * [*cancel*](https://docs.rs/google-cloudbuild1/1.0.7+20171205/google_cloudbuild1/struct.OperationCancelCall.html), [*get*](https://docs.rs/google-cloudbuild1/1.0.7+20171205/google_cloudbuild1/struct.OperationGetCall.html) and [*list*](https://docs.rs/google-cloudbuild1/1.0.7+20171205/google_cloudbuild1/struct.OperationListCall.html)
+* projects
+ * [*builds cancel*](https://docs.rs/google-cloudbuild1/1.0.7+20171205/google_cloudbuild1/struct.ProjectBuildCancelCall.html), [*builds create*](https://docs.rs/google-cloudbuild1/1.0.7+20171205/google_cloudbuild1/struct.ProjectBuildCreateCall.html), [*builds get*](https://docs.rs/google-cloudbuild1/1.0.7+20171205/google_cloudbuild1/struct.ProjectBuildGetCall.html), [*builds list*](https://docs.rs/google-cloudbuild1/1.0.7+20171205/google_cloudbuild1/struct.ProjectBuildListCall.html), [*builds retry*](https://docs.rs/google-cloudbuild1/1.0.7+20171205/google_cloudbuild1/struct.ProjectBuildRetryCall.html), [*triggers create*](https://docs.rs/google-cloudbuild1/1.0.7+20171205/google_cloudbuild1/struct.ProjectTriggerCreateCall.html), [*triggers delete*](https://docs.rs/google-cloudbuild1/1.0.7+20171205/google_cloudbuild1/struct.ProjectTriggerDeleteCall.html), [*triggers get*](https://docs.rs/google-cloudbuild1/1.0.7+20171205/google_cloudbuild1/struct.ProjectTriggerGetCall.html), [*triggers list*](https://docs.rs/google-cloudbuild1/1.0.7+20171205/google_cloudbuild1/struct.ProjectTriggerListCall.html), [*triggers patch*](https://docs.rs/google-cloudbuild1/1.0.7+20171205/google_cloudbuild1/struct.ProjectTriggerPatchCall.html) and [*triggers run*](https://docs.rs/google-cloudbuild1/1.0.7+20171205/google_cloudbuild1/struct.ProjectTriggerRunCall.html)
+
+
+
+
+# Structure of this Library
+
+The API is structured into the following primary items:
+
+* **[Hub](https://docs.rs/google-cloudbuild1/1.0.7+20171205/google_cloudbuild1/struct.CloudBuild.html)**
+    * a central object to maintain state and allow accessing all *Activities*
+    * creates [*Method Builders*](https://docs.rs/google-cloudbuild1/1.0.7+20171205/google_cloudbuild1/trait.MethodsBuilder.html) which in turn
+      allow access to individual [*Call Builders*](https://docs.rs/google-cloudbuild1/1.0.7+20171205/google_cloudbuild1/trait.CallBuilder.html)
+* **[Resources](https://docs.rs/google-cloudbuild1/1.0.7+20171205/google_cloudbuild1/trait.Resource.html)**
+    * primary types that you can apply *Activities* to
+    * a collection of properties and *Parts*
+    * **[Parts](https://docs.rs/google-cloudbuild1/1.0.7+20171205/google_cloudbuild1/trait.Part.html)**
+        * a collection of properties
+        * never directly used in *Activities*
+* **[Activities](https://docs.rs/google-cloudbuild1/1.0.7+20171205/google_cloudbuild1/trait.CallBuilder.html)**
+    * operations to apply to *Resources*
+
+All *structures* are marked with applicable traits to further categorize them and ease browsing.
+
+Generally speaking, you can invoke *Activities* like this:
+
+```Rust,ignore
+let r = hub.resource().activity(...).doit()
+```
+
+Or specifically ...
+
+```ignore
+let r = hub.operations().cancel(...).doit()
+let r = hub.projects().triggers_run(...).doit()
+let r = hub.projects().builds_create(...).doit()
+let r = hub.operations().list(...).doit()
+let r = hub.operations().get(...).doit()
+let r = hub.projects().builds_retry(...).doit()
+```
+
+The `resource()` and `activity(...)` calls create [builders][builder-pattern]. The second one dealing with `Activities` 
+supports various methods to configure the impending operation (not shown here). It is made such that all required arguments have to be 
+specified right away (i.e. `(...)`), whereas all optional ones can be [build up][builder-pattern] as desired.
+The `doit()` method performs the actual communication with the server and returns the respective result.
+
+# Usage
+
+## Setting up your Project
+
+To use this library, you would put the following lines into your `Cargo.toml` file:
+
+```toml
+[dependencies]
+google-cloudbuild1 = "*"
+```
+
+## A complete example
+
+```Rust
+extern crate hyper;
+extern crate hyper_rustls;
+extern crate yup_oauth2 as oauth2;
+extern crate google_cloudbuild1 as cloudbuild1;
+use cloudbuild1::{Result, Error};
+use std::default::Default;
+use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+use cloudbuild1::CloudBuild;
+
+// Get an ApplicationSecret instance by some means. It contains the `client_id` and 
+// `client_secret`, among other things.
+let secret: ApplicationSecret = Default::default();
+// Instantiate the authenticator. It will choose a suitable authentication flow for you, 
+// unless you replace  `None` with the desired Flow.
+// Provide your own `AuthenticatorDelegate` to adjust the way it operates and get feedback about 
+// what's going on. You probably want to bring in your own `TokenStorage` to persist tokens and
+// retrieve them from storage.
+let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+                              hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+                              <MemoryStorage as Default>::default(), None);
+let mut hub = CloudBuild::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+// You can configure optional parameters by calling the respective setters at will, and
+// execute the final call using `doit()`.
+// Values shown here are possibly random and not representative !
+let result = hub.operations().list("name")
+             .page_token("sit")
+             .page_size(-65)
+             .filter("sed")
+             .doit();
+
+match result {
+    Err(e) => match e {
+        // The Error enum provides details about what exactly happened.
+        // You can also just use its `Debug`, `Display` or `Error` traits
+         Error::HttpError(_)
+        |Error::MissingAPIKey
+        |Error::MissingToken(_)
+        |Error::Cancelled
+        |Error::UploadSizeLimitExceeded(_, _)
+        |Error::Failure(_)
+        |Error::BadRequest(_)
+        |Error::FieldClash(_)
+        |Error::JsonDecodeError(_, _) => println!("{}", e),
+    },
+    Ok(res) => println!("Success: {:?}", res),
+}
+
+```
+## Handling Errors
+
+All errors produced by the system are provided either as [Result](https://docs.rs/google-cloudbuild1/1.0.7+20171205/google_cloudbuild1/enum.Result.html) enumeration as return value of 
+the doit() methods, or handed as possibly intermediate results to either the 
+[Hub Delegate](https://docs.rs/google-cloudbuild1/1.0.7+20171205/google_cloudbuild1/trait.Delegate.html), or the [Authenticator Delegate](https://docs.rs/yup-oauth2/*/yup_oauth2/trait.AuthenticatorDelegate.html).
+
+When delegates handle errors or intermediate values, they may have a chance to instruct the system to retry. This 
+makes the system potentially resilient to all kinds of errors.
+
+## Uploads and Downloads
+If a method supports downloads, the response body, which is part of the [Result](https://docs.rs/google-cloudbuild1/1.0.7+20171205/google_cloudbuild1/enum.Result.html), should be
+read by you to obtain the media.
+If such a method also supports a [Response Result](https://docs.rs/google-cloudbuild1/1.0.7+20171205/google_cloudbuild1/trait.ResponseResult.html), it will return that by default.
+You can see it as meta-data for the actual media. To trigger a media download, you will have to set up the builder by making
+this call: `.param("alt", "media")`.
+
+Methods supporting uploads can do so using up to 2 different protocols: 
+*simple* and *resumable*. The distinctiveness of each is represented by customized 
+`doit(...)` methods, which are then named `upload(...)` and `upload_resumable(...)` respectively.
+
+## Customization and Callbacks
+
+You may alter the way an `doit()` method is called by providing a [delegate](https://docs.rs/google-cloudbuild1/1.0.7+20171205/google_cloudbuild1/trait.Delegate.html) to the 
+[Method Builder](https://docs.rs/google-cloudbuild1/1.0.7+20171205/google_cloudbuild1/trait.CallBuilder.html) before making the final `doit()` call. 
+Respective methods will be called to provide progress information, as well as determine whether the system should 
+retry on failure.
+
+The [delegate trait](https://docs.rs/google-cloudbuild1/1.0.7+20171205/google_cloudbuild1/trait.Delegate.html) is default-implemented, allowing you to customize it with minimal effort.
+
+## Optional Parts in Server-Requests
+
+All structures provided by this library are made to be [enocodable](https://docs.rs/google-cloudbuild1/1.0.7+20171205/google_cloudbuild1/trait.RequestValue.html) and 
+[decodable](https://docs.rs/google-cloudbuild1/1.0.7+20171205/google_cloudbuild1/trait.ResponseResult.html) via *json*. Optionals are used to indicate that partial requests are responses 
+are valid.
+Most optionals are are considered [Parts](https://docs.rs/google-cloudbuild1/1.0.7+20171205/google_cloudbuild1/trait.Part.html) which are identifiable by name, which will be sent to 
+the server to indicate either the set parts of the request or the desired parts in the response.
+
+## Builder Arguments
+
+Using [method builders](https://docs.rs/google-cloudbuild1/1.0.7+20171205/google_cloudbuild1/trait.CallBuilder.html), you are able to prepare an action call by repeatedly calling it's methods.
+These will always take a single argument, for which the following statements are true.
+
+* [PODs][wiki-pod] are handed by copy
+* strings are passed as `&str`
+* [request values](https://docs.rs/google-cloudbuild1/1.0.7+20171205/google_cloudbuild1/trait.RequestValue.html) are moved
+
+Arguments will always be copied or cloned into the builder, to make them independent of their original life times.
+
+[wiki-pod]: http://en.wikipedia.org/wiki/Plain_old_data_structure
+[builder-pattern]: http://en.wikipedia.org/wiki/Builder_pattern
+[google-go-api]: https://github.com/google/google-api-go-client
+
+# License
+The **cloudbuild1** library was generated by Sebastian Thiel, and is placed 
+under the *MIT* license.
+You can read the full text at the repository's [license file][repo-license].
+
+[repo-license]: https://github.com/Byron/google-apis-rsblob/master/LICENSE.md

--- a/gen/cloudbuild1/src/cmn.rs
+++ b/gen/cloudbuild1/src/cmn.rs
@@ -1,0 +1,753 @@
+// COPY OF 'src/rust/api/cmn.rs'
+// DO NOT EDIT
+use std::io::{self, Read, Seek, Cursor, Write, SeekFrom};
+use std;
+use std::fmt::{self, Display};
+use std::str::FromStr;
+use std::error;
+use std::thread::sleep;
+use std::time::Duration;
+
+use mime::{Mime, TopLevel, SubLevel, Attr, Value};
+use oauth2::{TokenType, Retry, self};
+use hyper;
+use hyper::header::{ContentType, ContentLength, Headers, UserAgent, Authorization, Header,
+                    HeaderFormat, Bearer};
+use hyper::http::h1::LINE_ENDING;
+use hyper::method::Method;
+use hyper::status::StatusCode;
+
+use serde_json as json;
+
+/// Identifies the Hub. There is only one per library, this trait is supposed
+/// to make intended use more explicit.
+/// The hub allows to access all resource methods more easily.
+pub trait Hub {}
+
+/// Identifies types for building methods of a particular resource type
+pub trait MethodsBuilder {}
+
+/// Identifies types which represent builders for a particular resource method
+pub trait CallBuilder {}
+
+/// Identifies types which can be inserted and deleted.
+/// Types with this trait are most commonly used by clients of this API.
+pub trait Resource {}
+
+/// Identifies types which are used in API responses.
+pub trait ResponseResult {}
+
+/// Identifies types which are used in API requests.
+pub trait RequestValue {}
+
+/// Identifies types which are not actually used by the API
+/// This might be a bug within the google API schema.
+pub trait UnusedType {}
+
+/// Identifies types which are only used as part of other types, which
+/// usually are carrying the `Resource` trait.
+pub trait Part {}
+
+/// Identifies types which are only used by other types internally.
+/// They have no special meaning, this trait just marks them for completeness.
+pub trait NestedType {}
+
+/// A utility to specify reader types which provide seeking capabilities too
+pub trait ReadSeek: Seek + Read {}
+impl<T: Seek + Read> ReadSeek for T {}
+
+/// A trait for all types that can convert themselves into a *parts* string
+pub trait ToParts {
+    fn to_parts(&self) -> String;
+}
+
+/// A utility type which can decode a server response that indicates error
+#[derive(Deserialize)]
+pub struct JsonServerError {
+    pub error: String,
+    pub error_description: Option<String>
+}
+
+/// A utility to represent detailed errors we might see in case there are BadRequests.
+/// The latter happen if the sent parameters or request structures are unsound
+#[derive(Deserialize, Serialize, Debug)]
+pub struct ErrorResponse {
+    error: ServerError,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct ServerError {
+    errors: Vec<ServerMessage>,
+    code: u16,
+    message: String,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct ServerMessage {
+    domain: String,
+    reason: String,
+    message: String,
+    #[serde(rename="locationType")]
+    location_type: Option<String>,
+    location: Option<String>
+}
+
+#[derive(Copy, Clone)]
+pub struct DummyNetworkStream;
+
+impl Read for DummyNetworkStream {
+    fn read(&mut self, _: &mut [u8]) -> io::Result<usize> {
+        Ok(0)
+    }
+}
+
+impl Write for DummyNetworkStream {
+    fn write(&mut self, _: &[u8]) -> io::Result<usize> {
+        Ok(0)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl hyper::net::NetworkStream for DummyNetworkStream {
+    fn peer_addr(&mut self) -> io::Result<std::net::SocketAddr> {
+        Ok("127.0.0.1:1337".parse().unwrap())
+    }
+
+    fn set_read_timeout(&self, _dur: Option<Duration>) -> io::Result<()> {
+        Ok(())
+    }
+
+    fn set_write_timeout(&self, _dur: Option<Duration>) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+
+/// A trait specifying functionality to help controlling any request performed by the API.
+/// The trait has a conservative default implementation.
+///
+/// It contains methods to deal with all common issues, as well with the ones related to
+/// uploading media
+pub trait Delegate {
+
+    /// Called at the beginning of any API request. The delegate should store the method
+    /// information if he is interesting in knowing more context when further calls to it
+    /// are made.
+    /// The matching `finished()` call will always be made, no matter whether or not the API
+    /// request was successful. That way, the delegate may easily maintain a clean state
+    /// between various API calls.
+    fn begin(&mut self, MethodInfo) {}
+
+    /// Called whenever there is an [HttpError](http://hyperium.github.io/hyper/hyper/error/enum.HttpError.html), usually if there are network problems.
+    ///
+    /// If you choose to retry after a duration, the duration should be chosen using the
+    /// [exponential backoff algorithm](http://en.wikipedia.org/wiki/Exponential_backoff).
+    ///
+    /// Return retry information.
+    fn http_error(&mut self, &hyper::Error) -> Retry {
+        Retry::Abort
+    }
+
+    /// Called whenever there is the need for your applications API key after
+    /// the official authenticator implementation didn't provide one, for some reason.
+    /// If this method returns None as well, the underlying operation will fail
+    fn api_key(&mut self) -> Option<String> {
+        None
+    }
+
+    /// Called whenever the Authenticator didn't yield a token. The delegate
+    /// may attempt to provide one, or just take it as a general information about the
+    /// impending failure.
+    /// The given Error provides information about why the token couldn't be acquired in the
+    /// first place
+    fn token(&mut self, err: &error::Error) -> Option<oauth2::Token> {
+        let _ = err;
+        None
+    }
+
+    /// Called during resumable uploads to provide a URL for the impending upload.
+    /// It was saved after a previous call to `store_upload_url(...)`, and if not None,
+    /// will be used instead of asking the server for a new upload URL.
+    /// This is useful in case a previous resumable upload was aborted/canceled, but should now
+    /// be resumed.
+    /// The returned URL will be used exactly once - if it fails again and the delegate allows
+    /// to retry, we will ask the server for a new upload URL.
+    fn upload_url(&mut self) -> Option<String> {
+        None
+    }
+
+    /// Called after we have retrieved a new upload URL for a resumable upload to store it
+    /// in case we fail or cancel. That way, we can attempt to resume the upload later,
+    /// see `upload_url()`.
+    /// It will also be called with None after a successful upload, which allows the delegate
+    /// to forget the URL. That way, we will not attempt to resume an upload that has already
+    /// finished.
+    fn store_upload_url(&mut self, url: Option<&str>) {
+        let _ = url;
+    }
+
+    /// Called whenever a server response could not be decoded from json.
+    /// It's for informational purposes only, the caller will return with an error
+    /// accordingly.
+    ///
+    /// # Arguments
+    ///
+    /// * `json_encoded_value` - The json-encoded value which failed to decode.
+    /// * `json_decode_error`  - The decoder error
+    fn response_json_decode_error(&mut self, json_encoded_value: &str, json_decode_error: &json::Error) {
+        let _ = json_encoded_value;
+        let _ = json_decode_error;
+    }
+
+    /// Called whenever the http request returns with a non-success status code.
+    /// This can involve authentication issues, or anything else that very much
+    /// depends on the used API method.
+    /// The delegate should check the status, header and decoded json error to decide
+    /// whether to retry or not. In the latter case, the underlying call will fail.
+    ///
+    /// If you choose to retry after a duration, the duration should be chosen using the
+    /// [exponential backoff algorithm](http://en.wikipedia.org/wiki/Exponential_backoff).
+    fn http_failure(&mut self, _: &hyper::client::Response, Option<JsonServerError>, _: Option<ServerError>) -> Retry {
+        Retry::Abort
+    }
+
+    /// Called prior to sending the main request of the given method. It can be used to time
+    /// the call or to print progress information.
+    /// It's also useful as you can be sure that a request will definitely be made.
+    fn pre_request(&mut self) { }
+
+    /// Return the size of each chunk of a resumable upload.
+    /// Must be a power of two, with 1<<18 being the smallest allowed chunk size.
+    /// Will be called once before starting any resumable upload.
+    fn chunk_size(&mut self) -> u64 {
+        1 << 23
+    }
+
+    /// Called before the given chunk is uploaded to the server.
+    /// If true is returned, the upload will be interrupted.
+    /// However, it may be resumable if you stored the upload URL in a previous call
+    /// to `store_upload_url()`
+    fn cancel_chunk_upload(&mut self, chunk: &ContentRange) -> bool {
+        let _ = chunk;
+        false
+    }
+
+    /// Called before the API request method returns, in every case. It can be used to clean up
+    /// internal state between calls to the API.
+    /// This call always has a matching call to `begin(...)`.
+    ///
+    /// # Arguments
+    ///
+    /// * `is_success` - a true value indicates the operation was successful. If false, you should
+    ///                  discard all values stored during `store_upload_url`.
+    fn finished(&mut self, is_success: bool) {
+        let _ = is_success;
+    }
+}
+
+/// A delegate with a conservative default implementation, which is used if no other delegate is
+/// set.
+#[derive(Default)]
+pub struct DefaultDelegate;
+
+impl Delegate for DefaultDelegate {}
+
+
+#[derive(Debug)]
+pub enum Error {
+    /// The http connection failed
+    HttpError(hyper::Error),
+
+    /// An attempt was made to upload a resource with size stored in field `.0`
+    /// even though the maximum upload size is what is stored in field `.1`.
+    UploadSizeLimitExceeded(u64, u64),
+
+    /// Represents information about a request that was not understood by the server.
+    /// Details are included.
+    BadRequest(ErrorResponse),
+
+    /// We needed an API key for authentication, but didn't obtain one.
+    /// Neither through the authenticator, nor through the Delegate.
+    MissingAPIKey,
+
+    /// We required a Token, but didn't get one from the Authenticator
+    MissingToken(Box<error::Error>),
+
+    /// The delgate instructed to cancel the operation
+    Cancelled,
+
+    /// An additional, free form field clashed with one of the built-in optional ones
+    FieldClash(&'static str),
+
+    /// Shows that we failed to decode the server response.
+    /// This can happen if the protocol changes in conjunction with strict json decoding.
+    JsonDecodeError(String, json::Error),
+
+    /// Indicates an HTTP repsonse with a non-success status code
+    Failure(hyper::client::Response),
+}
+
+
+impl Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Error::HttpError(ref err) => err.fmt(f),
+            Error::UploadSizeLimitExceeded(ref resource_size, ref max_size) =>
+                writeln!(f, "The media size {} exceeds the maximum allowed upload size of {}"
+                         , resource_size, max_size),
+            Error::MissingAPIKey => {
+                (writeln!(f, "The application's API key was not found in the configuration")).ok();
+                writeln!(f, "It is used as there are no Scopes defined for this method.")
+            },
+            Error::BadRequest(ref err) => {
+                try!(writeln!(f, "Bad Request ({}): {}", err.error.code, err.error.message));
+                for err in err.error.errors.iter() {
+                    try!(writeln!(f, "    {}: {}, {}{}",
+                                            err.domain,
+                                            err.message,
+                                            err.reason,
+                                            match &err.location {
+                                                &Some(ref loc) => format!("@{}", loc),
+                                                &None => String::new(),
+                                            }));
+                }
+                Ok(())
+            },
+            Error::MissingToken(ref err) =>
+                writeln!(f, "Token retrieval failed with error: {}", err),
+            Error::Cancelled =>
+                writeln!(f, "Operation cancelled by delegate"),
+            Error::FieldClash(field) =>
+                writeln!(f, "The custom parameter '{}' is already provided natively by the CallBuilder.", field),
+            Error::JsonDecodeError(ref json_str, ref err)
+                => writeln!(f, "{}: {}", err, json_str),
+            Error::Failure(ref response) =>
+                writeln!(f, "Http status indicates failure: {:?}", response),
+        }
+    }
+}
+
+impl error::Error for Error {
+    fn description(&self) -> &str {
+        match *self {
+            Error::HttpError(ref err) => err.description(),
+            Error::JsonDecodeError(_, ref err) => err.description(),
+            _ => "NO DESCRIPTION POSSIBLE - use `Display.fmt()` instead"
+        }
+    }
+
+    fn cause(&self) -> Option<&error::Error> {
+        match *self {
+            Error::HttpError(ref err) => err.cause(),
+            Error::JsonDecodeError(_, ref err) => err.cause(),
+            _ => None
+        }
+    }
+}
+
+/// A universal result type used as return for all calls.
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Contains information about an API request.
+pub struct MethodInfo {
+    pub id: &'static str,
+    pub http_method: Method,
+}
+
+const BOUNDARY: &'static str = "MDuXWGyeE33QFXGchb2VFWc4Z7945d";
+
+/// Provides a `Read` interface that converts multiple parts into the protocol
+/// identified by [RFC2387](https://tools.ietf.org/html/rfc2387).
+/// **Note**: This implementation is just as rich as it needs to be to perform uploads
+/// to google APIs, and might not be a fully-featured implementation.
+#[derive(Default)]
+pub struct MultiPartReader<'a> {
+    raw_parts: Vec<(Headers, &'a mut Read)>,
+    current_part: Option<(Cursor<Vec<u8>>, &'a mut Read)>,
+    last_part_boundary: Option<Cursor<Vec<u8>>>,
+}
+
+impl<'a> MultiPartReader<'a> {
+
+    /// Reserve memory for exactly the given amount of parts
+    pub fn reserve_exact(&mut self, cap: usize) {
+        self.raw_parts.reserve_exact(cap);
+    }
+
+    /// Add a new part to the queue of parts to be read on the first `read` call.
+    ///
+    /// # Arguments
+    ///
+    /// `headers` - identifying the body of the part. It's similar to the header
+    ///             in an ordinary single-part call, and should thus contain the
+    ///             same information.
+    /// `reader`  - a reader providing the part's body
+    /// `size`    - the amount of bytes provided by the reader. It will be put onto the header as
+    ///             content-size.
+    /// `mime`    - It will be put onto the content type
+    pub fn add_part(&mut self, reader: &'a mut Read, size: u64, mime_type: Mime) -> &mut MultiPartReader<'a> {
+        let mut headers = Headers::new();
+        headers.set(ContentType(mime_type));
+        headers.set(ContentLength(size));
+        self.raw_parts.push((headers, reader));
+        self
+    }
+
+    /// Returns the mime-type representing our multi-part message.
+    /// Use it with the ContentType header.
+    pub fn mime_type(&self) -> Mime {
+        Mime(
+            TopLevel::Multipart,
+            SubLevel::Ext("Related".to_string()),
+            vec![(Attr::Ext("boundary".to_string()), Value::Ext(BOUNDARY.to_string()))],
+        )
+    }
+
+    /// Returns true if we are totally used
+    fn is_depleted(&self) -> bool {
+        self.raw_parts.len() == 0 && self.current_part.is_none() && self.last_part_boundary.is_none()
+    }
+
+    /// Returns true if we are handling our last part
+    fn is_last_part(&self) -> bool {
+        self.raw_parts.len() == 0 && self.current_part.is_some()
+    }
+}
+
+impl<'a> Read for MultiPartReader<'a> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        match (self.raw_parts.len(),
+               self.current_part.is_none(),
+               self.last_part_boundary.is_none()) {
+            (_, _, false) => {
+                let br = self.last_part_boundary.as_mut().unwrap().read(buf).unwrap_or(0);
+                if br < buf.len() {
+                    self.last_part_boundary = None;
+                }
+                return Ok(br)
+            },
+            (0, true, true) => return Ok(0),
+            (n, true, _) if n > 0 => {
+                let (headers, reader) = self.raw_parts.remove(0);
+                let mut c = Cursor::new(Vec::<u8>::new());
+                (write!(&mut c, "{}--{}{}{}{}", LINE_ENDING, BOUNDARY, LINE_ENDING,
+                                                headers, LINE_ENDING)).unwrap();
+                c.seek(SeekFrom::Start(0)).unwrap();
+                self.current_part = Some((c, reader));
+            }
+            _ => {},
+        }
+
+        // read headers as long as possible
+        let (hb, rr) = {
+            let &mut (ref mut c, ref mut reader) = self.current_part.as_mut().unwrap();
+            let b = c.read(buf).unwrap_or(0);
+            (b, reader.read(&mut buf[b..]))
+        };
+
+        match rr {
+            Ok(bytes_read) => {
+                if hb < buf.len() && bytes_read == 0 {
+                    if self.is_last_part() {
+                        // before clearing the last part, we will add the boundary that
+                        // will be written last
+                        self.last_part_boundary = Some(Cursor::new(
+                                                        format!("{}--{}--", LINE_ENDING, BOUNDARY).into_bytes()))
+                    }
+                    // We are depleted - this can trigger the next part to come in
+                    self.current_part = None;
+                }
+                let mut total_bytes_read = hb + bytes_read;
+                while total_bytes_read < buf.len() && !self.is_depleted() {
+                    match self.read(&mut buf[total_bytes_read ..]) {
+                        Ok(br) => total_bytes_read += br,
+                        Err(err) => return Err(err),
+                    }
+                }
+                Ok(total_bytes_read)
+            }
+            Err(err) => {
+                // fail permanently
+                self.current_part = None;
+                self.last_part_boundary = None;
+                self.raw_parts.clear();
+                Err(err)
+            }
+        }
+    }
+}
+
+/// The `X-Upload-Content-Type` header.
+///
+/// Generated via rustc --pretty expanded -Z unstable-options, and manually
+/// processed to be more readable.
+#[derive(PartialEq, Debug, Clone)]
+pub struct XUploadContentType(pub Mime);
+
+impl ::std::ops::Deref for XUploadContentType {
+    type Target = Mime;
+    fn deref<'a>(&'a self) -> &'a Mime { &self.0 }
+}
+impl ::std::ops::DerefMut for XUploadContentType {
+    fn deref_mut<'a>(&'a mut self) -> &'a mut Mime { &mut self.0 }
+}
+impl Header for XUploadContentType {
+    fn header_name() -> &'static str { "X-Upload-Content-Type" }
+    fn parse_header(raw: &[Vec<u8>]) -> hyper::error::Result<Self> {
+        hyper::header::parsing::from_one_raw_str(raw).map(XUploadContentType)
+    }
+}
+impl HeaderFormat for XUploadContentType {
+    fn fmt_header(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        Display::fmt(&**self, f)
+    }
+}
+impl Display for XUploadContentType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(&**self, f)
+    }
+}
+
+#[derive(Clone, PartialEq, Debug)]
+pub struct Chunk {
+    pub first: u64,
+    pub last: u64
+}
+
+impl fmt::Display for Chunk {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        (write!(fmt, "{}-{}", self.first, self.last)).ok();
+        Ok(())
+    }
+}
+
+impl FromStr for Chunk {
+    type Err = &'static str;
+
+    /// NOTE: only implements `%i-%i`, not `*`
+    fn from_str(s: &str) -> std::result::Result<Chunk, &'static str> {
+        let parts: Vec<&str> = s.split('-').collect();
+        if parts.len() != 2 {
+            return Err("Expected two parts: %i-%i")
+        }
+        Ok(
+            Chunk {
+                first: match FromStr::from_str(parts[0]) {
+                    Ok(d) => d,
+                    _ => return Err("Couldn't parse 'first' as digit")
+                },
+                last: match FromStr::from_str(parts[1]) {
+                    Ok(d) => d,
+                    _ => return Err("Couldn't parse 'last' as digit")
+                }
+            }
+        )
+    }
+}
+
+/// Implements the Content-Range header, for serialization only
+#[derive(Clone, PartialEq, Debug)]
+pub struct ContentRange {
+    pub range: Option<Chunk>,
+    pub total_length: u64,
+}
+
+impl Header for ContentRange {
+    fn header_name() -> &'static str {
+        "Content-Range"
+    }
+
+    /// We are not parsable, as parsing is done by the `Range` header
+    fn parse_header(_: &[Vec<u8>]) -> hyper::error::Result<Self> {
+        Err(hyper::error::Error::Method)
+    }
+}
+
+
+impl HeaderFormat for ContentRange {
+    fn fmt_header(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        try!(fmt.write_str("bytes "));
+        match self.range {
+            Some(ref c) => try!(c.fmt(fmt)),
+            None => try!(fmt.write_str("*"))
+        }
+        (write!(fmt, "/{}", self.total_length)).ok();
+        Ok(())
+    }
+}
+
+#[derive(Clone, PartialEq, Debug)]
+pub struct RangeResponseHeader(pub Chunk);
+
+impl Header for RangeResponseHeader {
+    fn header_name() -> &'static str {
+        "Range"
+    }
+
+    fn parse_header(raw: &[Vec<u8>]) -> hyper::error::Result<Self> {
+        if raw.len() > 0 {
+            let v = &raw[0];
+            if let Ok(s) = std::str::from_utf8(v) {
+                const PREFIX: &'static str = "bytes ";
+                if s.starts_with(PREFIX) {
+                    if let Ok(c) = <Chunk as FromStr>::from_str(&s[PREFIX.len()..]) {
+                        return  Ok(RangeResponseHeader(c))
+                    }
+                }
+            }
+        }
+        Err(hyper::error::Error::Method)
+    }
+}
+
+impl HeaderFormat for RangeResponseHeader {
+    /// No implmentation necessary, we just need to parse
+    fn fmt_header(&self, _: &mut fmt::Formatter) -> fmt::Result {
+        Err(fmt::Error)
+    }
+}
+
+/// A utility type to perform a resumable upload from start to end.
+pub struct ResumableUploadHelper<'a, A: 'a> {
+    pub client: &'a mut hyper::client::Client,
+    pub delegate: &'a mut Delegate,
+    pub start_at: Option<u64>,
+    pub auth: &'a mut A,
+    pub user_agent: &'a str,
+    pub auth_header: Authorization<Bearer>,
+    pub url: &'a str,
+    pub reader: &'a mut ReadSeek,
+    pub media_type: Mime,
+    pub content_length: u64
+}
+
+impl<'a, A> ResumableUploadHelper<'a, A>
+    where A: oauth2::GetToken {
+
+    fn query_transfer_status(&mut self) -> std::result::Result<u64, hyper::Result<hyper::client::Response>> {
+        loop {
+            match self.client.post(self.url)
+                .header(UserAgent(self.user_agent.to_string()))
+                .header(ContentRange { range: None, total_length: self.content_length })
+                .header(self.auth_header.clone())
+                .send() {
+                Ok(r) => {
+                    // 308 = resume-incomplete == PermanentRedirect
+                    let headers = r.headers.clone();
+                    let h: &RangeResponseHeader = match headers.get() {
+                        Some(hh) if r.status == StatusCode::PermanentRedirect => hh,
+                        None|Some(_) => {
+                            if let Retry::After(d) = self.delegate.http_failure(&r, None, None) {
+                                sleep(d);
+                                continue;
+                            }
+                            return Err(Ok(r))
+                        }
+                    };
+                    return Ok(h.0.last)
+                }
+                Err(err) => {
+                    if let Retry::After(d) = self.delegate.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    return Err(Err(err))
+                }
+            }
+        }
+    }
+
+    /// returns None if operation was cancelled by delegate, or the HttpResult.
+    /// It can be that we return the result just because we didn't understand the status code -
+    /// caller should check for status himself before assuming it's OK to use
+    pub fn upload(&mut self) -> Option<hyper::Result<hyper::client::Response>> {
+        let mut start = match self.start_at {
+            Some(s) => s,
+            None => match self.query_transfer_status() {
+                Ok(s) => s,
+                Err(result) => return Some(result)
+            }
+        };
+
+        const MIN_CHUNK_SIZE: u64 = 1 << 18;
+        let chunk_size = match self.delegate.chunk_size() {
+            cs if cs > MIN_CHUNK_SIZE => cs,
+            _ => MIN_CHUNK_SIZE
+        };
+
+        self.reader.seek(SeekFrom::Start(start)).unwrap();
+        loop {
+            let request_size = match self.content_length - start {
+                rs if rs > chunk_size => chunk_size,
+                rs => rs
+            };
+
+            let mut section_reader = self.reader.take(request_size);
+            let range_header = ContentRange {
+                range: Some(Chunk {first: start, last: start + request_size - 1}),
+                total_length: self.content_length
+            };
+            start += request_size;
+            if self.delegate.cancel_chunk_upload(&range_header) {
+                return None
+            }
+            let res = self.client.post(self.url)
+                                 .header(range_header)
+                                 .header(ContentType(self.media_type.clone()))
+                                 .header(UserAgent(self.user_agent.to_string()))
+                                 .body(&mut section_reader)
+                                 .send();
+            match res {
+                Ok(mut res) => {
+                    if res.status == StatusCode::PermanentRedirect  {
+                        continue
+                    }
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let Retry::After(d) = self.delegate.http_failure(&res,
+                                                        json::from_str(&json_err).ok(),
+                                                        json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                    }
+                    return Some(Ok(res))
+                },
+                Err(err) => {
+                    if let Retry::After(d) = self.delegate.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    return Some(Err(err))
+                }
+            }
+        }
+    }
+}
+
+// Copy of src/rust/cli/cmn.rs
+// TODO(ST): Allow sharing common code between program types
+pub fn remove_json_null_values(value: &mut json::value::Value) {
+    match *value {
+        json::value::Value::Object(ref mut map) => {
+            let mut for_removal = Vec::new();
+
+            for (key, mut value) in map.iter_mut() {
+                if value.is_null() {
+                    for_removal.push(key.clone());
+                } else {
+                    remove_json_null_values(&mut value);
+                }
+            }
+
+            for key in &for_removal {
+                map.remove(key);
+            }
+        }
+        _ => {}
+    }
+}

--- a/gen/cloudbuild1/src/lib.rs
+++ b/gen/cloudbuild1/src/lib.rs
@@ -1,0 +1,5467 @@
+// DO NOT EDIT !
+// This file was generated automatically from 'src/mako/api/lib.rs.mako'
+// DO NOT EDIT !
+
+//! This documentation was generated from *Cloud Build* crate version *1.0.7+20171205*, where *20171205* is the exact revision of the *cloudbuild:v1* schema built by the [mako](http://www.makotemplates.org/) code generator *v1.0.7*.
+//! 
+//! Everything else about the *Cloud Build* *v1* API can be found at the
+//! [official documentation site](https://cloud.google.com/container-builder/docs/).
+//! The original source code is [on github](https://github.com/Byron/google-apis-rs/tree/master/gen/cloudbuild1).
+//! # Features
+//! 
+//! Handle the following *Resources* with ease from the central [hub](struct.CloudBuild.html) ... 
+//! 
+//! * [operations](struct.Operation.html)
+//!  * [*cancel*](struct.OperationCancelCall.html), [*get*](struct.OperationGetCall.html) and [*list*](struct.OperationListCall.html)
+//! * projects
+//!  * [*builds cancel*](struct.ProjectBuildCancelCall.html), [*builds create*](struct.ProjectBuildCreateCall.html), [*builds get*](struct.ProjectBuildGetCall.html), [*builds list*](struct.ProjectBuildListCall.html), [*builds retry*](struct.ProjectBuildRetryCall.html), [*triggers create*](struct.ProjectTriggerCreateCall.html), [*triggers delete*](struct.ProjectTriggerDeleteCall.html), [*triggers get*](struct.ProjectTriggerGetCall.html), [*triggers list*](struct.ProjectTriggerListCall.html), [*triggers patch*](struct.ProjectTriggerPatchCall.html) and [*triggers run*](struct.ProjectTriggerRunCall.html)
+//! 
+//! 
+//! 
+//! 
+//! Not what you are looking for ? Find all other Google APIs in their Rust [documentation index](http://byron.github.io/google-apis-rs).
+//! 
+//! # Structure of this Library
+//! 
+//! The API is structured into the following primary items:
+//! 
+//! * **[Hub](struct.CloudBuild.html)**
+//!     * a central object to maintain state and allow accessing all *Activities*
+//!     * creates [*Method Builders*](trait.MethodsBuilder.html) which in turn
+//!       allow access to individual [*Call Builders*](trait.CallBuilder.html)
+//! * **[Resources](trait.Resource.html)**
+//!     * primary types that you can apply *Activities* to
+//!     * a collection of properties and *Parts*
+//!     * **[Parts](trait.Part.html)**
+//!         * a collection of properties
+//!         * never directly used in *Activities*
+//! * **[Activities](trait.CallBuilder.html)**
+//!     * operations to apply to *Resources*
+//! 
+//! All *structures* are marked with applicable traits to further categorize them and ease browsing.
+//! 
+//! Generally speaking, you can invoke *Activities* like this:
+//! 
+//! ```Rust,ignore
+//! let r = hub.resource().activity(...).doit()
+//! ```
+//! 
+//! Or specifically ...
+//! 
+//! ```ignore
+//! let r = hub.operations().cancel(...).doit()
+//! let r = hub.projects().triggers_run(...).doit()
+//! let r = hub.projects().builds_create(...).doit()
+//! let r = hub.operations().list(...).doit()
+//! let r = hub.operations().get(...).doit()
+//! let r = hub.projects().builds_retry(...).doit()
+//! ```
+//! 
+//! The `resource()` and `activity(...)` calls create [builders][builder-pattern]. The second one dealing with `Activities` 
+//! supports various methods to configure the impending operation (not shown here). It is made such that all required arguments have to be 
+//! specified right away (i.e. `(...)`), whereas all optional ones can be [build up][builder-pattern] as desired.
+//! The `doit()` method performs the actual communication with the server and returns the respective result.
+//! 
+//! # Usage
+//! 
+//! ## Setting up your Project
+//! 
+//! To use this library, you would put the following lines into your `Cargo.toml` file:
+//! 
+//! ```toml
+//! [dependencies]
+//! google-cloudbuild1 = "*"
+//! ```
+//! 
+//! ## A complete example
+//! 
+//! ```test_harness,no_run
+//! extern crate hyper;
+//! extern crate hyper_rustls;
+//! extern crate yup_oauth2 as oauth2;
+//! extern crate google_cloudbuild1 as cloudbuild1;
+//! use cloudbuild1::{Result, Error};
+//! # #[test] fn egal() {
+//! use std::default::Default;
+//! use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+//! use cloudbuild1::CloudBuild;
+//! 
+//! // Get an ApplicationSecret instance by some means. It contains the `client_id` and 
+//! // `client_secret`, among other things.
+//! let secret: ApplicationSecret = Default::default();
+//! // Instantiate the authenticator. It will choose a suitable authentication flow for you, 
+//! // unless you replace  `None` with the desired Flow.
+//! // Provide your own `AuthenticatorDelegate` to adjust the way it operates and get feedback about 
+//! // what's going on. You probably want to bring in your own `TokenStorage` to persist tokens and
+//! // retrieve them from storage.
+//! let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+//!                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+//!                               <MemoryStorage as Default>::default(), None);
+//! let mut hub = CloudBuild::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+//! // You can configure optional parameters by calling the respective setters at will, and
+//! // execute the final call using `doit()`.
+//! // Values shown here are possibly random and not representative !
+//! let result = hub.operations().list("name")
+//!              .page_token("dolores")
+//!              .page_size(-63)
+//!              .filter("accusam")
+//!              .doit();
+//! 
+//! match result {
+//!     Err(e) => match e {
+//!         // The Error enum provides details about what exactly happened.
+//!         // You can also just use its `Debug`, `Display` or `Error` traits
+//!          Error::HttpError(_)
+//!         |Error::MissingAPIKey
+//!         |Error::MissingToken(_)
+//!         |Error::Cancelled
+//!         |Error::UploadSizeLimitExceeded(_, _)
+//!         |Error::Failure(_)
+//!         |Error::BadRequest(_)
+//!         |Error::FieldClash(_)
+//!         |Error::JsonDecodeError(_, _) => println!("{}", e),
+//!     },
+//!     Ok(res) => println!("Success: {:?}", res),
+//! }
+//! # }
+//! ```
+//! ## Handling Errors
+//! 
+//! All errors produced by the system are provided either as [Result](enum.Result.html) enumeration as return value of 
+//! the doit() methods, or handed as possibly intermediate results to either the 
+//! [Hub Delegate](trait.Delegate.html), or the [Authenticator Delegate](https://docs.rs/yup-oauth2/*/yup_oauth2/trait.AuthenticatorDelegate.html).
+//! 
+//! When delegates handle errors or intermediate values, they may have a chance to instruct the system to retry. This 
+//! makes the system potentially resilient to all kinds of errors.
+//! 
+//! ## Uploads and Downloads
+//! If a method supports downloads, the response body, which is part of the [Result](enum.Result.html), should be
+//! read by you to obtain the media.
+//! If such a method also supports a [Response Result](trait.ResponseResult.html), it will return that by default.
+//! You can see it as meta-data for the actual media. To trigger a media download, you will have to set up the builder by making
+//! this call: `.param("alt", "media")`.
+//! 
+//! Methods supporting uploads can do so using up to 2 different protocols: 
+//! *simple* and *resumable*. The distinctiveness of each is represented by customized 
+//! `doit(...)` methods, which are then named `upload(...)` and `upload_resumable(...)` respectively.
+//! 
+//! ## Customization and Callbacks
+//! 
+//! You may alter the way an `doit()` method is called by providing a [delegate](trait.Delegate.html) to the 
+//! [Method Builder](trait.CallBuilder.html) before making the final `doit()` call. 
+//! Respective methods will be called to provide progress information, as well as determine whether the system should 
+//! retry on failure.
+//! 
+//! The [delegate trait](trait.Delegate.html) is default-implemented, allowing you to customize it with minimal effort.
+//! 
+//! ## Optional Parts in Server-Requests
+//! 
+//! All structures provided by this library are made to be [enocodable](trait.RequestValue.html) and 
+//! [decodable](trait.ResponseResult.html) via *json*. Optionals are used to indicate that partial requests are responses 
+//! are valid.
+//! Most optionals are are considered [Parts](trait.Part.html) which are identifiable by name, which will be sent to 
+//! the server to indicate either the set parts of the request or the desired parts in the response.
+//! 
+//! ## Builder Arguments
+//! 
+//! Using [method builders](trait.CallBuilder.html), you are able to prepare an action call by repeatedly calling it's methods.
+//! These will always take a single argument, for which the following statements are true.
+//! 
+//! * [PODs][wiki-pod] are handed by copy
+//! * strings are passed as `&str`
+//! * [request values](trait.RequestValue.html) are moved
+//! 
+//! Arguments will always be copied or cloned into the builder, to make them independent of their original life times.
+//! 
+//! [wiki-pod]: http://en.wikipedia.org/wiki/Plain_old_data_structure
+//! [builder-pattern]: http://en.wikipedia.org/wiki/Builder_pattern
+//! [google-go-api]: https://github.com/google/google-api-go-client
+//! 
+//! 
+
+// Unused attributes happen thanks to defined, but unused structures
+// We don't warn about this, as depending on the API, some data structures or facilities are never used.
+// Instead of pre-determining this, we just disable the lint. It's manually tuned to not have any
+// unused imports in fully featured APIs. Same with unused_mut ... .
+#![allow(unused_imports, unused_mut, dead_code)]
+
+// DO NOT EDIT !
+// This file was generated automatically from 'src/mako/api/lib.rs.mako'
+// DO NOT EDIT !
+
+#[macro_use]
+extern crate serde_derive;
+
+extern crate hyper;
+extern crate serde;
+extern crate serde_json;
+extern crate yup_oauth2 as oauth2;
+extern crate mime;
+extern crate url;
+
+mod cmn;
+
+use std::collections::HashMap;
+use std::cell::RefCell;
+use std::borrow::BorrowMut;
+use std::default::Default;
+use std::collections::BTreeMap;
+use serde_json as json;
+use std::io;
+use std::fs;
+use std::mem;
+use std::thread::sleep;
+use std::time::Duration;
+
+pub use cmn::{MultiPartReader, ToParts, MethodInfo, Result, Error, CallBuilder, Hub, ReadSeek, Part,
+              ResponseResult, RequestValue, NestedType, Delegate, DefaultDelegate, MethodsBuilder,
+              Resource, ErrorResponse, remove_json_null_values};
+
+
+// ##############
+// UTILITIES ###
+// ############
+
+/// Identifies the an OAuth2 authorization scope.
+/// A scope is needed when requesting an
+/// [authorization token](https://developers.google.com/youtube/v3/guides/authentication).
+#[derive(PartialEq, Eq, Hash)]
+pub enum Scope {
+    /// View and manage your data across Google Cloud Platform services
+    CloudPlatform,
+}
+
+impl AsRef<str> for Scope {
+    fn as_ref(&self) -> &str {
+        match *self {
+            Scope::CloudPlatform => "https://www.googleapis.com/auth/cloud-platform",
+        }
+    }
+}
+
+impl Default for Scope {
+    fn default() -> Scope {
+        Scope::CloudPlatform
+    }
+}
+
+
+
+// ########
+// HUB ###
+// ######
+
+/// Central instance to access all CloudBuild related resource activities
+///
+/// # Examples
+///
+/// Instantiate a new hub
+///
+/// ```test_harness,no_run
+/// extern crate hyper;
+/// extern crate hyper_rustls;
+/// extern crate yup_oauth2 as oauth2;
+/// extern crate google_cloudbuild1 as cloudbuild1;
+/// use cloudbuild1::{Result, Error};
+/// # #[test] fn egal() {
+/// use std::default::Default;
+/// use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// use cloudbuild1::CloudBuild;
+/// 
+/// // Get an ApplicationSecret instance by some means. It contains the `client_id` and 
+/// // `client_secret`, among other things.
+/// let secret: ApplicationSecret = Default::default();
+/// // Instantiate the authenticator. It will choose a suitable authentication flow for you, 
+/// // unless you replace  `None` with the desired Flow.
+/// // Provide your own `AuthenticatorDelegate` to adjust the way it operates and get feedback about 
+/// // what's going on. You probably want to bring in your own `TokenStorage` to persist tokens and
+/// // retrieve them from storage.
+/// let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+///                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+///                               <MemoryStorage as Default>::default(), None);
+/// let mut hub = CloudBuild::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.operations().list("name")
+///              .page_token("justo")
+///              .page_size(-1)
+///              .filter("erat")
+///              .doit();
+/// 
+/// match result {
+///     Err(e) => match e {
+///         // The Error enum provides details about what exactly happened.
+///         // You can also just use its `Debug`, `Display` or `Error` traits
+///          Error::HttpError(_)
+///         |Error::MissingAPIKey
+///         |Error::MissingToken(_)
+///         |Error::Cancelled
+///         |Error::UploadSizeLimitExceeded(_, _)
+///         |Error::Failure(_)
+///         |Error::BadRequest(_)
+///         |Error::FieldClash(_)
+///         |Error::JsonDecodeError(_, _) => println!("{}", e),
+///     },
+///     Ok(res) => println!("Success: {:?}", res),
+/// }
+/// # }
+/// ```
+pub struct CloudBuild<C, A> {
+    client: RefCell<C>,
+    auth: RefCell<A>,
+    _user_agent: String,
+    _base_url: String,
+    _root_url: String,
+}
+
+impl<'a, C, A> Hub for CloudBuild<C, A> {}
+
+impl<'a, C, A> CloudBuild<C, A>
+    where  C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+    pub fn new(client: C, authenticator: A) -> CloudBuild<C, A> {
+        CloudBuild {
+            client: RefCell::new(client),
+            auth: RefCell::new(authenticator),
+            _user_agent: "google-api-rust-client/1.0.7".to_string(),
+            _base_url: "https://cloudbuild.googleapis.com/".to_string(),
+            _root_url: "https://cloudbuild.googleapis.com/".to_string(),
+        }
+    }
+
+    pub fn operations(&'a self) -> OperationMethods<'a, C, A> {
+        OperationMethods { hub: &self }
+    }
+    pub fn projects(&'a self) -> ProjectMethods<'a, C, A> {
+        ProjectMethods { hub: &self }
+    }
+
+    /// Set the user-agent header field to use in all requests to the server.
+    /// It defaults to `google-api-rust-client/1.0.7`.
+    ///
+    /// Returns the previously set user-agent.
+    pub fn user_agent(&mut self, agent_name: String) -> String {
+        mem::replace(&mut self._user_agent, agent_name)
+    }
+
+    /// Set the base url to use in all requests to the server.
+    /// It defaults to `https://cloudbuild.googleapis.com/`.
+    ///
+    /// Returns the previously set base url.
+    pub fn base_url(&mut self, new_base_url: String) -> String {
+        mem::replace(&mut self._base_url, new_base_url)
+    }
+
+    /// Set the root url to use in all requests to the server.
+    /// It defaults to `https://cloudbuild.googleapis.com/`.
+    ///
+    /// Returns the previously set root url.
+    pub fn root_url(&mut self, new_root_url: String) -> String {
+        mem::replace(&mut self._root_url, new_root_url)
+    }
+}
+
+
+// ############
+// SCHEMAS ###
+// ##########
+/// The request message for Operations.CancelOperation.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [cancel operations](struct.OperationCancelCall.html) (request)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct CancelOperationRequest { _never_set: Option<bool> }
+
+impl RequestValue for CancelOperationRequest {}
+
+
+/// RepoSource describes the location of the source in a Google Cloud Source
+/// Repository.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [triggers run projects](struct.ProjectTriggerRunCall.html) (request)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct RepoSource {
+    /// Name of the repo. If omitted, the name "default" is assumed.
+    #[serde(rename="repoName")]
+    pub repo_name: Option<String>,
+    /// Name of the tag to build.
+    #[serde(rename="tagName")]
+    pub tag_name: Option<String>,
+    /// ID of the project that owns the repo. If omitted, the project ID requesting
+    /// the build is assumed.
+    #[serde(rename="projectId")]
+    pub project_id: Option<String>,
+    /// Name of the branch to build.
+    #[serde(rename="branchName")]
+    pub branch_name: Option<String>,
+    /// Directory, relative to the source root, in which to run the build.
+    pub dir: Option<String>,
+    /// Explicit commit SHA to build.
+    #[serde(rename="commitSha")]
+    pub commit_sha: Option<String>,
+}
+
+impl RequestValue for RepoSource {}
+
+
+/// RetryBuildRequest specifies a build to retry.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [builds retry projects](struct.ProjectBuildRetryCall.html) (request)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct RetryBuildRequest { _never_set: Option<bool> }
+
+impl RequestValue for RetryBuildRequest {}
+
+
+/// Source describes the location of the source in a supported storage
+/// service.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Source {
+    /// If provided, get the source from this location in Google Cloud Storage.
+    #[serde(rename="storageSource")]
+    pub storage_source: Option<StorageSource>,
+    /// If provided, get source from this location in a Cloud Repo.
+    #[serde(rename="repoSource")]
+    pub repo_source: Option<RepoSource>,
+}
+
+impl Part for Source {}
+
+
+/// Secret pairs a set of secret environment variables containing encrypted
+/// values with the Cloud KMS key to use to decrypt the value.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Secret {
+    /// Map of environment variable name to its encrypted value.
+    /// 
+    /// Secret environment variables must be unique across all of a build's
+    /// secrets, and must be used by at least one build step. Values can be at most
+    /// 1 KB in size. There can be at most ten secret values across all of a
+    /// build's secrets.
+    #[serde(rename="secretEnv")]
+    pub secret_env: Option<HashMap<String, String>>,
+    /// Cloud KMS key name to use to decrypt these envs.
+    #[serde(rename="kmsKeyName")]
+    pub kms_key_name: Option<String>,
+}
+
+impl Part for Secret {}
+
+
+/// A build resource in the Container Builder API.
+/// 
+/// At a high level, a Build describes where to find source code, how to build
+/// it (for example, the builder image to run on the source), and what tag to
+/// apply to the built image when it is pushed to Google Container Registry.
+/// 
+/// Fields can include the following variables which will be expanded when the
+/// build is created:
+/// 
+/// - $PROJECT_ID: the project ID of the build.
+/// - $BUILD_ID: the autogenerated ID of the build.
+/// - $REPO_NAME: the source repository name specified by RepoSource.
+/// - $BRANCH_NAME: the branch name specified by RepoSource.
+/// - $TAG_NAME: the tag name specified by RepoSource.
+/// - $REVISION_ID or $COMMIT_SHA: the commit SHA specified by RepoSource or
+///   resolved from the specified branch or tag.
+/// - $SHORT_SHA: first 7 characters of $REVISION_ID or $COMMIT_SHA.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [builds cancel projects](struct.ProjectBuildCancelCall.html) (response)
+/// * [builds create projects](struct.ProjectBuildCreateCall.html) (request)
+/// * [builds get projects](struct.ProjectBuildGetCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Build {
+    /// Status of the build.
+    /// @OutputOnly
+    pub status: Option<String>,
+    /// A permanent fixed identifier for source.
+    /// @OutputOnly
+    #[serde(rename="sourceProvenance")]
+    pub source_provenance: Option<SourceProvenance>,
+    /// Tags for annotation of a Build. These are not docker tags.
+    pub tags: Option<Vec<String>>,
+    /// Customer-readable message about the current status.
+    /// @OutputOnly
+    #[serde(rename="statusDetail")]
+    pub status_detail: Option<String>,
+    /// Time at which the request to create the build was received.
+    /// @OutputOnly
+    #[serde(rename="createTime")]
+    pub create_time: Option<String>,
+    /// Results of the build.
+    /// @OutputOnly
+    pub results: Option<Results>,
+    /// Time at which execution of the build was started.
+    /// @OutputOnly
+    #[serde(rename="startTime")]
+    pub start_time: Option<String>,
+    /// A list of images to be pushed upon the successful completion of all build
+    /// steps.
+    /// 
+    /// The images will be pushed using the builder service account's credentials.
+    /// 
+    /// The digests of the pushed images will be stored in the Build resource's
+    /// results field.
+    /// 
+    /// If any of the images fail to be pushed, the build is marked FAILURE.
+    pub images: Option<Vec<String>>,
+    /// Unique identifier of the build.
+    /// @OutputOnly
+    pub id: Option<String>,
+    /// Time at which execution of the build was finished.
+    /// 
+    /// The difference between finish_time and start_time is the duration of the
+    /// build's execution.
+    /// @OutputOnly
+    #[serde(rename="finishTime")]
+    pub finish_time: Option<String>,
+    /// The ID of the BuildTrigger that triggered this build, if it was
+    /// triggered automatically.
+    /// @OutputOnly
+    #[serde(rename="buildTriggerId")]
+    pub build_trigger_id: Option<String>,
+    /// Secrets to decrypt using Cloud KMS.
+    pub secrets: Option<Vec<Secret>>,
+    /// Google Cloud Storage bucket where logs should be written (see
+    /// [Bucket Name
+    /// Requirements](https://cloud.google.com/storage/docs/bucket-naming#requirements)).
+    /// Logs file names will be of the format `${logs_bucket}/log-${build_id}.txt`.
+    #[serde(rename="logsBucket")]
+    pub logs_bucket: Option<String>,
+    /// Substitutions data for Build resource.
+    pub substitutions: Option<HashMap<String, String>>,
+    /// Describes where to find the source files to build.
+    pub source: Option<Source>,
+    /// Describes the operations to be performed on the workspace.
+    pub steps: Option<Vec<BuildStep>>,
+    /// Amount of time that this build should be allowed to run, to second
+    /// granularity. If this amount of time elapses, work on the build will cease
+    /// and the build status will be TIMEOUT.
+    /// 
+    /// Default time is ten minutes.
+    pub timeout: Option<String>,
+    /// ID of the project.
+    /// @OutputOnly.
+    #[serde(rename="projectId")]
+    pub project_id: Option<String>,
+    /// Special options for this build.
+    pub options: Option<BuildOptions>,
+    /// URL to logs for this build in Google Cloud Logging.
+    /// @OutputOnly
+    #[serde(rename="logUrl")]
+    pub log_url: Option<String>,
+}
+
+impl RequestValue for Build {}
+impl ResponseResult for Build {}
+
+
+/// A generic empty message that you can re-use to avoid defining duplicated
+/// empty messages in your APIs. A typical example is to use it as the request
+/// or the response type of an API method. For instance:
+/// 
+///     service Foo {
+///       rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
+///     }
+/// 
+/// The JSON representation for `Empty` is empty JSON object `{}`.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [triggers delete projects](struct.ProjectTriggerDeleteCall.html) (response)
+/// * [cancel operations](struct.OperationCancelCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Empty { _never_set: Option<bool> }
+
+impl ResponseResult for Empty {}
+
+
+/// BuiltImage describes an image built by the pipeline.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct BuiltImage {
+    /// Name used to push the container image to Google Container Registry, as
+    /// presented to `docker push`.
+    pub name: Option<String>,
+    /// Docker Registry 2.0 digest.
+    pub digest: Option<String>,
+}
+
+impl Part for BuiltImage {}
+
+
+/// The `Status` type defines a logical error model that is suitable for different
+/// programming environments, including REST APIs and RPC APIs. It is used by
+/// [gRPC](https://github.com/grpc). The error model is designed to be:
+/// 
+/// - Simple to use and understand for most users
+/// - Flexible enough to meet unexpected needs
+/// 
+/// # Overview
+/// 
+/// The `Status` message contains three pieces of data: error code, error message,
+/// and error details. The error code should be an enum value of
+/// google.rpc.Code, but it may accept additional error codes if needed.  The
+/// error message should be a developer-facing English message that helps
+/// developers *understand* and *resolve* the error. If a localized user-facing
+/// error message is needed, put the localized message in the error details or
+/// localize it in the client. The optional error details may contain arbitrary
+/// information about the error. There is a predefined set of error detail types
+/// in the package `google.rpc` that can be used for common error conditions.
+/// 
+/// # Language mapping
+/// 
+/// The `Status` message is the logical representation of the error model, but it
+/// is not necessarily the actual wire format. When the `Status` message is
+/// exposed in different client libraries and different wire protocols, it can be
+/// mapped differently. For example, it will likely be mapped to some exceptions
+/// in Java, but more likely mapped to some error codes in C.
+/// 
+/// # Other uses
+/// 
+/// The error model and the `Status` message can be used in a variety of
+/// environments, either with or without APIs, to provide a
+/// consistent developer experience across different environments.
+/// 
+/// Example uses of this error model include:
+/// 
+/// - Partial errors. If a service needs to return partial errors to the client,
+///     it may embed the `Status` in the normal response to indicate the partial
+///     errors.
+/// 
+/// - Workflow errors. A typical workflow has multiple steps. Each step may
+///     have a `Status` message for error reporting.
+/// 
+/// - Batch operations. If a client uses batch request and batch response, the
+///     `Status` message should be used directly inside batch response, one for
+///     each error sub-response.
+/// 
+/// - Asynchronous operations. If an API call embeds asynchronous operation
+///     results in its response, the status of those operations should be
+///     represented directly using the `Status` message.
+/// 
+/// - Logging. If some API errors are stored in logs, the message `Status` could
+///     be used directly after any stripping needed for security/privacy reasons.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Status {
+    /// A developer-facing error message, which should be in English. Any
+    /// user-facing error message should be localized and sent in the
+    /// google.rpc.Status.details field, or localized by the client.
+    pub message: Option<String>,
+    /// The status code, which should be an enum value of google.rpc.Code.
+    pub code: Option<i32>,
+    /// A list of messages that carry the error details.  There is a common set of
+    /// message types for APIs to use.
+    pub details: Option<Vec<HashMap<String, String>>>,
+}
+
+impl Part for Status {}
+
+
+/// Response containing existing BuildTriggers.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [triggers list projects](struct.ProjectTriggerListCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct ListBuildTriggersResponse {
+    /// BuildTriggers for the project, sorted by create_time descending.
+    pub triggers: Option<Vec<BuildTrigger>>,
+}
+
+impl ResponseResult for ListBuildTriggersResponse {}
+
+
+/// Container message for hash values.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Hash {
+    /// The type of hash that was performed.
+    #[serde(rename="type")]
+    pub type_: Option<String>,
+    /// The hash value.
+    pub value: Option<String>,
+}
+
+impl Part for Hash {}
+
+
+/// The response message for Operations.ListOperations.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [list operations](struct.OperationListCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct ListOperationsResponse {
+    /// The standard List next-page token.
+    #[serde(rename="nextPageToken")]
+    pub next_page_token: Option<String>,
+    /// A list of operations that matches the specified filter in the request.
+    pub operations: Option<Vec<Operation>>,
+}
+
+impl ResponseResult for ListOperationsResponse {}
+
+
+/// Optional arguments to enable specific features of builds.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct BuildOptions {
+    /// Requested disk size for the VM that runs the build. Note that this is *NOT*
+    /// "disk free"; some of the space will be used by the operating system and
+    /// build utilities. Also note that this is the minimum disk size that will be
+    /// allocated for the build -- the build may run with a larger disk than
+    /// requested. At present, the maximum disk size is 1000GB; builds that request
+    /// more than the maximum are rejected with an error.
+    #[serde(rename="diskSizeGb")]
+    pub disk_size_gb: Option<String>,
+    /// SubstitutionOption to allow unmatch substitutions.
+    #[serde(rename="substitutionOption")]
+    pub substitution_option: Option<String>,
+    /// GCE VM size to run the build on.
+    #[serde(rename="machineType")]
+    pub machine_type: Option<String>,
+    /// Requested hash for SourceProvenance.
+    #[serde(rename="sourceProvenanceHash")]
+    pub source_provenance_hash: Option<Vec<String>>,
+    /// Requested verifiability options.
+    #[serde(rename="requestedVerifyOption")]
+    pub requested_verify_option: Option<String>,
+    /// LogStreamingOption to define build log streaming behavior to Google Cloud
+    /// Storage.
+    #[serde(rename="logStreamingOption")]
+    pub log_streaming_option: Option<String>,
+}
+
+impl Part for BuildOptions {}
+
+
+/// Request to cancel an ongoing build.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [builds cancel projects](struct.ProjectBuildCancelCall.html) (request)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct CancelBuildRequest { _never_set: Option<bool> }
+
+impl RequestValue for CancelBuildRequest {}
+
+
+/// Configuration for an automated build in response to source repository
+/// changes.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [triggers create projects](struct.ProjectTriggerCreateCall.html) (request|response)
+/// * [triggers get projects](struct.ProjectTriggerGetCall.html) (response)
+/// * [triggers patch projects](struct.ProjectTriggerPatchCall.html) (request|response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct BuildTrigger {
+    /// Human-readable description of this trigger.
+    pub description: Option<String>,
+    /// Template describing the types of source changes to trigger a build.
+    /// 
+    /// Branch and tag names in trigger templates are interpreted as regular
+    /// expressions. Any branch or tag change that matches that regular expression
+    /// will trigger a build.
+    #[serde(rename="triggerTemplate")]
+    pub trigger_template: Option<RepoSource>,
+    /// Path, from the source root, to a file whose contents is used for the
+    /// template.
+    pub filename: Option<String>,
+    /// If true, the trigger will never result in a build.
+    pub disabled: Option<bool>,
+    /// Contents of the build template.
+    pub build: Option<Build>,
+    /// Unique identifier of the trigger.
+    /// 
+    /// @OutputOnly
+    pub id: Option<String>,
+    /// Substitutions data for Build resource.
+    pub substitutions: Option<HashMap<String, String>>,
+    /// Time when the trigger was created.
+    /// 
+    /// @OutputOnly
+    #[serde(rename="createTime")]
+    pub create_time: Option<String>,
+}
+
+impl RequestValue for BuildTrigger {}
+impl ResponseResult for BuildTrigger {}
+
+
+/// Results describes the artifacts created by the build pipeline.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Results {
+    /// Images that were built as a part of the build.
+    pub images: Option<Vec<BuiltImage>>,
+    /// List of build step digests, in order corresponding to build step indices.
+    #[serde(rename="buildStepImages")]
+    pub build_step_images: Option<Vec<String>>,
+}
+
+impl Part for Results {}
+
+
+/// BuildStep describes a step to perform in the build pipeline.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct BuildStep {
+    /// The ID(s) of the step(s) that this build step depends on.
+    /// This build step will not start until all the build steps in wait_for
+    /// have completed successfully. If wait_for is empty, this build step will
+    /// start when all previous build steps in the Build.Steps list have completed
+    /// successfully.
+    #[serde(rename="waitFor")]
+    pub wait_for: Option<Vec<String>>,
+    /// The name of the container image that will run this particular build step.
+    /// 
+    /// If the image is already available in the host's Docker daemon's cache, it
+    /// will be run directly. If not, the host will attempt to pull the image
+    /// first, using the builder service account's credentials if necessary.
+    /// 
+    /// The Docker daemon's cache will already have the latest versions of all of
+    /// the officially supported build steps
+    /// ([https://github.com/GoogleCloudPlatform/cloud-builders](https://github.com/GoogleCloudPlatform/cloud-builders)).
+    /// The Docker daemon will also have cached many of the layers for some popular
+    /// images, like "ubuntu", "debian", but they will be refreshed at the time you
+    /// attempt to use them.
+    /// 
+    /// If you built an image in a previous build step, it will be stored in the
+    /// host's Docker daemon's cache and is available to use as the name for a
+    /// later build step.
+    pub name: Option<String>,
+    /// A list of arguments that will be presented to the step when it is started.
+    /// 
+    /// If the image used to run the step's container has an entrypoint, these args
+    /// will be used as arguments to that entrypoint. If the image does not define
+    /// an entrypoint, the first element in args will be used as the entrypoint,
+    /// and the remainder will be used as arguments.
+    pub args: Option<Vec<String>>,
+    /// A list of environment variables which are encrypted using a Cloud KMS
+    /// crypto key. These values must be specified in the build's secrets.
+    #[serde(rename="secretEnv")]
+    pub secret_env: Option<Vec<String>>,
+    /// Optional entrypoint to be used instead of the build step image's default
+    /// If unset, the image's default will be used.
+    pub entrypoint: Option<String>,
+    /// A list of environment variable definitions to be used when running a step.
+    /// 
+    /// The elements are of the form "KEY=VALUE" for the environment variable "KEY"
+    /// being given the value "VALUE".
+    pub env: Option<Vec<String>>,
+    /// List of volumes to mount into the build step.
+    /// 
+    /// Each volume will be created as an empty volume prior to execution of the
+    /// build step. Upon completion of the build, volumes and their contents will
+    /// be discarded.
+    /// 
+    /// Using a named volume in only one step is not valid as it is indicative
+    /// of a mis-configured build request.
+    pub volumes: Option<Vec<Volume>>,
+    /// Optional unique identifier for this build step, used in wait_for to
+    /// reference this build step as a dependency.
+    pub id: Option<String>,
+    /// Working directory (relative to project source root) to use when running
+    /// this operation's container.
+    pub dir: Option<String>,
+}
+
+impl Part for BuildStep {}
+
+
+/// Volume describes a Docker container volume which is mounted into build steps
+/// in order to persist files across build step execution.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Volume {
+    /// Path at which to mount the volume.
+    /// 
+    /// Paths must be absolute and cannot conflict with other volume paths on the
+    /// same build step or with certain reserved volume paths.
+    pub path: Option<String>,
+    /// Name of the volume to mount.
+    /// 
+    /// Volume names must be unique per build step and must be valid names for
+    /// Docker volumes. Each named volume must be used by at least two build steps.
+    pub name: Option<String>,
+}
+
+impl Part for Volume {}
+
+
+/// Container message for hashes of byte content of files, used in
+/// SourceProvenance messages to verify integrity of source input to the build.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct FileHashes {
+    /// Collection of file hashes.
+    #[serde(rename="fileHash")]
+    pub file_hash: Option<Vec<Hash>>,
+}
+
+impl Part for FileHashes {}
+
+
+/// Provenance of the source. Ways to find the original source, or verify that
+/// some source was used for this build.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct SourceProvenance {
+    /// A copy of the build's source.repo_source, if exists, with any
+    /// revisions resolved.
+    #[serde(rename="resolvedRepoSource")]
+    pub resolved_repo_source: Option<RepoSource>,
+    /// Hash(es) of the build source, which can be used to verify that the original
+    /// source integrity was maintained in the build. Note that FileHashes will
+    /// only be populated if BuildOptions has requested a SourceProvenanceHash.
+    /// 
+    /// The keys to this map are file paths used as build source and the values
+    /// contain the hash values for those files.
+    /// 
+    /// If the build source came in a single package such as a gzipped tarfile
+    /// (.tar.gz), the FileHash will be for the single path to that file.
+    /// @OutputOnly
+    #[serde(rename="fileHashes")]
+    pub file_hashes: Option<HashMap<String, FileHashes>>,
+    /// A copy of the build's source.storage_source, if exists, with any
+    /// generations resolved.
+    #[serde(rename="resolvedStorageSource")]
+    pub resolved_storage_source: Option<StorageSource>,
+}
+
+impl Part for SourceProvenance {}
+
+
+/// StorageSource describes the location of the source in an archive file in
+/// Google Cloud Storage.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct StorageSource {
+    /// Google Cloud Storage generation for the object. If the generation is
+    /// omitted, the latest generation will be used.
+    pub generation: Option<String>,
+    /// Google Cloud Storage object containing source.
+    /// 
+    /// This object must be a gzipped archive file (.tar.gz) containing source to
+    /// build.
+    pub object: Option<String>,
+    /// Google Cloud Storage bucket containing source (see
+    /// [Bucket Name
+    /// Requirements](https://cloud.google.com/storage/docs/bucket-naming#requirements)).
+    pub bucket: Option<String>,
+}
+
+impl Part for StorageSource {}
+
+
+/// This resource represents a long-running operation that is the result of a
+/// network API call.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [cancel operations](struct.OperationCancelCall.html) (none)
+/// * [triggers run projects](struct.ProjectTriggerRunCall.html) (response)
+/// * [builds create projects](struct.ProjectBuildCreateCall.html) (response)
+/// * [list operations](struct.OperationListCall.html) (none)
+/// * [get operations](struct.OperationGetCall.html) (response)
+/// * [builds retry projects](struct.ProjectBuildRetryCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Operation {
+    /// The error result of the operation in case of failure or cancellation.
+    pub error: Option<Status>,
+    /// If the value is `false`, it means the operation is still in progress.
+    /// If `true`, the operation is completed, and either `error` or `response` is
+    /// available.
+    pub done: Option<bool>,
+    /// The normal response of the operation in case of success.  If the original
+    /// method returns no data on success, such as `Delete`, the response is
+    /// `google.protobuf.Empty`.  If the original method is standard
+    /// `Get`/`Create`/`Update`, the response should be the resource.  For other
+    /// methods, the response should have the type `XxxResponse`, where `Xxx`
+    /// is the original method name.  For example, if the original method name
+    /// is `TakeSnapshot()`, the inferred response type is
+    /// `TakeSnapshotResponse`.
+    pub response: Option<HashMap<String, String>>,
+    /// The server-assigned name, which is only unique within the same service that
+    /// originally returns it. If you use the default HTTP mapping, the
+    /// `name` should have the format of `operations/some/unique/name`.
+    pub name: Option<String>,
+    /// Service-specific metadata associated with the operation.  It typically
+    /// contains progress information and common metadata such as create time.
+    /// Some services might not provide such metadata.  Any method that returns a
+    /// long-running operation should document the metadata type, if any.
+    pub metadata: Option<HashMap<String, String>>,
+}
+
+impl Resource for Operation {}
+impl ResponseResult for Operation {}
+
+
+/// Response including listed builds.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [builds list projects](struct.ProjectBuildListCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct ListBuildsResponse {
+    /// Token to receive the next page of results.
+    #[serde(rename="nextPageToken")]
+    pub next_page_token: Option<String>,
+    /// Builds will be sorted by create_time, descending.
+    pub builds: Option<Vec<Build>>,
+}
+
+impl ResponseResult for ListBuildsResponse {}
+
+
+
+// ###################
+// MethodBuilders ###
+// #################
+
+/// A builder providing access to all methods supported on *operation* resources.
+/// It is not used directly, but through the `CloudBuild` hub.
+///
+/// # Example
+///
+/// Instantiate a resource builder
+///
+/// ```test_harness,no_run
+/// extern crate hyper;
+/// extern crate hyper_rustls;
+/// extern crate yup_oauth2 as oauth2;
+/// extern crate google_cloudbuild1 as cloudbuild1;
+/// 
+/// # #[test] fn egal() {
+/// use std::default::Default;
+/// use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// use cloudbuild1::CloudBuild;
+/// 
+/// let secret: ApplicationSecret = Default::default();
+/// let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+///                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+///                               <MemoryStorage as Default>::default(), None);
+/// let mut hub = CloudBuild::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // Usually you wouldn't bind this to a variable, but keep calling *CallBuilders*
+/// // like `cancel(...)`, `get(...)` and `list(...)`
+/// // to build up your call.
+/// let rb = hub.operations();
+/// # }
+/// ```
+pub struct OperationMethods<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a CloudBuild<C, A>,
+}
+
+impl<'a, C, A> MethodsBuilder for OperationMethods<'a, C, A> {}
+
+impl<'a, C, A> OperationMethods<'a, C, A> {
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Starts asynchronous cancellation on a long-running operation.  The server
+    /// makes a best effort to cancel the operation, but success is not
+    /// guaranteed.  If the server doesn't support this method, it returns
+    /// `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
+    /// Operations.GetOperation or
+    /// other methods to check whether the cancellation succeeded or whether the
+    /// operation completed despite cancellation. On successful cancellation,
+    /// the operation is not deleted; instead, it becomes an operation with
+    /// an Operation.error value with a google.rpc.Status.code of 1,
+    /// corresponding to `Code.CANCELLED`.
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    /// * `name` - The name of the operation resource to be cancelled.
+    pub fn cancel(&self, request: CancelOperationRequest, name: &str) -> OperationCancelCall<'a, C, A> {
+        OperationCancelCall {
+            hub: self.hub,
+            _request: request,
+            _name: name.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Lists operations that match the specified filter in the request. If the
+    /// server doesn't support this method, it returns `UNIMPLEMENTED`.
+    /// 
+    /// NOTE: the `name` binding allows API services to override the binding
+    /// to use different resource name schemes, such as `users/*/operations`. To
+    /// override the binding, API services can add a binding such as
+    /// `"/v1/{name=users/*}/operations"` to their service configuration.
+    /// For backwards compatibility, the default name includes the operations
+    /// collection id, however overriding users must ensure the name binding
+    /// is the parent resource, without the operations collection id.
+    /// 
+    /// # Arguments
+    ///
+    /// * `name` - The name of the operation's parent resource.
+    pub fn list(&self, name: &str) -> OperationListCall<'a, C, A> {
+        OperationListCall {
+            hub: self.hub,
+            _name: name.to_string(),
+            _page_token: Default::default(),
+            _page_size: Default::default(),
+            _filter: Default::default(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Gets the latest state of a long-running operation.  Clients can use this
+    /// method to poll the operation result at intervals as recommended by the API
+    /// service.
+    /// 
+    /// # Arguments
+    ///
+    /// * `name` - The name of the operation resource.
+    pub fn get(&self, name: &str) -> OperationGetCall<'a, C, A> {
+        OperationGetCall {
+            hub: self.hub,
+            _name: name.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+}
+
+
+
+/// A builder providing access to all methods supported on *project* resources.
+/// It is not used directly, but through the `CloudBuild` hub.
+///
+/// # Example
+///
+/// Instantiate a resource builder
+///
+/// ```test_harness,no_run
+/// extern crate hyper;
+/// extern crate hyper_rustls;
+/// extern crate yup_oauth2 as oauth2;
+/// extern crate google_cloudbuild1 as cloudbuild1;
+/// 
+/// # #[test] fn egal() {
+/// use std::default::Default;
+/// use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// use cloudbuild1::CloudBuild;
+/// 
+/// let secret: ApplicationSecret = Default::default();
+/// let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+///                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+///                               <MemoryStorage as Default>::default(), None);
+/// let mut hub = CloudBuild::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // Usually you wouldn't bind this to a variable, but keep calling *CallBuilders*
+/// // like `builds_cancel(...)`, `builds_create(...)`, `builds_get(...)`, `builds_list(...)`, `builds_retry(...)`, `triggers_create(...)`, `triggers_delete(...)`, `triggers_get(...)`, `triggers_list(...)`, `triggers_patch(...)` and `triggers_run(...)`
+/// // to build up your call.
+/// let rb = hub.projects();
+/// # }
+/// ```
+pub struct ProjectMethods<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a CloudBuild<C, A>,
+}
+
+impl<'a, C, A> MethodsBuilder for ProjectMethods<'a, C, A> {}
+
+impl<'a, C, A> ProjectMethods<'a, C, A> {
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Gets information about a BuildTrigger.
+    /// 
+    /// This API is experimental.
+    /// 
+    /// # Arguments
+    ///
+    /// * `projectId` - ID of the project that owns the trigger.
+    /// * `triggerId` - ID of the BuildTrigger to get.
+    pub fn triggers_get(&self, project_id: &str, trigger_id: &str) -> ProjectTriggerGetCall<'a, C, A> {
+        ProjectTriggerGetCall {
+            hub: self.hub,
+            _project_id: project_id.to_string(),
+            _trigger_id: trigger_id.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Lists existing BuildTrigger.
+    /// 
+    /// This API is experimental.
+    /// 
+    /// # Arguments
+    ///
+    /// * `projectId` - ID of the project for which to list BuildTriggers.
+    pub fn triggers_list(&self, project_id: &str) -> ProjectTriggerListCall<'a, C, A> {
+        ProjectTriggerListCall {
+            hub: self.hub,
+            _project_id: project_id.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Deletes an BuildTrigger by its project ID and trigger ID.
+    /// 
+    /// This API is experimental.
+    /// 
+    /// # Arguments
+    ///
+    /// * `projectId` - ID of the project that owns the trigger.
+    /// * `triggerId` - ID of the BuildTrigger to delete.
+    pub fn triggers_delete(&self, project_id: &str, trigger_id: &str) -> ProjectTriggerDeleteCall<'a, C, A> {
+        ProjectTriggerDeleteCall {
+            hub: self.hub,
+            _project_id: project_id.to_string(),
+            _trigger_id: trigger_id.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Cancels a requested build in progress.
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    /// * `projectId` - ID of the project.
+    /// * `id` - ID of the build.
+    pub fn builds_cancel(&self, request: CancelBuildRequest, project_id: &str, id: &str) -> ProjectBuildCancelCall<'a, C, A> {
+        ProjectBuildCancelCall {
+            hub: self.hub,
+            _request: request,
+            _project_id: project_id.to_string(),
+            _id: id.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Starts a build with the specified configuration.
+    /// 
+    /// The long-running Operation returned by this method will include the ID of
+    /// the build, which can be passed to GetBuild to determine its status (e.g.,
+    /// success or failure).
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    /// * `projectId` - ID of the project.
+    pub fn builds_create(&self, request: Build, project_id: &str) -> ProjectBuildCreateCall<'a, C, A> {
+        ProjectBuildCreateCall {
+            hub: self.hub,
+            _request: request,
+            _project_id: project_id.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Returns information about a previously requested build.
+    /// 
+    /// The Build that is returned includes its status (e.g., success or failure,
+    /// or in-progress), and timing information.
+    /// 
+    /// # Arguments
+    ///
+    /// * `projectId` - ID of the project.
+    /// * `id` - ID of the build.
+    pub fn builds_get(&self, project_id: &str, id: &str) -> ProjectBuildGetCall<'a, C, A> {
+        ProjectBuildGetCall {
+            hub: self.hub,
+            _project_id: project_id.to_string(),
+            _id: id.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Lists previously requested builds.
+    /// 
+    /// Previously requested builds may still be in-progress, or may have finished
+    /// successfully or unsuccessfully.
+    /// 
+    /// # Arguments
+    ///
+    /// * `projectId` - ID of the project.
+    pub fn builds_list(&self, project_id: &str) -> ProjectBuildListCall<'a, C, A> {
+        ProjectBuildListCall {
+            hub: self.hub,
+            _project_id: project_id.to_string(),
+            _page_token: Default::default(),
+            _page_size: Default::default(),
+            _filter: Default::default(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Runs a BuildTrigger at a particular source revision.
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    /// * `projectId` - ID of the project.
+    /// * `triggerId` - ID of the trigger.
+    pub fn triggers_run(&self, request: RepoSource, project_id: &str, trigger_id: &str) -> ProjectTriggerRunCall<'a, C, A> {
+        ProjectTriggerRunCall {
+            hub: self.hub,
+            _request: request,
+            _project_id: project_id.to_string(),
+            _trigger_id: trigger_id.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Creates a new build based on the given build.
+    /// 
+    /// This API creates a new build using the original build request,  which may
+    /// or may not result in an identical build.
+    /// 
+    /// For triggered builds:
+    /// 
+    /// * Triggered builds resolve to a precise revision, so a retry of a triggered
+    /// build will result in a build that uses the same revision.
+    /// 
+    /// For non-triggered builds that specify RepoSource:
+    /// 
+    /// * If the original build built from the tip of a branch, the retried build
+    /// will build from the tip of that branch, which may not be the same revision
+    /// as the original build.
+    /// * If the original build specified a commit sha or revision ID, the retried
+    /// build will use the identical source.
+    /// 
+    /// For builds that specify StorageSource:
+    /// 
+    /// * If the original build pulled source from Cloud Storage without specifying
+    /// the generation of the object, the new build will use the current object,
+    /// which may be different from the original build source.
+    /// * If the original build pulled source from Cloud Storage and specified the
+    /// generation of the object, the new build will attempt to use the same
+    /// object, which may or may not be available depending on the bucket's
+    /// lifecycle management settings.
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    /// * `projectId` - ID of the project.
+    /// * `id` - Build ID of the original build.
+    pub fn builds_retry(&self, request: RetryBuildRequest, project_id: &str, id: &str) -> ProjectBuildRetryCall<'a, C, A> {
+        ProjectBuildRetryCall {
+            hub: self.hub,
+            _request: request,
+            _project_id: project_id.to_string(),
+            _id: id.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Creates a new BuildTrigger.
+    /// 
+    /// This API is experimental.
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    /// * `projectId` - ID of the project for which to configure automatic builds.
+    pub fn triggers_create(&self, request: BuildTrigger, project_id: &str) -> ProjectTriggerCreateCall<'a, C, A> {
+        ProjectTriggerCreateCall {
+            hub: self.hub,
+            _request: request,
+            _project_id: project_id.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Updates an BuildTrigger by its project ID and trigger ID.
+    /// 
+    /// This API is experimental.
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    /// * `projectId` - ID of the project that owns the trigger.
+    /// * `triggerId` - ID of the BuildTrigger to update.
+    pub fn triggers_patch(&self, request: BuildTrigger, project_id: &str, trigger_id: &str) -> ProjectTriggerPatchCall<'a, C, A> {
+        ProjectTriggerPatchCall {
+            hub: self.hub,
+            _request: request,
+            _project_id: project_id.to_string(),
+            _trigger_id: trigger_id.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+}
+
+
+
+
+
+// ###################
+// CallBuilders   ###
+// #################
+
+/// Starts asynchronous cancellation on a long-running operation.  The server
+/// makes a best effort to cancel the operation, but success is not
+/// guaranteed.  If the server doesn't support this method, it returns
+/// `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
+/// Operations.GetOperation or
+/// other methods to check whether the cancellation succeeded or whether the
+/// operation completed despite cancellation. On successful cancellation,
+/// the operation is not deleted; instead, it becomes an operation with
+/// an Operation.error value with a google.rpc.Status.code of 1,
+/// corresponding to `Code.CANCELLED`.
+///
+/// A builder for the *cancel* method supported by a *operation* resource.
+/// It is not used directly, but through a `OperationMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_cloudbuild1 as cloudbuild1;
+/// use cloudbuild1::CancelOperationRequest;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use cloudbuild1::CloudBuild;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = CloudBuild::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = CancelOperationRequest::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.operations().cancel(req, "name")
+///              .doit();
+/// # }
+/// ```
+pub struct OperationCancelCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a CloudBuild<C, A>,
+    _request: CancelOperationRequest,
+    _name: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for OperationCancelCall<'a, C, A> {}
+
+impl<'a, C, A> OperationCancelCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, Empty)> {
+        use url::percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "cloudbuild.operations.cancel",
+                               http_method: hyper::method::Method::Post });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((4 + self._additional_params.len()));
+        params.push(("name", self._name.to_string()));
+        for &field in ["alt", "name"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1/{+name}:cancel";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{+name}", "name")].iter() {
+            let mut replace_with = String::new();
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = value.to_string();
+                    break;
+                }
+            }
+            if find_this.as_bytes()[1] == '+' as u8 {
+                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET);
+            }
+            url = url.replace(find_this, &replace_with);
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["name"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Post, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: CancelOperationRequest) -> OperationCancelCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// The name of the operation resource to be cancelled.
+    ///
+    /// Sets the *name* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn name(mut self, new_value: &str) -> OperationCancelCall<'a, C, A> {
+        self._name = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> OperationCancelCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> OperationCancelCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> OperationCancelCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Lists operations that match the specified filter in the request. If the
+/// server doesn't support this method, it returns `UNIMPLEMENTED`.
+/// 
+/// NOTE: the `name` binding allows API services to override the binding
+/// to use different resource name schemes, such as `users/*/operations`. To
+/// override the binding, API services can add a binding such as
+/// `"/v1/{name=users/*}/operations"` to their service configuration.
+/// For backwards compatibility, the default name includes the operations
+/// collection id, however overriding users must ensure the name binding
+/// is the parent resource, without the operations collection id.
+///
+/// A builder for the *list* method supported by a *operation* resource.
+/// It is not used directly, but through a `OperationMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_cloudbuild1 as cloudbuild1;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use cloudbuild1::CloudBuild;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = CloudBuild::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.operations().list("name")
+///              .page_token("nonumy")
+///              .page_size(-19)
+///              .filter("gubergren")
+///              .doit();
+/// # }
+/// ```
+pub struct OperationListCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a CloudBuild<C, A>,
+    _name: String,
+    _page_token: Option<String>,
+    _page_size: Option<i32>,
+    _filter: Option<String>,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for OperationListCall<'a, C, A> {}
+
+impl<'a, C, A> OperationListCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, ListOperationsResponse)> {
+        use url::percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "cloudbuild.operations.list",
+                               http_method: hyper::method::Method::Get });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((6 + self._additional_params.len()));
+        params.push(("name", self._name.to_string()));
+        if let Some(value) = self._page_token {
+            params.push(("pageToken", value.to_string()));
+        }
+        if let Some(value) = self._page_size {
+            params.push(("pageSize", value.to_string()));
+        }
+        if let Some(value) = self._filter {
+            params.push(("filter", value.to_string()));
+        }
+        for &field in ["alt", "name", "pageToken", "pageSize", "filter"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1/{+name}";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{+name}", "name")].iter() {
+            let mut replace_with = String::new();
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = value.to_string();
+                    break;
+                }
+            }
+            if find_this.as_bytes()[1] == '+' as u8 {
+                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET);
+            }
+            url = url.replace(find_this, &replace_with);
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["name"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Get, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    /// The name of the operation's parent resource.
+    ///
+    /// Sets the *name* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn name(mut self, new_value: &str) -> OperationListCall<'a, C, A> {
+        self._name = new_value.to_string();
+        self
+    }
+    /// The standard list page token.
+    ///
+    /// Sets the *page token* query property to the given value.
+    pub fn page_token(mut self, new_value: &str) -> OperationListCall<'a, C, A> {
+        self._page_token = Some(new_value.to_string());
+        self
+    }
+    /// The standard list page size.
+    ///
+    /// Sets the *page size* query property to the given value.
+    pub fn page_size(mut self, new_value: i32) -> OperationListCall<'a, C, A> {
+        self._page_size = Some(new_value);
+        self
+    }
+    /// The standard list filter.
+    ///
+    /// Sets the *filter* query property to the given value.
+    pub fn filter(mut self, new_value: &str) -> OperationListCall<'a, C, A> {
+        self._filter = Some(new_value.to_string());
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> OperationListCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> OperationListCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> OperationListCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Gets the latest state of a long-running operation.  Clients can use this
+/// method to poll the operation result at intervals as recommended by the API
+/// service.
+///
+/// A builder for the *get* method supported by a *operation* resource.
+/// It is not used directly, but through a `OperationMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_cloudbuild1 as cloudbuild1;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use cloudbuild1::CloudBuild;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = CloudBuild::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.operations().get("name")
+///              .doit();
+/// # }
+/// ```
+pub struct OperationGetCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a CloudBuild<C, A>,
+    _name: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for OperationGetCall<'a, C, A> {}
+
+impl<'a, C, A> OperationGetCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, Operation)> {
+        use url::percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "cloudbuild.operations.get",
+                               http_method: hyper::method::Method::Get });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((3 + self._additional_params.len()));
+        params.push(("name", self._name.to_string()));
+        for &field in ["alt", "name"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1/{+name}";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{+name}", "name")].iter() {
+            let mut replace_with = String::new();
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = value.to_string();
+                    break;
+                }
+            }
+            if find_this.as_bytes()[1] == '+' as u8 {
+                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET);
+            }
+            url = url.replace(find_this, &replace_with);
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["name"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Get, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    /// The name of the operation resource.
+    ///
+    /// Sets the *name* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn name(mut self, new_value: &str) -> OperationGetCall<'a, C, A> {
+        self._name = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> OperationGetCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> OperationGetCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> OperationGetCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Gets information about a BuildTrigger.
+/// 
+/// This API is experimental.
+///
+/// A builder for the *triggers.get* method supported by a *project* resource.
+/// It is not used directly, but through a `ProjectMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_cloudbuild1 as cloudbuild1;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use cloudbuild1::CloudBuild;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = CloudBuild::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.projects().triggers_get("projectId", "triggerId")
+///              .doit();
+/// # }
+/// ```
+pub struct ProjectTriggerGetCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a CloudBuild<C, A>,
+    _project_id: String,
+    _trigger_id: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for ProjectTriggerGetCall<'a, C, A> {}
+
+impl<'a, C, A> ProjectTriggerGetCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, BuildTrigger)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "cloudbuild.projects.triggers.get",
+                               http_method: hyper::method::Method::Get });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((4 + self._additional_params.len()));
+        params.push(("projectId", self._project_id.to_string()));
+        params.push(("triggerId", self._trigger_id.to_string()));
+        for &field in ["alt", "projectId", "triggerId"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1/projects/{projectId}/triggers/{triggerId}";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{projectId}", "projectId"), ("{triggerId}", "triggerId")].iter() {
+            let mut replace_with: Option<&str> = None;
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = Some(value);
+                    break;
+                }
+            }
+            url = url.replace(find_this, replace_with.expect("to find substitution value in params"));
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(2);
+            for param_name in ["triggerId", "projectId"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Get, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    /// ID of the project that owns the trigger.
+    ///
+    /// Sets the *project id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn project_id(mut self, new_value: &str) -> ProjectTriggerGetCall<'a, C, A> {
+        self._project_id = new_value.to_string();
+        self
+    }
+    /// ID of the BuildTrigger to get.
+    ///
+    /// Sets the *trigger id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn trigger_id(mut self, new_value: &str) -> ProjectTriggerGetCall<'a, C, A> {
+        self._trigger_id = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> ProjectTriggerGetCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> ProjectTriggerGetCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> ProjectTriggerGetCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Lists existing BuildTrigger.
+/// 
+/// This API is experimental.
+///
+/// A builder for the *triggers.list* method supported by a *project* resource.
+/// It is not used directly, but through a `ProjectMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_cloudbuild1 as cloudbuild1;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use cloudbuild1::CloudBuild;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = CloudBuild::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.projects().triggers_list("projectId")
+///              .doit();
+/// # }
+/// ```
+pub struct ProjectTriggerListCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a CloudBuild<C, A>,
+    _project_id: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for ProjectTriggerListCall<'a, C, A> {}
+
+impl<'a, C, A> ProjectTriggerListCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, ListBuildTriggersResponse)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "cloudbuild.projects.triggers.list",
+                               http_method: hyper::method::Method::Get });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((3 + self._additional_params.len()));
+        params.push(("projectId", self._project_id.to_string()));
+        for &field in ["alt", "projectId"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1/projects/{projectId}/triggers";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{projectId}", "projectId")].iter() {
+            let mut replace_with: Option<&str> = None;
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = Some(value);
+                    break;
+                }
+            }
+            url = url.replace(find_this, replace_with.expect("to find substitution value in params"));
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["projectId"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Get, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    /// ID of the project for which to list BuildTriggers.
+    ///
+    /// Sets the *project id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn project_id(mut self, new_value: &str) -> ProjectTriggerListCall<'a, C, A> {
+        self._project_id = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> ProjectTriggerListCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> ProjectTriggerListCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> ProjectTriggerListCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Deletes an BuildTrigger by its project ID and trigger ID.
+/// 
+/// This API is experimental.
+///
+/// A builder for the *triggers.delete* method supported by a *project* resource.
+/// It is not used directly, but through a `ProjectMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_cloudbuild1 as cloudbuild1;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use cloudbuild1::CloudBuild;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = CloudBuild::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.projects().triggers_delete("projectId", "triggerId")
+///              .doit();
+/// # }
+/// ```
+pub struct ProjectTriggerDeleteCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a CloudBuild<C, A>,
+    _project_id: String,
+    _trigger_id: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for ProjectTriggerDeleteCall<'a, C, A> {}
+
+impl<'a, C, A> ProjectTriggerDeleteCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, Empty)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "cloudbuild.projects.triggers.delete",
+                               http_method: hyper::method::Method::Delete });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((4 + self._additional_params.len()));
+        params.push(("projectId", self._project_id.to_string()));
+        params.push(("triggerId", self._trigger_id.to_string()));
+        for &field in ["alt", "projectId", "triggerId"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1/projects/{projectId}/triggers/{triggerId}";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{projectId}", "projectId"), ("{triggerId}", "triggerId")].iter() {
+            let mut replace_with: Option<&str> = None;
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = Some(value);
+                    break;
+                }
+            }
+            url = url.replace(find_this, replace_with.expect("to find substitution value in params"));
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(2);
+            for param_name in ["triggerId", "projectId"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Delete, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    /// ID of the project that owns the trigger.
+    ///
+    /// Sets the *project id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn project_id(mut self, new_value: &str) -> ProjectTriggerDeleteCall<'a, C, A> {
+        self._project_id = new_value.to_string();
+        self
+    }
+    /// ID of the BuildTrigger to delete.
+    ///
+    /// Sets the *trigger id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn trigger_id(mut self, new_value: &str) -> ProjectTriggerDeleteCall<'a, C, A> {
+        self._trigger_id = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> ProjectTriggerDeleteCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> ProjectTriggerDeleteCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> ProjectTriggerDeleteCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Cancels a requested build in progress.
+///
+/// A builder for the *builds.cancel* method supported by a *project* resource.
+/// It is not used directly, but through a `ProjectMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_cloudbuild1 as cloudbuild1;
+/// use cloudbuild1::CancelBuildRequest;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use cloudbuild1::CloudBuild;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = CloudBuild::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = CancelBuildRequest::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.projects().builds_cancel(req, "projectId", "id")
+///              .doit();
+/// # }
+/// ```
+pub struct ProjectBuildCancelCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a CloudBuild<C, A>,
+    _request: CancelBuildRequest,
+    _project_id: String,
+    _id: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for ProjectBuildCancelCall<'a, C, A> {}
+
+impl<'a, C, A> ProjectBuildCancelCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, Build)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "cloudbuild.projects.builds.cancel",
+                               http_method: hyper::method::Method::Post });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((5 + self._additional_params.len()));
+        params.push(("projectId", self._project_id.to_string()));
+        params.push(("id", self._id.to_string()));
+        for &field in ["alt", "projectId", "id"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1/projects/{projectId}/builds/{id}:cancel";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{projectId}", "projectId"), ("{id}", "id")].iter() {
+            let mut replace_with: Option<&str> = None;
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = Some(value);
+                    break;
+                }
+            }
+            url = url.replace(find_this, replace_with.expect("to find substitution value in params"));
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(2);
+            for param_name in ["id", "projectId"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Post, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: CancelBuildRequest) -> ProjectBuildCancelCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// ID of the project.
+    ///
+    /// Sets the *project id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn project_id(mut self, new_value: &str) -> ProjectBuildCancelCall<'a, C, A> {
+        self._project_id = new_value.to_string();
+        self
+    }
+    /// ID of the build.
+    ///
+    /// Sets the *id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn id(mut self, new_value: &str) -> ProjectBuildCancelCall<'a, C, A> {
+        self._id = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> ProjectBuildCancelCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> ProjectBuildCancelCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> ProjectBuildCancelCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Starts a build with the specified configuration.
+/// 
+/// The long-running Operation returned by this method will include the ID of
+/// the build, which can be passed to GetBuild to determine its status (e.g.,
+/// success or failure).
+///
+/// A builder for the *builds.create* method supported by a *project* resource.
+/// It is not used directly, but through a `ProjectMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_cloudbuild1 as cloudbuild1;
+/// use cloudbuild1::Build;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use cloudbuild1::CloudBuild;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = CloudBuild::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = Build::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.projects().builds_create(req, "projectId")
+///              .doit();
+/// # }
+/// ```
+pub struct ProjectBuildCreateCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a CloudBuild<C, A>,
+    _request: Build,
+    _project_id: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for ProjectBuildCreateCall<'a, C, A> {}
+
+impl<'a, C, A> ProjectBuildCreateCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, Operation)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "cloudbuild.projects.builds.create",
+                               http_method: hyper::method::Method::Post });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((4 + self._additional_params.len()));
+        params.push(("projectId", self._project_id.to_string()));
+        for &field in ["alt", "projectId"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1/projects/{projectId}/builds";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{projectId}", "projectId")].iter() {
+            let mut replace_with: Option<&str> = None;
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = Some(value);
+                    break;
+                }
+            }
+            url = url.replace(find_this, replace_with.expect("to find substitution value in params"));
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["projectId"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Post, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: Build) -> ProjectBuildCreateCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// ID of the project.
+    ///
+    /// Sets the *project id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn project_id(mut self, new_value: &str) -> ProjectBuildCreateCall<'a, C, A> {
+        self._project_id = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> ProjectBuildCreateCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> ProjectBuildCreateCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> ProjectBuildCreateCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Returns information about a previously requested build.
+/// 
+/// The Build that is returned includes its status (e.g., success or failure,
+/// or in-progress), and timing information.
+///
+/// A builder for the *builds.get* method supported by a *project* resource.
+/// It is not used directly, but through a `ProjectMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_cloudbuild1 as cloudbuild1;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use cloudbuild1::CloudBuild;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = CloudBuild::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.projects().builds_get("projectId", "id")
+///              .doit();
+/// # }
+/// ```
+pub struct ProjectBuildGetCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a CloudBuild<C, A>,
+    _project_id: String,
+    _id: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for ProjectBuildGetCall<'a, C, A> {}
+
+impl<'a, C, A> ProjectBuildGetCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, Build)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "cloudbuild.projects.builds.get",
+                               http_method: hyper::method::Method::Get });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((4 + self._additional_params.len()));
+        params.push(("projectId", self._project_id.to_string()));
+        params.push(("id", self._id.to_string()));
+        for &field in ["alt", "projectId", "id"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1/projects/{projectId}/builds/{id}";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{projectId}", "projectId"), ("{id}", "id")].iter() {
+            let mut replace_with: Option<&str> = None;
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = Some(value);
+                    break;
+                }
+            }
+            url = url.replace(find_this, replace_with.expect("to find substitution value in params"));
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(2);
+            for param_name in ["id", "projectId"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Get, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    /// ID of the project.
+    ///
+    /// Sets the *project id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn project_id(mut self, new_value: &str) -> ProjectBuildGetCall<'a, C, A> {
+        self._project_id = new_value.to_string();
+        self
+    }
+    /// ID of the build.
+    ///
+    /// Sets the *id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn id(mut self, new_value: &str) -> ProjectBuildGetCall<'a, C, A> {
+        self._id = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> ProjectBuildGetCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> ProjectBuildGetCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> ProjectBuildGetCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Lists previously requested builds.
+/// 
+/// Previously requested builds may still be in-progress, or may have finished
+/// successfully or unsuccessfully.
+///
+/// A builder for the *builds.list* method supported by a *project* resource.
+/// It is not used directly, but through a `ProjectMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_cloudbuild1 as cloudbuild1;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use cloudbuild1::CloudBuild;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = CloudBuild::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.projects().builds_list("projectId")
+///              .page_token("duo")
+///              .page_size(-32)
+///              .filter("sea")
+///              .doit();
+/// # }
+/// ```
+pub struct ProjectBuildListCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a CloudBuild<C, A>,
+    _project_id: String,
+    _page_token: Option<String>,
+    _page_size: Option<i32>,
+    _filter: Option<String>,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for ProjectBuildListCall<'a, C, A> {}
+
+impl<'a, C, A> ProjectBuildListCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, ListBuildsResponse)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "cloudbuild.projects.builds.list",
+                               http_method: hyper::method::Method::Get });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((6 + self._additional_params.len()));
+        params.push(("projectId", self._project_id.to_string()));
+        if let Some(value) = self._page_token {
+            params.push(("pageToken", value.to_string()));
+        }
+        if let Some(value) = self._page_size {
+            params.push(("pageSize", value.to_string()));
+        }
+        if let Some(value) = self._filter {
+            params.push(("filter", value.to_string()));
+        }
+        for &field in ["alt", "projectId", "pageToken", "pageSize", "filter"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1/projects/{projectId}/builds";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{projectId}", "projectId")].iter() {
+            let mut replace_with: Option<&str> = None;
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = Some(value);
+                    break;
+                }
+            }
+            url = url.replace(find_this, replace_with.expect("to find substitution value in params"));
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["projectId"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Get, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    /// ID of the project.
+    ///
+    /// Sets the *project id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn project_id(mut self, new_value: &str) -> ProjectBuildListCall<'a, C, A> {
+        self._project_id = new_value.to_string();
+        self
+    }
+    /// Token to provide to skip to a particular spot in the list.
+    ///
+    /// Sets the *page token* query property to the given value.
+    pub fn page_token(mut self, new_value: &str) -> ProjectBuildListCall<'a, C, A> {
+        self._page_token = Some(new_value.to_string());
+        self
+    }
+    /// Number of results to return in the list.
+    ///
+    /// Sets the *page size* query property to the given value.
+    pub fn page_size(mut self, new_value: i32) -> ProjectBuildListCall<'a, C, A> {
+        self._page_size = Some(new_value);
+        self
+    }
+    /// The raw filter text to constrain the results.
+    ///
+    /// Sets the *filter* query property to the given value.
+    pub fn filter(mut self, new_value: &str) -> ProjectBuildListCall<'a, C, A> {
+        self._filter = Some(new_value.to_string());
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> ProjectBuildListCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> ProjectBuildListCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> ProjectBuildListCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Runs a BuildTrigger at a particular source revision.
+///
+/// A builder for the *triggers.run* method supported by a *project* resource.
+/// It is not used directly, but through a `ProjectMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_cloudbuild1 as cloudbuild1;
+/// use cloudbuild1::RepoSource;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use cloudbuild1::CloudBuild;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = CloudBuild::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = RepoSource::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.projects().triggers_run(req, "projectId", "triggerId")
+///              .doit();
+/// # }
+/// ```
+pub struct ProjectTriggerRunCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a CloudBuild<C, A>,
+    _request: RepoSource,
+    _project_id: String,
+    _trigger_id: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for ProjectTriggerRunCall<'a, C, A> {}
+
+impl<'a, C, A> ProjectTriggerRunCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, Operation)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "cloudbuild.projects.triggers.run",
+                               http_method: hyper::method::Method::Post });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((5 + self._additional_params.len()));
+        params.push(("projectId", self._project_id.to_string()));
+        params.push(("triggerId", self._trigger_id.to_string()));
+        for &field in ["alt", "projectId", "triggerId"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1/projects/{projectId}/triggers/{triggerId}:run";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{projectId}", "projectId"), ("{triggerId}", "triggerId")].iter() {
+            let mut replace_with: Option<&str> = None;
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = Some(value);
+                    break;
+                }
+            }
+            url = url.replace(find_this, replace_with.expect("to find substitution value in params"));
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(2);
+            for param_name in ["triggerId", "projectId"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Post, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: RepoSource) -> ProjectTriggerRunCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// ID of the project.
+    ///
+    /// Sets the *project id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn project_id(mut self, new_value: &str) -> ProjectTriggerRunCall<'a, C, A> {
+        self._project_id = new_value.to_string();
+        self
+    }
+    /// ID of the trigger.
+    ///
+    /// Sets the *trigger id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn trigger_id(mut self, new_value: &str) -> ProjectTriggerRunCall<'a, C, A> {
+        self._trigger_id = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> ProjectTriggerRunCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> ProjectTriggerRunCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> ProjectTriggerRunCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Creates a new build based on the given build.
+/// 
+/// This API creates a new build using the original build request,  which may
+/// or may not result in an identical build.
+/// 
+/// For triggered builds:
+/// 
+/// * Triggered builds resolve to a precise revision, so a retry of a triggered
+/// build will result in a build that uses the same revision.
+/// 
+/// For non-triggered builds that specify RepoSource:
+/// 
+/// * If the original build built from the tip of a branch, the retried build
+/// will build from the tip of that branch, which may not be the same revision
+/// as the original build.
+/// * If the original build specified a commit sha or revision ID, the retried
+/// build will use the identical source.
+/// 
+/// For builds that specify StorageSource:
+/// 
+/// * If the original build pulled source from Cloud Storage without specifying
+/// the generation of the object, the new build will use the current object,
+/// which may be different from the original build source.
+/// * If the original build pulled source from Cloud Storage and specified the
+/// generation of the object, the new build will attempt to use the same
+/// object, which may or may not be available depending on the bucket's
+/// lifecycle management settings.
+///
+/// A builder for the *builds.retry* method supported by a *project* resource.
+/// It is not used directly, but through a `ProjectMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_cloudbuild1 as cloudbuild1;
+/// use cloudbuild1::RetryBuildRequest;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use cloudbuild1::CloudBuild;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = CloudBuild::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = RetryBuildRequest::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.projects().builds_retry(req, "projectId", "id")
+///              .doit();
+/// # }
+/// ```
+pub struct ProjectBuildRetryCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a CloudBuild<C, A>,
+    _request: RetryBuildRequest,
+    _project_id: String,
+    _id: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for ProjectBuildRetryCall<'a, C, A> {}
+
+impl<'a, C, A> ProjectBuildRetryCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, Operation)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "cloudbuild.projects.builds.retry",
+                               http_method: hyper::method::Method::Post });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((5 + self._additional_params.len()));
+        params.push(("projectId", self._project_id.to_string()));
+        params.push(("id", self._id.to_string()));
+        for &field in ["alt", "projectId", "id"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1/projects/{projectId}/builds/{id}:retry";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{projectId}", "projectId"), ("{id}", "id")].iter() {
+            let mut replace_with: Option<&str> = None;
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = Some(value);
+                    break;
+                }
+            }
+            url = url.replace(find_this, replace_with.expect("to find substitution value in params"));
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(2);
+            for param_name in ["id", "projectId"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Post, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: RetryBuildRequest) -> ProjectBuildRetryCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// ID of the project.
+    ///
+    /// Sets the *project id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn project_id(mut self, new_value: &str) -> ProjectBuildRetryCall<'a, C, A> {
+        self._project_id = new_value.to_string();
+        self
+    }
+    /// Build ID of the original build.
+    ///
+    /// Sets the *id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn id(mut self, new_value: &str) -> ProjectBuildRetryCall<'a, C, A> {
+        self._id = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> ProjectBuildRetryCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> ProjectBuildRetryCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> ProjectBuildRetryCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Creates a new BuildTrigger.
+/// 
+/// This API is experimental.
+///
+/// A builder for the *triggers.create* method supported by a *project* resource.
+/// It is not used directly, but through a `ProjectMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_cloudbuild1 as cloudbuild1;
+/// use cloudbuild1::BuildTrigger;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use cloudbuild1::CloudBuild;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = CloudBuild::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = BuildTrigger::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.projects().triggers_create(req, "projectId")
+///              .doit();
+/// # }
+/// ```
+pub struct ProjectTriggerCreateCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a CloudBuild<C, A>,
+    _request: BuildTrigger,
+    _project_id: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for ProjectTriggerCreateCall<'a, C, A> {}
+
+impl<'a, C, A> ProjectTriggerCreateCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, BuildTrigger)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "cloudbuild.projects.triggers.create",
+                               http_method: hyper::method::Method::Post });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((4 + self._additional_params.len()));
+        params.push(("projectId", self._project_id.to_string()));
+        for &field in ["alt", "projectId"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1/projects/{projectId}/triggers";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{projectId}", "projectId")].iter() {
+            let mut replace_with: Option<&str> = None;
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = Some(value);
+                    break;
+                }
+            }
+            url = url.replace(find_this, replace_with.expect("to find substitution value in params"));
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["projectId"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Post, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: BuildTrigger) -> ProjectTriggerCreateCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// ID of the project for which to configure automatic builds.
+    ///
+    /// Sets the *project id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn project_id(mut self, new_value: &str) -> ProjectTriggerCreateCall<'a, C, A> {
+        self._project_id = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> ProjectTriggerCreateCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> ProjectTriggerCreateCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> ProjectTriggerCreateCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Updates an BuildTrigger by its project ID and trigger ID.
+/// 
+/// This API is experimental.
+///
+/// A builder for the *triggers.patch* method supported by a *project* resource.
+/// It is not used directly, but through a `ProjectMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_cloudbuild1 as cloudbuild1;
+/// use cloudbuild1::BuildTrigger;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use cloudbuild1::CloudBuild;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = CloudBuild::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = BuildTrigger::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.projects().triggers_patch(req, "projectId", "triggerId")
+///              .doit();
+/// # }
+/// ```
+pub struct ProjectTriggerPatchCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a CloudBuild<C, A>,
+    _request: BuildTrigger,
+    _project_id: String,
+    _trigger_id: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for ProjectTriggerPatchCall<'a, C, A> {}
+
+impl<'a, C, A> ProjectTriggerPatchCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, BuildTrigger)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "cloudbuild.projects.triggers.patch",
+                               http_method: hyper::method::Method::Patch });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((5 + self._additional_params.len()));
+        params.push(("projectId", self._project_id.to_string()));
+        params.push(("triggerId", self._trigger_id.to_string()));
+        for &field in ["alt", "projectId", "triggerId"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1/projects/{projectId}/triggers/{triggerId}";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{projectId}", "projectId"), ("{triggerId}", "triggerId")].iter() {
+            let mut replace_with: Option<&str> = None;
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = Some(value);
+                    break;
+                }
+            }
+            url = url.replace(find_this, replace_with.expect("to find substitution value in params"));
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(2);
+            for param_name in ["triggerId", "projectId"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Patch, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: BuildTrigger) -> ProjectTriggerPatchCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// ID of the project that owns the trigger.
+    ///
+    /// Sets the *project id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn project_id(mut self, new_value: &str) -> ProjectTriggerPatchCall<'a, C, A> {
+        self._project_id = new_value.to_string();
+        self
+    }
+    /// ID of the BuildTrigger to update.
+    ///
+    /// Sets the *trigger id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn trigger_id(mut self, new_value: &str) -> ProjectTriggerPatchCall<'a, C, A> {
+        self._trigger_id = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> ProjectTriggerPatchCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> ProjectTriggerPatchCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> ProjectTriggerPatchCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+

--- a/gen/clouderrorreporting1_beta1-cli/Cargo.toml
+++ b/gen/clouderrorreporting1_beta1-cli/Cargo.toml
@@ -1,0 +1,40 @@
+# DO NOT EDIT !
+# This file was generated automatically from 'src/mako/Cargo.toml.mako'
+# DO NOT EDIT !
+[package]
+
+name = "google-clouderrorreporting1_beta1-cli"
+version = "1.0.7+20171201"
+authors = ["Sebastian Thiel <byronimo@gmail.com>"]
+description = "A complete library to interact with Clouderrorreporting (protocol v1beta1)"
+repository = "https://github.com/Byron/google-apis-rs/tree/master/gen/clouderrorreporting1_beta1-cli"
+homepage = "https://cloud.google.com/error-reporting/"
+documentation = "http://byron.github.io/google-apis-rs/google_clouderrorreporting1_beta1_cli"
+license = "MIT"
+keywords = ["clouderrorreporting", "google", "cli"]
+
+[[bin]]
+name = "clouderrorreporting1-beta1"
+
+[dev-dependencies]
+hyper-rustls = "^0.6"
+
+[dependencies]
+hyper = "^ 0.10"
+mime = "^ 0.2.0"
+serde = "^ 1.0"
+serde_json = "^ 1.0"
+serde_derive = "^ 1.0"
+yup-oauth2 = "^ 1.0"
+strsim = "^0.5"
+hyper-rustls = "^0.6"
+yup-hyper-mock = "^2.0"
+clap = "^2.0"
+
+[features]
+
+
+
+[dependencies.google-clouderrorreporting1_beta1]
+path = "../clouderrorreporting1_beta1"
+version = "1.0.7+20171201"

--- a/gen/clouderrorreporting1_beta1-cli/LICENSE.md
+++ b/gen/clouderrorreporting1_beta1-cli/LICENSE.md
@@ -1,0 +1,30 @@
+<!---
+DO NOT EDIT !
+This file was generated automatically from 'src/mako/LICENSE.md.mako'
+DO NOT EDIT !
+-->
+The MIT License (MIT)
+=====================
+
+Copyright © `2015-2016` `Sebastian Thiel`
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the “Software”), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.

--- a/gen/clouderrorreporting1_beta1-cli/README.md
+++ b/gen/clouderrorreporting1_beta1-cli/README.md
@@ -1,0 +1,119 @@
+<!---
+DO NOT EDIT !
+This file was generated automatically from 'src/mako/cli/README.md.mako'
+DO NOT EDIT !
+-->
+The `clouderrorreporting1-beta1` command-line interface *(CLI)* allows to use most features of the *Google Clouderrorreporting* service from the comfort of your terminal.
+
+By default all output is printed to standard out, but flags can be set to direct it into a file independent of your shell's
+capabilities. Errors will be printed to standard error, and cause the program's exit code to be non-zero.
+
+If data-structures are requested, these will be returned as pretty-printed JSON, to be useful as input to other tools.
+
+Everything else about the *Clouderrorreporting* API can be found at the
+[official documentation site](https://cloud.google.com/error-reporting/).
+
+# Installation and Source Code
+
+Install the command-line interface with cargo using:
+
+```bash
+cargo install google-clouderrorreporting1_beta1-cli
+```
+
+Find the source code [on github](https://github.com/Byron/google-apis-rs/tree/master/gen/clouderrorreporting1_beta1-cli).
+
+# Usage
+
+This documentation was generated from the *Clouderrorreporting* API at revision *20171201*. The CLI is at version *1.0.7*.
+
+```bash
+clouderrorreporting1-beta1 [options]
+        projects
+                delete-events <project-name> [-p <v>]... [-o <out>]
+                events-list <project-name> [-p <v>]... [-o <out>]
+                events-report <project-name> (-r <kv>)... [-p <v>]... [-o <out>]
+                group-stats-list <project-name> [-p <v>]... [-o <out>]
+                groups-get <group-name> [-p <v>]... [-o <out>]
+                groups-update <name> (-r <kv>)... [-p <v>]... [-o <out>]
+  clouderrorreporting1-beta1 --help
+
+Configuration:
+  [--scope <url>]...
+            Specify the authentication a method should be executed in. Each scope
+            requires the user to grant this application permission to use it.
+            If unset, it defaults to the shortest scope url for a particular method.
+  --config-dir <folder>
+            A directory into which we will store our persistent data. Defaults to
+            a user-writable directory that we will create during the first invocation.
+            [default: ~/.google-service-cli]
+  --debug
+            Output all server communication to standard error. `tx` and `rx` are placed
+            into the same stream.
+  --debug-auth
+            Output all communication related to authentication to standard error. `tx`
+            and `rx` are placed into the same stream.
+
+```
+
+# Configuration
+
+The program will store all persistent data in the `~/.google-service-cli` directory in *JSON* files prefixed with `clouderrorreporting1-beta1-`.  You can change the directory used to store configuration with the `--config-dir` flag on a per-invocation basis.
+
+More information about the various kinds of persistent data are given in the following paragraphs.
+
+# Authentication
+
+Most APIs require a user to authenticate any request. If this is the case, the [scope][scopes] determines the 
+set of permissions granted. The granularity of these is usually no more than *read-only* or *full-access*.
+
+If not set, the system will automatically select the smallest feasible scope, e.g. when invoking a
+method that is read-only, it will ask only for a read-only scope. 
+You may use the `--scope` flag to specify a scope directly. 
+All applicable scopes are documented in the respective method's CLI documentation.
+
+The first time a scope is used, the user is asked for permission. Follow the instructions given 
+by the CLI to grant permissions, or to decline.
+
+If a scope was authenticated by the user, the respective information will be stored as *JSON* in the configuration
+directory, e.g. `~/.google-service-cli/clouderrorreporting1-beta1-token-<scope-hash>.json`. No manual management of these tokens
+is necessary.
+
+To revoke granted authentication, please refer to the [official documentation][revoke-access].
+
+# Application Secrets
+
+In order to allow any application to use Google services, it will need to be registered using the 
+[Google Developer Console][google-dev-console]. APIs the application may use are then enabled for it
+one by one. Most APIs can be used for free and have a daily quota.
+
+To allow more comfortable usage of the CLI without forcing anyone to register an own application, the CLI
+comes with a default application secret that is configured accordingly. This also means that heavy usage
+all around the world may deplete the daily quota.
+
+You can workaround this limitation by putting your own secrets file at this location: 
+`~/.google-service-cli/clouderrorreporting1-beta1-secret.json`, assuming that the required *clouderrorreporting* API 
+was enabled for it. Such a secret file can be downloaded in the *Google Developer Console* at 
+*APIs & auth -> Credentials -> Download JSON* and used as is.
+
+Learn more about how to setup Google projects and enable APIs using the [official documentation][google-project-new].
+
+
+# Debugging
+
+Even though the CLI does its best to provide usable error messages, sometimes it might be desirable to know
+what exactly led to a particular issue. This is done by allowing all client-server communication to be 
+output to standard error *as-is*.
+
+The `--debug` flag will print all client-server communication to standard error, whereas the `--debug-auth` flag
+will cause all communication related to authentication to standard error.
+If the `--debug` flag is set, error-results will be debug-printed, possibly yielding more information about the 
+issue at hand.
+
+You may consider redirecting standard error into a file for ease of use, e.g. `clouderrorreporting1-beta1 --debug <resource> <method> [options] 2>debug.txt`.
+
+
+[scopes]: https://developers.google.com/+/api/oauth#scopes
+[revoke-access]: http://webapps.stackexchange.com/a/30849
+[google-dev-console]: https://console.developers.google.com/
+[google-project-new]: https://developers.google.com/console/help/new/

--- a/gen/clouderrorreporting1_beta1-cli/mkdocs.yml
+++ b/gen/clouderrorreporting1_beta1-cli/mkdocs.yml
@@ -1,0 +1,22 @@
+site_name: Clouderrorreporting v1.0.7+20171201
+site_url: http://byron.github.io/google-apis-rs/google-clouderrorreporting1_beta1-cli
+site_description: A complete library to interact with Clouderrorreporting (protocol v1beta1)
+
+repo_url: https://github.com/Byron/google-apis-rs/tree/master/gen/clouderrorreporting1_beta1-cli
+
+docs_dir: docs
+site_dir: build_html
+
+pages:
+- ['index.md', 'Home']
+- ['projects_delete-events.md', 'Projects', 'Delete Events']
+- ['projects_events-list.md', 'Projects', 'Events List']
+- ['projects_events-report.md', 'Projects', 'Events Report']
+- ['projects_group-stats-list.md', 'Projects', 'Group Stats List']
+- ['projects_groups-get.md', 'Projects', 'Groups Get']
+- ['projects_groups-update.md', 'Projects', 'Groups Update']
+
+theme: readthedocs
+
+copyright: Copyright &copy; 2015-2016, `Sebastian Thiel`
+

--- a/gen/clouderrorreporting1_beta1-cli/src/cmn.rs
+++ b/gen/clouderrorreporting1_beta1-cli/src/cmn.rs
@@ -1,0 +1,799 @@
+// COPY OF 'src/rust/cli/cmn.rs'
+// DO NOT EDIT
+use oauth2::{ApplicationSecret, ConsoleApplicationSecret, TokenStorage, Token};
+use serde_json as json;
+use serde_json::value::Value;
+use mime::Mime;
+use clap::{App, SubCommand};
+use strsim;
+
+use std::fs;
+use std::env;
+use std::io;
+use std::error::Error as StdError;
+use std::fmt;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+use std::string::ToString;
+use std::io::{Write, Read, stdout};
+
+use std::default::Default;
+
+const FIELD_SEP: char = '.';
+
+
+pub enum ComplexType {
+    Pod,
+    Vec,
+    Map,
+}
+
+// Null,
+// Bool(bool),
+// I64(i64),
+// U64(u64),
+// F64(f64),
+// String(String),
+
+pub enum JsonType {
+    Boolean,
+    Int,
+    Uint,
+    Float,
+    String,
+}
+
+pub struct JsonTypeInfo {
+    pub jtype: JsonType,
+    pub ctype: ComplexType,
+}
+
+// Based on @erickt user comment. Thanks for the idea !
+// Remove all keys whose values are null from given value (changed in place)
+pub fn remove_json_null_values(value: &mut Value) {
+    match *value {
+        Value::Object(ref mut map) => {
+            let mut for_removal = Vec::new();
+
+            for (key, mut value) in map.iter_mut() {
+                if value.is_null() {
+                    for_removal.push(key.clone());
+                } else {
+                    remove_json_null_values(&mut value);
+                }
+            }
+
+            for key in &for_removal {
+                map.remove(key);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn did_you_mean<'a>(v: &str, possible_values: &[&'a str]) -> Option<&'a str> {
+
+    let mut candidate: Option<(f64, &str)> = None;
+    for pv in possible_values {
+        let confidence = strsim::jaro_winkler(v, pv);
+        if confidence > 0.8 &&
+           (candidate.is_none() || (candidate.as_ref().unwrap().0 < confidence)) {
+            candidate = Some((confidence, pv));
+        }
+    }
+    match candidate {
+        None => None,
+        Some((_, candidate)) => Some(candidate),
+    }
+}
+
+pub enum CallType {
+    Upload(UploadProtocol),
+    Standard,
+}
+
+arg_enum!{
+    pub enum UploadProtocol {
+        Simple,
+        Resumable
+    }
+}
+
+impl AsRef<str> for UploadProtocol {
+    fn as_ref(&self) -> &str {
+        match *self {
+            UploadProtocol::Simple => "simple",
+            UploadProtocol::Resumable => "resumable",
+        }
+    }
+}
+
+impl AsRef<str> for CallType {
+    fn as_ref(&self) -> &str {
+        match *self {
+            CallType::Upload(ref proto) => proto.as_ref(),
+            CallType::Standard => "standard-request",
+        }
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct FieldCursor(Vec<String>);
+
+impl ToString for  FieldCursor {
+    fn to_string(&self) -> String {
+        self.0.join(".")
+    }
+}
+
+impl From<&'static str> for FieldCursor {
+    fn from(value: &'static str) -> FieldCursor {
+        let mut res = FieldCursor::default();
+        res.set(value).unwrap();
+        res
+    }
+}
+
+fn assure_entry<'a, 'b>(m: &'a mut json::Map<String, Value>, k: &'b String) -> &'a mut Value {
+    if m.contains_key(k) {
+        return m.get_mut(k).expect("value to exist");
+    }
+    m.insert(k.to_owned(), Value::Object(Default::default()));
+    m.get_mut(k).expect("value to exist")
+}
+
+impl FieldCursor {
+    pub fn set(&mut self, value: &str) -> Result<(), CLIError> {
+        if value.len() == 0 {
+            return Err(CLIError::Field(FieldError::Empty));
+        }
+
+        let mut first_is_field_sep = false;
+        let mut char_count: usize = 0;
+        let mut last_c = FIELD_SEP;
+        let mut num_conscutive_field_seps = 0;
+
+        let mut field = String::new();
+        let mut fields = self.0.clone();
+
+        let push_field = |fs: &mut Vec<String>, f: &mut String| {
+            if f.len() > 0 {
+                fs.push(f.clone());
+                f.truncate(0);
+            }
+        };
+
+        for (cid, c) in value.chars().enumerate() {
+            char_count += 1;
+
+            if c == FIELD_SEP {
+                if cid == 0 {
+                    first_is_field_sep = true;
+                }
+                num_conscutive_field_seps += 1;
+                if cid > 0 && last_c == FIELD_SEP {
+                    if fields.pop().is_none() {
+                        return Err(CLIError::Field(FieldError::PopOnEmpty(value.to_string())));
+                    }
+                } else {
+                    push_field(&mut fields, &mut field);
+                }
+            } else {
+                num_conscutive_field_seps = 0;
+                if cid == 1 {
+                    if first_is_field_sep {
+                        fields.truncate(0);
+                    }
+                }
+                field.push(c);
+            }
+
+            last_c = c;
+        }
+
+        push_field(&mut fields, &mut field);
+
+        if char_count == 1 && first_is_field_sep {
+            fields.truncate(0);
+        }
+        if char_count > 1 && num_conscutive_field_seps == 1 {
+            return Err(CLIError::Field(FieldError::TrailingFieldSep(value.to_string())));
+        }
+
+        self.0 = fields;
+        Ok(())
+    }
+
+    pub fn did_you_mean(value: &str, possible_values: &[&str]) -> Option<String> {
+        if value.len() == 0 {
+            return None;
+        }
+
+        let mut last_c = FIELD_SEP;
+
+        let mut field = String::new();
+        let mut output = String::new();
+
+        let push_field = |fs: &mut String, f: &mut String| {
+            if f.len() > 0 {
+                fs.push_str(match did_you_mean(&f, possible_values) {
+                    Some(candidate) => candidate,
+                    None => &f,
+                });
+                f.truncate(0);
+            }
+        };
+
+        for (cid, c) in value.chars().enumerate() {
+            if c == FIELD_SEP {
+                if last_c != FIELD_SEP {
+                    push_field(&mut output, &mut field);
+                }
+                output.push(c);
+            } else {
+                field.push(c);
+            }
+
+            last_c = c;
+        }
+
+        push_field(&mut output, &mut field);
+
+        if &output == value {
+            None
+        } else {
+            Some(output)
+        }
+    }
+
+    pub fn set_json_value(&self,
+                          mut object: &mut Value,
+                          value: &str,
+                          type_info: JsonTypeInfo,
+                          err: &mut InvalidOptionsError,
+                          orig_cursor: &FieldCursor) {
+        assert!(self.0.len() > 0);
+
+        for field in &self.0[..self.0.len() - 1] {
+            let tmp = object;
+            object = match *tmp {
+                Value::Object(ref mut mapping) => {
+                    assure_entry(mapping, &field)
+                }
+                _ => panic!("We don't expect non-object Values here ..."),
+            };
+        }
+
+        match *object {
+            Value::Object(ref mut mapping) => {
+                let field = &self.0[self.0.len() - 1];
+                let to_jval = |value: &str,
+                               jtype: JsonType,
+                               err: &mut InvalidOptionsError|
+                               -> Value {
+                    match jtype {
+                        JsonType::Boolean =>
+                            Value::Bool(arg_from_str(value, err, &field, "boolean")),
+                        JsonType::Int =>
+                            Value::Number(json::Number::from_f64(arg_from_str(value,
+                                                                              err,
+                                                                              &field,
+                                                                              "int"))
+                                              .expect("valid f64")),
+                        JsonType::Uint =>
+                            Value::Number(json::Number::from_f64(arg_from_str(value,
+                                                                              err,
+                                                                              &field,
+                                                                              "uint"))
+                                              .expect("valid f64")),
+                        JsonType::Float =>
+                            Value::Number(json::Number::from_f64(arg_from_str(value,
+                                                                              err,
+                                                                              &field,
+                                                                              "float"))
+                                              .expect("valid f64")),
+                        JsonType::String => Value::String(value.to_owned()),
+                    }
+                };
+
+                match type_info.ctype {
+                    ComplexType::Pod => {
+                        if mapping.insert(field.to_owned(), to_jval(value, type_info.jtype, err))
+                                  .is_some() {
+                            err.issues.push(CLIError::Field(FieldError::Duplicate(orig_cursor.to_string())));
+                        }
+                    }
+                    ComplexType::Vec => {
+                        match *assure_entry(mapping, field) {
+                            Value::Array(ref mut values) =>
+                                values.push(to_jval(value, type_info.jtype, err)),
+                            _ => unreachable!(),
+                        }
+                    }
+                    ComplexType::Map => {
+                        let (key, value) = parse_kv_arg(value, err, true);
+                        let jval = to_jval(value.unwrap_or(""), type_info.jtype, err);
+
+                        match *assure_entry(mapping, &field) {
+
+                            Value::Object(ref mut value_map) => {
+                                if value_map.insert(key.to_owned(), jval).is_some() {
+                                    err.issues.push(CLIError::Field(FieldError::Duplicate(orig_cursor.to_string())));
+                                }
+                            }
+                            _ => unreachable!(),
+                        }
+                    }
+                }
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    pub fn num_fields(&self) -> usize {
+        self.0.len()
+    }
+}
+
+pub fn parse_kv_arg<'a>(kv: &'a str,
+                        err: &mut InvalidOptionsError,
+                        for_hashmap: bool)
+                        -> (&'a str, Option<&'a str>) {
+    let mut add_err = || {
+        err.issues.push(CLIError::InvalidKeyValueSyntax(kv.to_string(), for_hashmap))
+    };
+    match kv.find('=') {
+        None => {
+            add_err();
+            return (kv, None);
+        }
+        Some(pos) => {
+            let key = &kv[..pos];
+            if kv.len() <= pos + 1 {
+                add_err();
+                return (key, Some(""));
+            }
+            (key, Some(&kv[pos + 1..]))
+        }
+    }
+}
+
+pub fn calltype_from_str(name: &str,
+                         valid_protocols: Vec<String>,
+                         err: &mut InvalidOptionsError)
+                         -> CallType {
+    CallType::Upload(match UploadProtocol::from_str(name) {
+        Ok(up) => up,
+        Err(msg) => {
+            err.issues.push(CLIError::InvalidUploadProtocol(name.to_string(), valid_protocols));
+            UploadProtocol::Simple
+        }
+    })
+}
+
+pub fn input_file_from_opts(file_path: &str, err: &mut InvalidOptionsError) -> Option<fs::File> {
+    match fs::File::open(file_path) {
+        Ok(f) => Some(f),
+        Err(io_err) => {
+            err.issues.push(CLIError::Input(InputError::Io((file_path.to_string(), io_err))));
+            None
+        }
+    }
+}
+
+pub fn input_mime_from_opts(mime: &str, err: &mut InvalidOptionsError) -> Option<Mime> {
+    match mime.parse() {
+        Ok(m) => Some(m),
+        Err(_) => {
+            err.issues.push(CLIError::Input(InputError::Mime(mime.to_string())));
+            None
+        }
+    }
+}
+
+pub fn writer_from_opts(arg: Option<&str>) -> Result<Box<Write>, io::Error> {
+    let f = arg.unwrap_or("-");
+    match f {
+        "-" => Ok(Box::new(stdout())),
+        _ => match fs::OpenOptions::new().create(true).write(true).open(f) {
+            Ok(f) => Ok(Box::new(f)),
+            Err(io_err) => Err(io_err),
+        },
+    }
+}
+
+
+pub fn arg_from_str<'a, T>(arg: &str,
+                           err: &mut InvalidOptionsError,
+                           arg_name: &'a str,
+                           arg_type: &'a str)
+                           -> T
+    where T: FromStr + Default,
+          <T as FromStr>::Err: fmt::Display
+{
+    match FromStr::from_str(arg) {
+        Err(perr) => {
+            err.issues.push(CLIError::ParseError(arg_name.to_owned(),
+                                                 arg_type.to_owned(),
+                                                 arg.to_string(),
+                                                 format!("{}", perr)));
+            Default::default()
+        }
+        Ok(v) => v,
+    }
+}
+
+pub struct JsonTokenStorage {
+    pub program_name: &'static str,
+    pub db_dir: String,
+}
+
+impl JsonTokenStorage {
+    fn path(&self, scope_hash: u64) -> PathBuf {
+        Path::new(&self.db_dir).join(&format!("{}-token-{}.json", self.program_name, scope_hash))
+    }
+}
+
+
+#[derive(Debug)]
+pub enum TokenStorageError {
+    Json(json::Error),
+    Io(io::Error),
+}
+
+impl fmt::Display for TokenStorageError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            TokenStorageError::Json(ref err) => writeln!(f, "Could not serialize secrets: {}", err),
+            TokenStorageError::Io(ref err) => writeln!(f, "Failed to write secret token: {}", err),
+        }
+    }
+}
+
+impl StdError for TokenStorageError {
+    fn description(&self) -> &str {
+        "Failure when getting or setting the token storage"
+    }
+}
+
+
+impl TokenStorage for JsonTokenStorage {
+    type Error = TokenStorageError;
+
+    // NOTE: logging might be interesting, currently we swallow all errors
+    fn set(&mut self,
+           scope_hash: u64,
+           _: &Vec<&str>,
+           token: Option<Token>)
+           -> Result<(), TokenStorageError> {
+        match token {
+            None => {
+                match fs::remove_file(self.path(scope_hash)) {
+                    Err(err) => match err.kind() {
+                        io::ErrorKind::NotFound => Ok(()),
+                        _ => Err(TokenStorageError::Io(err)),
+                    },
+                    Ok(_) => Ok(()),
+                }
+            }
+            Some(token) => {
+                match fs::OpenOptions::new().create(true).write(true).open(&self.path(scope_hash)) {
+                    Ok(mut f) => {
+                        match json::to_writer_pretty(&mut f, &token) {
+                            Ok(_) => Ok(()),
+                            Err(serde_err) => Err(TokenStorageError::Json(serde_err)),
+                        }
+                    }
+                    Err(io_err) => Err(TokenStorageError::Io(io_err)),
+                }
+            }
+        }
+    }
+
+    fn get(&self, scope_hash: u64, _: &Vec<&str>) -> Result<Option<Token>, TokenStorageError> {
+        match fs::File::open(&self.path(scope_hash)) {
+            Ok(f) => {
+                match json::de::from_reader(f) {
+                    Ok(token) => Ok(Some(token)),
+                    Err(err) => Err(TokenStorageError::Json(err)),
+                }
+            }
+            Err(io_err) => {
+                match io_err.kind() {
+                    io::ErrorKind::NotFound => Ok(None),
+                    _ => Err(TokenStorageError::Io(io_err)),
+                }
+            }
+        }
+    }
+}
+
+
+#[derive(Debug)]
+pub enum ApplicationSecretError {
+    DecoderError((String, json::Error)),
+    FormatError(String),
+}
+
+impl fmt::Display for ApplicationSecretError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            ApplicationSecretError::DecoderError((ref path, ref err)) =>
+                writeln!(f,
+                         "Could not decode file at '{}' with error: {}.",
+                         path,
+                         err),
+            ApplicationSecretError::FormatError(ref path) =>
+                writeln!(f,
+                         "'installed' field is unset in secret file at '{}'.",
+                         path),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum ConfigurationError {
+    DirectoryCreationFailed((String, io::Error)),
+    DirectoryUnset,
+    HomeExpansionFailed(String),
+    Secret(ApplicationSecretError),
+    Io((String, io::Error)),
+}
+
+impl fmt::Display for ConfigurationError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            ConfigurationError::DirectoryCreationFailed((ref dir, ref err)) =>
+                writeln!(f,
+                         "Directory '{}' could not be created with error: {}.",
+                         dir,
+                         err),
+            ConfigurationError::DirectoryUnset => writeln!(f, "--config-dir was unset or empty."),
+            ConfigurationError::HomeExpansionFailed(ref dir) =>
+                writeln!(f,
+                         "Couldn't find HOME directory of current user, failed to expand '{}'.",
+                         dir),
+            ConfigurationError::Secret(ref err) => writeln!(f, "Secret -> {}", err),
+            ConfigurationError::Io((ref path, ref err)) =>
+                writeln!(f,
+                         "IO operation failed on path '{}' with error: {}.",
+                         path,
+                         err),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum InputError {
+    Io((String, io::Error)),
+    Mime(String),
+}
+
+impl fmt::Display for InputError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            InputError::Io((ref file_path, ref io_err)) =>
+                writeln!(f,
+                         "Failed to open '{}' for reading with error: {}.",
+                         file_path,
+                         io_err),
+            InputError::Mime(ref mime) => writeln!(f, "'{}' is not a known mime-type.", mime),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum FieldError {
+    PopOnEmpty(String),
+    TrailingFieldSep(String),
+    Unknown(String, Option<String>, Option<String>),
+    Duplicate(String),
+    Empty,
+}
+
+
+impl fmt::Display for FieldError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            FieldError::PopOnEmpty(ref field) =>
+                writeln!(f, "'{}': Cannot move up on empty field cursor.", field),
+            FieldError::TrailingFieldSep(ref field) =>
+                writeln!(f,
+                         "'{}': Single field separator may not be last character.",
+                         field),
+            FieldError::Unknown(ref field, ref suggestion, ref value) => {
+                let suffix = match *suggestion {
+                    Some(ref s) => {
+                        let kv = match *value {
+                            Some(ref v) => format!("{}={}", s, v),
+                            None => s.clone(),
+                        };
+                        format!(" Did you mean '{}' ?", kv)
+                    }
+                    None => String::new(),
+                };
+                writeln!(f, "Field '{}' does not exist.{}", field, suffix)
+            }
+            FieldError::Duplicate(ref cursor) =>
+                writeln!(f, "Value at '{}' was already set", cursor),
+            FieldError::Empty => writeln!(f, "Field names must not be empty."),
+        }
+    }
+}
+
+
+#[derive(Debug)]
+pub enum CLIError {
+    Configuration(ConfigurationError),
+    ParseError(String, String, String, String),
+    UnknownParameter(String, Vec<&'static str>),
+    InvalidUploadProtocol(String, Vec<String>),
+    InvalidKeyValueSyntax(String, bool),
+    Input(InputError),
+    Field(FieldError),
+    MissingCommandError,
+    MissingMethodError(String),
+}
+
+impl fmt::Display for CLIError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            CLIError::Configuration(ref err) => write!(f, "Configuration -> {}", err),
+            CLIError::Input(ref err) => write!(f, "Input -> {}", err),
+            CLIError::Field(ref err) => write!(f, "Field -> {}", err),
+            CLIError::InvalidUploadProtocol(ref proto_name, ref valid_names) =>
+                writeln!(f,
+                         "'{}' is not a valid upload protocol. Choose from one of {}.",
+                         proto_name,
+                         valid_names.join(", ")),
+            CLIError::ParseError(ref arg_name, ref type_name, ref value, ref err_desc) =>
+                writeln!(f,
+                         "Failed to parse argument '{}' with value '{}' as {} with error: {}.",
+                         arg_name,
+                         value,
+                         type_name,
+                         err_desc),
+            CLIError::UnknownParameter(ref param_name, ref possible_values) => {
+                let suffix = match did_you_mean(param_name, &possible_values) {
+                    Some(v) => format!(" Did you mean '{}' ?", v),
+                    None => String::new(),
+                };
+                write!(f, "Parameter '{}' is unknown.{}\n", param_name, suffix)
+            }
+            CLIError::InvalidKeyValueSyntax(ref kv, is_hashmap) => {
+                let hashmap_info = if is_hashmap {
+                    "hashmap "
+                } else {
+                    ""
+                };
+                writeln!(f,
+                         "'{}' does not match {}pattern <key>=<value>.",
+                         kv,
+                         hashmap_info)
+            }
+            CLIError::MissingCommandError => writeln!(f, "Please specify the main sub-command."),
+            CLIError::MissingMethodError(ref cmd) =>
+                writeln!(f,
+                         "Please specify the method to call on the '{}' command.",
+                         cmd),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct InvalidOptionsError {
+    pub issues: Vec<CLIError>,
+    pub exit_code: i32,
+}
+
+impl fmt::Display for InvalidOptionsError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        for issue in &self.issues {
+            try!(issue.fmt(f));
+        }
+        Ok(())
+    }
+}
+
+impl InvalidOptionsError {
+    pub fn single(err: CLIError, exit_code: i32) -> InvalidOptionsError {
+        InvalidOptionsError {
+            issues: vec![err],
+            exit_code: exit_code,
+        }
+    }
+
+    pub fn new() -> InvalidOptionsError {
+        InvalidOptionsError {
+            issues: Vec::new(),
+            exit_code: 1,
+        }
+    }
+}
+
+pub fn assure_config_dir_exists(dir: &str) -> Result<String, CLIError> {
+    let trdir = dir.trim();
+    if trdir.len() == 0 {
+        return Err(CLIError::Configuration(ConfigurationError::DirectoryUnset));
+    }
+
+    let expanded_config_dir = if trdir.as_bytes()[0] == b'~' {
+        match env::var("HOME").ok().or(env::var("UserProfile").ok()) {
+            None => return Err(CLIError::Configuration(ConfigurationError::HomeExpansionFailed(trdir.to_string()))),
+            Some(mut user) => {
+                user.push_str(&trdir[1..]);
+                user
+            }
+        }
+    } else {
+        trdir.to_string()
+    };
+
+    if let Err(err) = fs::create_dir(&expanded_config_dir) {
+        if err.kind() != io::ErrorKind::AlreadyExists {
+            return Err(CLIError::Configuration(
+                    ConfigurationError::DirectoryCreationFailed((expanded_config_dir, err))));
+        }
+    }
+
+    Ok(expanded_config_dir)
+}
+
+pub fn application_secret_from_directory(dir: &str,
+                                         secret_basename: &str,
+                                         json_console_secret: &str)
+                                         -> Result<ApplicationSecret, CLIError> {
+    let secret_path = Path::new(dir).join(secret_basename);
+    let secret_str = || secret_path.as_path().to_str().unwrap().to_string();
+    let secret_io_error = |io_err: io::Error| {
+        Err(CLIError::Configuration(ConfigurationError::Io((secret_str(), io_err))))
+    };
+
+    for _ in 0..2 {
+        match fs::File::open(&secret_path) {
+            Err(mut err) => {
+                if err.kind() == io::ErrorKind::NotFound {
+                    // Write our built-in one - user may adjust the written file at will
+
+                    err = match fs::OpenOptions::new()
+                                    .create(true)
+                                    .write(true)
+                                    .open(&secret_path) {
+                        Err(cfe) => cfe,
+                        Ok(mut f) => {
+                            // Assure we convert 'ugly' json string into pretty one
+                            let console_secret: ConsoleApplicationSecret =
+                                json::from_str(json_console_secret).unwrap();
+                            match json::to_writer_pretty(&mut f, &console_secret) {
+                                Err(serde_err) =>
+                                    panic!("Unexpected serde error: {:#?}", serde_err),
+                                Ok(_) => continue,
+                            }
+                        }
+                    };
+                    // fall through to IO error handling
+                }
+                return secret_io_error(err);
+            }
+            Ok(f) => {
+                match json::de::from_reader::<_, ConsoleApplicationSecret>(f) {
+                    Err(json_err) =>
+                        return Err(CLIError::Configuration(
+                            ConfigurationError::Secret(
+                                ApplicationSecretError::DecoderError(
+                                                (secret_str(), json_err)
+                                              )))),
+                    Ok(console_secret) => match console_secret.installed {
+                        Some(secret) => return Ok(secret),
+                        None => return Err(
+                                        CLIError::Configuration(
+                                        ConfigurationError::Secret(
+                                        ApplicationSecretError::FormatError(secret_str())
+                                        ))),
+                    },
+                }
+            }
+        }
+    }
+    unreachable!();
+}

--- a/gen/clouderrorreporting1_beta1-cli/src/main.rs
+++ b/gen/clouderrorreporting1_beta1-cli/src/main.rs
@@ -1,0 +1,892 @@
+// DO NOT EDIT !
+// This file was generated automatically from 'src/mako/cli/main.rs.mako'
+// DO NOT EDIT !
+#![allow(unused_variables, unused_imports, dead_code, unused_mut)]
+
+#[macro_use]
+extern crate clap;
+extern crate yup_oauth2 as oauth2;
+extern crate yup_hyper_mock as mock;
+extern crate hyper_rustls;
+extern crate serde;
+extern crate serde_json;
+extern crate hyper;
+extern crate mime;
+extern crate strsim;
+extern crate google_clouderrorreporting1_beta1 as api;
+
+use std::env;
+use std::io::{self, Write};
+use clap::{App, SubCommand, Arg};
+
+mod cmn;
+
+use cmn::{InvalidOptionsError, CLIError, JsonTokenStorage, arg_from_str, writer_from_opts, parse_kv_arg,
+          input_file_from_opts, input_mime_from_opts, FieldCursor, FieldError, CallType, UploadProtocol,
+          calltype_from_str, remove_json_null_values, ComplexType, JsonType, JsonTypeInfo};
+
+use std::default::Default;
+use std::str::FromStr;
+
+use oauth2::{Authenticator, DefaultAuthenticatorDelegate, FlowType};
+use serde_json as json;
+use clap::ArgMatches;
+
+enum DoitError {
+    IoError(String, io::Error),
+    ApiError(api::Error),
+}
+
+struct Engine<'n> {
+    opt: ArgMatches<'n>,
+    hub: api::Clouderrorreporting<hyper::Client, Authenticator<DefaultAuthenticatorDelegate, JsonTokenStorage, hyper::Client>>,
+    gp: Vec<&'static str>,
+    gpm: Vec<(&'static str, &'static str)>,
+}
+
+
+impl<'n> Engine<'n> {
+    fn _projects_delete_events(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let mut call = self.hub.projects().delete_events(opt.value_of("project-name").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _projects_events_list(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let mut call = self.hub.projects().events_list(opt.value_of("project-name").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                "time-range-period" => {
+                    call = call.time_range_period(value.unwrap_or(""));
+                },
+                "service-filter-version" => {
+                    call = call.service_filter_version(value.unwrap_or(""));
+                },
+                "service-filter-service" => {
+                    call = call.service_filter_service(value.unwrap_or(""));
+                },
+                "service-filter-resource-type" => {
+                    call = call.service_filter_resource_type(value.unwrap_or(""));
+                },
+                "page-token" => {
+                    call = call.page_token(value.unwrap_or(""));
+                },
+                "page-size" => {
+                    call = call.page_size(arg_from_str(value.unwrap_or("-0"), err, "page-size", "integer"));
+                },
+                "group-id" => {
+                    call = call.group_id(value.unwrap_or(""));
+                },
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v.extend(["service-filter-resource-type", "time-range-period", "page-size", "service-filter-service", "page-token", "service-filter-version", "group-id"].iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _projects_events_report(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    "service-context.resource-type" => Some(("serviceContext.resourceType", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "service-context.version" => Some(("serviceContext.version", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "service-context.service" => Some(("serviceContext.service", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "message" => Some(("message", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "event-time" => Some(("eventTime", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "context.http-request.response-status-code" => Some(("context.httpRequest.responseStatusCode", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Pod })),
+                    "context.http-request.url" => Some(("context.httpRequest.url", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "context.http-request.referrer" => Some(("context.httpRequest.referrer", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "context.http-request.remote-ip" => Some(("context.httpRequest.remoteIp", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "context.http-request.user-agent" => Some(("context.httpRequest.userAgent", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "context.http-request.method" => Some(("context.httpRequest.method", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "context.user" => Some(("context.user", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "context.report-location.line-number" => Some(("context.reportLocation.lineNumber", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Pod })),
+                    "context.report-location.function-name" => Some(("context.reportLocation.functionName", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "context.report-location.file-path" => Some(("context.reportLocation.filePath", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec!["context", "event-time", "file-path", "function-name", "http-request", "line-number", "message", "method", "referrer", "remote-ip", "report-location", "resource-type", "response-status-code", "service", "service-context", "url", "user", "user-agent", "version"]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::ReportedErrorEvent = json::value::from_value(object).unwrap();
+        let mut call = self.hub.projects().events_report(request, opt.value_of("project-name").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _projects_group_stats_list(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let mut call = self.hub.projects().group_stats_list(opt.value_of("project-name").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                "timed-count-duration" => {
+                    call = call.timed_count_duration(arg_from_str(value.unwrap_or("-0"), err, "timed-count-duration", "int64"));
+                },
+                "time-range-period" => {
+                    call = call.time_range_period(value.unwrap_or(""));
+                },
+                "service-filter-version" => {
+                    call = call.service_filter_version(value.unwrap_or(""));
+                },
+                "service-filter-service" => {
+                    call = call.service_filter_service(value.unwrap_or(""));
+                },
+                "service-filter-resource-type" => {
+                    call = call.service_filter_resource_type(value.unwrap_or(""));
+                },
+                "page-token" => {
+                    call = call.page_token(value.unwrap_or(""));
+                },
+                "page-size" => {
+                    call = call.page_size(arg_from_str(value.unwrap_or("-0"), err, "page-size", "integer"));
+                },
+                "order" => {
+                    call = call.order(value.unwrap_or(""));
+                },
+                "group-id" => {
+                    call = call.add_group_id(value.unwrap_or(""));
+                },
+                "alignment-time" => {
+                    call = call.alignment_time(value.unwrap_or(""));
+                },
+                "alignment" => {
+                    call = call.alignment(value.unwrap_or(""));
+                },
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v.extend(["service-filter-resource-type", "time-range-period", "timed-count-duration", "page-size", "alignment-time", "service-filter-service", "group-id", "page-token", "service-filter-version", "order", "alignment"].iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _projects_groups_get(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let mut call = self.hub.projects().groups_get(opt.value_of("group-name").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _projects_groups_update(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    "name" => Some(("name", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "group-id" => Some(("groupId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec!["group-id", "name"]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::ErrorGroup = json::value::from_value(object).unwrap();
+        let mut call = self.hub.projects().groups_update(request, opt.value_of("name").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _doit(&self, dry_run: bool) -> Result<Result<(), DoitError>, Option<InvalidOptionsError>> {
+        let mut err = InvalidOptionsError::new();
+        let mut call_result: Result<(), DoitError> = Ok(());
+        let mut err_opt: Option<InvalidOptionsError> = None;
+        match self.opt.subcommand() {
+            ("projects", Some(opt)) => {
+                match opt.subcommand() {
+                    ("delete-events", Some(opt)) => {
+                        call_result = self._projects_delete_events(opt, dry_run, &mut err);
+                    },
+                    ("events-list", Some(opt)) => {
+                        call_result = self._projects_events_list(opt, dry_run, &mut err);
+                    },
+                    ("events-report", Some(opt)) => {
+                        call_result = self._projects_events_report(opt, dry_run, &mut err);
+                    },
+                    ("group-stats-list", Some(opt)) => {
+                        call_result = self._projects_group_stats_list(opt, dry_run, &mut err);
+                    },
+                    ("groups-get", Some(opt)) => {
+                        call_result = self._projects_groups_get(opt, dry_run, &mut err);
+                    },
+                    ("groups-update", Some(opt)) => {
+                        call_result = self._projects_groups_update(opt, dry_run, &mut err);
+                    },
+                    _ => {
+                        err.issues.push(CLIError::MissingMethodError("projects".to_string()));
+                        writeln!(io::stderr(), "{}\n", opt.usage()).ok();
+                    }
+                }
+            },
+            _ => {
+                err.issues.push(CLIError::MissingCommandError);
+                writeln!(io::stderr(), "{}\n", self.opt.usage()).ok();
+            }
+        }
+
+        if dry_run {
+            if err.issues.len() > 0 {
+                err_opt = Some(err);
+            }
+            Err(err_opt)
+        } else {
+            Ok(call_result)
+        }
+    }
+
+    // Please note that this call will fail if any part of the opt can't be handled
+    fn new(opt: ArgMatches<'n>) -> Result<Engine<'n>, InvalidOptionsError> {
+        let (config_dir, secret) = {
+            let config_dir = match cmn::assure_config_dir_exists(opt.value_of("folder").unwrap_or("~/.google-service-cli")) {
+                Err(e) => return Err(InvalidOptionsError::single(e, 3)),
+                Ok(p) => p,
+            };
+
+            match cmn::application_secret_from_directory(&config_dir, "clouderrorreporting1-beta1-secret.json",
+                                                         "{\"installed\":{\"auth_uri\":\"https://accounts.google.com/o/oauth2/auth\",\"client_secret\":\"hCsslbCUyfehWMmbkG8vTYxG\",\"token_uri\":\"https://accounts.google.com/o/oauth2/token\",\"client_email\":\"\",\"redirect_uris\":[\"urn:ietf:wg:oauth:2.0:oob\",\"oob\"],\"client_x509_cert_url\":\"\",\"client_id\":\"620010449518-9ngf7o4dhs0dka470npqvor6dc5lqb9b.apps.googleusercontent.com\",\"auth_provider_x509_cert_url\":\"https://www.googleapis.com/oauth2/v1/certs\"}}") {
+                Ok(secret) => (config_dir, secret),
+                Err(e) => return Err(InvalidOptionsError::single(e, 4))
+            }
+        };
+
+        let auth = Authenticator::new(  &secret, DefaultAuthenticatorDelegate,
+                                        if opt.is_present("debug-auth") {
+                                            hyper::Client::with_connector(mock::TeeConnector {
+                                                    connector: hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())
+                                                })
+                                        } else {
+                                            hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new()))
+                                        },
+                                        JsonTokenStorage {
+                                          program_name: "clouderrorreporting1-beta1",
+                                          db_dir: config_dir.clone(),
+                                        }, Some(FlowType::InstalledRedirect(54324)));
+
+        let client =
+            if opt.is_present("debug") {
+                hyper::Client::with_connector(mock::TeeConnector {
+                        connector: hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())
+                    })
+            } else {
+                hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new()))
+            };
+        let engine = Engine {
+            opt: opt,
+            hub: api::Clouderrorreporting::new(client, auth),
+            gp: vec!["$-xgafv", "access-token", "alt", "bearer-token", "callback", "fields", "key", "oauth-token", "pp", "pretty-print", "quota-user", "upload-type", "upload-protocol"],
+            gpm: vec![
+                    ("$-xgafv", "$.xgafv"),
+                    ("access-token", "access_token"),
+                    ("bearer-token", "bearer_token"),
+                    ("oauth-token", "oauth_token"),
+                    ("pretty-print", "prettyPrint"),
+                    ("quota-user", "quotaUser"),
+                    ("upload-type", "uploadType"),
+                    ("upload-protocol", "upload_protocol"),
+                ]
+        };
+
+        match engine._doit(true) {
+            Err(Some(err)) => Err(err),
+            Err(None)      => Ok(engine),
+            Ok(_)          => unreachable!(),
+        }
+    }
+
+    fn doit(&self) -> Result<(), DoitError> {
+        match self._doit(false) {
+            Ok(res) => res,
+            Err(_) => unreachable!(),
+        }
+    }
+}
+
+fn main() {
+    let mut exit_status = 0i32;
+    let arg_data = [
+        ("projects", "methods: 'delete-events', 'events-list', 'events-report', 'group-stats-list', 'groups-get' and 'groups-update'", vec![
+            ("delete-events",
+                    Some(r##"Deletes all error events of a given project."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_clouderrorreporting1_beta1_cli/projects_delete-events",
+                  vec![
+                    (Some(r##"project-name"##),
+                     None,
+                     Some(r##"[Required] The resource name of the Google Cloud Platform project. Written
+        as `projects/` plus the
+        [Google Cloud Platform project
+        ID](https://support.google.com/cloud/answer/6158840).
+        Example: `projects/my-project-123`."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("events-list",
+                    Some(r##"Lists the specified events."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_clouderrorreporting1_beta1_cli/projects_events-list",
+                  vec![
+                    (Some(r##"project-name"##),
+                     None,
+                     Some(r##"[Required] The resource name of the Google Cloud Platform project. Written
+        as `projects/` plus the
+        [Google Cloud Platform project
+        ID](https://support.google.com/cloud/answer/6158840).
+        Example: `projects/my-project-123`."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("events-report",
+                    Some(r##"Report an individual error event.
+        
+        This endpoint accepts <strong>either</strong> an OAuth token,
+        <strong>or</strong> an
+        <a href="https://support.google.com/cloud/answer/6158862">API key</a>
+        for authentication. To use an API key, append it to the URL as the value of
+        a `key` parameter. For example:
+        <pre>POST https://clouderrorreporting.googleapis.com/v1beta1/projects/example-project/events:report?key=123ABC456</pre>"##),
+                    "Details at http://byron.github.io/google-apis-rs/google_clouderrorreporting1_beta1_cli/projects_events-report",
+                  vec![
+                    (Some(r##"project-name"##),
+                     None,
+                     Some(r##"[Required] The resource name of the Google Cloud Platform project. Written
+        as `projects/` plus the
+        [Google Cloud Platform project ID](https://support.google.com/cloud/answer/6158840).
+        Example: `projects/my-project-123`."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("group-stats-list",
+                    Some(r##"Lists the specified groups."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_clouderrorreporting1_beta1_cli/projects_group-stats-list",
+                  vec![
+                    (Some(r##"project-name"##),
+                     None,
+                     Some(r##"[Required] The resource name of the Google Cloud Platform project. Written
+        as <code>projects/</code> plus the
+        <a href="https://support.google.com/cloud/answer/6158840">Google Cloud
+        Platform project ID</a>.
+        
+        Example: <code>projects/my-project-123</code>."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("groups-get",
+                    Some(r##"Get the specified group."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_clouderrorreporting1_beta1_cli/projects_groups-get",
+                  vec![
+                    (Some(r##"group-name"##),
+                     None,
+                     Some(r##"[Required] The group resource name. Written as
+        <code>projects/<var>projectID</var>/groups/<var>group_name</var></code>.
+        Call
+        <a href="/error-reporting/reference/rest/v1beta1/projects.groupStats/list">
+        <code>groupStats.list</code></a> to return a list of groups belonging to
+        this project.
+        
+        Example: <code>projects/my-project-123/groups/my-group</code>"##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("groups-update",
+                    Some(r##"Replace the data for the specified group.
+        Fails if the group does not exist."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_clouderrorreporting1_beta1_cli/projects_groups-update",
+                  vec![
+                    (Some(r##"name"##),
+                     None,
+                     Some(r##"The group resource name.
+        Example: <code>projects/my-project-123/groups/my-groupid</code>"##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ]),
+        
+    ];
+    
+    let mut app = App::new("clouderrorreporting1-beta1")
+           .author("Sebastian Thiel <byronimo@gmail.com>")
+           .version("1.0.7+20171201")
+           .about("Groups and counts similar errors from cloud services and applications, reports new errors, and provides access to error groups and their associated errors.
+           ")
+           .after_help("All documentation details can be found at http://byron.github.io/google-apis-rs/google_clouderrorreporting1_beta1_cli")
+           .arg(Arg::with_name("url")
+                   .long("scope")
+                   .help("Specify the authentication a method should be executed in. Each scope requires the user to grant this application permission to use it.If unset, it defaults to the shortest scope url for a particular method.")
+                   .multiple(true)
+                   .takes_value(true))
+           .arg(Arg::with_name("folder")
+                   .long("config-dir")
+                   .help("A directory into which we will store our persistent data. Defaults to a user-writable directory that we will create during the first invocation.[default: ~/.google-service-cli")
+                   .multiple(false)
+                   .takes_value(true))
+           .arg(Arg::with_name("debug")
+                   .long("debug")
+                   .help("Output all server communication to standard error. `tx` and `rx` are placed into the same stream.")
+                   .multiple(false)
+                   .takes_value(false))
+           .arg(Arg::with_name("debug-auth")
+                   .long("debug-auth")
+                   .help("Output all communication related to authentication to standard error. `tx` and `rx` are placed into the same stream.")
+                   .multiple(false)
+                   .takes_value(false));
+           
+           for &(main_command_name, about, ref subcommands) in arg_data.iter() {
+               let mut mcmd = SubCommand::with_name(main_command_name).about(about);
+           
+               for &(sub_command_name, ref desc, url_info, ref args) in subcommands {
+                   let mut scmd = SubCommand::with_name(sub_command_name);
+                   if let &Some(desc) = desc {
+                       scmd = scmd.about(desc);
+                   }
+                   scmd = scmd.after_help(url_info);
+           
+                   for &(ref arg_name, ref flag, ref desc, ref required, ref multi) in args {
+                       let arg_name_str =
+                           match (arg_name, flag) {
+                                   (&Some(an), _       ) => an,
+                                   (_        , &Some(f)) => f,
+                                    _                    => unreachable!(),
+                            };
+                       let mut arg = Arg::with_name(arg_name_str)
+                                         .empty_values(false);
+                       if let &Some(short_flag) = flag {
+                           arg = arg.short(short_flag);
+                       }
+                       if let &Some(desc) = desc {
+                           arg = arg.help(desc);
+                       }
+                       if arg_name.is_some() && flag.is_some() {
+                           arg = arg.takes_value(true);
+                       }
+                       if let &Some(required) = required {
+                           arg = arg.required(required);
+                       }
+                       if let &Some(multi) = multi {
+                           arg = arg.multiple(multi);
+                       }
+                       scmd = scmd.arg(arg);
+                   }
+                   mcmd = mcmd.subcommand(scmd);
+               }
+               app = app.subcommand(mcmd);
+           }
+           
+        let matches = app.get_matches();
+
+    let debug = matches.is_present("debug");
+    match Engine::new(matches) {
+        Err(err) => {
+            exit_status = err.exit_code;
+            writeln!(io::stderr(), "{}", err).ok();
+        },
+        Ok(engine) => {
+            if let Err(doit_err) = engine.doit() {
+                exit_status = 1;
+                match doit_err {
+                    DoitError::IoError(path, err) => {
+                        writeln!(io::stderr(), "Failed to open output file '{}': {}", path, err).ok();
+                    },
+                    DoitError::ApiError(err) => {
+                        if debug {
+                            writeln!(io::stderr(), "{:#?}", err).ok();
+                        } else {
+                            writeln!(io::stderr(), "{}", err).ok();
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    std::process::exit(exit_status);
+}

--- a/gen/clouderrorreporting1_beta1/Cargo.toml
+++ b/gen/clouderrorreporting1_beta1/Cargo.toml
@@ -1,0 +1,31 @@
+# DO NOT EDIT !
+# This file was generated automatically from 'src/mako/Cargo.toml.mako'
+# DO NOT EDIT !
+[package]
+
+name = "google-clouderrorreporting1_beta1"
+version = "1.0.7+20171201"
+authors = ["Sebastian Thiel <byronimo@gmail.com>"]
+description = "A complete library to interact with Clouderrorreporting (protocol v1beta1)"
+repository = "https://github.com/Byron/google-apis-rs/tree/master/gen/clouderrorreporting1_beta1"
+homepage = "https://cloud.google.com/error-reporting/"
+documentation = "https://docs.rs/google-clouderrorreporting1_beta1/1.0.7+20171201"
+license = "MIT"
+keywords = ["clouderrorreporting", "google", "protocol", "web", "api"]
+
+
+[dev-dependencies]
+hyper-rustls = "^0.6"
+
+[dependencies]
+hyper = "^ 0.10"
+mime = "^ 0.2.0"
+serde = "^ 1.0"
+serde_json = "^ 1.0"
+serde_derive = "^ 1.0"
+yup-oauth2 = "^ 1.0"
+url = "= 0.5"
+
+[features]
+
+

--- a/gen/clouderrorreporting1_beta1/LICENSE.md
+++ b/gen/clouderrorreporting1_beta1/LICENSE.md
@@ -1,0 +1,30 @@
+<!---
+DO NOT EDIT !
+This file was generated automatically from 'src/mako/LICENSE.md.mako'
+DO NOT EDIT !
+-->
+The MIT License (MIT)
+=====================
+
+Copyright © `2015-2016` `Sebastian Thiel`
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the “Software”), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.

--- a/gen/clouderrorreporting1_beta1/README.md
+++ b/gen/clouderrorreporting1_beta1/README.md
@@ -1,0 +1,181 @@
+<!---
+DO NOT EDIT !
+This file was generated automatically from 'src/mako/api/README.md.mako'
+DO NOT EDIT !
+-->
+The `google-clouderrorreporting1_beta1` library allows access to all features of the *Google Clouderrorreporting* service.
+
+This documentation was generated from *Clouderrorreporting* crate version *1.0.7+20171201*, where *20171201* is the exact revision of the *clouderrorreporting:v1beta1* schema built by the [mako](http://www.makotemplates.org/) code generator *v1.0.7*.
+
+Everything else about the *Clouderrorreporting* *v1_beta1* API can be found at the
+[official documentation site](https://cloud.google.com/error-reporting/).
+# Features
+
+Handle the following *Resources* with ease from the central [hub](https://docs.rs/google-clouderrorreporting1_beta1/1.0.7+20171201/google_clouderrorreporting1_beta1/struct.Clouderrorreporting.html) ... 
+
+* projects
+ * [*delete events*](https://docs.rs/google-clouderrorreporting1_beta1/1.0.7+20171201/google_clouderrorreporting1_beta1/struct.ProjectDeleteEventCall.html), [*events list*](https://docs.rs/google-clouderrorreporting1_beta1/1.0.7+20171201/google_clouderrorreporting1_beta1/struct.ProjectEventListCall.html), [*events report*](https://docs.rs/google-clouderrorreporting1_beta1/1.0.7+20171201/google_clouderrorreporting1_beta1/struct.ProjectEventReportCall.html), [*group stats list*](https://docs.rs/google-clouderrorreporting1_beta1/1.0.7+20171201/google_clouderrorreporting1_beta1/struct.ProjectGroupStatListCall.html), [*groups get*](https://docs.rs/google-clouderrorreporting1_beta1/1.0.7+20171201/google_clouderrorreporting1_beta1/struct.ProjectGroupGetCall.html) and [*groups update*](https://docs.rs/google-clouderrorreporting1_beta1/1.0.7+20171201/google_clouderrorreporting1_beta1/struct.ProjectGroupUpdateCall.html)
+
+
+
+
+# Structure of this Library
+
+The API is structured into the following primary items:
+
+* **[Hub](https://docs.rs/google-clouderrorreporting1_beta1/1.0.7+20171201/google_clouderrorreporting1_beta1/struct.Clouderrorreporting.html)**
+    * a central object to maintain state and allow accessing all *Activities*
+    * creates [*Method Builders*](https://docs.rs/google-clouderrorreporting1_beta1/1.0.7+20171201/google_clouderrorreporting1_beta1/trait.MethodsBuilder.html) which in turn
+      allow access to individual [*Call Builders*](https://docs.rs/google-clouderrorreporting1_beta1/1.0.7+20171201/google_clouderrorreporting1_beta1/trait.CallBuilder.html)
+* **[Resources](https://docs.rs/google-clouderrorreporting1_beta1/1.0.7+20171201/google_clouderrorreporting1_beta1/trait.Resource.html)**
+    * primary types that you can apply *Activities* to
+    * a collection of properties and *Parts*
+    * **[Parts](https://docs.rs/google-clouderrorreporting1_beta1/1.0.7+20171201/google_clouderrorreporting1_beta1/trait.Part.html)**
+        * a collection of properties
+        * never directly used in *Activities*
+* **[Activities](https://docs.rs/google-clouderrorreporting1_beta1/1.0.7+20171201/google_clouderrorreporting1_beta1/trait.CallBuilder.html)**
+    * operations to apply to *Resources*
+
+All *structures* are marked with applicable traits to further categorize them and ease browsing.
+
+Generally speaking, you can invoke *Activities* like this:
+
+```Rust,ignore
+let r = hub.resource().activity(...).doit()
+```
+
+Or specifically ...
+
+```ignore
+let r = hub.projects().groups_get(...).doit()
+let r = hub.projects().groups_update(...).doit()
+```
+
+The `resource()` and `activity(...)` calls create [builders][builder-pattern]. The second one dealing with `Activities` 
+supports various methods to configure the impending operation (not shown here). It is made such that all required arguments have to be 
+specified right away (i.e. `(...)`), whereas all optional ones can be [build up][builder-pattern] as desired.
+The `doit()` method performs the actual communication with the server and returns the respective result.
+
+# Usage
+
+## Setting up your Project
+
+To use this library, you would put the following lines into your `Cargo.toml` file:
+
+```toml
+[dependencies]
+google-clouderrorreporting1_beta1 = "*"
+```
+
+## A complete example
+
+```Rust
+extern crate hyper;
+extern crate hyper_rustls;
+extern crate yup_oauth2 as oauth2;
+extern crate google_clouderrorreporting1_beta1 as clouderrorreporting1_beta1;
+use clouderrorreporting1_beta1::ErrorGroup;
+use clouderrorreporting1_beta1::{Result, Error};
+use std::default::Default;
+use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+use clouderrorreporting1_beta1::Clouderrorreporting;
+
+// Get an ApplicationSecret instance by some means. It contains the `client_id` and 
+// `client_secret`, among other things.
+let secret: ApplicationSecret = Default::default();
+// Instantiate the authenticator. It will choose a suitable authentication flow for you, 
+// unless you replace  `None` with the desired Flow.
+// Provide your own `AuthenticatorDelegate` to adjust the way it operates and get feedback about 
+// what's going on. You probably want to bring in your own `TokenStorage` to persist tokens and
+// retrieve them from storage.
+let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+                              hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+                              <MemoryStorage as Default>::default(), None);
+let mut hub = Clouderrorreporting::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+// As the method needs a request, you would usually fill it with the desired information
+// into the respective structure. Some of the parts shown here might not be applicable !
+// Values shown here are possibly random and not representative !
+let mut req = ErrorGroup::default();
+
+// You can configure optional parameters by calling the respective setters at will, and
+// execute the final call using `doit()`.
+// Values shown here are possibly random and not representative !
+let result = hub.projects().groups_update(req, "name")
+             .doit();
+
+match result {
+    Err(e) => match e {
+        // The Error enum provides details about what exactly happened.
+        // You can also just use its `Debug`, `Display` or `Error` traits
+         Error::HttpError(_)
+        |Error::MissingAPIKey
+        |Error::MissingToken(_)
+        |Error::Cancelled
+        |Error::UploadSizeLimitExceeded(_, _)
+        |Error::Failure(_)
+        |Error::BadRequest(_)
+        |Error::FieldClash(_)
+        |Error::JsonDecodeError(_, _) => println!("{}", e),
+    },
+    Ok(res) => println!("Success: {:?}", res),
+}
+
+```
+## Handling Errors
+
+All errors produced by the system are provided either as [Result](https://docs.rs/google-clouderrorreporting1_beta1/1.0.7+20171201/google_clouderrorreporting1_beta1/enum.Result.html) enumeration as return value of 
+the doit() methods, or handed as possibly intermediate results to either the 
+[Hub Delegate](https://docs.rs/google-clouderrorreporting1_beta1/1.0.7+20171201/google_clouderrorreporting1_beta1/trait.Delegate.html), or the [Authenticator Delegate](https://docs.rs/yup-oauth2/*/yup_oauth2/trait.AuthenticatorDelegate.html).
+
+When delegates handle errors or intermediate values, they may have a chance to instruct the system to retry. This 
+makes the system potentially resilient to all kinds of errors.
+
+## Uploads and Downloads
+If a method supports downloads, the response body, which is part of the [Result](https://docs.rs/google-clouderrorreporting1_beta1/1.0.7+20171201/google_clouderrorreporting1_beta1/enum.Result.html), should be
+read by you to obtain the media.
+If such a method also supports a [Response Result](https://docs.rs/google-clouderrorreporting1_beta1/1.0.7+20171201/google_clouderrorreporting1_beta1/trait.ResponseResult.html), it will return that by default.
+You can see it as meta-data for the actual media. To trigger a media download, you will have to set up the builder by making
+this call: `.param("alt", "media")`.
+
+Methods supporting uploads can do so using up to 2 different protocols: 
+*simple* and *resumable*. The distinctiveness of each is represented by customized 
+`doit(...)` methods, which are then named `upload(...)` and `upload_resumable(...)` respectively.
+
+## Customization and Callbacks
+
+You may alter the way an `doit()` method is called by providing a [delegate](https://docs.rs/google-clouderrorreporting1_beta1/1.0.7+20171201/google_clouderrorreporting1_beta1/trait.Delegate.html) to the 
+[Method Builder](https://docs.rs/google-clouderrorreporting1_beta1/1.0.7+20171201/google_clouderrorreporting1_beta1/trait.CallBuilder.html) before making the final `doit()` call. 
+Respective methods will be called to provide progress information, as well as determine whether the system should 
+retry on failure.
+
+The [delegate trait](https://docs.rs/google-clouderrorreporting1_beta1/1.0.7+20171201/google_clouderrorreporting1_beta1/trait.Delegate.html) is default-implemented, allowing you to customize it with minimal effort.
+
+## Optional Parts in Server-Requests
+
+All structures provided by this library are made to be [enocodable](https://docs.rs/google-clouderrorreporting1_beta1/1.0.7+20171201/google_clouderrorreporting1_beta1/trait.RequestValue.html) and 
+[decodable](https://docs.rs/google-clouderrorreporting1_beta1/1.0.7+20171201/google_clouderrorreporting1_beta1/trait.ResponseResult.html) via *json*. Optionals are used to indicate that partial requests are responses 
+are valid.
+Most optionals are are considered [Parts](https://docs.rs/google-clouderrorreporting1_beta1/1.0.7+20171201/google_clouderrorreporting1_beta1/trait.Part.html) which are identifiable by name, which will be sent to 
+the server to indicate either the set parts of the request or the desired parts in the response.
+
+## Builder Arguments
+
+Using [method builders](https://docs.rs/google-clouderrorreporting1_beta1/1.0.7+20171201/google_clouderrorreporting1_beta1/trait.CallBuilder.html), you are able to prepare an action call by repeatedly calling it's methods.
+These will always take a single argument, for which the following statements are true.
+
+* [PODs][wiki-pod] are handed by copy
+* strings are passed as `&str`
+* [request values](https://docs.rs/google-clouderrorreporting1_beta1/1.0.7+20171201/google_clouderrorreporting1_beta1/trait.RequestValue.html) are moved
+
+Arguments will always be copied or cloned into the builder, to make them independent of their original life times.
+
+[wiki-pod]: http://en.wikipedia.org/wiki/Plain_old_data_structure
+[builder-pattern]: http://en.wikipedia.org/wiki/Builder_pattern
+[google-go-api]: https://github.com/google/google-api-go-client
+
+# License
+The **clouderrorreporting1_beta1** library was generated by Sebastian Thiel, and is placed 
+under the *MIT* license.
+You can read the full text at the repository's [license file][repo-license].
+
+[repo-license]: https://github.com/Byron/google-apis-rsblob/master/LICENSE.md

--- a/gen/clouderrorreporting1_beta1/src/cmn.rs
+++ b/gen/clouderrorreporting1_beta1/src/cmn.rs
@@ -1,0 +1,753 @@
+// COPY OF 'src/rust/api/cmn.rs'
+// DO NOT EDIT
+use std::io::{self, Read, Seek, Cursor, Write, SeekFrom};
+use std;
+use std::fmt::{self, Display};
+use std::str::FromStr;
+use std::error;
+use std::thread::sleep;
+use std::time::Duration;
+
+use mime::{Mime, TopLevel, SubLevel, Attr, Value};
+use oauth2::{TokenType, Retry, self};
+use hyper;
+use hyper::header::{ContentType, ContentLength, Headers, UserAgent, Authorization, Header,
+                    HeaderFormat, Bearer};
+use hyper::http::h1::LINE_ENDING;
+use hyper::method::Method;
+use hyper::status::StatusCode;
+
+use serde_json as json;
+
+/// Identifies the Hub. There is only one per library, this trait is supposed
+/// to make intended use more explicit.
+/// The hub allows to access all resource methods more easily.
+pub trait Hub {}
+
+/// Identifies types for building methods of a particular resource type
+pub trait MethodsBuilder {}
+
+/// Identifies types which represent builders for a particular resource method
+pub trait CallBuilder {}
+
+/// Identifies types which can be inserted and deleted.
+/// Types with this trait are most commonly used by clients of this API.
+pub trait Resource {}
+
+/// Identifies types which are used in API responses.
+pub trait ResponseResult {}
+
+/// Identifies types which are used in API requests.
+pub trait RequestValue {}
+
+/// Identifies types which are not actually used by the API
+/// This might be a bug within the google API schema.
+pub trait UnusedType {}
+
+/// Identifies types which are only used as part of other types, which
+/// usually are carrying the `Resource` trait.
+pub trait Part {}
+
+/// Identifies types which are only used by other types internally.
+/// They have no special meaning, this trait just marks them for completeness.
+pub trait NestedType {}
+
+/// A utility to specify reader types which provide seeking capabilities too
+pub trait ReadSeek: Seek + Read {}
+impl<T: Seek + Read> ReadSeek for T {}
+
+/// A trait for all types that can convert themselves into a *parts* string
+pub trait ToParts {
+    fn to_parts(&self) -> String;
+}
+
+/// A utility type which can decode a server response that indicates error
+#[derive(Deserialize)]
+pub struct JsonServerError {
+    pub error: String,
+    pub error_description: Option<String>
+}
+
+/// A utility to represent detailed errors we might see in case there are BadRequests.
+/// The latter happen if the sent parameters or request structures are unsound
+#[derive(Deserialize, Serialize, Debug)]
+pub struct ErrorResponse {
+    error: ServerError,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct ServerError {
+    errors: Vec<ServerMessage>,
+    code: u16,
+    message: String,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct ServerMessage {
+    domain: String,
+    reason: String,
+    message: String,
+    #[serde(rename="locationType")]
+    location_type: Option<String>,
+    location: Option<String>
+}
+
+#[derive(Copy, Clone)]
+pub struct DummyNetworkStream;
+
+impl Read for DummyNetworkStream {
+    fn read(&mut self, _: &mut [u8]) -> io::Result<usize> {
+        Ok(0)
+    }
+}
+
+impl Write for DummyNetworkStream {
+    fn write(&mut self, _: &[u8]) -> io::Result<usize> {
+        Ok(0)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl hyper::net::NetworkStream for DummyNetworkStream {
+    fn peer_addr(&mut self) -> io::Result<std::net::SocketAddr> {
+        Ok("127.0.0.1:1337".parse().unwrap())
+    }
+
+    fn set_read_timeout(&self, _dur: Option<Duration>) -> io::Result<()> {
+        Ok(())
+    }
+
+    fn set_write_timeout(&self, _dur: Option<Duration>) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+
+/// A trait specifying functionality to help controlling any request performed by the API.
+/// The trait has a conservative default implementation.
+///
+/// It contains methods to deal with all common issues, as well with the ones related to
+/// uploading media
+pub trait Delegate {
+
+    /// Called at the beginning of any API request. The delegate should store the method
+    /// information if he is interesting in knowing more context when further calls to it
+    /// are made.
+    /// The matching `finished()` call will always be made, no matter whether or not the API
+    /// request was successful. That way, the delegate may easily maintain a clean state
+    /// between various API calls.
+    fn begin(&mut self, MethodInfo) {}
+
+    /// Called whenever there is an [HttpError](http://hyperium.github.io/hyper/hyper/error/enum.HttpError.html), usually if there are network problems.
+    ///
+    /// If you choose to retry after a duration, the duration should be chosen using the
+    /// [exponential backoff algorithm](http://en.wikipedia.org/wiki/Exponential_backoff).
+    ///
+    /// Return retry information.
+    fn http_error(&mut self, &hyper::Error) -> Retry {
+        Retry::Abort
+    }
+
+    /// Called whenever there is the need for your applications API key after
+    /// the official authenticator implementation didn't provide one, for some reason.
+    /// If this method returns None as well, the underlying operation will fail
+    fn api_key(&mut self) -> Option<String> {
+        None
+    }
+
+    /// Called whenever the Authenticator didn't yield a token. The delegate
+    /// may attempt to provide one, or just take it as a general information about the
+    /// impending failure.
+    /// The given Error provides information about why the token couldn't be acquired in the
+    /// first place
+    fn token(&mut self, err: &error::Error) -> Option<oauth2::Token> {
+        let _ = err;
+        None
+    }
+
+    /// Called during resumable uploads to provide a URL for the impending upload.
+    /// It was saved after a previous call to `store_upload_url(...)`, and if not None,
+    /// will be used instead of asking the server for a new upload URL.
+    /// This is useful in case a previous resumable upload was aborted/canceled, but should now
+    /// be resumed.
+    /// The returned URL will be used exactly once - if it fails again and the delegate allows
+    /// to retry, we will ask the server for a new upload URL.
+    fn upload_url(&mut self) -> Option<String> {
+        None
+    }
+
+    /// Called after we have retrieved a new upload URL for a resumable upload to store it
+    /// in case we fail or cancel. That way, we can attempt to resume the upload later,
+    /// see `upload_url()`.
+    /// It will also be called with None after a successful upload, which allows the delegate
+    /// to forget the URL. That way, we will not attempt to resume an upload that has already
+    /// finished.
+    fn store_upload_url(&mut self, url: Option<&str>) {
+        let _ = url;
+    }
+
+    /// Called whenever a server response could not be decoded from json.
+    /// It's for informational purposes only, the caller will return with an error
+    /// accordingly.
+    ///
+    /// # Arguments
+    ///
+    /// * `json_encoded_value` - The json-encoded value which failed to decode.
+    /// * `json_decode_error`  - The decoder error
+    fn response_json_decode_error(&mut self, json_encoded_value: &str, json_decode_error: &json::Error) {
+        let _ = json_encoded_value;
+        let _ = json_decode_error;
+    }
+
+    /// Called whenever the http request returns with a non-success status code.
+    /// This can involve authentication issues, or anything else that very much
+    /// depends on the used API method.
+    /// The delegate should check the status, header and decoded json error to decide
+    /// whether to retry or not. In the latter case, the underlying call will fail.
+    ///
+    /// If you choose to retry after a duration, the duration should be chosen using the
+    /// [exponential backoff algorithm](http://en.wikipedia.org/wiki/Exponential_backoff).
+    fn http_failure(&mut self, _: &hyper::client::Response, Option<JsonServerError>, _: Option<ServerError>) -> Retry {
+        Retry::Abort
+    }
+
+    /// Called prior to sending the main request of the given method. It can be used to time
+    /// the call or to print progress information.
+    /// It's also useful as you can be sure that a request will definitely be made.
+    fn pre_request(&mut self) { }
+
+    /// Return the size of each chunk of a resumable upload.
+    /// Must be a power of two, with 1<<18 being the smallest allowed chunk size.
+    /// Will be called once before starting any resumable upload.
+    fn chunk_size(&mut self) -> u64 {
+        1 << 23
+    }
+
+    /// Called before the given chunk is uploaded to the server.
+    /// If true is returned, the upload will be interrupted.
+    /// However, it may be resumable if you stored the upload URL in a previous call
+    /// to `store_upload_url()`
+    fn cancel_chunk_upload(&mut self, chunk: &ContentRange) -> bool {
+        let _ = chunk;
+        false
+    }
+
+    /// Called before the API request method returns, in every case. It can be used to clean up
+    /// internal state between calls to the API.
+    /// This call always has a matching call to `begin(...)`.
+    ///
+    /// # Arguments
+    ///
+    /// * `is_success` - a true value indicates the operation was successful. If false, you should
+    ///                  discard all values stored during `store_upload_url`.
+    fn finished(&mut self, is_success: bool) {
+        let _ = is_success;
+    }
+}
+
+/// A delegate with a conservative default implementation, which is used if no other delegate is
+/// set.
+#[derive(Default)]
+pub struct DefaultDelegate;
+
+impl Delegate for DefaultDelegate {}
+
+
+#[derive(Debug)]
+pub enum Error {
+    /// The http connection failed
+    HttpError(hyper::Error),
+
+    /// An attempt was made to upload a resource with size stored in field `.0`
+    /// even though the maximum upload size is what is stored in field `.1`.
+    UploadSizeLimitExceeded(u64, u64),
+
+    /// Represents information about a request that was not understood by the server.
+    /// Details are included.
+    BadRequest(ErrorResponse),
+
+    /// We needed an API key for authentication, but didn't obtain one.
+    /// Neither through the authenticator, nor through the Delegate.
+    MissingAPIKey,
+
+    /// We required a Token, but didn't get one from the Authenticator
+    MissingToken(Box<error::Error>),
+
+    /// The delgate instructed to cancel the operation
+    Cancelled,
+
+    /// An additional, free form field clashed with one of the built-in optional ones
+    FieldClash(&'static str),
+
+    /// Shows that we failed to decode the server response.
+    /// This can happen if the protocol changes in conjunction with strict json decoding.
+    JsonDecodeError(String, json::Error),
+
+    /// Indicates an HTTP repsonse with a non-success status code
+    Failure(hyper::client::Response),
+}
+
+
+impl Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Error::HttpError(ref err) => err.fmt(f),
+            Error::UploadSizeLimitExceeded(ref resource_size, ref max_size) =>
+                writeln!(f, "The media size {} exceeds the maximum allowed upload size of {}"
+                         , resource_size, max_size),
+            Error::MissingAPIKey => {
+                (writeln!(f, "The application's API key was not found in the configuration")).ok();
+                writeln!(f, "It is used as there are no Scopes defined for this method.")
+            },
+            Error::BadRequest(ref err) => {
+                try!(writeln!(f, "Bad Request ({}): {}", err.error.code, err.error.message));
+                for err in err.error.errors.iter() {
+                    try!(writeln!(f, "    {}: {}, {}{}",
+                                            err.domain,
+                                            err.message,
+                                            err.reason,
+                                            match &err.location {
+                                                &Some(ref loc) => format!("@{}", loc),
+                                                &None => String::new(),
+                                            }));
+                }
+                Ok(())
+            },
+            Error::MissingToken(ref err) =>
+                writeln!(f, "Token retrieval failed with error: {}", err),
+            Error::Cancelled =>
+                writeln!(f, "Operation cancelled by delegate"),
+            Error::FieldClash(field) =>
+                writeln!(f, "The custom parameter '{}' is already provided natively by the CallBuilder.", field),
+            Error::JsonDecodeError(ref json_str, ref err)
+                => writeln!(f, "{}: {}", err, json_str),
+            Error::Failure(ref response) =>
+                writeln!(f, "Http status indicates failure: {:?}", response),
+        }
+    }
+}
+
+impl error::Error for Error {
+    fn description(&self) -> &str {
+        match *self {
+            Error::HttpError(ref err) => err.description(),
+            Error::JsonDecodeError(_, ref err) => err.description(),
+            _ => "NO DESCRIPTION POSSIBLE - use `Display.fmt()` instead"
+        }
+    }
+
+    fn cause(&self) -> Option<&error::Error> {
+        match *self {
+            Error::HttpError(ref err) => err.cause(),
+            Error::JsonDecodeError(_, ref err) => err.cause(),
+            _ => None
+        }
+    }
+}
+
+/// A universal result type used as return for all calls.
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Contains information about an API request.
+pub struct MethodInfo {
+    pub id: &'static str,
+    pub http_method: Method,
+}
+
+const BOUNDARY: &'static str = "MDuXWGyeE33QFXGchb2VFWc4Z7945d";
+
+/// Provides a `Read` interface that converts multiple parts into the protocol
+/// identified by [RFC2387](https://tools.ietf.org/html/rfc2387).
+/// **Note**: This implementation is just as rich as it needs to be to perform uploads
+/// to google APIs, and might not be a fully-featured implementation.
+#[derive(Default)]
+pub struct MultiPartReader<'a> {
+    raw_parts: Vec<(Headers, &'a mut Read)>,
+    current_part: Option<(Cursor<Vec<u8>>, &'a mut Read)>,
+    last_part_boundary: Option<Cursor<Vec<u8>>>,
+}
+
+impl<'a> MultiPartReader<'a> {
+
+    /// Reserve memory for exactly the given amount of parts
+    pub fn reserve_exact(&mut self, cap: usize) {
+        self.raw_parts.reserve_exact(cap);
+    }
+
+    /// Add a new part to the queue of parts to be read on the first `read` call.
+    ///
+    /// # Arguments
+    ///
+    /// `headers` - identifying the body of the part. It's similar to the header
+    ///             in an ordinary single-part call, and should thus contain the
+    ///             same information.
+    /// `reader`  - a reader providing the part's body
+    /// `size`    - the amount of bytes provided by the reader. It will be put onto the header as
+    ///             content-size.
+    /// `mime`    - It will be put onto the content type
+    pub fn add_part(&mut self, reader: &'a mut Read, size: u64, mime_type: Mime) -> &mut MultiPartReader<'a> {
+        let mut headers = Headers::new();
+        headers.set(ContentType(mime_type));
+        headers.set(ContentLength(size));
+        self.raw_parts.push((headers, reader));
+        self
+    }
+
+    /// Returns the mime-type representing our multi-part message.
+    /// Use it with the ContentType header.
+    pub fn mime_type(&self) -> Mime {
+        Mime(
+            TopLevel::Multipart,
+            SubLevel::Ext("Related".to_string()),
+            vec![(Attr::Ext("boundary".to_string()), Value::Ext(BOUNDARY.to_string()))],
+        )
+    }
+
+    /// Returns true if we are totally used
+    fn is_depleted(&self) -> bool {
+        self.raw_parts.len() == 0 && self.current_part.is_none() && self.last_part_boundary.is_none()
+    }
+
+    /// Returns true if we are handling our last part
+    fn is_last_part(&self) -> bool {
+        self.raw_parts.len() == 0 && self.current_part.is_some()
+    }
+}
+
+impl<'a> Read for MultiPartReader<'a> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        match (self.raw_parts.len(),
+               self.current_part.is_none(),
+               self.last_part_boundary.is_none()) {
+            (_, _, false) => {
+                let br = self.last_part_boundary.as_mut().unwrap().read(buf).unwrap_or(0);
+                if br < buf.len() {
+                    self.last_part_boundary = None;
+                }
+                return Ok(br)
+            },
+            (0, true, true) => return Ok(0),
+            (n, true, _) if n > 0 => {
+                let (headers, reader) = self.raw_parts.remove(0);
+                let mut c = Cursor::new(Vec::<u8>::new());
+                (write!(&mut c, "{}--{}{}{}{}", LINE_ENDING, BOUNDARY, LINE_ENDING,
+                                                headers, LINE_ENDING)).unwrap();
+                c.seek(SeekFrom::Start(0)).unwrap();
+                self.current_part = Some((c, reader));
+            }
+            _ => {},
+        }
+
+        // read headers as long as possible
+        let (hb, rr) = {
+            let &mut (ref mut c, ref mut reader) = self.current_part.as_mut().unwrap();
+            let b = c.read(buf).unwrap_or(0);
+            (b, reader.read(&mut buf[b..]))
+        };
+
+        match rr {
+            Ok(bytes_read) => {
+                if hb < buf.len() && bytes_read == 0 {
+                    if self.is_last_part() {
+                        // before clearing the last part, we will add the boundary that
+                        // will be written last
+                        self.last_part_boundary = Some(Cursor::new(
+                                                        format!("{}--{}--", LINE_ENDING, BOUNDARY).into_bytes()))
+                    }
+                    // We are depleted - this can trigger the next part to come in
+                    self.current_part = None;
+                }
+                let mut total_bytes_read = hb + bytes_read;
+                while total_bytes_read < buf.len() && !self.is_depleted() {
+                    match self.read(&mut buf[total_bytes_read ..]) {
+                        Ok(br) => total_bytes_read += br,
+                        Err(err) => return Err(err),
+                    }
+                }
+                Ok(total_bytes_read)
+            }
+            Err(err) => {
+                // fail permanently
+                self.current_part = None;
+                self.last_part_boundary = None;
+                self.raw_parts.clear();
+                Err(err)
+            }
+        }
+    }
+}
+
+/// The `X-Upload-Content-Type` header.
+///
+/// Generated via rustc --pretty expanded -Z unstable-options, and manually
+/// processed to be more readable.
+#[derive(PartialEq, Debug, Clone)]
+pub struct XUploadContentType(pub Mime);
+
+impl ::std::ops::Deref for XUploadContentType {
+    type Target = Mime;
+    fn deref<'a>(&'a self) -> &'a Mime { &self.0 }
+}
+impl ::std::ops::DerefMut for XUploadContentType {
+    fn deref_mut<'a>(&'a mut self) -> &'a mut Mime { &mut self.0 }
+}
+impl Header for XUploadContentType {
+    fn header_name() -> &'static str { "X-Upload-Content-Type" }
+    fn parse_header(raw: &[Vec<u8>]) -> hyper::error::Result<Self> {
+        hyper::header::parsing::from_one_raw_str(raw).map(XUploadContentType)
+    }
+}
+impl HeaderFormat for XUploadContentType {
+    fn fmt_header(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        Display::fmt(&**self, f)
+    }
+}
+impl Display for XUploadContentType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(&**self, f)
+    }
+}
+
+#[derive(Clone, PartialEq, Debug)]
+pub struct Chunk {
+    pub first: u64,
+    pub last: u64
+}
+
+impl fmt::Display for Chunk {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        (write!(fmt, "{}-{}", self.first, self.last)).ok();
+        Ok(())
+    }
+}
+
+impl FromStr for Chunk {
+    type Err = &'static str;
+
+    /// NOTE: only implements `%i-%i`, not `*`
+    fn from_str(s: &str) -> std::result::Result<Chunk, &'static str> {
+        let parts: Vec<&str> = s.split('-').collect();
+        if parts.len() != 2 {
+            return Err("Expected two parts: %i-%i")
+        }
+        Ok(
+            Chunk {
+                first: match FromStr::from_str(parts[0]) {
+                    Ok(d) => d,
+                    _ => return Err("Couldn't parse 'first' as digit")
+                },
+                last: match FromStr::from_str(parts[1]) {
+                    Ok(d) => d,
+                    _ => return Err("Couldn't parse 'last' as digit")
+                }
+            }
+        )
+    }
+}
+
+/// Implements the Content-Range header, for serialization only
+#[derive(Clone, PartialEq, Debug)]
+pub struct ContentRange {
+    pub range: Option<Chunk>,
+    pub total_length: u64,
+}
+
+impl Header for ContentRange {
+    fn header_name() -> &'static str {
+        "Content-Range"
+    }
+
+    /// We are not parsable, as parsing is done by the `Range` header
+    fn parse_header(_: &[Vec<u8>]) -> hyper::error::Result<Self> {
+        Err(hyper::error::Error::Method)
+    }
+}
+
+
+impl HeaderFormat for ContentRange {
+    fn fmt_header(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        try!(fmt.write_str("bytes "));
+        match self.range {
+            Some(ref c) => try!(c.fmt(fmt)),
+            None => try!(fmt.write_str("*"))
+        }
+        (write!(fmt, "/{}", self.total_length)).ok();
+        Ok(())
+    }
+}
+
+#[derive(Clone, PartialEq, Debug)]
+pub struct RangeResponseHeader(pub Chunk);
+
+impl Header for RangeResponseHeader {
+    fn header_name() -> &'static str {
+        "Range"
+    }
+
+    fn parse_header(raw: &[Vec<u8>]) -> hyper::error::Result<Self> {
+        if raw.len() > 0 {
+            let v = &raw[0];
+            if let Ok(s) = std::str::from_utf8(v) {
+                const PREFIX: &'static str = "bytes ";
+                if s.starts_with(PREFIX) {
+                    if let Ok(c) = <Chunk as FromStr>::from_str(&s[PREFIX.len()..]) {
+                        return  Ok(RangeResponseHeader(c))
+                    }
+                }
+            }
+        }
+        Err(hyper::error::Error::Method)
+    }
+}
+
+impl HeaderFormat for RangeResponseHeader {
+    /// No implmentation necessary, we just need to parse
+    fn fmt_header(&self, _: &mut fmt::Formatter) -> fmt::Result {
+        Err(fmt::Error)
+    }
+}
+
+/// A utility type to perform a resumable upload from start to end.
+pub struct ResumableUploadHelper<'a, A: 'a> {
+    pub client: &'a mut hyper::client::Client,
+    pub delegate: &'a mut Delegate,
+    pub start_at: Option<u64>,
+    pub auth: &'a mut A,
+    pub user_agent: &'a str,
+    pub auth_header: Authorization<Bearer>,
+    pub url: &'a str,
+    pub reader: &'a mut ReadSeek,
+    pub media_type: Mime,
+    pub content_length: u64
+}
+
+impl<'a, A> ResumableUploadHelper<'a, A>
+    where A: oauth2::GetToken {
+
+    fn query_transfer_status(&mut self) -> std::result::Result<u64, hyper::Result<hyper::client::Response>> {
+        loop {
+            match self.client.post(self.url)
+                .header(UserAgent(self.user_agent.to_string()))
+                .header(ContentRange { range: None, total_length: self.content_length })
+                .header(self.auth_header.clone())
+                .send() {
+                Ok(r) => {
+                    // 308 = resume-incomplete == PermanentRedirect
+                    let headers = r.headers.clone();
+                    let h: &RangeResponseHeader = match headers.get() {
+                        Some(hh) if r.status == StatusCode::PermanentRedirect => hh,
+                        None|Some(_) => {
+                            if let Retry::After(d) = self.delegate.http_failure(&r, None, None) {
+                                sleep(d);
+                                continue;
+                            }
+                            return Err(Ok(r))
+                        }
+                    };
+                    return Ok(h.0.last)
+                }
+                Err(err) => {
+                    if let Retry::After(d) = self.delegate.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    return Err(Err(err))
+                }
+            }
+        }
+    }
+
+    /// returns None if operation was cancelled by delegate, or the HttpResult.
+    /// It can be that we return the result just because we didn't understand the status code -
+    /// caller should check for status himself before assuming it's OK to use
+    pub fn upload(&mut self) -> Option<hyper::Result<hyper::client::Response>> {
+        let mut start = match self.start_at {
+            Some(s) => s,
+            None => match self.query_transfer_status() {
+                Ok(s) => s,
+                Err(result) => return Some(result)
+            }
+        };
+
+        const MIN_CHUNK_SIZE: u64 = 1 << 18;
+        let chunk_size = match self.delegate.chunk_size() {
+            cs if cs > MIN_CHUNK_SIZE => cs,
+            _ => MIN_CHUNK_SIZE
+        };
+
+        self.reader.seek(SeekFrom::Start(start)).unwrap();
+        loop {
+            let request_size = match self.content_length - start {
+                rs if rs > chunk_size => chunk_size,
+                rs => rs
+            };
+
+            let mut section_reader = self.reader.take(request_size);
+            let range_header = ContentRange {
+                range: Some(Chunk {first: start, last: start + request_size - 1}),
+                total_length: self.content_length
+            };
+            start += request_size;
+            if self.delegate.cancel_chunk_upload(&range_header) {
+                return None
+            }
+            let res = self.client.post(self.url)
+                                 .header(range_header)
+                                 .header(ContentType(self.media_type.clone()))
+                                 .header(UserAgent(self.user_agent.to_string()))
+                                 .body(&mut section_reader)
+                                 .send();
+            match res {
+                Ok(mut res) => {
+                    if res.status == StatusCode::PermanentRedirect  {
+                        continue
+                    }
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let Retry::After(d) = self.delegate.http_failure(&res,
+                                                        json::from_str(&json_err).ok(),
+                                                        json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                    }
+                    return Some(Ok(res))
+                },
+                Err(err) => {
+                    if let Retry::After(d) = self.delegate.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    return Some(Err(err))
+                }
+            }
+        }
+    }
+}
+
+// Copy of src/rust/cli/cmn.rs
+// TODO(ST): Allow sharing common code between program types
+pub fn remove_json_null_values(value: &mut json::value::Value) {
+    match *value {
+        json::value::Value::Object(ref mut map) => {
+            let mut for_removal = Vec::new();
+
+            for (key, mut value) in map.iter_mut() {
+                if value.is_null() {
+                    for_removal.push(key.clone());
+                } else {
+                    remove_json_null_values(&mut value);
+                }
+            }
+
+            for key in &for_removal {
+                map.remove(key);
+            }
+        }
+        _ => {}
+    }
+}

--- a/gen/clouderrorreporting1_beta1/src/lib.rs
+++ b/gen/clouderrorreporting1_beta1/src/lib.rs
@@ -1,0 +1,2845 @@
+// DO NOT EDIT !
+// This file was generated automatically from 'src/mako/api/lib.rs.mako'
+// DO NOT EDIT !
+
+//! This documentation was generated from *Clouderrorreporting* crate version *1.0.7+20171201*, where *20171201* is the exact revision of the *clouderrorreporting:v1beta1* schema built by the [mako](http://www.makotemplates.org/) code generator *v1.0.7*.
+//! 
+//! Everything else about the *Clouderrorreporting* *v1_beta1* API can be found at the
+//! [official documentation site](https://cloud.google.com/error-reporting/).
+//! The original source code is [on github](https://github.com/Byron/google-apis-rs/tree/master/gen/clouderrorreporting1_beta1).
+//! # Features
+//! 
+//! Handle the following *Resources* with ease from the central [hub](struct.Clouderrorreporting.html) ... 
+//! 
+//! * projects
+//!  * [*delete events*](struct.ProjectDeleteEventCall.html), [*events list*](struct.ProjectEventListCall.html), [*events report*](struct.ProjectEventReportCall.html), [*group stats list*](struct.ProjectGroupStatListCall.html), [*groups get*](struct.ProjectGroupGetCall.html) and [*groups update*](struct.ProjectGroupUpdateCall.html)
+//! 
+//! 
+//! 
+//! 
+//! Not what you are looking for ? Find all other Google APIs in their Rust [documentation index](http://byron.github.io/google-apis-rs).
+//! 
+//! # Structure of this Library
+//! 
+//! The API is structured into the following primary items:
+//! 
+//! * **[Hub](struct.Clouderrorreporting.html)**
+//!     * a central object to maintain state and allow accessing all *Activities*
+//!     * creates [*Method Builders*](trait.MethodsBuilder.html) which in turn
+//!       allow access to individual [*Call Builders*](trait.CallBuilder.html)
+//! * **[Resources](trait.Resource.html)**
+//!     * primary types that you can apply *Activities* to
+//!     * a collection of properties and *Parts*
+//!     * **[Parts](trait.Part.html)**
+//!         * a collection of properties
+//!         * never directly used in *Activities*
+//! * **[Activities](trait.CallBuilder.html)**
+//!     * operations to apply to *Resources*
+//! 
+//! All *structures* are marked with applicable traits to further categorize them and ease browsing.
+//! 
+//! Generally speaking, you can invoke *Activities* like this:
+//! 
+//! ```Rust,ignore
+//! let r = hub.resource().activity(...).doit()
+//! ```
+//! 
+//! Or specifically ...
+//! 
+//! ```ignore
+//! let r = hub.projects().groups_get(...).doit()
+//! let r = hub.projects().groups_update(...).doit()
+//! ```
+//! 
+//! The `resource()` and `activity(...)` calls create [builders][builder-pattern]. The second one dealing with `Activities` 
+//! supports various methods to configure the impending operation (not shown here). It is made such that all required arguments have to be 
+//! specified right away (i.e. `(...)`), whereas all optional ones can be [build up][builder-pattern] as desired.
+//! The `doit()` method performs the actual communication with the server and returns the respective result.
+//! 
+//! # Usage
+//! 
+//! ## Setting up your Project
+//! 
+//! To use this library, you would put the following lines into your `Cargo.toml` file:
+//! 
+//! ```toml
+//! [dependencies]
+//! google-clouderrorreporting1_beta1 = "*"
+//! ```
+//! 
+//! ## A complete example
+//! 
+//! ```test_harness,no_run
+//! extern crate hyper;
+//! extern crate hyper_rustls;
+//! extern crate yup_oauth2 as oauth2;
+//! extern crate google_clouderrorreporting1_beta1 as clouderrorreporting1_beta1;
+//! use clouderrorreporting1_beta1::ErrorGroup;
+//! use clouderrorreporting1_beta1::{Result, Error};
+//! # #[test] fn egal() {
+//! use std::default::Default;
+//! use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+//! use clouderrorreporting1_beta1::Clouderrorreporting;
+//! 
+//! // Get an ApplicationSecret instance by some means. It contains the `client_id` and 
+//! // `client_secret`, among other things.
+//! let secret: ApplicationSecret = Default::default();
+//! // Instantiate the authenticator. It will choose a suitable authentication flow for you, 
+//! // unless you replace  `None` with the desired Flow.
+//! // Provide your own `AuthenticatorDelegate` to adjust the way it operates and get feedback about 
+//! // what's going on. You probably want to bring in your own `TokenStorage` to persist tokens and
+//! // retrieve them from storage.
+//! let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+//!                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+//!                               <MemoryStorage as Default>::default(), None);
+//! let mut hub = Clouderrorreporting::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+//! // As the method needs a request, you would usually fill it with the desired information
+//! // into the respective structure. Some of the parts shown here might not be applicable !
+//! // Values shown here are possibly random and not representative !
+//! let mut req = ErrorGroup::default();
+//! 
+//! // You can configure optional parameters by calling the respective setters at will, and
+//! // execute the final call using `doit()`.
+//! // Values shown here are possibly random and not representative !
+//! let result = hub.projects().groups_update(req, "name")
+//!              .doit();
+//! 
+//! match result {
+//!     Err(e) => match e {
+//!         // The Error enum provides details about what exactly happened.
+//!         // You can also just use its `Debug`, `Display` or `Error` traits
+//!          Error::HttpError(_)
+//!         |Error::MissingAPIKey
+//!         |Error::MissingToken(_)
+//!         |Error::Cancelled
+//!         |Error::UploadSizeLimitExceeded(_, _)
+//!         |Error::Failure(_)
+//!         |Error::BadRequest(_)
+//!         |Error::FieldClash(_)
+//!         |Error::JsonDecodeError(_, _) => println!("{}", e),
+//!     },
+//!     Ok(res) => println!("Success: {:?}", res),
+//! }
+//! # }
+//! ```
+//! ## Handling Errors
+//! 
+//! All errors produced by the system are provided either as [Result](enum.Result.html) enumeration as return value of 
+//! the doit() methods, or handed as possibly intermediate results to either the 
+//! [Hub Delegate](trait.Delegate.html), or the [Authenticator Delegate](https://docs.rs/yup-oauth2/*/yup_oauth2/trait.AuthenticatorDelegate.html).
+//! 
+//! When delegates handle errors or intermediate values, they may have a chance to instruct the system to retry. This 
+//! makes the system potentially resilient to all kinds of errors.
+//! 
+//! ## Uploads and Downloads
+//! If a method supports downloads, the response body, which is part of the [Result](enum.Result.html), should be
+//! read by you to obtain the media.
+//! If such a method also supports a [Response Result](trait.ResponseResult.html), it will return that by default.
+//! You can see it as meta-data for the actual media. To trigger a media download, you will have to set up the builder by making
+//! this call: `.param("alt", "media")`.
+//! 
+//! Methods supporting uploads can do so using up to 2 different protocols: 
+//! *simple* and *resumable*. The distinctiveness of each is represented by customized 
+//! `doit(...)` methods, which are then named `upload(...)` and `upload_resumable(...)` respectively.
+//! 
+//! ## Customization and Callbacks
+//! 
+//! You may alter the way an `doit()` method is called by providing a [delegate](trait.Delegate.html) to the 
+//! [Method Builder](trait.CallBuilder.html) before making the final `doit()` call. 
+//! Respective methods will be called to provide progress information, as well as determine whether the system should 
+//! retry on failure.
+//! 
+//! The [delegate trait](trait.Delegate.html) is default-implemented, allowing you to customize it with minimal effort.
+//! 
+//! ## Optional Parts in Server-Requests
+//! 
+//! All structures provided by this library are made to be [enocodable](trait.RequestValue.html) and 
+//! [decodable](trait.ResponseResult.html) via *json*. Optionals are used to indicate that partial requests are responses 
+//! are valid.
+//! Most optionals are are considered [Parts](trait.Part.html) which are identifiable by name, which will be sent to 
+//! the server to indicate either the set parts of the request or the desired parts in the response.
+//! 
+//! ## Builder Arguments
+//! 
+//! Using [method builders](trait.CallBuilder.html), you are able to prepare an action call by repeatedly calling it's methods.
+//! These will always take a single argument, for which the following statements are true.
+//! 
+//! * [PODs][wiki-pod] are handed by copy
+//! * strings are passed as `&str`
+//! * [request values](trait.RequestValue.html) are moved
+//! 
+//! Arguments will always be copied or cloned into the builder, to make them independent of their original life times.
+//! 
+//! [wiki-pod]: http://en.wikipedia.org/wiki/Plain_old_data_structure
+//! [builder-pattern]: http://en.wikipedia.org/wiki/Builder_pattern
+//! [google-go-api]: https://github.com/google/google-api-go-client
+//! 
+//! 
+
+// Unused attributes happen thanks to defined, but unused structures
+// We don't warn about this, as depending on the API, some data structures or facilities are never used.
+// Instead of pre-determining this, we just disable the lint. It's manually tuned to not have any
+// unused imports in fully featured APIs. Same with unused_mut ... .
+#![allow(unused_imports, unused_mut, dead_code)]
+
+// DO NOT EDIT !
+// This file was generated automatically from 'src/mako/api/lib.rs.mako'
+// DO NOT EDIT !
+
+#[macro_use]
+extern crate serde_derive;
+
+extern crate hyper;
+extern crate serde;
+extern crate serde_json;
+extern crate yup_oauth2 as oauth2;
+extern crate mime;
+extern crate url;
+
+mod cmn;
+
+use std::collections::HashMap;
+use std::cell::RefCell;
+use std::borrow::BorrowMut;
+use std::default::Default;
+use std::collections::BTreeMap;
+use serde_json as json;
+use std::io;
+use std::fs;
+use std::mem;
+use std::thread::sleep;
+use std::time::Duration;
+
+pub use cmn::{MultiPartReader, ToParts, MethodInfo, Result, Error, CallBuilder, Hub, ReadSeek, Part,
+              ResponseResult, RequestValue, NestedType, Delegate, DefaultDelegate, MethodsBuilder,
+              Resource, ErrorResponse, remove_json_null_values};
+
+
+// ##############
+// UTILITIES ###
+// ############
+
+/// Identifies the an OAuth2 authorization scope.
+/// A scope is needed when requesting an
+/// [authorization token](https://developers.google.com/youtube/v3/guides/authentication).
+#[derive(PartialEq, Eq, Hash)]
+pub enum Scope {
+    /// View and manage your data across Google Cloud Platform services
+    CloudPlatform,
+}
+
+impl AsRef<str> for Scope {
+    fn as_ref(&self) -> &str {
+        match *self {
+            Scope::CloudPlatform => "https://www.googleapis.com/auth/cloud-platform",
+        }
+    }
+}
+
+impl Default for Scope {
+    fn default() -> Scope {
+        Scope::CloudPlatform
+    }
+}
+
+
+
+// ########
+// HUB ###
+// ######
+
+/// Central instance to access all Clouderrorreporting related resource activities
+///
+/// # Examples
+///
+/// Instantiate a new hub
+///
+/// ```test_harness,no_run
+/// extern crate hyper;
+/// extern crate hyper_rustls;
+/// extern crate yup_oauth2 as oauth2;
+/// extern crate google_clouderrorreporting1_beta1 as clouderrorreporting1_beta1;
+/// use clouderrorreporting1_beta1::ErrorGroup;
+/// use clouderrorreporting1_beta1::{Result, Error};
+/// # #[test] fn egal() {
+/// use std::default::Default;
+/// use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// use clouderrorreporting1_beta1::Clouderrorreporting;
+/// 
+/// // Get an ApplicationSecret instance by some means. It contains the `client_id` and 
+/// // `client_secret`, among other things.
+/// let secret: ApplicationSecret = Default::default();
+/// // Instantiate the authenticator. It will choose a suitable authentication flow for you, 
+/// // unless you replace  `None` with the desired Flow.
+/// // Provide your own `AuthenticatorDelegate` to adjust the way it operates and get feedback about 
+/// // what's going on. You probably want to bring in your own `TokenStorage` to persist tokens and
+/// // retrieve them from storage.
+/// let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+///                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+///                               <MemoryStorage as Default>::default(), None);
+/// let mut hub = Clouderrorreporting::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = ErrorGroup::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.projects().groups_update(req, "name")
+///              .doit();
+/// 
+/// match result {
+///     Err(e) => match e {
+///         // The Error enum provides details about what exactly happened.
+///         // You can also just use its `Debug`, `Display` or `Error` traits
+///          Error::HttpError(_)
+///         |Error::MissingAPIKey
+///         |Error::MissingToken(_)
+///         |Error::Cancelled
+///         |Error::UploadSizeLimitExceeded(_, _)
+///         |Error::Failure(_)
+///         |Error::BadRequest(_)
+///         |Error::FieldClash(_)
+///         |Error::JsonDecodeError(_, _) => println!("{}", e),
+///     },
+///     Ok(res) => println!("Success: {:?}", res),
+/// }
+/// # }
+/// ```
+pub struct Clouderrorreporting<C, A> {
+    client: RefCell<C>,
+    auth: RefCell<A>,
+    _user_agent: String,
+    _base_url: String,
+    _root_url: String,
+}
+
+impl<'a, C, A> Hub for Clouderrorreporting<C, A> {}
+
+impl<'a, C, A> Clouderrorreporting<C, A>
+    where  C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+    pub fn new(client: C, authenticator: A) -> Clouderrorreporting<C, A> {
+        Clouderrorreporting {
+            client: RefCell::new(client),
+            auth: RefCell::new(authenticator),
+            _user_agent: "google-api-rust-client/1.0.7".to_string(),
+            _base_url: "https://clouderrorreporting.googleapis.com/".to_string(),
+            _root_url: "https://clouderrorreporting.googleapis.com/".to_string(),
+        }
+    }
+
+    pub fn projects(&'a self) -> ProjectMethods<'a, C, A> {
+        ProjectMethods { hub: &self }
+    }
+
+    /// Set the user-agent header field to use in all requests to the server.
+    /// It defaults to `google-api-rust-client/1.0.7`.
+    ///
+    /// Returns the previously set user-agent.
+    pub fn user_agent(&mut self, agent_name: String) -> String {
+        mem::replace(&mut self._user_agent, agent_name)
+    }
+
+    /// Set the base url to use in all requests to the server.
+    /// It defaults to `https://clouderrorreporting.googleapis.com/`.
+    ///
+    /// Returns the previously set base url.
+    pub fn base_url(&mut self, new_base_url: String) -> String {
+        mem::replace(&mut self._base_url, new_base_url)
+    }
+
+    /// Set the root url to use in all requests to the server.
+    /// It defaults to `https://clouderrorreporting.googleapis.com/`.
+    ///
+    /// Returns the previously set root url.
+    pub fn root_url(&mut self, new_root_url: String) -> String {
+        mem::replace(&mut self._root_url, new_root_url)
+    }
+}
+
+
+// ############
+// SCHEMAS ###
+// ##########
+/// The number of errors in a given time period.
+/// All numbers are approximate since the error events are sampled
+/// before counting them.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct TimedCount {
+    /// Approximate number of occurrences in the given time period.
+    pub count: Option<String>,
+    /// End of the time period to which `count` refers (excluded).
+    #[serde(rename="endTime")]
+    pub end_time: Option<String>,
+    /// Start of the time period to which `count` refers (included).
+    #[serde(rename="startTime")]
+    pub start_time: Option<String>,
+}
+
+impl Part for TimedCount {}
+
+
+/// Information related to tracking the progress on resolving the error.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct TrackingIssue {
+    /// A URL pointing to a related entry in an issue tracking system.
+    /// Example: https://github.com/user/project/issues/4
+    pub url: Option<String>,
+}
+
+impl Part for TrackingIssue {}
+
+
+/// Contains a set of requested error events.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [events list projects](struct.ProjectEventListCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct ListEventsResponse {
+    /// If non-empty, more results are available.
+    /// Pass this token, along with the same query parameters as the first
+    /// request, to view the next page of results.
+    #[serde(rename="nextPageToken")]
+    pub next_page_token: Option<String>,
+    /// The error events which match the given request.
+    #[serde(rename="errorEvents")]
+    pub error_events: Option<Vec<ErrorEvent>>,
+    /// The timestamp specifies the start time to which the request was restricted.
+    #[serde(rename="timeRangeBegin")]
+    pub time_range_begin: Option<String>,
+}
+
+impl ResponseResult for ListEventsResponse {}
+
+
+/// A description of the context in which an error occurred.
+/// This data should be provided by the application when reporting an error,
+/// unless the
+/// error report has been generated automatically from Google App Engine logs.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct ErrorContext {
+    /// The HTTP request which was processed when the error was
+    /// triggered.
+    #[serde(rename="httpRequest")]
+    pub http_request: Option<HttpRequestContext>,
+    /// Source code that was used to build the executable which has
+    /// caused the given error message.
+    #[serde(rename="sourceReferences")]
+    pub source_references: Option<Vec<SourceReference>>,
+    /// The user who caused or was affected by the crash.
+    /// This can be a user ID, an email address, or an arbitrary token that
+    /// uniquely identifies the user.
+    /// When sending an error report, leave this field empty if the user was not
+    /// logged in. In this case the
+    /// Error Reporting system will use other data, such as remote IP address, to
+    /// distinguish affected users. See `affected_users_count` in
+    /// `ErrorGroupStats`.
+    pub user: Option<String>,
+    /// The location in the source code where the decision was made to
+    /// report the error, usually the place where it was logged.
+    /// For a logged exception this would be the source line where the
+    /// exception is logged, usually close to the place where it was
+    /// caught.
+    #[serde(rename="reportLocation")]
+    pub report_location: Option<SourceLocation>,
+}
+
+impl Part for ErrorContext {}
+
+
+/// Description of a group of similar error events.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [groups get projects](struct.ProjectGroupGetCall.html) (response)
+/// * [groups update projects](struct.ProjectGroupUpdateCall.html) (request|response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct ErrorGroup {
+    /// Associated tracking issues.
+    #[serde(rename="trackingIssues")]
+    pub tracking_issues: Option<Vec<TrackingIssue>>,
+    /// The group resource name.
+    /// Example: <code>projects/my-project-123/groups/my-groupid</code>
+    pub name: Option<String>,
+    /// Group IDs are unique for a given project. If the same kind of error
+    /// occurs in different service contexts, it will receive the same group ID.
+    #[serde(rename="groupId")]
+    pub group_id: Option<String>,
+}
+
+impl RequestValue for ErrorGroup {}
+impl ResponseResult for ErrorGroup {}
+
+
+/// Indicates a location in the source code of the service for which errors are
+/// reported. `functionName` must be provided by the application when reporting
+/// an error, unless the error report contains a `message` with a supported
+/// exception stack trace. All fields are optional for the later case.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct SourceLocation {
+    /// The source code filename, which can include a truncated relative
+    /// path, or a full path from a production machine.
+    #[serde(rename="filePath")]
+    pub file_path: Option<String>,
+    /// Human-readable name of a function or method.
+    /// The value can include optional context like the class or package name.
+    /// For example, `my.package.MyClass.method` in case of Java.
+    #[serde(rename="functionName")]
+    pub function_name: Option<String>,
+    /// 1-based. 0 indicates that the line number is unknown.
+    #[serde(rename="lineNumber")]
+    pub line_number: Option<i32>,
+}
+
+impl Part for SourceLocation {}
+
+
+/// Response message for deleting error events.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [delete events projects](struct.ProjectDeleteEventCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct DeleteEventsResponse { _never_set: Option<bool> }
+
+impl ResponseResult for DeleteEventsResponse {}
+
+
+/// Describes a running service that sends errors.
+/// Its version changes over time and multiple versions can run in parallel.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct ServiceContext {
+    /// Type of the MonitoredResource. List of possible values:
+    /// https://cloud.google.com/monitoring/api/resources
+    /// 
+    /// Value is set automatically for incoming errors and must not be set when
+    /// reporting errors.
+    #[serde(rename="resourceType")]
+    pub resource_type: Option<String>,
+    /// Represents the source code version that the developer provided,
+    /// which could represent a version label or a Git SHA-1 hash, for example.
+    /// For App Engine standard environment, the version is set to the version of
+    /// the app.
+    pub version: Option<String>,
+    /// An identifier of the service, such as the name of the
+    /// executable, job, or Google App Engine service name. This field is expected
+    /// to have a low number of values that are relatively stable over time, as
+    /// opposed to `version`, which can be changed whenever new code is deployed.
+    /// 
+    /// Contains the service name for error reports extracted from Google
+    /// App Engine logs or `default` if the App Engine default service is used.
+    pub service: Option<String>,
+}
+
+impl Part for ServiceContext {}
+
+
+/// A reference to a particular snapshot of the source tree used to build and
+/// deploy an application.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct SourceReference {
+    /// The canonical and persistent identifier of the deployed revision.
+    /// Example (git): "0035781c50ec7aa23385dc841529ce8a4b70db1b"
+    #[serde(rename="revisionId")]
+    pub revision_id: Option<String>,
+    /// Optional. A URI string identifying the repository.
+    /// Example: "https://github.com/GoogleCloudPlatform/kubernetes.git"
+    pub repository: Option<String>,
+}
+
+impl Part for SourceReference {}
+
+
+/// An error event which is reported to the Error Reporting system.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [events report projects](struct.ProjectEventReportCall.html) (request)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct ReportedErrorEvent {
+    /// [Required] The service context in which this error has occurred.
+    #[serde(rename="serviceContext")]
+    pub service_context: Option<ServiceContext>,
+    /// [Required] The error message.
+    /// If no `context.reportLocation` is provided, the message must contain a
+    /// header (typically consisting of the exception type name and an error
+    /// message) and an exception stack trace in one of the supported programming
+    /// languages and formats.
+    /// Supported languages are Java, Python, JavaScript, Ruby, C#, PHP, and Go.
+    /// Supported stack trace formats are:
+    /// 
+    /// * **Java**: Must be the return value of [`Throwable.printStackTrace()`](https://docs.oracle.com/javase/7/docs/api/java/lang/Throwable.html#printStackTrace%28%29).
+    /// * **Python**: Must be the return value of [`traceback.format_exc()`](https://docs.python.org/2/library/traceback.html#traceback.format_exc).
+    /// * **JavaScript**: Must be the value of [`error.stack`](https://github.com/v8/v8/wiki/Stack-Trace-API)
+    /// as returned by V8.
+    /// * **Ruby**: Must contain frames returned by [`Exception.backtrace`](https://ruby-doc.org/core-2.2.0/Exception.html#method-i-backtrace).
+    /// * **C#**: Must be the return value of [`Exception.ToString()`](https://msdn.microsoft.com/en-us/library/system.exception.tostring.aspx).
+    /// * **PHP**: Must start with `PHP (Notice|Parse error|Fatal error|Warning)`
+    /// and contain the result of [`(string)$exception`](http://php.net/manual/en/exception.tostring.php).
+    /// * **Go**: Must be the return value of [`runtime.Stack()`](https://golang.org/pkg/runtime/debug/#Stack).
+    pub message: Option<String>,
+    /// [Optional] Time when the event occurred.
+    /// If not provided, the time when the event was received by the
+    /// Error Reporting system will be used.
+    #[serde(rename="eventTime")]
+    pub event_time: Option<String>,
+    /// [Optional] A description of the context in which the error occurred.
+    pub context: Option<ErrorContext>,
+}
+
+impl RequestValue for ReportedErrorEvent {}
+
+
+/// Contains a set of requested error group stats.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [group stats list projects](struct.ProjectGroupStatListCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct ListGroupStatsResponse {
+    /// If non-empty, more results are available.
+    /// Pass this token, along with the same query parameters as the first
+    /// request, to view the next page of results.
+    #[serde(rename="nextPageToken")]
+    pub next_page_token: Option<String>,
+    /// The timestamp specifies the start time to which the request was restricted.
+    /// The start time is set based on the requested time range. It may be adjusted
+    /// to a later time if a project has exceeded the storage quota and older data
+    /// has been deleted.
+    #[serde(rename="timeRangeBegin")]
+    pub time_range_begin: Option<String>,
+    /// The error group stats which match the given request.
+    #[serde(rename="errorGroupStats")]
+    pub error_group_stats: Option<Vec<ErrorGroupStats>>,
+}
+
+impl ResponseResult for ListGroupStatsResponse {}
+
+
+/// Data extracted for a specific group based on certain filter criteria,
+/// such as a given time period and/or service filter.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct ErrorGroupStats {
+    /// Approximate total number of events in the given group that match
+    /// the filter criteria.
+    pub count: Option<String>,
+    /// Approximate first occurrence that was ever seen for this group
+    /// and which matches the given filter criteria, ignoring the
+    /// time_range that was specified in the request.
+    #[serde(rename="firstSeenTime")]
+    pub first_seen_time: Option<String>,
+    /// Approximate number of affected users in the given group that
+    /// match the filter criteria.
+    /// Users are distinguished by data in the `ErrorContext` of the
+    /// individual error events, such as their login name or their remote
+    /// IP address in case of HTTP requests.
+    /// The number of affected users can be zero even if the number of
+    /// errors is non-zero if no data was provided from which the
+    /// affected user could be deduced.
+    /// Users are counted based on data in the request
+    /// context that was provided in the error report. If more users are
+    /// implicitly affected, such as due to a crash of the whole service,
+    /// this is not reflected here.
+    #[serde(rename="affectedUsersCount")]
+    pub affected_users_count: Option<i64>,
+    /// Group data that is independent of the filter criteria.
+    pub group: Option<ErrorGroup>,
+    /// Approximate number of occurrences over time.
+    /// Timed counts returned by ListGroups are guaranteed to be:
+    /// 
+    /// - Inside the requested time interval
+    /// - Non-overlapping, and
+    /// - Ordered by ascending time.
+    #[serde(rename="timedCounts")]
+    pub timed_counts: Option<Vec<TimedCount>>,
+    /// Approximate last occurrence that was ever seen for this group and
+    /// which matches the given filter criteria, ignoring the time_range
+    /// that was specified in the request.
+    #[serde(rename="lastSeenTime")]
+    pub last_seen_time: Option<String>,
+    /// An arbitrary event that is chosen as representative for the whole group.
+    /// The representative event is intended to be used as a quick preview for
+    /// the whole group. Events in the group are usually sufficiently similar
+    /// to each other such that showing an arbitrary representative provides
+    /// insight into the characteristics of the group as a whole.
+    pub representative: Option<ErrorEvent>,
+    /// The total number of services with a non-zero error count for the given
+    /// filter criteria.
+    #[serde(rename="numAffectedServices")]
+    pub num_affected_services: Option<i32>,
+    /// Service contexts with a non-zero error count for the given filter
+    /// criteria. This list can be truncated if multiple services are affected.
+    /// Refer to `num_affected_services` for the total count.
+    #[serde(rename="affectedServices")]
+    pub affected_services: Option<Vec<ServiceContext>>,
+}
+
+impl Part for ErrorGroupStats {}
+
+
+/// Response for reporting an individual error event.
+/// Data may be added to this message in the future.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [events report projects](struct.ProjectEventReportCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct ReportErrorEventResponse { _never_set: Option<bool> }
+
+impl ResponseResult for ReportErrorEventResponse {}
+
+
+/// HTTP request data that is related to a reported error.
+/// This data should be provided by the application when reporting an error,
+/// unless the
+/// error report has been generated automatically from Google App Engine logs.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct HttpRequestContext {
+    /// The HTTP response status code for the request.
+    #[serde(rename="responseStatusCode")]
+    pub response_status_code: Option<i32>,
+    /// The IP address from which the request originated.
+    /// This can be IPv4, IPv6, or a token which is derived from the
+    /// IP address, depending on the data that has been provided
+    /// in the error report.
+    #[serde(rename="remoteIp")]
+    pub remote_ip: Option<String>,
+    /// The user agent information that is provided with the request.
+    #[serde(rename="userAgent")]
+    pub user_agent: Option<String>,
+    /// The URL of the request.
+    pub url: Option<String>,
+    /// The referrer information that is provided with the request.
+    pub referrer: Option<String>,
+    /// The type of HTTP request, such as `GET`, `POST`, etc.
+    pub method: Option<String>,
+}
+
+impl Part for HttpRequestContext {}
+
+
+/// An error event which is returned by the Error Reporting system.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct ErrorEvent {
+    /// The `ServiceContext` for which this error was reported.
+    #[serde(rename="serviceContext")]
+    pub service_context: Option<ServiceContext>,
+    /// The stack trace that was reported or logged by the service.
+    pub message: Option<String>,
+    /// Time when the event occurred as provided in the error report.
+    /// If the report did not contain a timestamp, the time the error was received
+    /// by the Error Reporting system is used.
+    #[serde(rename="eventTime")]
+    pub event_time: Option<String>,
+    /// Data about the context in which the error occurred.
+    pub context: Option<ErrorContext>,
+}
+
+impl Part for ErrorEvent {}
+
+
+
+// ###################
+// MethodBuilders ###
+// #################
+
+/// A builder providing access to all methods supported on *project* resources.
+/// It is not used directly, but through the `Clouderrorreporting` hub.
+///
+/// # Example
+///
+/// Instantiate a resource builder
+///
+/// ```test_harness,no_run
+/// extern crate hyper;
+/// extern crate hyper_rustls;
+/// extern crate yup_oauth2 as oauth2;
+/// extern crate google_clouderrorreporting1_beta1 as clouderrorreporting1_beta1;
+/// 
+/// # #[test] fn egal() {
+/// use std::default::Default;
+/// use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// use clouderrorreporting1_beta1::Clouderrorreporting;
+/// 
+/// let secret: ApplicationSecret = Default::default();
+/// let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+///                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+///                               <MemoryStorage as Default>::default(), None);
+/// let mut hub = Clouderrorreporting::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // Usually you wouldn't bind this to a variable, but keep calling *CallBuilders*
+/// // like `delete_events(...)`, `events_list(...)`, `events_report(...)`, `group_stats_list(...)`, `groups_get(...)` and `groups_update(...)`
+/// // to build up your call.
+/// let rb = hub.projects();
+/// # }
+/// ```
+pub struct ProjectMethods<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a Clouderrorreporting<C, A>,
+}
+
+impl<'a, C, A> MethodsBuilder for ProjectMethods<'a, C, A> {}
+
+impl<'a, C, A> ProjectMethods<'a, C, A> {
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Get the specified group.
+    /// 
+    /// # Arguments
+    ///
+    /// * `groupName` - [Required] The group resource name. Written as
+    ///                 <code>projects/<var>projectID</var>/groups/<var>group_name</var></code>.
+    ///                 Call
+    ///                 <a href="/error-reporting/reference/rest/v1beta1/projects.groupStats/list">
+    ///                 <code>groupStats.list</code></a> to return a list of groups belonging to
+    ///                 this project.
+    ///                 Example: <code>projects/my-project-123/groups/my-group</code>
+    pub fn groups_get(&self, group_name: &str) -> ProjectGroupGetCall<'a, C, A> {
+        ProjectGroupGetCall {
+            hub: self.hub,
+            _group_name: group_name.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Lists the specified groups.
+    /// 
+    /// # Arguments
+    ///
+    /// * `projectName` - [Required] The resource name of the Google Cloud Platform project. Written
+    ///                   as <code>projects/</code> plus the
+    ///                   <a href="https://support.google.com/cloud/answer/6158840">Google Cloud
+    ///                   Platform project ID</a>.
+    ///                   Example: <code>projects/my-project-123</code>.
+    pub fn group_stats_list(&self, project_name: &str) -> ProjectGroupStatListCall<'a, C, A> {
+        ProjectGroupStatListCall {
+            hub: self.hub,
+            _project_name: project_name.to_string(),
+            _timed_count_duration: Default::default(),
+            _time_range_period: Default::default(),
+            _service_filter_version: Default::default(),
+            _service_filter_service: Default::default(),
+            _service_filter_resource_type: Default::default(),
+            _page_token: Default::default(),
+            _page_size: Default::default(),
+            _order: Default::default(),
+            _group_id: Default::default(),
+            _alignment_time: Default::default(),
+            _alignment: Default::default(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Deletes all error events of a given project.
+    /// 
+    /// # Arguments
+    ///
+    /// * `projectName` - [Required] The resource name of the Google Cloud Platform project. Written
+    ///                   as `projects/` plus the
+    ///                   [Google Cloud Platform project
+    ///                   ID](https://support.google.com/cloud/answer/6158840).
+    ///                   Example: `projects/my-project-123`.
+    pub fn delete_events(&self, project_name: &str) -> ProjectDeleteEventCall<'a, C, A> {
+        ProjectDeleteEventCall {
+            hub: self.hub,
+            _project_name: project_name.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Lists the specified events.
+    /// 
+    /// # Arguments
+    ///
+    /// * `projectName` - [Required] The resource name of the Google Cloud Platform project. Written
+    ///                   as `projects/` plus the
+    ///                   [Google Cloud Platform project
+    ///                   ID](https://support.google.com/cloud/answer/6158840).
+    ///                   Example: `projects/my-project-123`.
+    pub fn events_list(&self, project_name: &str) -> ProjectEventListCall<'a, C, A> {
+        ProjectEventListCall {
+            hub: self.hub,
+            _project_name: project_name.to_string(),
+            _time_range_period: Default::default(),
+            _service_filter_version: Default::default(),
+            _service_filter_service: Default::default(),
+            _service_filter_resource_type: Default::default(),
+            _page_token: Default::default(),
+            _page_size: Default::default(),
+            _group_id: Default::default(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Replace the data for the specified group.
+    /// Fails if the group does not exist.
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    /// * `name` - The group resource name.
+    ///            Example: <code>projects/my-project-123/groups/my-groupid</code>
+    pub fn groups_update(&self, request: ErrorGroup, name: &str) -> ProjectGroupUpdateCall<'a, C, A> {
+        ProjectGroupUpdateCall {
+            hub: self.hub,
+            _request: request,
+            _name: name.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Report an individual error event.
+    /// 
+    /// This endpoint accepts <strong>either</strong> an OAuth token,
+    /// <strong>or</strong> an
+    /// <a href="https://support.google.com/cloud/answer/6158862">API key</a>
+    /// for authentication. To use an API key, append it to the URL as the value of
+    /// a `key` parameter. For example:
+    /// <pre>POST https://clouderrorreporting.googleapis.com/v1beta1/projects/example-project/events:report?key=123ABC456</pre>
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    /// * `projectName` - [Required] The resource name of the Google Cloud Platform project. Written
+    ///                   as `projects/` plus the
+    ///                   [Google Cloud Platform project ID](https://support.google.com/cloud/answer/6158840).
+    ///                   Example: `projects/my-project-123`.
+    pub fn events_report(&self, request: ReportedErrorEvent, project_name: &str) -> ProjectEventReportCall<'a, C, A> {
+        ProjectEventReportCall {
+            hub: self.hub,
+            _request: request,
+            _project_name: project_name.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+}
+
+
+
+
+
+// ###################
+// CallBuilders   ###
+// #################
+
+/// Get the specified group.
+///
+/// A builder for the *groups.get* method supported by a *project* resource.
+/// It is not used directly, but through a `ProjectMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_clouderrorreporting1_beta1 as clouderrorreporting1_beta1;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use clouderrorreporting1_beta1::Clouderrorreporting;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = Clouderrorreporting::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.projects().groups_get("groupName")
+///              .doit();
+/// # }
+/// ```
+pub struct ProjectGroupGetCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a Clouderrorreporting<C, A>,
+    _group_name: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for ProjectGroupGetCall<'a, C, A> {}
+
+impl<'a, C, A> ProjectGroupGetCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, ErrorGroup)> {
+        use url::percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "clouderrorreporting.projects.groups.get",
+                               http_method: hyper::method::Method::Get });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((3 + self._additional_params.len()));
+        params.push(("groupName", self._group_name.to_string()));
+        for &field in ["alt", "groupName"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1beta1/{+groupName}";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{+groupName}", "groupName")].iter() {
+            let mut replace_with = String::new();
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = value.to_string();
+                    break;
+                }
+            }
+            if find_this.as_bytes()[1] == '+' as u8 {
+                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET);
+            }
+            url = url.replace(find_this, &replace_with);
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["groupName"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Get, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    /// [Required] The group resource name. Written as
+    /// <code>projects/<var>projectID</var>/groups/<var>group_name</var></code>.
+    /// Call
+    /// <a href="/error-reporting/reference/rest/v1beta1/projects.groupStats/list">
+    /// <code>groupStats.list</code></a> to return a list of groups belonging to
+    /// this project.
+    /// 
+    /// Example: <code>projects/my-project-123/groups/my-group</code>
+    ///
+    /// Sets the *group name* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn group_name(mut self, new_value: &str) -> ProjectGroupGetCall<'a, C, A> {
+        self._group_name = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> ProjectGroupGetCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> ProjectGroupGetCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> ProjectGroupGetCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Lists the specified groups.
+///
+/// A builder for the *groupStats.list* method supported by a *project* resource.
+/// It is not used directly, but through a `ProjectMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_clouderrorreporting1_beta1 as clouderrorreporting1_beta1;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use clouderrorreporting1_beta1::Clouderrorreporting;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = Clouderrorreporting::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.projects().group_stats_list("projectName")
+///              .timed_count_duration(-18)
+///              .time_range_period("kasd")
+///              .service_filter_version("accusam")
+///              .service_filter_service("takimata")
+///              .service_filter_resource_type("justo")
+///              .page_token("amet.")
+///              .page_size(-81)
+///              .order("labore")
+///              .add_group_id("sea")
+///              .alignment_time("nonumy")
+///              .alignment("dolores")
+///              .doit();
+/// # }
+/// ```
+pub struct ProjectGroupStatListCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a Clouderrorreporting<C, A>,
+    _project_name: String,
+    _timed_count_duration: Option<i64>,
+    _time_range_period: Option<String>,
+    _service_filter_version: Option<String>,
+    _service_filter_service: Option<String>,
+    _service_filter_resource_type: Option<String>,
+    _page_token: Option<String>,
+    _page_size: Option<i32>,
+    _order: Option<String>,
+    _group_id: Vec<String>,
+    _alignment_time: Option<String>,
+    _alignment: Option<String>,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for ProjectGroupStatListCall<'a, C, A> {}
+
+impl<'a, C, A> ProjectGroupStatListCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, ListGroupStatsResponse)> {
+        use url::percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "clouderrorreporting.projects.groupStats.list",
+                               http_method: hyper::method::Method::Get });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((14 + self._additional_params.len()));
+        params.push(("projectName", self._project_name.to_string()));
+        if let Some(value) = self._timed_count_duration {
+            params.push(("timedCountDuration", value.to_string()));
+        }
+        if let Some(value) = self._time_range_period {
+            params.push(("timeRange.period", value.to_string()));
+        }
+        if let Some(value) = self._service_filter_version {
+            params.push(("serviceFilter.version", value.to_string()));
+        }
+        if let Some(value) = self._service_filter_service {
+            params.push(("serviceFilter.service", value.to_string()));
+        }
+        if let Some(value) = self._service_filter_resource_type {
+            params.push(("serviceFilter.resourceType", value.to_string()));
+        }
+        if let Some(value) = self._page_token {
+            params.push(("pageToken", value.to_string()));
+        }
+        if let Some(value) = self._page_size {
+            params.push(("pageSize", value.to_string()));
+        }
+        if let Some(value) = self._order {
+            params.push(("order", value.to_string()));
+        }
+        if self._group_id.len() > 0 {
+            for f in self._group_id.iter() {
+                params.push(("groupId", f.to_string()));
+            }
+        }
+        if let Some(value) = self._alignment_time {
+            params.push(("alignmentTime", value.to_string()));
+        }
+        if let Some(value) = self._alignment {
+            params.push(("alignment", value.to_string()));
+        }
+        for &field in ["alt", "projectName", "timedCountDuration", "timeRange.period", "serviceFilter.version", "serviceFilter.service", "serviceFilter.resourceType", "pageToken", "pageSize", "order", "groupId", "alignmentTime", "alignment"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1beta1/{+projectName}/groupStats";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{+projectName}", "projectName")].iter() {
+            let mut replace_with = String::new();
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = value.to_string();
+                    break;
+                }
+            }
+            if find_this.as_bytes()[1] == '+' as u8 {
+                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET);
+            }
+            url = url.replace(find_this, &replace_with);
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["projectName"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Get, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    /// [Required] The resource name of the Google Cloud Platform project. Written
+    /// as <code>projects/</code> plus the
+    /// <a href="https://support.google.com/cloud/answer/6158840">Google Cloud
+    /// Platform project ID</a>.
+    /// 
+    /// Example: <code>projects/my-project-123</code>.
+    ///
+    /// Sets the *project name* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn project_name(mut self, new_value: &str) -> ProjectGroupStatListCall<'a, C, A> {
+        self._project_name = new_value.to_string();
+        self
+    }
+    /// [Optional] The preferred duration for a single returned `TimedCount`.
+    /// If not set, no timed counts are returned.
+    ///
+    /// Sets the *timed count duration* query property to the given value.
+    pub fn timed_count_duration(mut self, new_value: i64) -> ProjectGroupStatListCall<'a, C, A> {
+        self._timed_count_duration = Some(new_value);
+        self
+    }
+    /// Restricts the query to the specified time range.
+    ///
+    /// Sets the *time range.period* query property to the given value.
+    pub fn time_range_period(mut self, new_value: &str) -> ProjectGroupStatListCall<'a, C, A> {
+        self._time_range_period = Some(new_value.to_string());
+        self
+    }
+    /// [Optional] The exact value to match against
+    /// [`ServiceContext.version`](/error-reporting/reference/rest/v1beta1/ServiceContext#FIELDS.version).
+    ///
+    /// Sets the *service filter.version* query property to the given value.
+    pub fn service_filter_version(mut self, new_value: &str) -> ProjectGroupStatListCall<'a, C, A> {
+        self._service_filter_version = Some(new_value.to_string());
+        self
+    }
+    /// [Optional] The exact value to match against
+    /// [`ServiceContext.service`](/error-reporting/reference/rest/v1beta1/ServiceContext#FIELDS.service).
+    ///
+    /// Sets the *service filter.service* query property to the given value.
+    pub fn service_filter_service(mut self, new_value: &str) -> ProjectGroupStatListCall<'a, C, A> {
+        self._service_filter_service = Some(new_value.to_string());
+        self
+    }
+    /// [Optional] The exact value to match against
+    /// [`ServiceContext.resource_type`](/error-reporting/reference/rest/v1beta1/ServiceContext#FIELDS.resource_type).
+    ///
+    /// Sets the *service filter.resource type* query property to the given value.
+    pub fn service_filter_resource_type(mut self, new_value: &str) -> ProjectGroupStatListCall<'a, C, A> {
+        self._service_filter_resource_type = Some(new_value.to_string());
+        self
+    }
+    /// [Optional] A `next_page_token` provided by a previous response. To view
+    /// additional results, pass this token along with the identical query
+    /// parameters as the first request.
+    ///
+    /// Sets the *page token* query property to the given value.
+    pub fn page_token(mut self, new_value: &str) -> ProjectGroupStatListCall<'a, C, A> {
+        self._page_token = Some(new_value.to_string());
+        self
+    }
+    /// [Optional] The maximum number of results to return per response.
+    /// Default is 20.
+    ///
+    /// Sets the *page size* query property to the given value.
+    pub fn page_size(mut self, new_value: i32) -> ProjectGroupStatListCall<'a, C, A> {
+        self._page_size = Some(new_value);
+        self
+    }
+    /// [Optional] The sort order in which the results are returned.
+    /// Default is `COUNT_DESC`.
+    ///
+    /// Sets the *order* query property to the given value.
+    pub fn order(mut self, new_value: &str) -> ProjectGroupStatListCall<'a, C, A> {
+        self._order = Some(new_value.to_string());
+        self
+    }
+    /// [Optional] List all <code>ErrorGroupStats</code> with these IDs.
+    ///
+    /// Append the given value to the *group id* query property.
+    /// Each appended value will retain its original ordering and be '/'-separated in the URL's parameters.
+    pub fn add_group_id(mut self, new_value: &str) -> ProjectGroupStatListCall<'a, C, A> {
+        self._group_id.push(new_value.to_string());
+        self
+    }
+    /// [Optional] Time where the timed counts shall be aligned if rounded
+    /// alignment is chosen. Default is 00:00 UTC.
+    ///
+    /// Sets the *alignment time* query property to the given value.
+    pub fn alignment_time(mut self, new_value: &str) -> ProjectGroupStatListCall<'a, C, A> {
+        self._alignment_time = Some(new_value.to_string());
+        self
+    }
+    /// [Optional] The alignment of the timed counts to be returned.
+    /// Default is `ALIGNMENT_EQUAL_AT_END`.
+    ///
+    /// Sets the *alignment* query property to the given value.
+    pub fn alignment(mut self, new_value: &str) -> ProjectGroupStatListCall<'a, C, A> {
+        self._alignment = Some(new_value.to_string());
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> ProjectGroupStatListCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> ProjectGroupStatListCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> ProjectGroupStatListCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Deletes all error events of a given project.
+///
+/// A builder for the *deleteEvents* method supported by a *project* resource.
+/// It is not used directly, but through a `ProjectMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_clouderrorreporting1_beta1 as clouderrorreporting1_beta1;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use clouderrorreporting1_beta1::Clouderrorreporting;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = Clouderrorreporting::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.projects().delete_events("projectName")
+///              .doit();
+/// # }
+/// ```
+pub struct ProjectDeleteEventCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a Clouderrorreporting<C, A>,
+    _project_name: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for ProjectDeleteEventCall<'a, C, A> {}
+
+impl<'a, C, A> ProjectDeleteEventCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, DeleteEventsResponse)> {
+        use url::percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "clouderrorreporting.projects.deleteEvents",
+                               http_method: hyper::method::Method::Delete });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((3 + self._additional_params.len()));
+        params.push(("projectName", self._project_name.to_string()));
+        for &field in ["alt", "projectName"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1beta1/{+projectName}/events";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{+projectName}", "projectName")].iter() {
+            let mut replace_with = String::new();
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = value.to_string();
+                    break;
+                }
+            }
+            if find_this.as_bytes()[1] == '+' as u8 {
+                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET);
+            }
+            url = url.replace(find_this, &replace_with);
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["projectName"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Delete, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    /// [Required] The resource name of the Google Cloud Platform project. Written
+    /// as `projects/` plus the
+    /// [Google Cloud Platform project
+    /// ID](https://support.google.com/cloud/answer/6158840).
+    /// Example: `projects/my-project-123`.
+    ///
+    /// Sets the *project name* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn project_name(mut self, new_value: &str) -> ProjectDeleteEventCall<'a, C, A> {
+        self._project_name = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> ProjectDeleteEventCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> ProjectDeleteEventCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> ProjectDeleteEventCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Lists the specified events.
+///
+/// A builder for the *events.list* method supported by a *project* resource.
+/// It is not used directly, but through a `ProjectMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_clouderrorreporting1_beta1 as clouderrorreporting1_beta1;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use clouderrorreporting1_beta1::Clouderrorreporting;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = Clouderrorreporting::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.projects().events_list("projectName")
+///              .time_range_period("aliquyam")
+///              .service_filter_version("ea")
+///              .service_filter_service("no")
+///              .service_filter_resource_type("justo")
+///              .page_token("justo")
+///              .page_size(-34)
+///              .group_id("et")
+///              .doit();
+/// # }
+/// ```
+pub struct ProjectEventListCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a Clouderrorreporting<C, A>,
+    _project_name: String,
+    _time_range_period: Option<String>,
+    _service_filter_version: Option<String>,
+    _service_filter_service: Option<String>,
+    _service_filter_resource_type: Option<String>,
+    _page_token: Option<String>,
+    _page_size: Option<i32>,
+    _group_id: Option<String>,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for ProjectEventListCall<'a, C, A> {}
+
+impl<'a, C, A> ProjectEventListCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, ListEventsResponse)> {
+        use url::percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "clouderrorreporting.projects.events.list",
+                               http_method: hyper::method::Method::Get });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((10 + self._additional_params.len()));
+        params.push(("projectName", self._project_name.to_string()));
+        if let Some(value) = self._time_range_period {
+            params.push(("timeRange.period", value.to_string()));
+        }
+        if let Some(value) = self._service_filter_version {
+            params.push(("serviceFilter.version", value.to_string()));
+        }
+        if let Some(value) = self._service_filter_service {
+            params.push(("serviceFilter.service", value.to_string()));
+        }
+        if let Some(value) = self._service_filter_resource_type {
+            params.push(("serviceFilter.resourceType", value.to_string()));
+        }
+        if let Some(value) = self._page_token {
+            params.push(("pageToken", value.to_string()));
+        }
+        if let Some(value) = self._page_size {
+            params.push(("pageSize", value.to_string()));
+        }
+        if let Some(value) = self._group_id {
+            params.push(("groupId", value.to_string()));
+        }
+        for &field in ["alt", "projectName", "timeRange.period", "serviceFilter.version", "serviceFilter.service", "serviceFilter.resourceType", "pageToken", "pageSize", "groupId"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1beta1/{+projectName}/events";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{+projectName}", "projectName")].iter() {
+            let mut replace_with = String::new();
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = value.to_string();
+                    break;
+                }
+            }
+            if find_this.as_bytes()[1] == '+' as u8 {
+                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET);
+            }
+            url = url.replace(find_this, &replace_with);
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["projectName"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Get, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    /// [Required] The resource name of the Google Cloud Platform project. Written
+    /// as `projects/` plus the
+    /// [Google Cloud Platform project
+    /// ID](https://support.google.com/cloud/answer/6158840).
+    /// Example: `projects/my-project-123`.
+    ///
+    /// Sets the *project name* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn project_name(mut self, new_value: &str) -> ProjectEventListCall<'a, C, A> {
+        self._project_name = new_value.to_string();
+        self
+    }
+    /// Restricts the query to the specified time range.
+    ///
+    /// Sets the *time range.period* query property to the given value.
+    pub fn time_range_period(mut self, new_value: &str) -> ProjectEventListCall<'a, C, A> {
+        self._time_range_period = Some(new_value.to_string());
+        self
+    }
+    /// [Optional] The exact value to match against
+    /// [`ServiceContext.version`](/error-reporting/reference/rest/v1beta1/ServiceContext#FIELDS.version).
+    ///
+    /// Sets the *service filter.version* query property to the given value.
+    pub fn service_filter_version(mut self, new_value: &str) -> ProjectEventListCall<'a, C, A> {
+        self._service_filter_version = Some(new_value.to_string());
+        self
+    }
+    /// [Optional] The exact value to match against
+    /// [`ServiceContext.service`](/error-reporting/reference/rest/v1beta1/ServiceContext#FIELDS.service).
+    ///
+    /// Sets the *service filter.service* query property to the given value.
+    pub fn service_filter_service(mut self, new_value: &str) -> ProjectEventListCall<'a, C, A> {
+        self._service_filter_service = Some(new_value.to_string());
+        self
+    }
+    /// [Optional] The exact value to match against
+    /// [`ServiceContext.resource_type`](/error-reporting/reference/rest/v1beta1/ServiceContext#FIELDS.resource_type).
+    ///
+    /// Sets the *service filter.resource type* query property to the given value.
+    pub fn service_filter_resource_type(mut self, new_value: &str) -> ProjectEventListCall<'a, C, A> {
+        self._service_filter_resource_type = Some(new_value.to_string());
+        self
+    }
+    /// [Optional] A `next_page_token` provided by a previous response.
+    ///
+    /// Sets the *page token* query property to the given value.
+    pub fn page_token(mut self, new_value: &str) -> ProjectEventListCall<'a, C, A> {
+        self._page_token = Some(new_value.to_string());
+        self
+    }
+    /// [Optional] The maximum number of results to return per response.
+    ///
+    /// Sets the *page size* query property to the given value.
+    pub fn page_size(mut self, new_value: i32) -> ProjectEventListCall<'a, C, A> {
+        self._page_size = Some(new_value);
+        self
+    }
+    /// [Required] The group for which events shall be returned.
+    ///
+    /// Sets the *group id* query property to the given value.
+    pub fn group_id(mut self, new_value: &str) -> ProjectEventListCall<'a, C, A> {
+        self._group_id = Some(new_value.to_string());
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> ProjectEventListCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> ProjectEventListCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> ProjectEventListCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Replace the data for the specified group.
+/// Fails if the group does not exist.
+///
+/// A builder for the *groups.update* method supported by a *project* resource.
+/// It is not used directly, but through a `ProjectMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_clouderrorreporting1_beta1 as clouderrorreporting1_beta1;
+/// use clouderrorreporting1_beta1::ErrorGroup;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use clouderrorreporting1_beta1::Clouderrorreporting;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = Clouderrorreporting::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = ErrorGroup::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.projects().groups_update(req, "name")
+///              .doit();
+/// # }
+/// ```
+pub struct ProjectGroupUpdateCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a Clouderrorreporting<C, A>,
+    _request: ErrorGroup,
+    _name: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for ProjectGroupUpdateCall<'a, C, A> {}
+
+impl<'a, C, A> ProjectGroupUpdateCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, ErrorGroup)> {
+        use url::percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "clouderrorreporting.projects.groups.update",
+                               http_method: hyper::method::Method::Put });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((4 + self._additional_params.len()));
+        params.push(("name", self._name.to_string()));
+        for &field in ["alt", "name"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1beta1/{+name}";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{+name}", "name")].iter() {
+            let mut replace_with = String::new();
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = value.to_string();
+                    break;
+                }
+            }
+            if find_this.as_bytes()[1] == '+' as u8 {
+                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET);
+            }
+            url = url.replace(find_this, &replace_with);
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["name"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Put, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: ErrorGroup) -> ProjectGroupUpdateCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// The group resource name.
+    /// Example: <code>projects/my-project-123/groups/my-groupid</code>
+    ///
+    /// Sets the *name* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn name(mut self, new_value: &str) -> ProjectGroupUpdateCall<'a, C, A> {
+        self._name = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> ProjectGroupUpdateCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> ProjectGroupUpdateCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> ProjectGroupUpdateCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Report an individual error event.
+/// 
+/// This endpoint accepts <strong>either</strong> an OAuth token,
+/// <strong>or</strong> an
+/// <a href="https://support.google.com/cloud/answer/6158862">API key</a>
+/// for authentication. To use an API key, append it to the URL as the value of
+/// a `key` parameter. For example:
+/// <pre>POST https://clouderrorreporting.googleapis.com/v1beta1/projects/example-project/events:report?key=123ABC456</pre>
+///
+/// A builder for the *events.report* method supported by a *project* resource.
+/// It is not used directly, but through a `ProjectMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_clouderrorreporting1_beta1 as clouderrorreporting1_beta1;
+/// use clouderrorreporting1_beta1::ReportedErrorEvent;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use clouderrorreporting1_beta1::Clouderrorreporting;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = Clouderrorreporting::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = ReportedErrorEvent::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.projects().events_report(req, "projectName")
+///              .doit();
+/// # }
+/// ```
+pub struct ProjectEventReportCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a Clouderrorreporting<C, A>,
+    _request: ReportedErrorEvent,
+    _project_name: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for ProjectEventReportCall<'a, C, A> {}
+
+impl<'a, C, A> ProjectEventReportCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, ReportErrorEventResponse)> {
+        use url::percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "clouderrorreporting.projects.events.report",
+                               http_method: hyper::method::Method::Post });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((4 + self._additional_params.len()));
+        params.push(("projectName", self._project_name.to_string()));
+        for &field in ["alt", "projectName"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1beta1/{+projectName}/events:report";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{+projectName}", "projectName")].iter() {
+            let mut replace_with = String::new();
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = value.to_string();
+                    break;
+                }
+            }
+            if find_this.as_bytes()[1] == '+' as u8 {
+                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET);
+            }
+            url = url.replace(find_this, &replace_with);
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["projectName"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Post, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: ReportedErrorEvent) -> ProjectEventReportCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// [Required] The resource name of the Google Cloud Platform project. Written
+    /// as `projects/` plus the
+    /// [Google Cloud Platform project ID](https://support.google.com/cloud/answer/6158840).
+    /// Example: `projects/my-project-123`.
+    ///
+    /// Sets the *project name* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn project_name(mut self, new_value: &str) -> ProjectEventReportCall<'a, C, A> {
+        self._project_name = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> ProjectEventReportCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> ProjectEventReportCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> ProjectEventReportCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+

--- a/gen/cloudtrace1-cli/Cargo.toml
+++ b/gen/cloudtrace1-cli/Cargo.toml
@@ -1,0 +1,40 @@
+# DO NOT EDIT !
+# This file was generated automatically from 'src/mako/Cargo.toml.mako'
+# DO NOT EDIT !
+[package]
+
+name = "google-cloudtrace1-cli"
+version = "1.0.7+20171202"
+authors = ["Sebastian Thiel <byronimo@gmail.com>"]
+description = "A complete library to interact with Cloud Trace (protocol v1)"
+repository = "https://github.com/Byron/google-apis-rs/tree/master/gen/cloudtrace1-cli"
+homepage = "https://cloud.google.com/trace"
+documentation = "http://byron.github.io/google-apis-rs/google_cloudtrace1_cli"
+license = "MIT"
+keywords = ["cloudtrace", "google", "cli"]
+
+[[bin]]
+name = "cloudtrace1"
+
+[dev-dependencies]
+hyper-rustls = "^0.6"
+
+[dependencies]
+hyper = "^ 0.10"
+mime = "^ 0.2.0"
+serde = "^ 1.0"
+serde_json = "^ 1.0"
+serde_derive = "^ 1.0"
+yup-oauth2 = "^ 1.0"
+strsim = "^0.5"
+hyper-rustls = "^0.6"
+yup-hyper-mock = "^2.0"
+clap = "^2.0"
+
+[features]
+
+
+
+[dependencies.google-cloudtrace1]
+path = "../cloudtrace1"
+version = "1.0.7+20171202"

--- a/gen/cloudtrace1-cli/LICENSE.md
+++ b/gen/cloudtrace1-cli/LICENSE.md
@@ -1,0 +1,30 @@
+<!---
+DO NOT EDIT !
+This file was generated automatically from 'src/mako/LICENSE.md.mako'
+DO NOT EDIT !
+-->
+The MIT License (MIT)
+=====================
+
+Copyright © `2015-2016` `Sebastian Thiel`
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the “Software”), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.

--- a/gen/cloudtrace1-cli/README.md
+++ b/gen/cloudtrace1-cli/README.md
@@ -1,0 +1,116 @@
+<!---
+DO NOT EDIT !
+This file was generated automatically from 'src/mako/cli/README.md.mako'
+DO NOT EDIT !
+-->
+The `cloudtrace1` command-line interface *(CLI)* allows to use most features of the *Google Cloud Trace* service from the comfort of your terminal.
+
+By default all output is printed to standard out, but flags can be set to direct it into a file independent of your shell's
+capabilities. Errors will be printed to standard error, and cause the program's exit code to be non-zero.
+
+If data-structures are requested, these will be returned as pretty-printed JSON, to be useful as input to other tools.
+
+Everything else about the *Cloud Trace* API can be found at the
+[official documentation site](https://cloud.google.com/trace).
+
+# Installation and Source Code
+
+Install the command-line interface with cargo using:
+
+```bash
+cargo install google-cloudtrace1-cli
+```
+
+Find the source code [on github](https://github.com/Byron/google-apis-rs/tree/master/gen/cloudtrace1-cli).
+
+# Usage
+
+This documentation was generated from the *Cloud Trace* API at revision *20171202*. The CLI is at version *1.0.7*.
+
+```bash
+cloudtrace1 [options]
+        projects
+                patch-traces <project-id> (-r <kv>)... [-p <v>]... [-o <out>]
+                traces-get <project-id> <trace-id> [-p <v>]... [-o <out>]
+                traces-list <project-id> [-p <v>]... [-o <out>]
+  cloudtrace1 --help
+
+Configuration:
+  [--scope <url>]...
+            Specify the authentication a method should be executed in. Each scope
+            requires the user to grant this application permission to use it.
+            If unset, it defaults to the shortest scope url for a particular method.
+  --config-dir <folder>
+            A directory into which we will store our persistent data. Defaults to
+            a user-writable directory that we will create during the first invocation.
+            [default: ~/.google-service-cli]
+  --debug
+            Output all server communication to standard error. `tx` and `rx` are placed
+            into the same stream.
+  --debug-auth
+            Output all communication related to authentication to standard error. `tx`
+            and `rx` are placed into the same stream.
+
+```
+
+# Configuration
+
+The program will store all persistent data in the `~/.google-service-cli` directory in *JSON* files prefixed with `cloudtrace1-`.  You can change the directory used to store configuration with the `--config-dir` flag on a per-invocation basis.
+
+More information about the various kinds of persistent data are given in the following paragraphs.
+
+# Authentication
+
+Most APIs require a user to authenticate any request. If this is the case, the [scope][scopes] determines the 
+set of permissions granted. The granularity of these is usually no more than *read-only* or *full-access*.
+
+If not set, the system will automatically select the smallest feasible scope, e.g. when invoking a
+method that is read-only, it will ask only for a read-only scope. 
+You may use the `--scope` flag to specify a scope directly. 
+All applicable scopes are documented in the respective method's CLI documentation.
+
+The first time a scope is used, the user is asked for permission. Follow the instructions given 
+by the CLI to grant permissions, or to decline.
+
+If a scope was authenticated by the user, the respective information will be stored as *JSON* in the configuration
+directory, e.g. `~/.google-service-cli/cloudtrace1-token-<scope-hash>.json`. No manual management of these tokens
+is necessary.
+
+To revoke granted authentication, please refer to the [official documentation][revoke-access].
+
+# Application Secrets
+
+In order to allow any application to use Google services, it will need to be registered using the 
+[Google Developer Console][google-dev-console]. APIs the application may use are then enabled for it
+one by one. Most APIs can be used for free and have a daily quota.
+
+To allow more comfortable usage of the CLI without forcing anyone to register an own application, the CLI
+comes with a default application secret that is configured accordingly. This also means that heavy usage
+all around the world may deplete the daily quota.
+
+You can workaround this limitation by putting your own secrets file at this location: 
+`~/.google-service-cli/cloudtrace1-secret.json`, assuming that the required *cloudtrace* API 
+was enabled for it. Such a secret file can be downloaded in the *Google Developer Console* at 
+*APIs & auth -> Credentials -> Download JSON* and used as is.
+
+Learn more about how to setup Google projects and enable APIs using the [official documentation][google-project-new].
+
+
+# Debugging
+
+Even though the CLI does its best to provide usable error messages, sometimes it might be desirable to know
+what exactly led to a particular issue. This is done by allowing all client-server communication to be 
+output to standard error *as-is*.
+
+The `--debug` flag will print all client-server communication to standard error, whereas the `--debug-auth` flag
+will cause all communication related to authentication to standard error.
+If the `--debug` flag is set, error-results will be debug-printed, possibly yielding more information about the 
+issue at hand.
+
+You may consider redirecting standard error into a file for ease of use, e.g. `cloudtrace1 --debug <resource> <method> [options] 2>debug.txt`.
+
+
+[scopes]: https://developers.google.com/+/api/oauth#scopes
+[revoke-access]: http://webapps.stackexchange.com/a/30849
+[google-dev-console]: https://console.developers.google.com/
+[google-project-new]: https://developers.google.com/console/help/new/

--- a/gen/cloudtrace1-cli/mkdocs.yml
+++ b/gen/cloudtrace1-cli/mkdocs.yml
@@ -1,0 +1,19 @@
+site_name: Cloud Trace v1.0.7+20171202
+site_url: http://byron.github.io/google-apis-rs/google-cloudtrace1-cli
+site_description: A complete library to interact with Cloud Trace (protocol v1)
+
+repo_url: https://github.com/Byron/google-apis-rs/tree/master/gen/cloudtrace1-cli
+
+docs_dir: docs
+site_dir: build_html
+
+pages:
+- ['index.md', 'Home']
+- ['projects_patch-traces.md', 'Projects', 'Patch Traces']
+- ['projects_traces-get.md', 'Projects', 'Traces Get']
+- ['projects_traces-list.md', 'Projects', 'Traces List']
+
+theme: readthedocs
+
+copyright: Copyright &copy; 2015-2016, `Sebastian Thiel`
+

--- a/gen/cloudtrace1-cli/src/cmn.rs
+++ b/gen/cloudtrace1-cli/src/cmn.rs
@@ -1,0 +1,799 @@
+// COPY OF 'src/rust/cli/cmn.rs'
+// DO NOT EDIT
+use oauth2::{ApplicationSecret, ConsoleApplicationSecret, TokenStorage, Token};
+use serde_json as json;
+use serde_json::value::Value;
+use mime::Mime;
+use clap::{App, SubCommand};
+use strsim;
+
+use std::fs;
+use std::env;
+use std::io;
+use std::error::Error as StdError;
+use std::fmt;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+use std::string::ToString;
+use std::io::{Write, Read, stdout};
+
+use std::default::Default;
+
+const FIELD_SEP: char = '.';
+
+
+pub enum ComplexType {
+    Pod,
+    Vec,
+    Map,
+}
+
+// Null,
+// Bool(bool),
+// I64(i64),
+// U64(u64),
+// F64(f64),
+// String(String),
+
+pub enum JsonType {
+    Boolean,
+    Int,
+    Uint,
+    Float,
+    String,
+}
+
+pub struct JsonTypeInfo {
+    pub jtype: JsonType,
+    pub ctype: ComplexType,
+}
+
+// Based on @erickt user comment. Thanks for the idea !
+// Remove all keys whose values are null from given value (changed in place)
+pub fn remove_json_null_values(value: &mut Value) {
+    match *value {
+        Value::Object(ref mut map) => {
+            let mut for_removal = Vec::new();
+
+            for (key, mut value) in map.iter_mut() {
+                if value.is_null() {
+                    for_removal.push(key.clone());
+                } else {
+                    remove_json_null_values(&mut value);
+                }
+            }
+
+            for key in &for_removal {
+                map.remove(key);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn did_you_mean<'a>(v: &str, possible_values: &[&'a str]) -> Option<&'a str> {
+
+    let mut candidate: Option<(f64, &str)> = None;
+    for pv in possible_values {
+        let confidence = strsim::jaro_winkler(v, pv);
+        if confidence > 0.8 &&
+           (candidate.is_none() || (candidate.as_ref().unwrap().0 < confidence)) {
+            candidate = Some((confidence, pv));
+        }
+    }
+    match candidate {
+        None => None,
+        Some((_, candidate)) => Some(candidate),
+    }
+}
+
+pub enum CallType {
+    Upload(UploadProtocol),
+    Standard,
+}
+
+arg_enum!{
+    pub enum UploadProtocol {
+        Simple,
+        Resumable
+    }
+}
+
+impl AsRef<str> for UploadProtocol {
+    fn as_ref(&self) -> &str {
+        match *self {
+            UploadProtocol::Simple => "simple",
+            UploadProtocol::Resumable => "resumable",
+        }
+    }
+}
+
+impl AsRef<str> for CallType {
+    fn as_ref(&self) -> &str {
+        match *self {
+            CallType::Upload(ref proto) => proto.as_ref(),
+            CallType::Standard => "standard-request",
+        }
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct FieldCursor(Vec<String>);
+
+impl ToString for  FieldCursor {
+    fn to_string(&self) -> String {
+        self.0.join(".")
+    }
+}
+
+impl From<&'static str> for FieldCursor {
+    fn from(value: &'static str) -> FieldCursor {
+        let mut res = FieldCursor::default();
+        res.set(value).unwrap();
+        res
+    }
+}
+
+fn assure_entry<'a, 'b>(m: &'a mut json::Map<String, Value>, k: &'b String) -> &'a mut Value {
+    if m.contains_key(k) {
+        return m.get_mut(k).expect("value to exist");
+    }
+    m.insert(k.to_owned(), Value::Object(Default::default()));
+    m.get_mut(k).expect("value to exist")
+}
+
+impl FieldCursor {
+    pub fn set(&mut self, value: &str) -> Result<(), CLIError> {
+        if value.len() == 0 {
+            return Err(CLIError::Field(FieldError::Empty));
+        }
+
+        let mut first_is_field_sep = false;
+        let mut char_count: usize = 0;
+        let mut last_c = FIELD_SEP;
+        let mut num_conscutive_field_seps = 0;
+
+        let mut field = String::new();
+        let mut fields = self.0.clone();
+
+        let push_field = |fs: &mut Vec<String>, f: &mut String| {
+            if f.len() > 0 {
+                fs.push(f.clone());
+                f.truncate(0);
+            }
+        };
+
+        for (cid, c) in value.chars().enumerate() {
+            char_count += 1;
+
+            if c == FIELD_SEP {
+                if cid == 0 {
+                    first_is_field_sep = true;
+                }
+                num_conscutive_field_seps += 1;
+                if cid > 0 && last_c == FIELD_SEP {
+                    if fields.pop().is_none() {
+                        return Err(CLIError::Field(FieldError::PopOnEmpty(value.to_string())));
+                    }
+                } else {
+                    push_field(&mut fields, &mut field);
+                }
+            } else {
+                num_conscutive_field_seps = 0;
+                if cid == 1 {
+                    if first_is_field_sep {
+                        fields.truncate(0);
+                    }
+                }
+                field.push(c);
+            }
+
+            last_c = c;
+        }
+
+        push_field(&mut fields, &mut field);
+
+        if char_count == 1 && first_is_field_sep {
+            fields.truncate(0);
+        }
+        if char_count > 1 && num_conscutive_field_seps == 1 {
+            return Err(CLIError::Field(FieldError::TrailingFieldSep(value.to_string())));
+        }
+
+        self.0 = fields;
+        Ok(())
+    }
+
+    pub fn did_you_mean(value: &str, possible_values: &[&str]) -> Option<String> {
+        if value.len() == 0 {
+            return None;
+        }
+
+        let mut last_c = FIELD_SEP;
+
+        let mut field = String::new();
+        let mut output = String::new();
+
+        let push_field = |fs: &mut String, f: &mut String| {
+            if f.len() > 0 {
+                fs.push_str(match did_you_mean(&f, possible_values) {
+                    Some(candidate) => candidate,
+                    None => &f,
+                });
+                f.truncate(0);
+            }
+        };
+
+        for (cid, c) in value.chars().enumerate() {
+            if c == FIELD_SEP {
+                if last_c != FIELD_SEP {
+                    push_field(&mut output, &mut field);
+                }
+                output.push(c);
+            } else {
+                field.push(c);
+            }
+
+            last_c = c;
+        }
+
+        push_field(&mut output, &mut field);
+
+        if &output == value {
+            None
+        } else {
+            Some(output)
+        }
+    }
+
+    pub fn set_json_value(&self,
+                          mut object: &mut Value,
+                          value: &str,
+                          type_info: JsonTypeInfo,
+                          err: &mut InvalidOptionsError,
+                          orig_cursor: &FieldCursor) {
+        assert!(self.0.len() > 0);
+
+        for field in &self.0[..self.0.len() - 1] {
+            let tmp = object;
+            object = match *tmp {
+                Value::Object(ref mut mapping) => {
+                    assure_entry(mapping, &field)
+                }
+                _ => panic!("We don't expect non-object Values here ..."),
+            };
+        }
+
+        match *object {
+            Value::Object(ref mut mapping) => {
+                let field = &self.0[self.0.len() - 1];
+                let to_jval = |value: &str,
+                               jtype: JsonType,
+                               err: &mut InvalidOptionsError|
+                               -> Value {
+                    match jtype {
+                        JsonType::Boolean =>
+                            Value::Bool(arg_from_str(value, err, &field, "boolean")),
+                        JsonType::Int =>
+                            Value::Number(json::Number::from_f64(arg_from_str(value,
+                                                                              err,
+                                                                              &field,
+                                                                              "int"))
+                                              .expect("valid f64")),
+                        JsonType::Uint =>
+                            Value::Number(json::Number::from_f64(arg_from_str(value,
+                                                                              err,
+                                                                              &field,
+                                                                              "uint"))
+                                              .expect("valid f64")),
+                        JsonType::Float =>
+                            Value::Number(json::Number::from_f64(arg_from_str(value,
+                                                                              err,
+                                                                              &field,
+                                                                              "float"))
+                                              .expect("valid f64")),
+                        JsonType::String => Value::String(value.to_owned()),
+                    }
+                };
+
+                match type_info.ctype {
+                    ComplexType::Pod => {
+                        if mapping.insert(field.to_owned(), to_jval(value, type_info.jtype, err))
+                                  .is_some() {
+                            err.issues.push(CLIError::Field(FieldError::Duplicate(orig_cursor.to_string())));
+                        }
+                    }
+                    ComplexType::Vec => {
+                        match *assure_entry(mapping, field) {
+                            Value::Array(ref mut values) =>
+                                values.push(to_jval(value, type_info.jtype, err)),
+                            _ => unreachable!(),
+                        }
+                    }
+                    ComplexType::Map => {
+                        let (key, value) = parse_kv_arg(value, err, true);
+                        let jval = to_jval(value.unwrap_or(""), type_info.jtype, err);
+
+                        match *assure_entry(mapping, &field) {
+
+                            Value::Object(ref mut value_map) => {
+                                if value_map.insert(key.to_owned(), jval).is_some() {
+                                    err.issues.push(CLIError::Field(FieldError::Duplicate(orig_cursor.to_string())));
+                                }
+                            }
+                            _ => unreachable!(),
+                        }
+                    }
+                }
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    pub fn num_fields(&self) -> usize {
+        self.0.len()
+    }
+}
+
+pub fn parse_kv_arg<'a>(kv: &'a str,
+                        err: &mut InvalidOptionsError,
+                        for_hashmap: bool)
+                        -> (&'a str, Option<&'a str>) {
+    let mut add_err = || {
+        err.issues.push(CLIError::InvalidKeyValueSyntax(kv.to_string(), for_hashmap))
+    };
+    match kv.find('=') {
+        None => {
+            add_err();
+            return (kv, None);
+        }
+        Some(pos) => {
+            let key = &kv[..pos];
+            if kv.len() <= pos + 1 {
+                add_err();
+                return (key, Some(""));
+            }
+            (key, Some(&kv[pos + 1..]))
+        }
+    }
+}
+
+pub fn calltype_from_str(name: &str,
+                         valid_protocols: Vec<String>,
+                         err: &mut InvalidOptionsError)
+                         -> CallType {
+    CallType::Upload(match UploadProtocol::from_str(name) {
+        Ok(up) => up,
+        Err(msg) => {
+            err.issues.push(CLIError::InvalidUploadProtocol(name.to_string(), valid_protocols));
+            UploadProtocol::Simple
+        }
+    })
+}
+
+pub fn input_file_from_opts(file_path: &str, err: &mut InvalidOptionsError) -> Option<fs::File> {
+    match fs::File::open(file_path) {
+        Ok(f) => Some(f),
+        Err(io_err) => {
+            err.issues.push(CLIError::Input(InputError::Io((file_path.to_string(), io_err))));
+            None
+        }
+    }
+}
+
+pub fn input_mime_from_opts(mime: &str, err: &mut InvalidOptionsError) -> Option<Mime> {
+    match mime.parse() {
+        Ok(m) => Some(m),
+        Err(_) => {
+            err.issues.push(CLIError::Input(InputError::Mime(mime.to_string())));
+            None
+        }
+    }
+}
+
+pub fn writer_from_opts(arg: Option<&str>) -> Result<Box<Write>, io::Error> {
+    let f = arg.unwrap_or("-");
+    match f {
+        "-" => Ok(Box::new(stdout())),
+        _ => match fs::OpenOptions::new().create(true).write(true).open(f) {
+            Ok(f) => Ok(Box::new(f)),
+            Err(io_err) => Err(io_err),
+        },
+    }
+}
+
+
+pub fn arg_from_str<'a, T>(arg: &str,
+                           err: &mut InvalidOptionsError,
+                           arg_name: &'a str,
+                           arg_type: &'a str)
+                           -> T
+    where T: FromStr + Default,
+          <T as FromStr>::Err: fmt::Display
+{
+    match FromStr::from_str(arg) {
+        Err(perr) => {
+            err.issues.push(CLIError::ParseError(arg_name.to_owned(),
+                                                 arg_type.to_owned(),
+                                                 arg.to_string(),
+                                                 format!("{}", perr)));
+            Default::default()
+        }
+        Ok(v) => v,
+    }
+}
+
+pub struct JsonTokenStorage {
+    pub program_name: &'static str,
+    pub db_dir: String,
+}
+
+impl JsonTokenStorage {
+    fn path(&self, scope_hash: u64) -> PathBuf {
+        Path::new(&self.db_dir).join(&format!("{}-token-{}.json", self.program_name, scope_hash))
+    }
+}
+
+
+#[derive(Debug)]
+pub enum TokenStorageError {
+    Json(json::Error),
+    Io(io::Error),
+}
+
+impl fmt::Display for TokenStorageError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            TokenStorageError::Json(ref err) => writeln!(f, "Could not serialize secrets: {}", err),
+            TokenStorageError::Io(ref err) => writeln!(f, "Failed to write secret token: {}", err),
+        }
+    }
+}
+
+impl StdError for TokenStorageError {
+    fn description(&self) -> &str {
+        "Failure when getting or setting the token storage"
+    }
+}
+
+
+impl TokenStorage for JsonTokenStorage {
+    type Error = TokenStorageError;
+
+    // NOTE: logging might be interesting, currently we swallow all errors
+    fn set(&mut self,
+           scope_hash: u64,
+           _: &Vec<&str>,
+           token: Option<Token>)
+           -> Result<(), TokenStorageError> {
+        match token {
+            None => {
+                match fs::remove_file(self.path(scope_hash)) {
+                    Err(err) => match err.kind() {
+                        io::ErrorKind::NotFound => Ok(()),
+                        _ => Err(TokenStorageError::Io(err)),
+                    },
+                    Ok(_) => Ok(()),
+                }
+            }
+            Some(token) => {
+                match fs::OpenOptions::new().create(true).write(true).open(&self.path(scope_hash)) {
+                    Ok(mut f) => {
+                        match json::to_writer_pretty(&mut f, &token) {
+                            Ok(_) => Ok(()),
+                            Err(serde_err) => Err(TokenStorageError::Json(serde_err)),
+                        }
+                    }
+                    Err(io_err) => Err(TokenStorageError::Io(io_err)),
+                }
+            }
+        }
+    }
+
+    fn get(&self, scope_hash: u64, _: &Vec<&str>) -> Result<Option<Token>, TokenStorageError> {
+        match fs::File::open(&self.path(scope_hash)) {
+            Ok(f) => {
+                match json::de::from_reader(f) {
+                    Ok(token) => Ok(Some(token)),
+                    Err(err) => Err(TokenStorageError::Json(err)),
+                }
+            }
+            Err(io_err) => {
+                match io_err.kind() {
+                    io::ErrorKind::NotFound => Ok(None),
+                    _ => Err(TokenStorageError::Io(io_err)),
+                }
+            }
+        }
+    }
+}
+
+
+#[derive(Debug)]
+pub enum ApplicationSecretError {
+    DecoderError((String, json::Error)),
+    FormatError(String),
+}
+
+impl fmt::Display for ApplicationSecretError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            ApplicationSecretError::DecoderError((ref path, ref err)) =>
+                writeln!(f,
+                         "Could not decode file at '{}' with error: {}.",
+                         path,
+                         err),
+            ApplicationSecretError::FormatError(ref path) =>
+                writeln!(f,
+                         "'installed' field is unset in secret file at '{}'.",
+                         path),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum ConfigurationError {
+    DirectoryCreationFailed((String, io::Error)),
+    DirectoryUnset,
+    HomeExpansionFailed(String),
+    Secret(ApplicationSecretError),
+    Io((String, io::Error)),
+}
+
+impl fmt::Display for ConfigurationError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            ConfigurationError::DirectoryCreationFailed((ref dir, ref err)) =>
+                writeln!(f,
+                         "Directory '{}' could not be created with error: {}.",
+                         dir,
+                         err),
+            ConfigurationError::DirectoryUnset => writeln!(f, "--config-dir was unset or empty."),
+            ConfigurationError::HomeExpansionFailed(ref dir) =>
+                writeln!(f,
+                         "Couldn't find HOME directory of current user, failed to expand '{}'.",
+                         dir),
+            ConfigurationError::Secret(ref err) => writeln!(f, "Secret -> {}", err),
+            ConfigurationError::Io((ref path, ref err)) =>
+                writeln!(f,
+                         "IO operation failed on path '{}' with error: {}.",
+                         path,
+                         err),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum InputError {
+    Io((String, io::Error)),
+    Mime(String),
+}
+
+impl fmt::Display for InputError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            InputError::Io((ref file_path, ref io_err)) =>
+                writeln!(f,
+                         "Failed to open '{}' for reading with error: {}.",
+                         file_path,
+                         io_err),
+            InputError::Mime(ref mime) => writeln!(f, "'{}' is not a known mime-type.", mime),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum FieldError {
+    PopOnEmpty(String),
+    TrailingFieldSep(String),
+    Unknown(String, Option<String>, Option<String>),
+    Duplicate(String),
+    Empty,
+}
+
+
+impl fmt::Display for FieldError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            FieldError::PopOnEmpty(ref field) =>
+                writeln!(f, "'{}': Cannot move up on empty field cursor.", field),
+            FieldError::TrailingFieldSep(ref field) =>
+                writeln!(f,
+                         "'{}': Single field separator may not be last character.",
+                         field),
+            FieldError::Unknown(ref field, ref suggestion, ref value) => {
+                let suffix = match *suggestion {
+                    Some(ref s) => {
+                        let kv = match *value {
+                            Some(ref v) => format!("{}={}", s, v),
+                            None => s.clone(),
+                        };
+                        format!(" Did you mean '{}' ?", kv)
+                    }
+                    None => String::new(),
+                };
+                writeln!(f, "Field '{}' does not exist.{}", field, suffix)
+            }
+            FieldError::Duplicate(ref cursor) =>
+                writeln!(f, "Value at '{}' was already set", cursor),
+            FieldError::Empty => writeln!(f, "Field names must not be empty."),
+        }
+    }
+}
+
+
+#[derive(Debug)]
+pub enum CLIError {
+    Configuration(ConfigurationError),
+    ParseError(String, String, String, String),
+    UnknownParameter(String, Vec<&'static str>),
+    InvalidUploadProtocol(String, Vec<String>),
+    InvalidKeyValueSyntax(String, bool),
+    Input(InputError),
+    Field(FieldError),
+    MissingCommandError,
+    MissingMethodError(String),
+}
+
+impl fmt::Display for CLIError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            CLIError::Configuration(ref err) => write!(f, "Configuration -> {}", err),
+            CLIError::Input(ref err) => write!(f, "Input -> {}", err),
+            CLIError::Field(ref err) => write!(f, "Field -> {}", err),
+            CLIError::InvalidUploadProtocol(ref proto_name, ref valid_names) =>
+                writeln!(f,
+                         "'{}' is not a valid upload protocol. Choose from one of {}.",
+                         proto_name,
+                         valid_names.join(", ")),
+            CLIError::ParseError(ref arg_name, ref type_name, ref value, ref err_desc) =>
+                writeln!(f,
+                         "Failed to parse argument '{}' with value '{}' as {} with error: {}.",
+                         arg_name,
+                         value,
+                         type_name,
+                         err_desc),
+            CLIError::UnknownParameter(ref param_name, ref possible_values) => {
+                let suffix = match did_you_mean(param_name, &possible_values) {
+                    Some(v) => format!(" Did you mean '{}' ?", v),
+                    None => String::new(),
+                };
+                write!(f, "Parameter '{}' is unknown.{}\n", param_name, suffix)
+            }
+            CLIError::InvalidKeyValueSyntax(ref kv, is_hashmap) => {
+                let hashmap_info = if is_hashmap {
+                    "hashmap "
+                } else {
+                    ""
+                };
+                writeln!(f,
+                         "'{}' does not match {}pattern <key>=<value>.",
+                         kv,
+                         hashmap_info)
+            }
+            CLIError::MissingCommandError => writeln!(f, "Please specify the main sub-command."),
+            CLIError::MissingMethodError(ref cmd) =>
+                writeln!(f,
+                         "Please specify the method to call on the '{}' command.",
+                         cmd),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct InvalidOptionsError {
+    pub issues: Vec<CLIError>,
+    pub exit_code: i32,
+}
+
+impl fmt::Display for InvalidOptionsError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        for issue in &self.issues {
+            try!(issue.fmt(f));
+        }
+        Ok(())
+    }
+}
+
+impl InvalidOptionsError {
+    pub fn single(err: CLIError, exit_code: i32) -> InvalidOptionsError {
+        InvalidOptionsError {
+            issues: vec![err],
+            exit_code: exit_code,
+        }
+    }
+
+    pub fn new() -> InvalidOptionsError {
+        InvalidOptionsError {
+            issues: Vec::new(),
+            exit_code: 1,
+        }
+    }
+}
+
+pub fn assure_config_dir_exists(dir: &str) -> Result<String, CLIError> {
+    let trdir = dir.trim();
+    if trdir.len() == 0 {
+        return Err(CLIError::Configuration(ConfigurationError::DirectoryUnset));
+    }
+
+    let expanded_config_dir = if trdir.as_bytes()[0] == b'~' {
+        match env::var("HOME").ok().or(env::var("UserProfile").ok()) {
+            None => return Err(CLIError::Configuration(ConfigurationError::HomeExpansionFailed(trdir.to_string()))),
+            Some(mut user) => {
+                user.push_str(&trdir[1..]);
+                user
+            }
+        }
+    } else {
+        trdir.to_string()
+    };
+
+    if let Err(err) = fs::create_dir(&expanded_config_dir) {
+        if err.kind() != io::ErrorKind::AlreadyExists {
+            return Err(CLIError::Configuration(
+                    ConfigurationError::DirectoryCreationFailed((expanded_config_dir, err))));
+        }
+    }
+
+    Ok(expanded_config_dir)
+}
+
+pub fn application_secret_from_directory(dir: &str,
+                                         secret_basename: &str,
+                                         json_console_secret: &str)
+                                         -> Result<ApplicationSecret, CLIError> {
+    let secret_path = Path::new(dir).join(secret_basename);
+    let secret_str = || secret_path.as_path().to_str().unwrap().to_string();
+    let secret_io_error = |io_err: io::Error| {
+        Err(CLIError::Configuration(ConfigurationError::Io((secret_str(), io_err))))
+    };
+
+    for _ in 0..2 {
+        match fs::File::open(&secret_path) {
+            Err(mut err) => {
+                if err.kind() == io::ErrorKind::NotFound {
+                    // Write our built-in one - user may adjust the written file at will
+
+                    err = match fs::OpenOptions::new()
+                                    .create(true)
+                                    .write(true)
+                                    .open(&secret_path) {
+                        Err(cfe) => cfe,
+                        Ok(mut f) => {
+                            // Assure we convert 'ugly' json string into pretty one
+                            let console_secret: ConsoleApplicationSecret =
+                                json::from_str(json_console_secret).unwrap();
+                            match json::to_writer_pretty(&mut f, &console_secret) {
+                                Err(serde_err) =>
+                                    panic!("Unexpected serde error: {:#?}", serde_err),
+                                Ok(_) => continue,
+                            }
+                        }
+                    };
+                    // fall through to IO error handling
+                }
+                return secret_io_error(err);
+            }
+            Ok(f) => {
+                match json::de::from_reader::<_, ConsoleApplicationSecret>(f) {
+                    Err(json_err) =>
+                        return Err(CLIError::Configuration(
+                            ConfigurationError::Secret(
+                                ApplicationSecretError::DecoderError(
+                                                (secret_str(), json_err)
+                                              )))),
+                    Ok(console_secret) => match console_secret.installed {
+                        Some(secret) => return Ok(secret),
+                        None => return Err(
+                                        CLIError::Configuration(
+                                        ConfigurationError::Secret(
+                                        ApplicationSecretError::FormatError(secret_str())
+                                        ))),
+                    },
+                }
+            }
+        }
+    }
+    unreachable!();
+}

--- a/gen/cloudtrace1-cli/src/main.rs
+++ b/gen/cloudtrace1-cli/src/main.rs
@@ -1,0 +1,550 @@
+// DO NOT EDIT !
+// This file was generated automatically from 'src/mako/cli/main.rs.mako'
+// DO NOT EDIT !
+#![allow(unused_variables, unused_imports, dead_code, unused_mut)]
+
+#[macro_use]
+extern crate clap;
+extern crate yup_oauth2 as oauth2;
+extern crate yup_hyper_mock as mock;
+extern crate hyper_rustls;
+extern crate serde;
+extern crate serde_json;
+extern crate hyper;
+extern crate mime;
+extern crate strsim;
+extern crate google_cloudtrace1 as api;
+
+use std::env;
+use std::io::{self, Write};
+use clap::{App, SubCommand, Arg};
+
+mod cmn;
+
+use cmn::{InvalidOptionsError, CLIError, JsonTokenStorage, arg_from_str, writer_from_opts, parse_kv_arg,
+          input_file_from_opts, input_mime_from_opts, FieldCursor, FieldError, CallType, UploadProtocol,
+          calltype_from_str, remove_json_null_values, ComplexType, JsonType, JsonTypeInfo};
+
+use std::default::Default;
+use std::str::FromStr;
+
+use oauth2::{Authenticator, DefaultAuthenticatorDelegate, FlowType};
+use serde_json as json;
+use clap::ArgMatches;
+
+enum DoitError {
+    IoError(String, io::Error),
+    ApiError(api::Error),
+}
+
+struct Engine<'n> {
+    opt: ArgMatches<'n>,
+    hub: api::CloudTrace<hyper::Client, Authenticator<DefaultAuthenticatorDelegate, JsonTokenStorage, hyper::Client>>,
+    gp: Vec<&'static str>,
+    gpm: Vec<(&'static str, &'static str)>,
+}
+
+
+impl<'n> Engine<'n> {
+    fn _projects_patch_traces(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec![]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::Traces = json::value::from_value(object).unwrap();
+        let mut call = self.hub.projects().patch_traces(request, opt.value_of("project-id").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _projects_traces_get(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let mut call = self.hub.projects().traces_get(opt.value_of("project-id").unwrap_or(""), opt.value_of("trace-id").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _projects_traces_list(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let mut call = self.hub.projects().traces_list(opt.value_of("project-id").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                "view" => {
+                    call = call.view(value.unwrap_or(""));
+                },
+                "start-time" => {
+                    call = call.start_time(value.unwrap_or(""));
+                },
+                "page-token" => {
+                    call = call.page_token(value.unwrap_or(""));
+                },
+                "page-size" => {
+                    call = call.page_size(arg_from_str(value.unwrap_or("-0"), err, "page-size", "integer"));
+                },
+                "order-by" => {
+                    call = call.order_by(value.unwrap_or(""));
+                },
+                "filter" => {
+                    call = call.filter(value.unwrap_or(""));
+                },
+                "end-time" => {
+                    call = call.end_time(value.unwrap_or(""));
+                },
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v.extend(["order-by", "page-size", "filter", "page-token", "start-time", "end-time", "view"].iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _doit(&self, dry_run: bool) -> Result<Result<(), DoitError>, Option<InvalidOptionsError>> {
+        let mut err = InvalidOptionsError::new();
+        let mut call_result: Result<(), DoitError> = Ok(());
+        let mut err_opt: Option<InvalidOptionsError> = None;
+        match self.opt.subcommand() {
+            ("projects", Some(opt)) => {
+                match opt.subcommand() {
+                    ("patch-traces", Some(opt)) => {
+                        call_result = self._projects_patch_traces(opt, dry_run, &mut err);
+                    },
+                    ("traces-get", Some(opt)) => {
+                        call_result = self._projects_traces_get(opt, dry_run, &mut err);
+                    },
+                    ("traces-list", Some(opt)) => {
+                        call_result = self._projects_traces_list(opt, dry_run, &mut err);
+                    },
+                    _ => {
+                        err.issues.push(CLIError::MissingMethodError("projects".to_string()));
+                        writeln!(io::stderr(), "{}\n", opt.usage()).ok();
+                    }
+                }
+            },
+            _ => {
+                err.issues.push(CLIError::MissingCommandError);
+                writeln!(io::stderr(), "{}\n", self.opt.usage()).ok();
+            }
+        }
+
+        if dry_run {
+            if err.issues.len() > 0 {
+                err_opt = Some(err);
+            }
+            Err(err_opt)
+        } else {
+            Ok(call_result)
+        }
+    }
+
+    // Please note that this call will fail if any part of the opt can't be handled
+    fn new(opt: ArgMatches<'n>) -> Result<Engine<'n>, InvalidOptionsError> {
+        let (config_dir, secret) = {
+            let config_dir = match cmn::assure_config_dir_exists(opt.value_of("folder").unwrap_or("~/.google-service-cli")) {
+                Err(e) => return Err(InvalidOptionsError::single(e, 3)),
+                Ok(p) => p,
+            };
+
+            match cmn::application_secret_from_directory(&config_dir, "cloudtrace1-secret.json",
+                                                         "{\"installed\":{\"auth_uri\":\"https://accounts.google.com/o/oauth2/auth\",\"client_secret\":\"hCsslbCUyfehWMmbkG8vTYxG\",\"token_uri\":\"https://accounts.google.com/o/oauth2/token\",\"client_email\":\"\",\"redirect_uris\":[\"urn:ietf:wg:oauth:2.0:oob\",\"oob\"],\"client_x509_cert_url\":\"\",\"client_id\":\"620010449518-9ngf7o4dhs0dka470npqvor6dc5lqb9b.apps.googleusercontent.com\",\"auth_provider_x509_cert_url\":\"https://www.googleapis.com/oauth2/v1/certs\"}}") {
+                Ok(secret) => (config_dir, secret),
+                Err(e) => return Err(InvalidOptionsError::single(e, 4))
+            }
+        };
+
+        let auth = Authenticator::new(  &secret, DefaultAuthenticatorDelegate,
+                                        if opt.is_present("debug-auth") {
+                                            hyper::Client::with_connector(mock::TeeConnector {
+                                                    connector: hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())
+                                                })
+                                        } else {
+                                            hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new()))
+                                        },
+                                        JsonTokenStorage {
+                                          program_name: "cloudtrace1",
+                                          db_dir: config_dir.clone(),
+                                        }, Some(FlowType::InstalledRedirect(54324)));
+
+        let client =
+            if opt.is_present("debug") {
+                hyper::Client::with_connector(mock::TeeConnector {
+                        connector: hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())
+                    })
+            } else {
+                hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new()))
+            };
+        let engine = Engine {
+            opt: opt,
+            hub: api::CloudTrace::new(client, auth),
+            gp: vec!["$-xgafv", "access-token", "alt", "bearer-token", "callback", "fields", "key", "oauth-token", "pp", "pretty-print", "quota-user", "upload-type", "upload-protocol"],
+            gpm: vec![
+                    ("$-xgafv", "$.xgafv"),
+                    ("access-token", "access_token"),
+                    ("bearer-token", "bearer_token"),
+                    ("oauth-token", "oauth_token"),
+                    ("pretty-print", "prettyPrint"),
+                    ("quota-user", "quotaUser"),
+                    ("upload-type", "uploadType"),
+                    ("upload-protocol", "upload_protocol"),
+                ]
+        };
+
+        match engine._doit(true) {
+            Err(Some(err)) => Err(err),
+            Err(None)      => Ok(engine),
+            Ok(_)          => unreachable!(),
+        }
+    }
+
+    fn doit(&self) -> Result<(), DoitError> {
+        match self._doit(false) {
+            Ok(res) => res,
+            Err(_) => unreachable!(),
+        }
+    }
+}
+
+fn main() {
+    let mut exit_status = 0i32;
+    let arg_data = [
+        ("projects", "methods: 'patch-traces', 'traces-get' and 'traces-list'", vec![
+            ("patch-traces",
+                    Some(r##"Sends new traces to Stackdriver Trace or updates existing traces. If the ID
+        of a trace that you send matches that of an existing trace, any fields
+        in the existing trace and its spans are overwritten by the provided values,
+        and any new fields provided are merged with the existing trace data. If the
+        ID does not match, a new trace is created."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_cloudtrace1_cli/projects_patch-traces",
+                  vec![
+                    (Some(r##"project-id"##),
+                     None,
+                     Some(r##"ID of the Cloud project where the trace data is stored."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("traces-get",
+                    Some(r##"Gets a single trace by its ID."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_cloudtrace1_cli/projects_traces-get",
+                  vec![
+                    (Some(r##"project-id"##),
+                     None,
+                     Some(r##"ID of the Cloud project where the trace data is stored."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"trace-id"##),
+                     None,
+                     Some(r##"ID of the trace to return."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("traces-list",
+                    Some(r##"Returns of a list of traces that match the specified filter conditions."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_cloudtrace1_cli/projects_traces-list",
+                  vec![
+                    (Some(r##"project-id"##),
+                     None,
+                     Some(r##"ID of the Cloud project where the trace data is stored."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ]),
+        
+    ];
+    
+    let mut app = App::new("cloudtrace1")
+           .author("Sebastian Thiel <byronimo@gmail.com>")
+           .version("1.0.7+20171202")
+           .about("Sends application trace data to Stackdriver Trace for viewing. Trace data is collected for all App Engine applications by default. Trace data from other applications can be provided using this API.
+           ")
+           .after_help("All documentation details can be found at http://byron.github.io/google-apis-rs/google_cloudtrace1_cli")
+           .arg(Arg::with_name("url")
+                   .long("scope")
+                   .help("Specify the authentication a method should be executed in. Each scope requires the user to grant this application permission to use it.If unset, it defaults to the shortest scope url for a particular method.")
+                   .multiple(true)
+                   .takes_value(true))
+           .arg(Arg::with_name("folder")
+                   .long("config-dir")
+                   .help("A directory into which we will store our persistent data. Defaults to a user-writable directory that we will create during the first invocation.[default: ~/.google-service-cli")
+                   .multiple(false)
+                   .takes_value(true))
+           .arg(Arg::with_name("debug")
+                   .long("debug")
+                   .help("Output all server communication to standard error. `tx` and `rx` are placed into the same stream.")
+                   .multiple(false)
+                   .takes_value(false))
+           .arg(Arg::with_name("debug-auth")
+                   .long("debug-auth")
+                   .help("Output all communication related to authentication to standard error. `tx` and `rx` are placed into the same stream.")
+                   .multiple(false)
+                   .takes_value(false));
+           
+           for &(main_command_name, about, ref subcommands) in arg_data.iter() {
+               let mut mcmd = SubCommand::with_name(main_command_name).about(about);
+           
+               for &(sub_command_name, ref desc, url_info, ref args) in subcommands {
+                   let mut scmd = SubCommand::with_name(sub_command_name);
+                   if let &Some(desc) = desc {
+                       scmd = scmd.about(desc);
+                   }
+                   scmd = scmd.after_help(url_info);
+           
+                   for &(ref arg_name, ref flag, ref desc, ref required, ref multi) in args {
+                       let arg_name_str =
+                           match (arg_name, flag) {
+                                   (&Some(an), _       ) => an,
+                                   (_        , &Some(f)) => f,
+                                    _                    => unreachable!(),
+                            };
+                       let mut arg = Arg::with_name(arg_name_str)
+                                         .empty_values(false);
+                       if let &Some(short_flag) = flag {
+                           arg = arg.short(short_flag);
+                       }
+                       if let &Some(desc) = desc {
+                           arg = arg.help(desc);
+                       }
+                       if arg_name.is_some() && flag.is_some() {
+                           arg = arg.takes_value(true);
+                       }
+                       if let &Some(required) = required {
+                           arg = arg.required(required);
+                       }
+                       if let &Some(multi) = multi {
+                           arg = arg.multiple(multi);
+                       }
+                       scmd = scmd.arg(arg);
+                   }
+                   mcmd = mcmd.subcommand(scmd);
+               }
+               app = app.subcommand(mcmd);
+           }
+           
+        let matches = app.get_matches();
+
+    let debug = matches.is_present("debug");
+    match Engine::new(matches) {
+        Err(err) => {
+            exit_status = err.exit_code;
+            writeln!(io::stderr(), "{}", err).ok();
+        },
+        Ok(engine) => {
+            if let Err(doit_err) = engine.doit() {
+                exit_status = 1;
+                match doit_err {
+                    DoitError::IoError(path, err) => {
+                        writeln!(io::stderr(), "Failed to open output file '{}': {}", path, err).ok();
+                    },
+                    DoitError::ApiError(err) => {
+                        if debug {
+                            writeln!(io::stderr(), "{:#?}", err).ok();
+                        } else {
+                            writeln!(io::stderr(), "{}", err).ok();
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    std::process::exit(exit_status);
+}

--- a/gen/cloudtrace1/Cargo.toml
+++ b/gen/cloudtrace1/Cargo.toml
@@ -1,0 +1,31 @@
+# DO NOT EDIT !
+# This file was generated automatically from 'src/mako/Cargo.toml.mako'
+# DO NOT EDIT !
+[package]
+
+name = "google-cloudtrace1"
+version = "1.0.7+20171202"
+authors = ["Sebastian Thiel <byronimo@gmail.com>"]
+description = "A complete library to interact with Cloud Trace (protocol v1)"
+repository = "https://github.com/Byron/google-apis-rs/tree/master/gen/cloudtrace1"
+homepage = "https://cloud.google.com/trace"
+documentation = "https://docs.rs/google-cloudtrace1/1.0.7+20171202"
+license = "MIT"
+keywords = ["cloudtrace", "google", "protocol", "web", "api"]
+
+
+[dev-dependencies]
+hyper-rustls = "^0.6"
+
+[dependencies]
+hyper = "^ 0.10"
+mime = "^ 0.2.0"
+serde = "^ 1.0"
+serde_json = "^ 1.0"
+serde_derive = "^ 1.0"
+yup-oauth2 = "^ 1.0"
+url = "= 0.5"
+
+[features]
+
+

--- a/gen/cloudtrace1/LICENSE.md
+++ b/gen/cloudtrace1/LICENSE.md
@@ -1,0 +1,30 @@
+<!---
+DO NOT EDIT !
+This file was generated automatically from 'src/mako/LICENSE.md.mako'
+DO NOT EDIT !
+-->
+The MIT License (MIT)
+=====================
+
+Copyright © `2015-2016` `Sebastian Thiel`
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the “Software”), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.

--- a/gen/cloudtrace1/README.md
+++ b/gen/cloudtrace1/README.md
@@ -1,0 +1,174 @@
+<!---
+DO NOT EDIT !
+This file was generated automatically from 'src/mako/api/README.md.mako'
+DO NOT EDIT !
+-->
+The `google-cloudtrace1` library allows access to all features of the *Google Cloud Trace* service.
+
+This documentation was generated from *Cloud Trace* crate version *1.0.7+20171202*, where *20171202* is the exact revision of the *cloudtrace:v1* schema built by the [mako](http://www.makotemplates.org/) code generator *v1.0.7*.
+
+Everything else about the *Cloud Trace* *v1* API can be found at the
+[official documentation site](https://cloud.google.com/trace).
+# Features
+
+Handle the following *Resources* with ease from the central [hub](https://docs.rs/google-cloudtrace1/1.0.7+20171202/google_cloudtrace1/struct.CloudTrace.html) ... 
+
+* projects
+ * [*patch traces*](https://docs.rs/google-cloudtrace1/1.0.7+20171202/google_cloudtrace1/struct.ProjectPatchTraceCall.html), [*traces get*](https://docs.rs/google-cloudtrace1/1.0.7+20171202/google_cloudtrace1/struct.ProjectTraceGetCall.html) and [*traces list*](https://docs.rs/google-cloudtrace1/1.0.7+20171202/google_cloudtrace1/struct.ProjectTraceListCall.html)
+
+
+
+
+# Structure of this Library
+
+The API is structured into the following primary items:
+
+* **[Hub](https://docs.rs/google-cloudtrace1/1.0.7+20171202/google_cloudtrace1/struct.CloudTrace.html)**
+    * a central object to maintain state and allow accessing all *Activities*
+    * creates [*Method Builders*](https://docs.rs/google-cloudtrace1/1.0.7+20171202/google_cloudtrace1/trait.MethodsBuilder.html) which in turn
+      allow access to individual [*Call Builders*](https://docs.rs/google-cloudtrace1/1.0.7+20171202/google_cloudtrace1/trait.CallBuilder.html)
+* **[Resources](https://docs.rs/google-cloudtrace1/1.0.7+20171202/google_cloudtrace1/trait.Resource.html)**
+    * primary types that you can apply *Activities* to
+    * a collection of properties and *Parts*
+    * **[Parts](https://docs.rs/google-cloudtrace1/1.0.7+20171202/google_cloudtrace1/trait.Part.html)**
+        * a collection of properties
+        * never directly used in *Activities*
+* **[Activities](https://docs.rs/google-cloudtrace1/1.0.7+20171202/google_cloudtrace1/trait.CallBuilder.html)**
+    * operations to apply to *Resources*
+
+All *structures* are marked with applicable traits to further categorize them and ease browsing.
+
+Generally speaking, you can invoke *Activities* like this:
+
+```Rust,ignore
+let r = hub.resource().activity(...).doit()
+```
+
+Or specifically ...
+
+```ignore
+let r = hub.projects().traces_get(...).doit()
+```
+
+The `resource()` and `activity(...)` calls create [builders][builder-pattern]. The second one dealing with `Activities` 
+supports various methods to configure the impending operation (not shown here). It is made such that all required arguments have to be 
+specified right away (i.e. `(...)`), whereas all optional ones can be [build up][builder-pattern] as desired.
+The `doit()` method performs the actual communication with the server and returns the respective result.
+
+# Usage
+
+## Setting up your Project
+
+To use this library, you would put the following lines into your `Cargo.toml` file:
+
+```toml
+[dependencies]
+google-cloudtrace1 = "*"
+```
+
+## A complete example
+
+```Rust
+extern crate hyper;
+extern crate hyper_rustls;
+extern crate yup_oauth2 as oauth2;
+extern crate google_cloudtrace1 as cloudtrace1;
+use cloudtrace1::{Result, Error};
+use std::default::Default;
+use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+use cloudtrace1::CloudTrace;
+
+// Get an ApplicationSecret instance by some means. It contains the `client_id` and 
+// `client_secret`, among other things.
+let secret: ApplicationSecret = Default::default();
+// Instantiate the authenticator. It will choose a suitable authentication flow for you, 
+// unless you replace  `None` with the desired Flow.
+// Provide your own `AuthenticatorDelegate` to adjust the way it operates and get feedback about 
+// what's going on. You probably want to bring in your own `TokenStorage` to persist tokens and
+// retrieve them from storage.
+let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+                              hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+                              <MemoryStorage as Default>::default(), None);
+let mut hub = CloudTrace::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+// You can configure optional parameters by calling the respective setters at will, and
+// execute the final call using `doit()`.
+// Values shown here are possibly random and not representative !
+let result = hub.projects().traces_get("projectId", "traceId")
+             .doit();
+
+match result {
+    Err(e) => match e {
+        // The Error enum provides details about what exactly happened.
+        // You can also just use its `Debug`, `Display` or `Error` traits
+         Error::HttpError(_)
+        |Error::MissingAPIKey
+        |Error::MissingToken(_)
+        |Error::Cancelled
+        |Error::UploadSizeLimitExceeded(_, _)
+        |Error::Failure(_)
+        |Error::BadRequest(_)
+        |Error::FieldClash(_)
+        |Error::JsonDecodeError(_, _) => println!("{}", e),
+    },
+    Ok(res) => println!("Success: {:?}", res),
+}
+
+```
+## Handling Errors
+
+All errors produced by the system are provided either as [Result](https://docs.rs/google-cloudtrace1/1.0.7+20171202/google_cloudtrace1/enum.Result.html) enumeration as return value of 
+the doit() methods, or handed as possibly intermediate results to either the 
+[Hub Delegate](https://docs.rs/google-cloudtrace1/1.0.7+20171202/google_cloudtrace1/trait.Delegate.html), or the [Authenticator Delegate](https://docs.rs/yup-oauth2/*/yup_oauth2/trait.AuthenticatorDelegate.html).
+
+When delegates handle errors or intermediate values, they may have a chance to instruct the system to retry. This 
+makes the system potentially resilient to all kinds of errors.
+
+## Uploads and Downloads
+If a method supports downloads, the response body, which is part of the [Result](https://docs.rs/google-cloudtrace1/1.0.7+20171202/google_cloudtrace1/enum.Result.html), should be
+read by you to obtain the media.
+If such a method also supports a [Response Result](https://docs.rs/google-cloudtrace1/1.0.7+20171202/google_cloudtrace1/trait.ResponseResult.html), it will return that by default.
+You can see it as meta-data for the actual media. To trigger a media download, you will have to set up the builder by making
+this call: `.param("alt", "media")`.
+
+Methods supporting uploads can do so using up to 2 different protocols: 
+*simple* and *resumable*. The distinctiveness of each is represented by customized 
+`doit(...)` methods, which are then named `upload(...)` and `upload_resumable(...)` respectively.
+
+## Customization and Callbacks
+
+You may alter the way an `doit()` method is called by providing a [delegate](https://docs.rs/google-cloudtrace1/1.0.7+20171202/google_cloudtrace1/trait.Delegate.html) to the 
+[Method Builder](https://docs.rs/google-cloudtrace1/1.0.7+20171202/google_cloudtrace1/trait.CallBuilder.html) before making the final `doit()` call. 
+Respective methods will be called to provide progress information, as well as determine whether the system should 
+retry on failure.
+
+The [delegate trait](https://docs.rs/google-cloudtrace1/1.0.7+20171202/google_cloudtrace1/trait.Delegate.html) is default-implemented, allowing you to customize it with minimal effort.
+
+## Optional Parts in Server-Requests
+
+All structures provided by this library are made to be [enocodable](https://docs.rs/google-cloudtrace1/1.0.7+20171202/google_cloudtrace1/trait.RequestValue.html) and 
+[decodable](https://docs.rs/google-cloudtrace1/1.0.7+20171202/google_cloudtrace1/trait.ResponseResult.html) via *json*. Optionals are used to indicate that partial requests are responses 
+are valid.
+Most optionals are are considered [Parts](https://docs.rs/google-cloudtrace1/1.0.7+20171202/google_cloudtrace1/trait.Part.html) which are identifiable by name, which will be sent to 
+the server to indicate either the set parts of the request or the desired parts in the response.
+
+## Builder Arguments
+
+Using [method builders](https://docs.rs/google-cloudtrace1/1.0.7+20171202/google_cloudtrace1/trait.CallBuilder.html), you are able to prepare an action call by repeatedly calling it's methods.
+These will always take a single argument, for which the following statements are true.
+
+* [PODs][wiki-pod] are handed by copy
+* strings are passed as `&str`
+* [request values](https://docs.rs/google-cloudtrace1/1.0.7+20171202/google_cloudtrace1/trait.RequestValue.html) are moved
+
+Arguments will always be copied or cloned into the builder, to make them independent of their original life times.
+
+[wiki-pod]: http://en.wikipedia.org/wiki/Plain_old_data_structure
+[builder-pattern]: http://en.wikipedia.org/wiki/Builder_pattern
+[google-go-api]: https://github.com/google/google-api-go-client
+
+# License
+The **cloudtrace1** library was generated by Sebastian Thiel, and is placed 
+under the *MIT* license.
+You can read the full text at the repository's [license file][repo-license].
+
+[repo-license]: https://github.com/Byron/google-apis-rsblob/master/LICENSE.md

--- a/gen/cloudtrace1/src/cmn.rs
+++ b/gen/cloudtrace1/src/cmn.rs
@@ -1,0 +1,753 @@
+// COPY OF 'src/rust/api/cmn.rs'
+// DO NOT EDIT
+use std::io::{self, Read, Seek, Cursor, Write, SeekFrom};
+use std;
+use std::fmt::{self, Display};
+use std::str::FromStr;
+use std::error;
+use std::thread::sleep;
+use std::time::Duration;
+
+use mime::{Mime, TopLevel, SubLevel, Attr, Value};
+use oauth2::{TokenType, Retry, self};
+use hyper;
+use hyper::header::{ContentType, ContentLength, Headers, UserAgent, Authorization, Header,
+                    HeaderFormat, Bearer};
+use hyper::http::h1::LINE_ENDING;
+use hyper::method::Method;
+use hyper::status::StatusCode;
+
+use serde_json as json;
+
+/// Identifies the Hub. There is only one per library, this trait is supposed
+/// to make intended use more explicit.
+/// The hub allows to access all resource methods more easily.
+pub trait Hub {}
+
+/// Identifies types for building methods of a particular resource type
+pub trait MethodsBuilder {}
+
+/// Identifies types which represent builders for a particular resource method
+pub trait CallBuilder {}
+
+/// Identifies types which can be inserted and deleted.
+/// Types with this trait are most commonly used by clients of this API.
+pub trait Resource {}
+
+/// Identifies types which are used in API responses.
+pub trait ResponseResult {}
+
+/// Identifies types which are used in API requests.
+pub trait RequestValue {}
+
+/// Identifies types which are not actually used by the API
+/// This might be a bug within the google API schema.
+pub trait UnusedType {}
+
+/// Identifies types which are only used as part of other types, which
+/// usually are carrying the `Resource` trait.
+pub trait Part {}
+
+/// Identifies types which are only used by other types internally.
+/// They have no special meaning, this trait just marks them for completeness.
+pub trait NestedType {}
+
+/// A utility to specify reader types which provide seeking capabilities too
+pub trait ReadSeek: Seek + Read {}
+impl<T: Seek + Read> ReadSeek for T {}
+
+/// A trait for all types that can convert themselves into a *parts* string
+pub trait ToParts {
+    fn to_parts(&self) -> String;
+}
+
+/// A utility type which can decode a server response that indicates error
+#[derive(Deserialize)]
+pub struct JsonServerError {
+    pub error: String,
+    pub error_description: Option<String>
+}
+
+/// A utility to represent detailed errors we might see in case there are BadRequests.
+/// The latter happen if the sent parameters or request structures are unsound
+#[derive(Deserialize, Serialize, Debug)]
+pub struct ErrorResponse {
+    error: ServerError,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct ServerError {
+    errors: Vec<ServerMessage>,
+    code: u16,
+    message: String,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct ServerMessage {
+    domain: String,
+    reason: String,
+    message: String,
+    #[serde(rename="locationType")]
+    location_type: Option<String>,
+    location: Option<String>
+}
+
+#[derive(Copy, Clone)]
+pub struct DummyNetworkStream;
+
+impl Read for DummyNetworkStream {
+    fn read(&mut self, _: &mut [u8]) -> io::Result<usize> {
+        Ok(0)
+    }
+}
+
+impl Write for DummyNetworkStream {
+    fn write(&mut self, _: &[u8]) -> io::Result<usize> {
+        Ok(0)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl hyper::net::NetworkStream for DummyNetworkStream {
+    fn peer_addr(&mut self) -> io::Result<std::net::SocketAddr> {
+        Ok("127.0.0.1:1337".parse().unwrap())
+    }
+
+    fn set_read_timeout(&self, _dur: Option<Duration>) -> io::Result<()> {
+        Ok(())
+    }
+
+    fn set_write_timeout(&self, _dur: Option<Duration>) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+
+/// A trait specifying functionality to help controlling any request performed by the API.
+/// The trait has a conservative default implementation.
+///
+/// It contains methods to deal with all common issues, as well with the ones related to
+/// uploading media
+pub trait Delegate {
+
+    /// Called at the beginning of any API request. The delegate should store the method
+    /// information if he is interesting in knowing more context when further calls to it
+    /// are made.
+    /// The matching `finished()` call will always be made, no matter whether or not the API
+    /// request was successful. That way, the delegate may easily maintain a clean state
+    /// between various API calls.
+    fn begin(&mut self, MethodInfo) {}
+
+    /// Called whenever there is an [HttpError](http://hyperium.github.io/hyper/hyper/error/enum.HttpError.html), usually if there are network problems.
+    ///
+    /// If you choose to retry after a duration, the duration should be chosen using the
+    /// [exponential backoff algorithm](http://en.wikipedia.org/wiki/Exponential_backoff).
+    ///
+    /// Return retry information.
+    fn http_error(&mut self, &hyper::Error) -> Retry {
+        Retry::Abort
+    }
+
+    /// Called whenever there is the need for your applications API key after
+    /// the official authenticator implementation didn't provide one, for some reason.
+    /// If this method returns None as well, the underlying operation will fail
+    fn api_key(&mut self) -> Option<String> {
+        None
+    }
+
+    /// Called whenever the Authenticator didn't yield a token. The delegate
+    /// may attempt to provide one, or just take it as a general information about the
+    /// impending failure.
+    /// The given Error provides information about why the token couldn't be acquired in the
+    /// first place
+    fn token(&mut self, err: &error::Error) -> Option<oauth2::Token> {
+        let _ = err;
+        None
+    }
+
+    /// Called during resumable uploads to provide a URL for the impending upload.
+    /// It was saved after a previous call to `store_upload_url(...)`, and if not None,
+    /// will be used instead of asking the server for a new upload URL.
+    /// This is useful in case a previous resumable upload was aborted/canceled, but should now
+    /// be resumed.
+    /// The returned URL will be used exactly once - if it fails again and the delegate allows
+    /// to retry, we will ask the server for a new upload URL.
+    fn upload_url(&mut self) -> Option<String> {
+        None
+    }
+
+    /// Called after we have retrieved a new upload URL for a resumable upload to store it
+    /// in case we fail or cancel. That way, we can attempt to resume the upload later,
+    /// see `upload_url()`.
+    /// It will also be called with None after a successful upload, which allows the delegate
+    /// to forget the URL. That way, we will not attempt to resume an upload that has already
+    /// finished.
+    fn store_upload_url(&mut self, url: Option<&str>) {
+        let _ = url;
+    }
+
+    /// Called whenever a server response could not be decoded from json.
+    /// It's for informational purposes only, the caller will return with an error
+    /// accordingly.
+    ///
+    /// # Arguments
+    ///
+    /// * `json_encoded_value` - The json-encoded value which failed to decode.
+    /// * `json_decode_error`  - The decoder error
+    fn response_json_decode_error(&mut self, json_encoded_value: &str, json_decode_error: &json::Error) {
+        let _ = json_encoded_value;
+        let _ = json_decode_error;
+    }
+
+    /// Called whenever the http request returns with a non-success status code.
+    /// This can involve authentication issues, or anything else that very much
+    /// depends on the used API method.
+    /// The delegate should check the status, header and decoded json error to decide
+    /// whether to retry or not. In the latter case, the underlying call will fail.
+    ///
+    /// If you choose to retry after a duration, the duration should be chosen using the
+    /// [exponential backoff algorithm](http://en.wikipedia.org/wiki/Exponential_backoff).
+    fn http_failure(&mut self, _: &hyper::client::Response, Option<JsonServerError>, _: Option<ServerError>) -> Retry {
+        Retry::Abort
+    }
+
+    /// Called prior to sending the main request of the given method. It can be used to time
+    /// the call or to print progress information.
+    /// It's also useful as you can be sure that a request will definitely be made.
+    fn pre_request(&mut self) { }
+
+    /// Return the size of each chunk of a resumable upload.
+    /// Must be a power of two, with 1<<18 being the smallest allowed chunk size.
+    /// Will be called once before starting any resumable upload.
+    fn chunk_size(&mut self) -> u64 {
+        1 << 23
+    }
+
+    /// Called before the given chunk is uploaded to the server.
+    /// If true is returned, the upload will be interrupted.
+    /// However, it may be resumable if you stored the upload URL in a previous call
+    /// to `store_upload_url()`
+    fn cancel_chunk_upload(&mut self, chunk: &ContentRange) -> bool {
+        let _ = chunk;
+        false
+    }
+
+    /// Called before the API request method returns, in every case. It can be used to clean up
+    /// internal state between calls to the API.
+    /// This call always has a matching call to `begin(...)`.
+    ///
+    /// # Arguments
+    ///
+    /// * `is_success` - a true value indicates the operation was successful. If false, you should
+    ///                  discard all values stored during `store_upload_url`.
+    fn finished(&mut self, is_success: bool) {
+        let _ = is_success;
+    }
+}
+
+/// A delegate with a conservative default implementation, which is used if no other delegate is
+/// set.
+#[derive(Default)]
+pub struct DefaultDelegate;
+
+impl Delegate for DefaultDelegate {}
+
+
+#[derive(Debug)]
+pub enum Error {
+    /// The http connection failed
+    HttpError(hyper::Error),
+
+    /// An attempt was made to upload a resource with size stored in field `.0`
+    /// even though the maximum upload size is what is stored in field `.1`.
+    UploadSizeLimitExceeded(u64, u64),
+
+    /// Represents information about a request that was not understood by the server.
+    /// Details are included.
+    BadRequest(ErrorResponse),
+
+    /// We needed an API key for authentication, but didn't obtain one.
+    /// Neither through the authenticator, nor through the Delegate.
+    MissingAPIKey,
+
+    /// We required a Token, but didn't get one from the Authenticator
+    MissingToken(Box<error::Error>),
+
+    /// The delgate instructed to cancel the operation
+    Cancelled,
+
+    /// An additional, free form field clashed with one of the built-in optional ones
+    FieldClash(&'static str),
+
+    /// Shows that we failed to decode the server response.
+    /// This can happen if the protocol changes in conjunction with strict json decoding.
+    JsonDecodeError(String, json::Error),
+
+    /// Indicates an HTTP repsonse with a non-success status code
+    Failure(hyper::client::Response),
+}
+
+
+impl Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Error::HttpError(ref err) => err.fmt(f),
+            Error::UploadSizeLimitExceeded(ref resource_size, ref max_size) =>
+                writeln!(f, "The media size {} exceeds the maximum allowed upload size of {}"
+                         , resource_size, max_size),
+            Error::MissingAPIKey => {
+                (writeln!(f, "The application's API key was not found in the configuration")).ok();
+                writeln!(f, "It is used as there are no Scopes defined for this method.")
+            },
+            Error::BadRequest(ref err) => {
+                try!(writeln!(f, "Bad Request ({}): {}", err.error.code, err.error.message));
+                for err in err.error.errors.iter() {
+                    try!(writeln!(f, "    {}: {}, {}{}",
+                                            err.domain,
+                                            err.message,
+                                            err.reason,
+                                            match &err.location {
+                                                &Some(ref loc) => format!("@{}", loc),
+                                                &None => String::new(),
+                                            }));
+                }
+                Ok(())
+            },
+            Error::MissingToken(ref err) =>
+                writeln!(f, "Token retrieval failed with error: {}", err),
+            Error::Cancelled =>
+                writeln!(f, "Operation cancelled by delegate"),
+            Error::FieldClash(field) =>
+                writeln!(f, "The custom parameter '{}' is already provided natively by the CallBuilder.", field),
+            Error::JsonDecodeError(ref json_str, ref err)
+                => writeln!(f, "{}: {}", err, json_str),
+            Error::Failure(ref response) =>
+                writeln!(f, "Http status indicates failure: {:?}", response),
+        }
+    }
+}
+
+impl error::Error for Error {
+    fn description(&self) -> &str {
+        match *self {
+            Error::HttpError(ref err) => err.description(),
+            Error::JsonDecodeError(_, ref err) => err.description(),
+            _ => "NO DESCRIPTION POSSIBLE - use `Display.fmt()` instead"
+        }
+    }
+
+    fn cause(&self) -> Option<&error::Error> {
+        match *self {
+            Error::HttpError(ref err) => err.cause(),
+            Error::JsonDecodeError(_, ref err) => err.cause(),
+            _ => None
+        }
+    }
+}
+
+/// A universal result type used as return for all calls.
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Contains information about an API request.
+pub struct MethodInfo {
+    pub id: &'static str,
+    pub http_method: Method,
+}
+
+const BOUNDARY: &'static str = "MDuXWGyeE33QFXGchb2VFWc4Z7945d";
+
+/// Provides a `Read` interface that converts multiple parts into the protocol
+/// identified by [RFC2387](https://tools.ietf.org/html/rfc2387).
+/// **Note**: This implementation is just as rich as it needs to be to perform uploads
+/// to google APIs, and might not be a fully-featured implementation.
+#[derive(Default)]
+pub struct MultiPartReader<'a> {
+    raw_parts: Vec<(Headers, &'a mut Read)>,
+    current_part: Option<(Cursor<Vec<u8>>, &'a mut Read)>,
+    last_part_boundary: Option<Cursor<Vec<u8>>>,
+}
+
+impl<'a> MultiPartReader<'a> {
+
+    /// Reserve memory for exactly the given amount of parts
+    pub fn reserve_exact(&mut self, cap: usize) {
+        self.raw_parts.reserve_exact(cap);
+    }
+
+    /// Add a new part to the queue of parts to be read on the first `read` call.
+    ///
+    /// # Arguments
+    ///
+    /// `headers` - identifying the body of the part. It's similar to the header
+    ///             in an ordinary single-part call, and should thus contain the
+    ///             same information.
+    /// `reader`  - a reader providing the part's body
+    /// `size`    - the amount of bytes provided by the reader. It will be put onto the header as
+    ///             content-size.
+    /// `mime`    - It will be put onto the content type
+    pub fn add_part(&mut self, reader: &'a mut Read, size: u64, mime_type: Mime) -> &mut MultiPartReader<'a> {
+        let mut headers = Headers::new();
+        headers.set(ContentType(mime_type));
+        headers.set(ContentLength(size));
+        self.raw_parts.push((headers, reader));
+        self
+    }
+
+    /// Returns the mime-type representing our multi-part message.
+    /// Use it with the ContentType header.
+    pub fn mime_type(&self) -> Mime {
+        Mime(
+            TopLevel::Multipart,
+            SubLevel::Ext("Related".to_string()),
+            vec![(Attr::Ext("boundary".to_string()), Value::Ext(BOUNDARY.to_string()))],
+        )
+    }
+
+    /// Returns true if we are totally used
+    fn is_depleted(&self) -> bool {
+        self.raw_parts.len() == 0 && self.current_part.is_none() && self.last_part_boundary.is_none()
+    }
+
+    /// Returns true if we are handling our last part
+    fn is_last_part(&self) -> bool {
+        self.raw_parts.len() == 0 && self.current_part.is_some()
+    }
+}
+
+impl<'a> Read for MultiPartReader<'a> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        match (self.raw_parts.len(),
+               self.current_part.is_none(),
+               self.last_part_boundary.is_none()) {
+            (_, _, false) => {
+                let br = self.last_part_boundary.as_mut().unwrap().read(buf).unwrap_or(0);
+                if br < buf.len() {
+                    self.last_part_boundary = None;
+                }
+                return Ok(br)
+            },
+            (0, true, true) => return Ok(0),
+            (n, true, _) if n > 0 => {
+                let (headers, reader) = self.raw_parts.remove(0);
+                let mut c = Cursor::new(Vec::<u8>::new());
+                (write!(&mut c, "{}--{}{}{}{}", LINE_ENDING, BOUNDARY, LINE_ENDING,
+                                                headers, LINE_ENDING)).unwrap();
+                c.seek(SeekFrom::Start(0)).unwrap();
+                self.current_part = Some((c, reader));
+            }
+            _ => {},
+        }
+
+        // read headers as long as possible
+        let (hb, rr) = {
+            let &mut (ref mut c, ref mut reader) = self.current_part.as_mut().unwrap();
+            let b = c.read(buf).unwrap_or(0);
+            (b, reader.read(&mut buf[b..]))
+        };
+
+        match rr {
+            Ok(bytes_read) => {
+                if hb < buf.len() && bytes_read == 0 {
+                    if self.is_last_part() {
+                        // before clearing the last part, we will add the boundary that
+                        // will be written last
+                        self.last_part_boundary = Some(Cursor::new(
+                                                        format!("{}--{}--", LINE_ENDING, BOUNDARY).into_bytes()))
+                    }
+                    // We are depleted - this can trigger the next part to come in
+                    self.current_part = None;
+                }
+                let mut total_bytes_read = hb + bytes_read;
+                while total_bytes_read < buf.len() && !self.is_depleted() {
+                    match self.read(&mut buf[total_bytes_read ..]) {
+                        Ok(br) => total_bytes_read += br,
+                        Err(err) => return Err(err),
+                    }
+                }
+                Ok(total_bytes_read)
+            }
+            Err(err) => {
+                // fail permanently
+                self.current_part = None;
+                self.last_part_boundary = None;
+                self.raw_parts.clear();
+                Err(err)
+            }
+        }
+    }
+}
+
+/// The `X-Upload-Content-Type` header.
+///
+/// Generated via rustc --pretty expanded -Z unstable-options, and manually
+/// processed to be more readable.
+#[derive(PartialEq, Debug, Clone)]
+pub struct XUploadContentType(pub Mime);
+
+impl ::std::ops::Deref for XUploadContentType {
+    type Target = Mime;
+    fn deref<'a>(&'a self) -> &'a Mime { &self.0 }
+}
+impl ::std::ops::DerefMut for XUploadContentType {
+    fn deref_mut<'a>(&'a mut self) -> &'a mut Mime { &mut self.0 }
+}
+impl Header for XUploadContentType {
+    fn header_name() -> &'static str { "X-Upload-Content-Type" }
+    fn parse_header(raw: &[Vec<u8>]) -> hyper::error::Result<Self> {
+        hyper::header::parsing::from_one_raw_str(raw).map(XUploadContentType)
+    }
+}
+impl HeaderFormat for XUploadContentType {
+    fn fmt_header(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        Display::fmt(&**self, f)
+    }
+}
+impl Display for XUploadContentType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(&**self, f)
+    }
+}
+
+#[derive(Clone, PartialEq, Debug)]
+pub struct Chunk {
+    pub first: u64,
+    pub last: u64
+}
+
+impl fmt::Display for Chunk {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        (write!(fmt, "{}-{}", self.first, self.last)).ok();
+        Ok(())
+    }
+}
+
+impl FromStr for Chunk {
+    type Err = &'static str;
+
+    /// NOTE: only implements `%i-%i`, not `*`
+    fn from_str(s: &str) -> std::result::Result<Chunk, &'static str> {
+        let parts: Vec<&str> = s.split('-').collect();
+        if parts.len() != 2 {
+            return Err("Expected two parts: %i-%i")
+        }
+        Ok(
+            Chunk {
+                first: match FromStr::from_str(parts[0]) {
+                    Ok(d) => d,
+                    _ => return Err("Couldn't parse 'first' as digit")
+                },
+                last: match FromStr::from_str(parts[1]) {
+                    Ok(d) => d,
+                    _ => return Err("Couldn't parse 'last' as digit")
+                }
+            }
+        )
+    }
+}
+
+/// Implements the Content-Range header, for serialization only
+#[derive(Clone, PartialEq, Debug)]
+pub struct ContentRange {
+    pub range: Option<Chunk>,
+    pub total_length: u64,
+}
+
+impl Header for ContentRange {
+    fn header_name() -> &'static str {
+        "Content-Range"
+    }
+
+    /// We are not parsable, as parsing is done by the `Range` header
+    fn parse_header(_: &[Vec<u8>]) -> hyper::error::Result<Self> {
+        Err(hyper::error::Error::Method)
+    }
+}
+
+
+impl HeaderFormat for ContentRange {
+    fn fmt_header(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        try!(fmt.write_str("bytes "));
+        match self.range {
+            Some(ref c) => try!(c.fmt(fmt)),
+            None => try!(fmt.write_str("*"))
+        }
+        (write!(fmt, "/{}", self.total_length)).ok();
+        Ok(())
+    }
+}
+
+#[derive(Clone, PartialEq, Debug)]
+pub struct RangeResponseHeader(pub Chunk);
+
+impl Header for RangeResponseHeader {
+    fn header_name() -> &'static str {
+        "Range"
+    }
+
+    fn parse_header(raw: &[Vec<u8>]) -> hyper::error::Result<Self> {
+        if raw.len() > 0 {
+            let v = &raw[0];
+            if let Ok(s) = std::str::from_utf8(v) {
+                const PREFIX: &'static str = "bytes ";
+                if s.starts_with(PREFIX) {
+                    if let Ok(c) = <Chunk as FromStr>::from_str(&s[PREFIX.len()..]) {
+                        return  Ok(RangeResponseHeader(c))
+                    }
+                }
+            }
+        }
+        Err(hyper::error::Error::Method)
+    }
+}
+
+impl HeaderFormat for RangeResponseHeader {
+    /// No implmentation necessary, we just need to parse
+    fn fmt_header(&self, _: &mut fmt::Formatter) -> fmt::Result {
+        Err(fmt::Error)
+    }
+}
+
+/// A utility type to perform a resumable upload from start to end.
+pub struct ResumableUploadHelper<'a, A: 'a> {
+    pub client: &'a mut hyper::client::Client,
+    pub delegate: &'a mut Delegate,
+    pub start_at: Option<u64>,
+    pub auth: &'a mut A,
+    pub user_agent: &'a str,
+    pub auth_header: Authorization<Bearer>,
+    pub url: &'a str,
+    pub reader: &'a mut ReadSeek,
+    pub media_type: Mime,
+    pub content_length: u64
+}
+
+impl<'a, A> ResumableUploadHelper<'a, A>
+    where A: oauth2::GetToken {
+
+    fn query_transfer_status(&mut self) -> std::result::Result<u64, hyper::Result<hyper::client::Response>> {
+        loop {
+            match self.client.post(self.url)
+                .header(UserAgent(self.user_agent.to_string()))
+                .header(ContentRange { range: None, total_length: self.content_length })
+                .header(self.auth_header.clone())
+                .send() {
+                Ok(r) => {
+                    // 308 = resume-incomplete == PermanentRedirect
+                    let headers = r.headers.clone();
+                    let h: &RangeResponseHeader = match headers.get() {
+                        Some(hh) if r.status == StatusCode::PermanentRedirect => hh,
+                        None|Some(_) => {
+                            if let Retry::After(d) = self.delegate.http_failure(&r, None, None) {
+                                sleep(d);
+                                continue;
+                            }
+                            return Err(Ok(r))
+                        }
+                    };
+                    return Ok(h.0.last)
+                }
+                Err(err) => {
+                    if let Retry::After(d) = self.delegate.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    return Err(Err(err))
+                }
+            }
+        }
+    }
+
+    /// returns None if operation was cancelled by delegate, or the HttpResult.
+    /// It can be that we return the result just because we didn't understand the status code -
+    /// caller should check for status himself before assuming it's OK to use
+    pub fn upload(&mut self) -> Option<hyper::Result<hyper::client::Response>> {
+        let mut start = match self.start_at {
+            Some(s) => s,
+            None => match self.query_transfer_status() {
+                Ok(s) => s,
+                Err(result) => return Some(result)
+            }
+        };
+
+        const MIN_CHUNK_SIZE: u64 = 1 << 18;
+        let chunk_size = match self.delegate.chunk_size() {
+            cs if cs > MIN_CHUNK_SIZE => cs,
+            _ => MIN_CHUNK_SIZE
+        };
+
+        self.reader.seek(SeekFrom::Start(start)).unwrap();
+        loop {
+            let request_size = match self.content_length - start {
+                rs if rs > chunk_size => chunk_size,
+                rs => rs
+            };
+
+            let mut section_reader = self.reader.take(request_size);
+            let range_header = ContentRange {
+                range: Some(Chunk {first: start, last: start + request_size - 1}),
+                total_length: self.content_length
+            };
+            start += request_size;
+            if self.delegate.cancel_chunk_upload(&range_header) {
+                return None
+            }
+            let res = self.client.post(self.url)
+                                 .header(range_header)
+                                 .header(ContentType(self.media_type.clone()))
+                                 .header(UserAgent(self.user_agent.to_string()))
+                                 .body(&mut section_reader)
+                                 .send();
+            match res {
+                Ok(mut res) => {
+                    if res.status == StatusCode::PermanentRedirect  {
+                        continue
+                    }
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let Retry::After(d) = self.delegate.http_failure(&res,
+                                                        json::from_str(&json_err).ok(),
+                                                        json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                    }
+                    return Some(Ok(res))
+                },
+                Err(err) => {
+                    if let Retry::After(d) = self.delegate.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    return Some(Err(err))
+                }
+            }
+        }
+    }
+}
+
+// Copy of src/rust/cli/cmn.rs
+// TODO(ST): Allow sharing common code between program types
+pub fn remove_json_null_values(value: &mut json::value::Value) {
+    match *value {
+        json::value::Value::Object(ref mut map) => {
+            let mut for_removal = Vec::new();
+
+            for (key, mut value) in map.iter_mut() {
+                if value.is_null() {
+                    for_removal.push(key.clone());
+                } else {
+                    remove_json_null_values(&mut value);
+                }
+            }
+
+            for key in &for_removal {
+                map.remove(key);
+            }
+        }
+        _ => {}
+    }
+}

--- a/gen/cloudtrace1/src/lib.rs
+++ b/gen/cloudtrace1/src/lib.rs
@@ -1,0 +1,1569 @@
+// DO NOT EDIT !
+// This file was generated automatically from 'src/mako/api/lib.rs.mako'
+// DO NOT EDIT !
+
+//! This documentation was generated from *Cloud Trace* crate version *1.0.7+20171202*, where *20171202* is the exact revision of the *cloudtrace:v1* schema built by the [mako](http://www.makotemplates.org/) code generator *v1.0.7*.
+//! 
+//! Everything else about the *Cloud Trace* *v1* API can be found at the
+//! [official documentation site](https://cloud.google.com/trace).
+//! The original source code is [on github](https://github.com/Byron/google-apis-rs/tree/master/gen/cloudtrace1).
+//! # Features
+//! 
+//! Handle the following *Resources* with ease from the central [hub](struct.CloudTrace.html) ... 
+//! 
+//! * projects
+//!  * [*patch traces*](struct.ProjectPatchTraceCall.html), [*traces get*](struct.ProjectTraceGetCall.html) and [*traces list*](struct.ProjectTraceListCall.html)
+//! 
+//! 
+//! 
+//! 
+//! Not what you are looking for ? Find all other Google APIs in their Rust [documentation index](http://byron.github.io/google-apis-rs).
+//! 
+//! # Structure of this Library
+//! 
+//! The API is structured into the following primary items:
+//! 
+//! * **[Hub](struct.CloudTrace.html)**
+//!     * a central object to maintain state and allow accessing all *Activities*
+//!     * creates [*Method Builders*](trait.MethodsBuilder.html) which in turn
+//!       allow access to individual [*Call Builders*](trait.CallBuilder.html)
+//! * **[Resources](trait.Resource.html)**
+//!     * primary types that you can apply *Activities* to
+//!     * a collection of properties and *Parts*
+//!     * **[Parts](trait.Part.html)**
+//!         * a collection of properties
+//!         * never directly used in *Activities*
+//! * **[Activities](trait.CallBuilder.html)**
+//!     * operations to apply to *Resources*
+//! 
+//! All *structures* are marked with applicable traits to further categorize them and ease browsing.
+//! 
+//! Generally speaking, you can invoke *Activities* like this:
+//! 
+//! ```Rust,ignore
+//! let r = hub.resource().activity(...).doit()
+//! ```
+//! 
+//! Or specifically ...
+//! 
+//! ```ignore
+//! let r = hub.projects().traces_get(...).doit()
+//! ```
+//! 
+//! The `resource()` and `activity(...)` calls create [builders][builder-pattern]. The second one dealing with `Activities` 
+//! supports various methods to configure the impending operation (not shown here). It is made such that all required arguments have to be 
+//! specified right away (i.e. `(...)`), whereas all optional ones can be [build up][builder-pattern] as desired.
+//! The `doit()` method performs the actual communication with the server and returns the respective result.
+//! 
+//! # Usage
+//! 
+//! ## Setting up your Project
+//! 
+//! To use this library, you would put the following lines into your `Cargo.toml` file:
+//! 
+//! ```toml
+//! [dependencies]
+//! google-cloudtrace1 = "*"
+//! ```
+//! 
+//! ## A complete example
+//! 
+//! ```test_harness,no_run
+//! extern crate hyper;
+//! extern crate hyper_rustls;
+//! extern crate yup_oauth2 as oauth2;
+//! extern crate google_cloudtrace1 as cloudtrace1;
+//! use cloudtrace1::{Result, Error};
+//! # #[test] fn egal() {
+//! use std::default::Default;
+//! use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+//! use cloudtrace1::CloudTrace;
+//! 
+//! // Get an ApplicationSecret instance by some means. It contains the `client_id` and 
+//! // `client_secret`, among other things.
+//! let secret: ApplicationSecret = Default::default();
+//! // Instantiate the authenticator. It will choose a suitable authentication flow for you, 
+//! // unless you replace  `None` with the desired Flow.
+//! // Provide your own `AuthenticatorDelegate` to adjust the way it operates and get feedback about 
+//! // what's going on. You probably want to bring in your own `TokenStorage` to persist tokens and
+//! // retrieve them from storage.
+//! let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+//!                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+//!                               <MemoryStorage as Default>::default(), None);
+//! let mut hub = CloudTrace::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+//! // You can configure optional parameters by calling the respective setters at will, and
+//! // execute the final call using `doit()`.
+//! // Values shown here are possibly random and not representative !
+//! let result = hub.projects().traces_get("projectId", "traceId")
+//!              .doit();
+//! 
+//! match result {
+//!     Err(e) => match e {
+//!         // The Error enum provides details about what exactly happened.
+//!         // You can also just use its `Debug`, `Display` or `Error` traits
+//!          Error::HttpError(_)
+//!         |Error::MissingAPIKey
+//!         |Error::MissingToken(_)
+//!         |Error::Cancelled
+//!         |Error::UploadSizeLimitExceeded(_, _)
+//!         |Error::Failure(_)
+//!         |Error::BadRequest(_)
+//!         |Error::FieldClash(_)
+//!         |Error::JsonDecodeError(_, _) => println!("{}", e),
+//!     },
+//!     Ok(res) => println!("Success: {:?}", res),
+//! }
+//! # }
+//! ```
+//! ## Handling Errors
+//! 
+//! All errors produced by the system are provided either as [Result](enum.Result.html) enumeration as return value of 
+//! the doit() methods, or handed as possibly intermediate results to either the 
+//! [Hub Delegate](trait.Delegate.html), or the [Authenticator Delegate](https://docs.rs/yup-oauth2/*/yup_oauth2/trait.AuthenticatorDelegate.html).
+//! 
+//! When delegates handle errors or intermediate values, they may have a chance to instruct the system to retry. This 
+//! makes the system potentially resilient to all kinds of errors.
+//! 
+//! ## Uploads and Downloads
+//! If a method supports downloads, the response body, which is part of the [Result](enum.Result.html), should be
+//! read by you to obtain the media.
+//! If such a method also supports a [Response Result](trait.ResponseResult.html), it will return that by default.
+//! You can see it as meta-data for the actual media. To trigger a media download, you will have to set up the builder by making
+//! this call: `.param("alt", "media")`.
+//! 
+//! Methods supporting uploads can do so using up to 2 different protocols: 
+//! *simple* and *resumable*. The distinctiveness of each is represented by customized 
+//! `doit(...)` methods, which are then named `upload(...)` and `upload_resumable(...)` respectively.
+//! 
+//! ## Customization and Callbacks
+//! 
+//! You may alter the way an `doit()` method is called by providing a [delegate](trait.Delegate.html) to the 
+//! [Method Builder](trait.CallBuilder.html) before making the final `doit()` call. 
+//! Respective methods will be called to provide progress information, as well as determine whether the system should 
+//! retry on failure.
+//! 
+//! The [delegate trait](trait.Delegate.html) is default-implemented, allowing you to customize it with minimal effort.
+//! 
+//! ## Optional Parts in Server-Requests
+//! 
+//! All structures provided by this library are made to be [enocodable](trait.RequestValue.html) and 
+//! [decodable](trait.ResponseResult.html) via *json*. Optionals are used to indicate that partial requests are responses 
+//! are valid.
+//! Most optionals are are considered [Parts](trait.Part.html) which are identifiable by name, which will be sent to 
+//! the server to indicate either the set parts of the request or the desired parts in the response.
+//! 
+//! ## Builder Arguments
+//! 
+//! Using [method builders](trait.CallBuilder.html), you are able to prepare an action call by repeatedly calling it's methods.
+//! These will always take a single argument, for which the following statements are true.
+//! 
+//! * [PODs][wiki-pod] are handed by copy
+//! * strings are passed as `&str`
+//! * [request values](trait.RequestValue.html) are moved
+//! 
+//! Arguments will always be copied or cloned into the builder, to make them independent of their original life times.
+//! 
+//! [wiki-pod]: http://en.wikipedia.org/wiki/Plain_old_data_structure
+//! [builder-pattern]: http://en.wikipedia.org/wiki/Builder_pattern
+//! [google-go-api]: https://github.com/google/google-api-go-client
+//! 
+//! 
+
+// Unused attributes happen thanks to defined, but unused structures
+// We don't warn about this, as depending on the API, some data structures or facilities are never used.
+// Instead of pre-determining this, we just disable the lint. It's manually tuned to not have any
+// unused imports in fully featured APIs. Same with unused_mut ... .
+#![allow(unused_imports, unused_mut, dead_code)]
+
+// DO NOT EDIT !
+// This file was generated automatically from 'src/mako/api/lib.rs.mako'
+// DO NOT EDIT !
+
+#[macro_use]
+extern crate serde_derive;
+
+extern crate hyper;
+extern crate serde;
+extern crate serde_json;
+extern crate yup_oauth2 as oauth2;
+extern crate mime;
+extern crate url;
+
+mod cmn;
+
+use std::collections::HashMap;
+use std::cell::RefCell;
+use std::borrow::BorrowMut;
+use std::default::Default;
+use std::collections::BTreeMap;
+use serde_json as json;
+use std::io;
+use std::fs;
+use std::mem;
+use std::thread::sleep;
+use std::time::Duration;
+
+pub use cmn::{MultiPartReader, ToParts, MethodInfo, Result, Error, CallBuilder, Hub, ReadSeek, Part,
+              ResponseResult, RequestValue, NestedType, Delegate, DefaultDelegate, MethodsBuilder,
+              Resource, ErrorResponse, remove_json_null_values};
+
+
+// ##############
+// UTILITIES ###
+// ############
+
+/// Identifies the an OAuth2 authorization scope.
+/// A scope is needed when requesting an
+/// [authorization token](https://developers.google.com/youtube/v3/guides/authentication).
+#[derive(PartialEq, Eq, Hash)]
+pub enum Scope {
+    /// Write Trace data for a project or application
+    TraceAppend,
+
+    /// View and manage your data across Google Cloud Platform services
+    CloudPlatform,
+
+    /// Read Trace data for a project or application
+    TraceReadonly,
+}
+
+impl AsRef<str> for Scope {
+    fn as_ref(&self) -> &str {
+        match *self {
+            Scope::TraceAppend => "https://www.googleapis.com/auth/trace.append",
+            Scope::CloudPlatform => "https://www.googleapis.com/auth/cloud-platform",
+            Scope::TraceReadonly => "https://www.googleapis.com/auth/trace.readonly",
+        }
+    }
+}
+
+impl Default for Scope {
+    fn default() -> Scope {
+        Scope::TraceReadonly
+    }
+}
+
+
+
+// ########
+// HUB ###
+// ######
+
+/// Central instance to access all CloudTrace related resource activities
+///
+/// # Examples
+///
+/// Instantiate a new hub
+///
+/// ```test_harness,no_run
+/// extern crate hyper;
+/// extern crate hyper_rustls;
+/// extern crate yup_oauth2 as oauth2;
+/// extern crate google_cloudtrace1 as cloudtrace1;
+/// use cloudtrace1::{Result, Error};
+/// # #[test] fn egal() {
+/// use std::default::Default;
+/// use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// use cloudtrace1::CloudTrace;
+/// 
+/// // Get an ApplicationSecret instance by some means. It contains the `client_id` and 
+/// // `client_secret`, among other things.
+/// let secret: ApplicationSecret = Default::default();
+/// // Instantiate the authenticator. It will choose a suitable authentication flow for you, 
+/// // unless you replace  `None` with the desired Flow.
+/// // Provide your own `AuthenticatorDelegate` to adjust the way it operates and get feedback about 
+/// // what's going on. You probably want to bring in your own `TokenStorage` to persist tokens and
+/// // retrieve them from storage.
+/// let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+///                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+///                               <MemoryStorage as Default>::default(), None);
+/// let mut hub = CloudTrace::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.projects().traces_get("projectId", "traceId")
+///              .doit();
+/// 
+/// match result {
+///     Err(e) => match e {
+///         // The Error enum provides details about what exactly happened.
+///         // You can also just use its `Debug`, `Display` or `Error` traits
+///          Error::HttpError(_)
+///         |Error::MissingAPIKey
+///         |Error::MissingToken(_)
+///         |Error::Cancelled
+///         |Error::UploadSizeLimitExceeded(_, _)
+///         |Error::Failure(_)
+///         |Error::BadRequest(_)
+///         |Error::FieldClash(_)
+///         |Error::JsonDecodeError(_, _) => println!("{}", e),
+///     },
+///     Ok(res) => println!("Success: {:?}", res),
+/// }
+/// # }
+/// ```
+pub struct CloudTrace<C, A> {
+    client: RefCell<C>,
+    auth: RefCell<A>,
+    _user_agent: String,
+    _base_url: String,
+    _root_url: String,
+}
+
+impl<'a, C, A> Hub for CloudTrace<C, A> {}
+
+impl<'a, C, A> CloudTrace<C, A>
+    where  C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+    pub fn new(client: C, authenticator: A) -> CloudTrace<C, A> {
+        CloudTrace {
+            client: RefCell::new(client),
+            auth: RefCell::new(authenticator),
+            _user_agent: "google-api-rust-client/1.0.7".to_string(),
+            _base_url: "https://cloudtrace.googleapis.com/".to_string(),
+            _root_url: "https://cloudtrace.googleapis.com/".to_string(),
+        }
+    }
+
+    pub fn projects(&'a self) -> ProjectMethods<'a, C, A> {
+        ProjectMethods { hub: &self }
+    }
+
+    /// Set the user-agent header field to use in all requests to the server.
+    /// It defaults to `google-api-rust-client/1.0.7`.
+    ///
+    /// Returns the previously set user-agent.
+    pub fn user_agent(&mut self, agent_name: String) -> String {
+        mem::replace(&mut self._user_agent, agent_name)
+    }
+
+    /// Set the base url to use in all requests to the server.
+    /// It defaults to `https://cloudtrace.googleapis.com/`.
+    ///
+    /// Returns the previously set base url.
+    pub fn base_url(&mut self, new_base_url: String) -> String {
+        mem::replace(&mut self._base_url, new_base_url)
+    }
+
+    /// Set the root url to use in all requests to the server.
+    /// It defaults to `https://cloudtrace.googleapis.com/`.
+    ///
+    /// Returns the previously set root url.
+    pub fn root_url(&mut self, new_root_url: String) -> String {
+        mem::replace(&mut self._root_url, new_root_url)
+    }
+}
+
+
+// ############
+// SCHEMAS ###
+// ##########
+/// The response message for the `ListTraces` method.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [traces list projects](struct.ProjectTraceListCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct ListTracesResponse {
+    /// If defined, indicates that there are more traces that match the request
+    /// and that this value should be passed to the next request to continue
+    /// retrieving additional traces.
+    #[serde(rename="nextPageToken")]
+    pub next_page_token: Option<String>,
+    /// List of trace records returned.
+    pub traces: Option<Vec<Trace>>,
+}
+
+impl ResponseResult for ListTracesResponse {}
+
+
+/// List of new or updated traces.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [patch traces projects](struct.ProjectPatchTraceCall.html) (request)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Traces {
+    /// List of traces.
+    pub traces: Option<Vec<Trace>>,
+}
+
+impl RequestValue for Traces {}
+
+
+/// A span represents a single timed event within a trace. Spans can be nested
+/// and form a trace tree. Often, a trace contains a root span that describes the
+/// end-to-end latency of an operation and, optionally, one or more subspans for
+/// its suboperations. Spans do not need to be contiguous. There may be gaps
+/// between spans in a trace.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct TraceSpan {
+    /// Distinguishes between spans generated in a particular context. For example,
+    /// two spans with the same name may be distinguished using `RPC_CLIENT`
+    /// and `RPC_SERVER` to identify queueing latency associated with the span.
+    pub kind: Option<String>,
+    /// ID of the parent span, if any. Optional.
+    #[serde(rename="parentSpanId")]
+    pub parent_span_id: Option<String>,
+    /// Name of the span. Must be less than 128 bytes. The span name is sanitized
+    /// and displayed in the Stackdriver Trace tool in the
+    /// {% dynamic print site_values.console_name %}.
+    /// The name may be a method name or some other per-call site name.
+    /// For the same executable and the same call point, a best practice is
+    /// to use a consistent name, which makes it easier to correlate
+    /// cross-trace spans.
+    pub name: Option<String>,
+    /// Start time of the span in nanoseconds from the UNIX epoch.
+    #[serde(rename="startTime")]
+    pub start_time: Option<String>,
+    /// Identifier for the span. Must be a 64-bit integer other than 0 and
+    /// unique within a trace.
+    #[serde(rename="spanId")]
+    pub span_id: Option<String>,
+    /// Collection of labels associated with the span. Label keys must be less than
+    /// 128 bytes. Label values must be less than 16 kilobytes (10MB for
+    /// `/stacktrace` values).
+    /// 
+    /// Some predefined label keys exist, or you may create your own. When creating
+    /// your own, we recommend the following formats:
+    /// 
+    /// * `/category/product/key` for agents of well-known products (e.g.
+    ///   `/db/mongodb/read_size`).
+    /// * `short_host/path/key` for domain-specific keys (e.g.
+    ///   `foo.com/myproduct/bar`)
+    /// 
+    /// Predefined labels include:
+    /// 
+    /// *   `/agent`
+    /// *   `/component`
+    /// *   `/error/message`
+    /// *   `/error/name`
+    /// *   `/http/client_city`
+    /// *   `/http/client_country`
+    /// *   `/http/client_protocol`
+    /// *   `/http/client_region`
+    /// *   `/http/host`
+    /// *   `/http/method`
+    /// *   `/http/redirected_url`
+    /// *   `/http/request/size`
+    /// *   `/http/response/size`
+    /// *   `/http/status_code`
+    /// *   `/http/url`
+    /// *   `/http/user_agent`
+    /// *   `/pid`
+    /// *   `/stacktrace`
+    /// *   `/tid`
+    pub labels: Option<HashMap<String, String>>,
+    /// End time of the span in nanoseconds from the UNIX epoch.
+    #[serde(rename="endTime")]
+    pub end_time: Option<String>,
+}
+
+impl Part for TraceSpan {}
+
+
+/// A generic empty message that you can re-use to avoid defining duplicated
+/// empty messages in your APIs. A typical example is to use it as the request
+/// or the response type of an API method. For instance:
+/// 
+///     service Foo {
+///       rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
+///     }
+/// 
+/// The JSON representation for `Empty` is empty JSON object `{}`.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [patch traces projects](struct.ProjectPatchTraceCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Empty { _never_set: Option<bool> }
+
+impl ResponseResult for Empty {}
+
+
+/// A trace describes how long it takes for an application to perform an
+/// operation. It consists of a set of spans, each of which represent a single
+/// timed event within the operation.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [traces get projects](struct.ProjectTraceGetCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Trace {
+    /// Project ID of the Cloud project where the trace data is stored.
+    #[serde(rename="projectId")]
+    pub project_id: Option<String>,
+    /// Globally unique identifier for the trace. This identifier is a 128-bit
+    /// numeric value formatted as a 32-byte hex string.
+    #[serde(rename="traceId")]
+    pub trace_id: Option<String>,
+    /// Collection of spans in the trace.
+    pub spans: Option<Vec<TraceSpan>>,
+}
+
+impl ResponseResult for Trace {}
+
+
+
+// ###################
+// MethodBuilders ###
+// #################
+
+/// A builder providing access to all methods supported on *project* resources.
+/// It is not used directly, but through the `CloudTrace` hub.
+///
+/// # Example
+///
+/// Instantiate a resource builder
+///
+/// ```test_harness,no_run
+/// extern crate hyper;
+/// extern crate hyper_rustls;
+/// extern crate yup_oauth2 as oauth2;
+/// extern crate google_cloudtrace1 as cloudtrace1;
+/// 
+/// # #[test] fn egal() {
+/// use std::default::Default;
+/// use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// use cloudtrace1::CloudTrace;
+/// 
+/// let secret: ApplicationSecret = Default::default();
+/// let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+///                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+///                               <MemoryStorage as Default>::default(), None);
+/// let mut hub = CloudTrace::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // Usually you wouldn't bind this to a variable, but keep calling *CallBuilders*
+/// // like `patch_traces(...)`, `traces_get(...)` and `traces_list(...)`
+/// // to build up your call.
+/// let rb = hub.projects();
+/// # }
+/// ```
+pub struct ProjectMethods<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a CloudTrace<C, A>,
+}
+
+impl<'a, C, A> MethodsBuilder for ProjectMethods<'a, C, A> {}
+
+impl<'a, C, A> ProjectMethods<'a, C, A> {
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Gets a single trace by its ID.
+    /// 
+    /// # Arguments
+    ///
+    /// * `projectId` - ID of the Cloud project where the trace data is stored.
+    /// * `traceId` - ID of the trace to return.
+    pub fn traces_get(&self, project_id: &str, trace_id: &str) -> ProjectTraceGetCall<'a, C, A> {
+        ProjectTraceGetCall {
+            hub: self.hub,
+            _project_id: project_id.to_string(),
+            _trace_id: trace_id.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Sends new traces to Stackdriver Trace or updates existing traces. If the ID
+    /// of a trace that you send matches that of an existing trace, any fields
+    /// in the existing trace and its spans are overwritten by the provided values,
+    /// and any new fields provided are merged with the existing trace data. If the
+    /// ID does not match, a new trace is created.
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    /// * `projectId` - ID of the Cloud project where the trace data is stored.
+    pub fn patch_traces(&self, request: Traces, project_id: &str) -> ProjectPatchTraceCall<'a, C, A> {
+        ProjectPatchTraceCall {
+            hub: self.hub,
+            _request: request,
+            _project_id: project_id.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Returns of a list of traces that match the specified filter conditions.
+    /// 
+    /// # Arguments
+    ///
+    /// * `projectId` - ID of the Cloud project where the trace data is stored.
+    pub fn traces_list(&self, project_id: &str) -> ProjectTraceListCall<'a, C, A> {
+        ProjectTraceListCall {
+            hub: self.hub,
+            _project_id: project_id.to_string(),
+            _view: Default::default(),
+            _start_time: Default::default(),
+            _page_token: Default::default(),
+            _page_size: Default::default(),
+            _order_by: Default::default(),
+            _filter: Default::default(),
+            _end_time: Default::default(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+}
+
+
+
+
+
+// ###################
+// CallBuilders   ###
+// #################
+
+/// Gets a single trace by its ID.
+///
+/// A builder for the *traces.get* method supported by a *project* resource.
+/// It is not used directly, but through a `ProjectMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_cloudtrace1 as cloudtrace1;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use cloudtrace1::CloudTrace;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = CloudTrace::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.projects().traces_get("projectId", "traceId")
+///              .doit();
+/// # }
+/// ```
+pub struct ProjectTraceGetCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a CloudTrace<C, A>,
+    _project_id: String,
+    _trace_id: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for ProjectTraceGetCall<'a, C, A> {}
+
+impl<'a, C, A> ProjectTraceGetCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, Trace)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "cloudtrace.projects.traces.get",
+                               http_method: hyper::method::Method::Get });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((4 + self._additional_params.len()));
+        params.push(("projectId", self._project_id.to_string()));
+        params.push(("traceId", self._trace_id.to_string()));
+        for &field in ["alt", "projectId", "traceId"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1/projects/{projectId}/traces/{traceId}";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::TraceReadonly.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{projectId}", "projectId"), ("{traceId}", "traceId")].iter() {
+            let mut replace_with: Option<&str> = None;
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = Some(value);
+                    break;
+                }
+            }
+            url = url.replace(find_this, replace_with.expect("to find substitution value in params"));
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(2);
+            for param_name in ["traceId", "projectId"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Get, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    /// ID of the Cloud project where the trace data is stored.
+    ///
+    /// Sets the *project id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn project_id(mut self, new_value: &str) -> ProjectTraceGetCall<'a, C, A> {
+        self._project_id = new_value.to_string();
+        self
+    }
+    /// ID of the trace to return.
+    ///
+    /// Sets the *trace id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn trace_id(mut self, new_value: &str) -> ProjectTraceGetCall<'a, C, A> {
+        self._trace_id = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> ProjectTraceGetCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> ProjectTraceGetCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::TraceReadonly`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> ProjectTraceGetCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Sends new traces to Stackdriver Trace or updates existing traces. If the ID
+/// of a trace that you send matches that of an existing trace, any fields
+/// in the existing trace and its spans are overwritten by the provided values,
+/// and any new fields provided are merged with the existing trace data. If the
+/// ID does not match, a new trace is created.
+///
+/// A builder for the *patchTraces* method supported by a *project* resource.
+/// It is not used directly, but through a `ProjectMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_cloudtrace1 as cloudtrace1;
+/// use cloudtrace1::Traces;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use cloudtrace1::CloudTrace;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = CloudTrace::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = Traces::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.projects().patch_traces(req, "projectId")
+///              .doit();
+/// # }
+/// ```
+pub struct ProjectPatchTraceCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a CloudTrace<C, A>,
+    _request: Traces,
+    _project_id: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for ProjectPatchTraceCall<'a, C, A> {}
+
+impl<'a, C, A> ProjectPatchTraceCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, Empty)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "cloudtrace.projects.patchTraces",
+                               http_method: hyper::method::Method::Patch });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((4 + self._additional_params.len()));
+        params.push(("projectId", self._project_id.to_string()));
+        for &field in ["alt", "projectId"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1/projects/{projectId}/traces";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{projectId}", "projectId")].iter() {
+            let mut replace_with: Option<&str> = None;
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = Some(value);
+                    break;
+                }
+            }
+            url = url.replace(find_this, replace_with.expect("to find substitution value in params"));
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["projectId"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Patch, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: Traces) -> ProjectPatchTraceCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// ID of the Cloud project where the trace data is stored.
+    ///
+    /// Sets the *project id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn project_id(mut self, new_value: &str) -> ProjectPatchTraceCall<'a, C, A> {
+        self._project_id = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> ProjectPatchTraceCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> ProjectPatchTraceCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> ProjectPatchTraceCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Returns of a list of traces that match the specified filter conditions.
+///
+/// A builder for the *traces.list* method supported by a *project* resource.
+/// It is not used directly, but through a `ProjectMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_cloudtrace1 as cloudtrace1;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use cloudtrace1::CloudTrace;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = CloudTrace::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.projects().traces_list("projectId")
+///              .view("amet.")
+///              .start_time("erat")
+///              .page_token("labore")
+///              .page_size(-9)
+///              .order_by("nonumy")
+///              .filter("dolores")
+///              .end_time("gubergren")
+///              .doit();
+/// # }
+/// ```
+pub struct ProjectTraceListCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a CloudTrace<C, A>,
+    _project_id: String,
+    _view: Option<String>,
+    _start_time: Option<String>,
+    _page_token: Option<String>,
+    _page_size: Option<i32>,
+    _order_by: Option<String>,
+    _filter: Option<String>,
+    _end_time: Option<String>,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for ProjectTraceListCall<'a, C, A> {}
+
+impl<'a, C, A> ProjectTraceListCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, ListTracesResponse)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "cloudtrace.projects.traces.list",
+                               http_method: hyper::method::Method::Get });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((10 + self._additional_params.len()));
+        params.push(("projectId", self._project_id.to_string()));
+        if let Some(value) = self._view {
+            params.push(("view", value.to_string()));
+        }
+        if let Some(value) = self._start_time {
+            params.push(("startTime", value.to_string()));
+        }
+        if let Some(value) = self._page_token {
+            params.push(("pageToken", value.to_string()));
+        }
+        if let Some(value) = self._page_size {
+            params.push(("pageSize", value.to_string()));
+        }
+        if let Some(value) = self._order_by {
+            params.push(("orderBy", value.to_string()));
+        }
+        if let Some(value) = self._filter {
+            params.push(("filter", value.to_string()));
+        }
+        if let Some(value) = self._end_time {
+            params.push(("endTime", value.to_string()));
+        }
+        for &field in ["alt", "projectId", "view", "startTime", "pageToken", "pageSize", "orderBy", "filter", "endTime"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1/projects/{projectId}/traces";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::TraceReadonly.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{projectId}", "projectId")].iter() {
+            let mut replace_with: Option<&str> = None;
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = Some(value);
+                    break;
+                }
+            }
+            url = url.replace(find_this, replace_with.expect("to find substitution value in params"));
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["projectId"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Get, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    /// ID of the Cloud project where the trace data is stored.
+    ///
+    /// Sets the *project id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn project_id(mut self, new_value: &str) -> ProjectTraceListCall<'a, C, A> {
+        self._project_id = new_value.to_string();
+        self
+    }
+    /// Type of data returned for traces in the list. Optional. Default is
+    /// `MINIMAL`.
+    ///
+    /// Sets the *view* query property to the given value.
+    pub fn view(mut self, new_value: &str) -> ProjectTraceListCall<'a, C, A> {
+        self._view = Some(new_value.to_string());
+        self
+    }
+    /// Start of the time interval (inclusive) during which the trace data was
+    /// collected from the application.
+    ///
+    /// Sets the *start time* query property to the given value.
+    pub fn start_time(mut self, new_value: &str) -> ProjectTraceListCall<'a, C, A> {
+        self._start_time = Some(new_value.to_string());
+        self
+    }
+    /// Token identifying the page of results to return. If provided, use the
+    /// value of the `next_page_token` field from a previous request. Optional.
+    ///
+    /// Sets the *page token* query property to the given value.
+    pub fn page_token(mut self, new_value: &str) -> ProjectTraceListCall<'a, C, A> {
+        self._page_token = Some(new_value.to_string());
+        self
+    }
+    /// Maximum number of traces to return. If not specified or <= 0, the
+    /// implementation selects a reasonable value.  The implementation may
+    /// return fewer traces than the requested page size. Optional.
+    ///
+    /// Sets the *page size* query property to the given value.
+    pub fn page_size(mut self, new_value: i32) -> ProjectTraceListCall<'a, C, A> {
+        self._page_size = Some(new_value);
+        self
+    }
+    /// Field used to sort the returned traces. Optional.
+    /// Can be one of the following:
+    /// 
+    /// *   `trace_id`
+    /// *   `name` (`name` field of root span in the trace)
+    /// *   `duration` (difference between `end_time` and `start_time` fields of
+    ///      the root span)
+    /// *   `start` (`start_time` field of the root span)
+    /// 
+    /// Descending order can be specified by appending `desc` to the sort field
+    /// (for example, `name desc`).
+    /// 
+    /// Only one sort field is permitted.
+    ///
+    /// Sets the *order by* query property to the given value.
+    pub fn order_by(mut self, new_value: &str) -> ProjectTraceListCall<'a, C, A> {
+        self._order_by = Some(new_value.to_string());
+        self
+    }
+    /// An optional filter against labels for the request.
+    /// 
+    /// By default, searches use prefix matching. To specify exact match, prepend
+    /// a plus symbol (`+`) to the search term.
+    /// Multiple terms are ANDed. Syntax:
+    /// 
+    /// *   `root:NAME_PREFIX` or `NAME_PREFIX`: Return traces where any root
+    ///     span starts with `NAME_PREFIX`.
+    /// *   `+root:NAME` or `+NAME`: Return traces where any root span's name is
+    ///     exactly `NAME`.
+    /// *   `span:NAME_PREFIX`: Return traces where any span starts with
+    ///     `NAME_PREFIX`.
+    /// *   `+span:NAME`: Return traces where any span's name is exactly
+    ///     `NAME`.
+    /// *   `latency:DURATION`: Return traces whose overall latency is
+    ///     greater or equal to than `DURATION`. Accepted units are nanoseconds
+    ///     (`ns`), milliseconds (`ms`), and seconds (`s`). Default is `ms`. For
+    ///     example, `latency:24ms` returns traces whose overall latency
+    ///     is greater than or equal to 24 milliseconds.
+    /// *   `label:LABEL_KEY`: Return all traces containing the specified
+    ///     label key (exact match, case-sensitive) regardless of the key:value
+    ///     pair's value (including empty values).
+    /// *   `LABEL_KEY:VALUE_PREFIX`: Return all traces containing the specified
+    ///     label key (exact match, case-sensitive) whose value starts with
+    ///     `VALUE_PREFIX`. Both a key and a value must be specified.
+    /// *   `+LABEL_KEY:VALUE`: Return all traces containing a key:value pair
+    ///     exactly matching the specified text. Both a key and a value must be
+    ///     specified.
+    /// *   `method:VALUE`: Equivalent to `/http/method:VALUE`.
+    /// *   `url:VALUE`: Equivalent to `/http/url:VALUE`.
+    ///
+    /// Sets the *filter* query property to the given value.
+    pub fn filter(mut self, new_value: &str) -> ProjectTraceListCall<'a, C, A> {
+        self._filter = Some(new_value.to_string());
+        self
+    }
+    /// End of the time interval (inclusive) during which the trace data was
+    /// collected from the application.
+    ///
+    /// Sets the *end time* query property to the given value.
+    pub fn end_time(mut self, new_value: &str) -> ProjectTraceListCall<'a, C, A> {
+        self._end_time = Some(new_value.to_string());
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> ProjectTraceListCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> ProjectTraceListCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::TraceReadonly`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> ProjectTraceListCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+

--- a/gen/cloudtrace2-cli/Cargo.toml
+++ b/gen/cloudtrace2-cli/Cargo.toml
@@ -1,0 +1,40 @@
+# DO NOT EDIT !
+# This file was generated automatically from 'src/mako/Cargo.toml.mako'
+# DO NOT EDIT !
+[package]
+
+name = "google-cloudtrace2-cli"
+version = "1.0.7+20171202"
+authors = ["Sebastian Thiel <byronimo@gmail.com>"]
+description = "A complete library to interact with Cloud Trace (protocol v2)"
+repository = "https://github.com/Byron/google-apis-rs/tree/master/gen/cloudtrace2-cli"
+homepage = "https://cloud.google.com/trace"
+documentation = "http://byron.github.io/google-apis-rs/google_cloudtrace2_cli"
+license = "MIT"
+keywords = ["cloudtrace", "google", "cli"]
+
+[[bin]]
+name = "cloudtrace2"
+
+[dev-dependencies]
+hyper-rustls = "^0.6"
+
+[dependencies]
+hyper = "^ 0.10"
+mime = "^ 0.2.0"
+serde = "^ 1.0"
+serde_json = "^ 1.0"
+serde_derive = "^ 1.0"
+yup-oauth2 = "^ 1.0"
+strsim = "^0.5"
+hyper-rustls = "^0.6"
+yup-hyper-mock = "^2.0"
+clap = "^2.0"
+
+[features]
+
+
+
+[dependencies.google-cloudtrace2]
+path = "../cloudtrace2"
+version = "1.0.7+20171202"

--- a/gen/cloudtrace2-cli/LICENSE.md
+++ b/gen/cloudtrace2-cli/LICENSE.md
@@ -1,0 +1,30 @@
+<!---
+DO NOT EDIT !
+This file was generated automatically from 'src/mako/LICENSE.md.mako'
+DO NOT EDIT !
+-->
+The MIT License (MIT)
+=====================
+
+Copyright © `2015-2016` `Sebastian Thiel`
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the “Software”), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.

--- a/gen/cloudtrace2-cli/README.md
+++ b/gen/cloudtrace2-cli/README.md
@@ -1,0 +1,115 @@
+<!---
+DO NOT EDIT !
+This file was generated automatically from 'src/mako/cli/README.md.mako'
+DO NOT EDIT !
+-->
+The `cloudtrace2` command-line interface *(CLI)* allows to use most features of the *Google Cloud Trace* service from the comfort of your terminal.
+
+By default all output is printed to standard out, but flags can be set to direct it into a file independent of your shell's
+capabilities. Errors will be printed to standard error, and cause the program's exit code to be non-zero.
+
+If data-structures are requested, these will be returned as pretty-printed JSON, to be useful as input to other tools.
+
+Everything else about the *Cloud Trace* API can be found at the
+[official documentation site](https://cloud.google.com/trace).
+
+# Installation and Source Code
+
+Install the command-line interface with cargo using:
+
+```bash
+cargo install google-cloudtrace2-cli
+```
+
+Find the source code [on github](https://github.com/Byron/google-apis-rs/tree/master/gen/cloudtrace2-cli).
+
+# Usage
+
+This documentation was generated from the *Cloud Trace* API at revision *20171202*. The CLI is at version *1.0.7*.
+
+```bash
+cloudtrace2 [options]
+        projects
+                traces-batch-write <name> (-r <kv>)... [-p <v>]... [-o <out>]
+                traces-spans-create <name> (-r <kv>)... [-p <v>]... [-o <out>]
+  cloudtrace2 --help
+
+Configuration:
+  [--scope <url>]...
+            Specify the authentication a method should be executed in. Each scope
+            requires the user to grant this application permission to use it.
+            If unset, it defaults to the shortest scope url for a particular method.
+  --config-dir <folder>
+            A directory into which we will store our persistent data. Defaults to
+            a user-writable directory that we will create during the first invocation.
+            [default: ~/.google-service-cli]
+  --debug
+            Output all server communication to standard error. `tx` and `rx` are placed
+            into the same stream.
+  --debug-auth
+            Output all communication related to authentication to standard error. `tx`
+            and `rx` are placed into the same stream.
+
+```
+
+# Configuration
+
+The program will store all persistent data in the `~/.google-service-cli` directory in *JSON* files prefixed with `cloudtrace2-`.  You can change the directory used to store configuration with the `--config-dir` flag on a per-invocation basis.
+
+More information about the various kinds of persistent data are given in the following paragraphs.
+
+# Authentication
+
+Most APIs require a user to authenticate any request. If this is the case, the [scope][scopes] determines the 
+set of permissions granted. The granularity of these is usually no more than *read-only* or *full-access*.
+
+If not set, the system will automatically select the smallest feasible scope, e.g. when invoking a
+method that is read-only, it will ask only for a read-only scope. 
+You may use the `--scope` flag to specify a scope directly. 
+All applicable scopes are documented in the respective method's CLI documentation.
+
+The first time a scope is used, the user is asked for permission. Follow the instructions given 
+by the CLI to grant permissions, or to decline.
+
+If a scope was authenticated by the user, the respective information will be stored as *JSON* in the configuration
+directory, e.g. `~/.google-service-cli/cloudtrace2-token-<scope-hash>.json`. No manual management of these tokens
+is necessary.
+
+To revoke granted authentication, please refer to the [official documentation][revoke-access].
+
+# Application Secrets
+
+In order to allow any application to use Google services, it will need to be registered using the 
+[Google Developer Console][google-dev-console]. APIs the application may use are then enabled for it
+one by one. Most APIs can be used for free and have a daily quota.
+
+To allow more comfortable usage of the CLI without forcing anyone to register an own application, the CLI
+comes with a default application secret that is configured accordingly. This also means that heavy usage
+all around the world may deplete the daily quota.
+
+You can workaround this limitation by putting your own secrets file at this location: 
+`~/.google-service-cli/cloudtrace2-secret.json`, assuming that the required *cloudtrace* API 
+was enabled for it. Such a secret file can be downloaded in the *Google Developer Console* at 
+*APIs & auth -> Credentials -> Download JSON* and used as is.
+
+Learn more about how to setup Google projects and enable APIs using the [official documentation][google-project-new].
+
+
+# Debugging
+
+Even though the CLI does its best to provide usable error messages, sometimes it might be desirable to know
+what exactly led to a particular issue. This is done by allowing all client-server communication to be 
+output to standard error *as-is*.
+
+The `--debug` flag will print all client-server communication to standard error, whereas the `--debug-auth` flag
+will cause all communication related to authentication to standard error.
+If the `--debug` flag is set, error-results will be debug-printed, possibly yielding more information about the 
+issue at hand.
+
+You may consider redirecting standard error into a file for ease of use, e.g. `cloudtrace2 --debug <resource> <method> [options] 2>debug.txt`.
+
+
+[scopes]: https://developers.google.com/+/api/oauth#scopes
+[revoke-access]: http://webapps.stackexchange.com/a/30849
+[google-dev-console]: https://console.developers.google.com/
+[google-project-new]: https://developers.google.com/console/help/new/

--- a/gen/cloudtrace2-cli/mkdocs.yml
+++ b/gen/cloudtrace2-cli/mkdocs.yml
@@ -1,0 +1,18 @@
+site_name: Cloud Trace v1.0.7+20171202
+site_url: http://byron.github.io/google-apis-rs/google-cloudtrace2-cli
+site_description: A complete library to interact with Cloud Trace (protocol v2)
+
+repo_url: https://github.com/Byron/google-apis-rs/tree/master/gen/cloudtrace2-cli
+
+docs_dir: docs
+site_dir: build_html
+
+pages:
+- ['index.md', 'Home']
+- ['projects_traces-batch-write.md', 'Projects', 'Traces Batch Write']
+- ['projects_traces-spans-create.md', 'Projects', 'Traces Spans Create']
+
+theme: readthedocs
+
+copyright: Copyright &copy; 2015-2016, `Sebastian Thiel`
+

--- a/gen/cloudtrace2-cli/src/cmn.rs
+++ b/gen/cloudtrace2-cli/src/cmn.rs
@@ -1,0 +1,799 @@
+// COPY OF 'src/rust/cli/cmn.rs'
+// DO NOT EDIT
+use oauth2::{ApplicationSecret, ConsoleApplicationSecret, TokenStorage, Token};
+use serde_json as json;
+use serde_json::value::Value;
+use mime::Mime;
+use clap::{App, SubCommand};
+use strsim;
+
+use std::fs;
+use std::env;
+use std::io;
+use std::error::Error as StdError;
+use std::fmt;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+use std::string::ToString;
+use std::io::{Write, Read, stdout};
+
+use std::default::Default;
+
+const FIELD_SEP: char = '.';
+
+
+pub enum ComplexType {
+    Pod,
+    Vec,
+    Map,
+}
+
+// Null,
+// Bool(bool),
+// I64(i64),
+// U64(u64),
+// F64(f64),
+// String(String),
+
+pub enum JsonType {
+    Boolean,
+    Int,
+    Uint,
+    Float,
+    String,
+}
+
+pub struct JsonTypeInfo {
+    pub jtype: JsonType,
+    pub ctype: ComplexType,
+}
+
+// Based on @erickt user comment. Thanks for the idea !
+// Remove all keys whose values are null from given value (changed in place)
+pub fn remove_json_null_values(value: &mut Value) {
+    match *value {
+        Value::Object(ref mut map) => {
+            let mut for_removal = Vec::new();
+
+            for (key, mut value) in map.iter_mut() {
+                if value.is_null() {
+                    for_removal.push(key.clone());
+                } else {
+                    remove_json_null_values(&mut value);
+                }
+            }
+
+            for key in &for_removal {
+                map.remove(key);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn did_you_mean<'a>(v: &str, possible_values: &[&'a str]) -> Option<&'a str> {
+
+    let mut candidate: Option<(f64, &str)> = None;
+    for pv in possible_values {
+        let confidence = strsim::jaro_winkler(v, pv);
+        if confidence > 0.8 &&
+           (candidate.is_none() || (candidate.as_ref().unwrap().0 < confidence)) {
+            candidate = Some((confidence, pv));
+        }
+    }
+    match candidate {
+        None => None,
+        Some((_, candidate)) => Some(candidate),
+    }
+}
+
+pub enum CallType {
+    Upload(UploadProtocol),
+    Standard,
+}
+
+arg_enum!{
+    pub enum UploadProtocol {
+        Simple,
+        Resumable
+    }
+}
+
+impl AsRef<str> for UploadProtocol {
+    fn as_ref(&self) -> &str {
+        match *self {
+            UploadProtocol::Simple => "simple",
+            UploadProtocol::Resumable => "resumable",
+        }
+    }
+}
+
+impl AsRef<str> for CallType {
+    fn as_ref(&self) -> &str {
+        match *self {
+            CallType::Upload(ref proto) => proto.as_ref(),
+            CallType::Standard => "standard-request",
+        }
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct FieldCursor(Vec<String>);
+
+impl ToString for  FieldCursor {
+    fn to_string(&self) -> String {
+        self.0.join(".")
+    }
+}
+
+impl From<&'static str> for FieldCursor {
+    fn from(value: &'static str) -> FieldCursor {
+        let mut res = FieldCursor::default();
+        res.set(value).unwrap();
+        res
+    }
+}
+
+fn assure_entry<'a, 'b>(m: &'a mut json::Map<String, Value>, k: &'b String) -> &'a mut Value {
+    if m.contains_key(k) {
+        return m.get_mut(k).expect("value to exist");
+    }
+    m.insert(k.to_owned(), Value::Object(Default::default()));
+    m.get_mut(k).expect("value to exist")
+}
+
+impl FieldCursor {
+    pub fn set(&mut self, value: &str) -> Result<(), CLIError> {
+        if value.len() == 0 {
+            return Err(CLIError::Field(FieldError::Empty));
+        }
+
+        let mut first_is_field_sep = false;
+        let mut char_count: usize = 0;
+        let mut last_c = FIELD_SEP;
+        let mut num_conscutive_field_seps = 0;
+
+        let mut field = String::new();
+        let mut fields = self.0.clone();
+
+        let push_field = |fs: &mut Vec<String>, f: &mut String| {
+            if f.len() > 0 {
+                fs.push(f.clone());
+                f.truncate(0);
+            }
+        };
+
+        for (cid, c) in value.chars().enumerate() {
+            char_count += 1;
+
+            if c == FIELD_SEP {
+                if cid == 0 {
+                    first_is_field_sep = true;
+                }
+                num_conscutive_field_seps += 1;
+                if cid > 0 && last_c == FIELD_SEP {
+                    if fields.pop().is_none() {
+                        return Err(CLIError::Field(FieldError::PopOnEmpty(value.to_string())));
+                    }
+                } else {
+                    push_field(&mut fields, &mut field);
+                }
+            } else {
+                num_conscutive_field_seps = 0;
+                if cid == 1 {
+                    if first_is_field_sep {
+                        fields.truncate(0);
+                    }
+                }
+                field.push(c);
+            }
+
+            last_c = c;
+        }
+
+        push_field(&mut fields, &mut field);
+
+        if char_count == 1 && first_is_field_sep {
+            fields.truncate(0);
+        }
+        if char_count > 1 && num_conscutive_field_seps == 1 {
+            return Err(CLIError::Field(FieldError::TrailingFieldSep(value.to_string())));
+        }
+
+        self.0 = fields;
+        Ok(())
+    }
+
+    pub fn did_you_mean(value: &str, possible_values: &[&str]) -> Option<String> {
+        if value.len() == 0 {
+            return None;
+        }
+
+        let mut last_c = FIELD_SEP;
+
+        let mut field = String::new();
+        let mut output = String::new();
+
+        let push_field = |fs: &mut String, f: &mut String| {
+            if f.len() > 0 {
+                fs.push_str(match did_you_mean(&f, possible_values) {
+                    Some(candidate) => candidate,
+                    None => &f,
+                });
+                f.truncate(0);
+            }
+        };
+
+        for (cid, c) in value.chars().enumerate() {
+            if c == FIELD_SEP {
+                if last_c != FIELD_SEP {
+                    push_field(&mut output, &mut field);
+                }
+                output.push(c);
+            } else {
+                field.push(c);
+            }
+
+            last_c = c;
+        }
+
+        push_field(&mut output, &mut field);
+
+        if &output == value {
+            None
+        } else {
+            Some(output)
+        }
+    }
+
+    pub fn set_json_value(&self,
+                          mut object: &mut Value,
+                          value: &str,
+                          type_info: JsonTypeInfo,
+                          err: &mut InvalidOptionsError,
+                          orig_cursor: &FieldCursor) {
+        assert!(self.0.len() > 0);
+
+        for field in &self.0[..self.0.len() - 1] {
+            let tmp = object;
+            object = match *tmp {
+                Value::Object(ref mut mapping) => {
+                    assure_entry(mapping, &field)
+                }
+                _ => panic!("We don't expect non-object Values here ..."),
+            };
+        }
+
+        match *object {
+            Value::Object(ref mut mapping) => {
+                let field = &self.0[self.0.len() - 1];
+                let to_jval = |value: &str,
+                               jtype: JsonType,
+                               err: &mut InvalidOptionsError|
+                               -> Value {
+                    match jtype {
+                        JsonType::Boolean =>
+                            Value::Bool(arg_from_str(value, err, &field, "boolean")),
+                        JsonType::Int =>
+                            Value::Number(json::Number::from_f64(arg_from_str(value,
+                                                                              err,
+                                                                              &field,
+                                                                              "int"))
+                                              .expect("valid f64")),
+                        JsonType::Uint =>
+                            Value::Number(json::Number::from_f64(arg_from_str(value,
+                                                                              err,
+                                                                              &field,
+                                                                              "uint"))
+                                              .expect("valid f64")),
+                        JsonType::Float =>
+                            Value::Number(json::Number::from_f64(arg_from_str(value,
+                                                                              err,
+                                                                              &field,
+                                                                              "float"))
+                                              .expect("valid f64")),
+                        JsonType::String => Value::String(value.to_owned()),
+                    }
+                };
+
+                match type_info.ctype {
+                    ComplexType::Pod => {
+                        if mapping.insert(field.to_owned(), to_jval(value, type_info.jtype, err))
+                                  .is_some() {
+                            err.issues.push(CLIError::Field(FieldError::Duplicate(orig_cursor.to_string())));
+                        }
+                    }
+                    ComplexType::Vec => {
+                        match *assure_entry(mapping, field) {
+                            Value::Array(ref mut values) =>
+                                values.push(to_jval(value, type_info.jtype, err)),
+                            _ => unreachable!(),
+                        }
+                    }
+                    ComplexType::Map => {
+                        let (key, value) = parse_kv_arg(value, err, true);
+                        let jval = to_jval(value.unwrap_or(""), type_info.jtype, err);
+
+                        match *assure_entry(mapping, &field) {
+
+                            Value::Object(ref mut value_map) => {
+                                if value_map.insert(key.to_owned(), jval).is_some() {
+                                    err.issues.push(CLIError::Field(FieldError::Duplicate(orig_cursor.to_string())));
+                                }
+                            }
+                            _ => unreachable!(),
+                        }
+                    }
+                }
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    pub fn num_fields(&self) -> usize {
+        self.0.len()
+    }
+}
+
+pub fn parse_kv_arg<'a>(kv: &'a str,
+                        err: &mut InvalidOptionsError,
+                        for_hashmap: bool)
+                        -> (&'a str, Option<&'a str>) {
+    let mut add_err = || {
+        err.issues.push(CLIError::InvalidKeyValueSyntax(kv.to_string(), for_hashmap))
+    };
+    match kv.find('=') {
+        None => {
+            add_err();
+            return (kv, None);
+        }
+        Some(pos) => {
+            let key = &kv[..pos];
+            if kv.len() <= pos + 1 {
+                add_err();
+                return (key, Some(""));
+            }
+            (key, Some(&kv[pos + 1..]))
+        }
+    }
+}
+
+pub fn calltype_from_str(name: &str,
+                         valid_protocols: Vec<String>,
+                         err: &mut InvalidOptionsError)
+                         -> CallType {
+    CallType::Upload(match UploadProtocol::from_str(name) {
+        Ok(up) => up,
+        Err(msg) => {
+            err.issues.push(CLIError::InvalidUploadProtocol(name.to_string(), valid_protocols));
+            UploadProtocol::Simple
+        }
+    })
+}
+
+pub fn input_file_from_opts(file_path: &str, err: &mut InvalidOptionsError) -> Option<fs::File> {
+    match fs::File::open(file_path) {
+        Ok(f) => Some(f),
+        Err(io_err) => {
+            err.issues.push(CLIError::Input(InputError::Io((file_path.to_string(), io_err))));
+            None
+        }
+    }
+}
+
+pub fn input_mime_from_opts(mime: &str, err: &mut InvalidOptionsError) -> Option<Mime> {
+    match mime.parse() {
+        Ok(m) => Some(m),
+        Err(_) => {
+            err.issues.push(CLIError::Input(InputError::Mime(mime.to_string())));
+            None
+        }
+    }
+}
+
+pub fn writer_from_opts(arg: Option<&str>) -> Result<Box<Write>, io::Error> {
+    let f = arg.unwrap_or("-");
+    match f {
+        "-" => Ok(Box::new(stdout())),
+        _ => match fs::OpenOptions::new().create(true).write(true).open(f) {
+            Ok(f) => Ok(Box::new(f)),
+            Err(io_err) => Err(io_err),
+        },
+    }
+}
+
+
+pub fn arg_from_str<'a, T>(arg: &str,
+                           err: &mut InvalidOptionsError,
+                           arg_name: &'a str,
+                           arg_type: &'a str)
+                           -> T
+    where T: FromStr + Default,
+          <T as FromStr>::Err: fmt::Display
+{
+    match FromStr::from_str(arg) {
+        Err(perr) => {
+            err.issues.push(CLIError::ParseError(arg_name.to_owned(),
+                                                 arg_type.to_owned(),
+                                                 arg.to_string(),
+                                                 format!("{}", perr)));
+            Default::default()
+        }
+        Ok(v) => v,
+    }
+}
+
+pub struct JsonTokenStorage {
+    pub program_name: &'static str,
+    pub db_dir: String,
+}
+
+impl JsonTokenStorage {
+    fn path(&self, scope_hash: u64) -> PathBuf {
+        Path::new(&self.db_dir).join(&format!("{}-token-{}.json", self.program_name, scope_hash))
+    }
+}
+
+
+#[derive(Debug)]
+pub enum TokenStorageError {
+    Json(json::Error),
+    Io(io::Error),
+}
+
+impl fmt::Display for TokenStorageError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            TokenStorageError::Json(ref err) => writeln!(f, "Could not serialize secrets: {}", err),
+            TokenStorageError::Io(ref err) => writeln!(f, "Failed to write secret token: {}", err),
+        }
+    }
+}
+
+impl StdError for TokenStorageError {
+    fn description(&self) -> &str {
+        "Failure when getting or setting the token storage"
+    }
+}
+
+
+impl TokenStorage for JsonTokenStorage {
+    type Error = TokenStorageError;
+
+    // NOTE: logging might be interesting, currently we swallow all errors
+    fn set(&mut self,
+           scope_hash: u64,
+           _: &Vec<&str>,
+           token: Option<Token>)
+           -> Result<(), TokenStorageError> {
+        match token {
+            None => {
+                match fs::remove_file(self.path(scope_hash)) {
+                    Err(err) => match err.kind() {
+                        io::ErrorKind::NotFound => Ok(()),
+                        _ => Err(TokenStorageError::Io(err)),
+                    },
+                    Ok(_) => Ok(()),
+                }
+            }
+            Some(token) => {
+                match fs::OpenOptions::new().create(true).write(true).open(&self.path(scope_hash)) {
+                    Ok(mut f) => {
+                        match json::to_writer_pretty(&mut f, &token) {
+                            Ok(_) => Ok(()),
+                            Err(serde_err) => Err(TokenStorageError::Json(serde_err)),
+                        }
+                    }
+                    Err(io_err) => Err(TokenStorageError::Io(io_err)),
+                }
+            }
+        }
+    }
+
+    fn get(&self, scope_hash: u64, _: &Vec<&str>) -> Result<Option<Token>, TokenStorageError> {
+        match fs::File::open(&self.path(scope_hash)) {
+            Ok(f) => {
+                match json::de::from_reader(f) {
+                    Ok(token) => Ok(Some(token)),
+                    Err(err) => Err(TokenStorageError::Json(err)),
+                }
+            }
+            Err(io_err) => {
+                match io_err.kind() {
+                    io::ErrorKind::NotFound => Ok(None),
+                    _ => Err(TokenStorageError::Io(io_err)),
+                }
+            }
+        }
+    }
+}
+
+
+#[derive(Debug)]
+pub enum ApplicationSecretError {
+    DecoderError((String, json::Error)),
+    FormatError(String),
+}
+
+impl fmt::Display for ApplicationSecretError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            ApplicationSecretError::DecoderError((ref path, ref err)) =>
+                writeln!(f,
+                         "Could not decode file at '{}' with error: {}.",
+                         path,
+                         err),
+            ApplicationSecretError::FormatError(ref path) =>
+                writeln!(f,
+                         "'installed' field is unset in secret file at '{}'.",
+                         path),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum ConfigurationError {
+    DirectoryCreationFailed((String, io::Error)),
+    DirectoryUnset,
+    HomeExpansionFailed(String),
+    Secret(ApplicationSecretError),
+    Io((String, io::Error)),
+}
+
+impl fmt::Display for ConfigurationError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            ConfigurationError::DirectoryCreationFailed((ref dir, ref err)) =>
+                writeln!(f,
+                         "Directory '{}' could not be created with error: {}.",
+                         dir,
+                         err),
+            ConfigurationError::DirectoryUnset => writeln!(f, "--config-dir was unset or empty."),
+            ConfigurationError::HomeExpansionFailed(ref dir) =>
+                writeln!(f,
+                         "Couldn't find HOME directory of current user, failed to expand '{}'.",
+                         dir),
+            ConfigurationError::Secret(ref err) => writeln!(f, "Secret -> {}", err),
+            ConfigurationError::Io((ref path, ref err)) =>
+                writeln!(f,
+                         "IO operation failed on path '{}' with error: {}.",
+                         path,
+                         err),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum InputError {
+    Io((String, io::Error)),
+    Mime(String),
+}
+
+impl fmt::Display for InputError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            InputError::Io((ref file_path, ref io_err)) =>
+                writeln!(f,
+                         "Failed to open '{}' for reading with error: {}.",
+                         file_path,
+                         io_err),
+            InputError::Mime(ref mime) => writeln!(f, "'{}' is not a known mime-type.", mime),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum FieldError {
+    PopOnEmpty(String),
+    TrailingFieldSep(String),
+    Unknown(String, Option<String>, Option<String>),
+    Duplicate(String),
+    Empty,
+}
+
+
+impl fmt::Display for FieldError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            FieldError::PopOnEmpty(ref field) =>
+                writeln!(f, "'{}': Cannot move up on empty field cursor.", field),
+            FieldError::TrailingFieldSep(ref field) =>
+                writeln!(f,
+                         "'{}': Single field separator may not be last character.",
+                         field),
+            FieldError::Unknown(ref field, ref suggestion, ref value) => {
+                let suffix = match *suggestion {
+                    Some(ref s) => {
+                        let kv = match *value {
+                            Some(ref v) => format!("{}={}", s, v),
+                            None => s.clone(),
+                        };
+                        format!(" Did you mean '{}' ?", kv)
+                    }
+                    None => String::new(),
+                };
+                writeln!(f, "Field '{}' does not exist.{}", field, suffix)
+            }
+            FieldError::Duplicate(ref cursor) =>
+                writeln!(f, "Value at '{}' was already set", cursor),
+            FieldError::Empty => writeln!(f, "Field names must not be empty."),
+        }
+    }
+}
+
+
+#[derive(Debug)]
+pub enum CLIError {
+    Configuration(ConfigurationError),
+    ParseError(String, String, String, String),
+    UnknownParameter(String, Vec<&'static str>),
+    InvalidUploadProtocol(String, Vec<String>),
+    InvalidKeyValueSyntax(String, bool),
+    Input(InputError),
+    Field(FieldError),
+    MissingCommandError,
+    MissingMethodError(String),
+}
+
+impl fmt::Display for CLIError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            CLIError::Configuration(ref err) => write!(f, "Configuration -> {}", err),
+            CLIError::Input(ref err) => write!(f, "Input -> {}", err),
+            CLIError::Field(ref err) => write!(f, "Field -> {}", err),
+            CLIError::InvalidUploadProtocol(ref proto_name, ref valid_names) =>
+                writeln!(f,
+                         "'{}' is not a valid upload protocol. Choose from one of {}.",
+                         proto_name,
+                         valid_names.join(", ")),
+            CLIError::ParseError(ref arg_name, ref type_name, ref value, ref err_desc) =>
+                writeln!(f,
+                         "Failed to parse argument '{}' with value '{}' as {} with error: {}.",
+                         arg_name,
+                         value,
+                         type_name,
+                         err_desc),
+            CLIError::UnknownParameter(ref param_name, ref possible_values) => {
+                let suffix = match did_you_mean(param_name, &possible_values) {
+                    Some(v) => format!(" Did you mean '{}' ?", v),
+                    None => String::new(),
+                };
+                write!(f, "Parameter '{}' is unknown.{}\n", param_name, suffix)
+            }
+            CLIError::InvalidKeyValueSyntax(ref kv, is_hashmap) => {
+                let hashmap_info = if is_hashmap {
+                    "hashmap "
+                } else {
+                    ""
+                };
+                writeln!(f,
+                         "'{}' does not match {}pattern <key>=<value>.",
+                         kv,
+                         hashmap_info)
+            }
+            CLIError::MissingCommandError => writeln!(f, "Please specify the main sub-command."),
+            CLIError::MissingMethodError(ref cmd) =>
+                writeln!(f,
+                         "Please specify the method to call on the '{}' command.",
+                         cmd),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct InvalidOptionsError {
+    pub issues: Vec<CLIError>,
+    pub exit_code: i32,
+}
+
+impl fmt::Display for InvalidOptionsError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        for issue in &self.issues {
+            try!(issue.fmt(f));
+        }
+        Ok(())
+    }
+}
+
+impl InvalidOptionsError {
+    pub fn single(err: CLIError, exit_code: i32) -> InvalidOptionsError {
+        InvalidOptionsError {
+            issues: vec![err],
+            exit_code: exit_code,
+        }
+    }
+
+    pub fn new() -> InvalidOptionsError {
+        InvalidOptionsError {
+            issues: Vec::new(),
+            exit_code: 1,
+        }
+    }
+}
+
+pub fn assure_config_dir_exists(dir: &str) -> Result<String, CLIError> {
+    let trdir = dir.trim();
+    if trdir.len() == 0 {
+        return Err(CLIError::Configuration(ConfigurationError::DirectoryUnset));
+    }
+
+    let expanded_config_dir = if trdir.as_bytes()[0] == b'~' {
+        match env::var("HOME").ok().or(env::var("UserProfile").ok()) {
+            None => return Err(CLIError::Configuration(ConfigurationError::HomeExpansionFailed(trdir.to_string()))),
+            Some(mut user) => {
+                user.push_str(&trdir[1..]);
+                user
+            }
+        }
+    } else {
+        trdir.to_string()
+    };
+
+    if let Err(err) = fs::create_dir(&expanded_config_dir) {
+        if err.kind() != io::ErrorKind::AlreadyExists {
+            return Err(CLIError::Configuration(
+                    ConfigurationError::DirectoryCreationFailed((expanded_config_dir, err))));
+        }
+    }
+
+    Ok(expanded_config_dir)
+}
+
+pub fn application_secret_from_directory(dir: &str,
+                                         secret_basename: &str,
+                                         json_console_secret: &str)
+                                         -> Result<ApplicationSecret, CLIError> {
+    let secret_path = Path::new(dir).join(secret_basename);
+    let secret_str = || secret_path.as_path().to_str().unwrap().to_string();
+    let secret_io_error = |io_err: io::Error| {
+        Err(CLIError::Configuration(ConfigurationError::Io((secret_str(), io_err))))
+    };
+
+    for _ in 0..2 {
+        match fs::File::open(&secret_path) {
+            Err(mut err) => {
+                if err.kind() == io::ErrorKind::NotFound {
+                    // Write our built-in one - user may adjust the written file at will
+
+                    err = match fs::OpenOptions::new()
+                                    .create(true)
+                                    .write(true)
+                                    .open(&secret_path) {
+                        Err(cfe) => cfe,
+                        Ok(mut f) => {
+                            // Assure we convert 'ugly' json string into pretty one
+                            let console_secret: ConsoleApplicationSecret =
+                                json::from_str(json_console_secret).unwrap();
+                            match json::to_writer_pretty(&mut f, &console_secret) {
+                                Err(serde_err) =>
+                                    panic!("Unexpected serde error: {:#?}", serde_err),
+                                Ok(_) => continue,
+                            }
+                        }
+                    };
+                    // fall through to IO error handling
+                }
+                return secret_io_error(err);
+            }
+            Ok(f) => {
+                match json::de::from_reader::<_, ConsoleApplicationSecret>(f) {
+                    Err(json_err) =>
+                        return Err(CLIError::Configuration(
+                            ConfigurationError::Secret(
+                                ApplicationSecretError::DecoderError(
+                                                (secret_str(), json_err)
+                                              )))),
+                    Ok(console_secret) => match console_secret.installed {
+                        Some(secret) => return Ok(secret),
+                        None => return Err(
+                                        CLIError::Configuration(
+                                        ConfigurationError::Secret(
+                                        ApplicationSecretError::FormatError(secret_str())
+                                        ))),
+                    },
+                }
+            }
+        }
+    }
+    unreachable!();
+}

--- a/gen/cloudtrace2-cli/src/main.rs
+++ b/gen/cloudtrace2-cli/src/main.rs
@@ -1,0 +1,504 @@
+// DO NOT EDIT !
+// This file was generated automatically from 'src/mako/cli/main.rs.mako'
+// DO NOT EDIT !
+#![allow(unused_variables, unused_imports, dead_code, unused_mut)]
+
+#[macro_use]
+extern crate clap;
+extern crate yup_oauth2 as oauth2;
+extern crate yup_hyper_mock as mock;
+extern crate hyper_rustls;
+extern crate serde;
+extern crate serde_json;
+extern crate hyper;
+extern crate mime;
+extern crate strsim;
+extern crate google_cloudtrace2 as api;
+
+use std::env;
+use std::io::{self, Write};
+use clap::{App, SubCommand, Arg};
+
+mod cmn;
+
+use cmn::{InvalidOptionsError, CLIError, JsonTokenStorage, arg_from_str, writer_from_opts, parse_kv_arg,
+          input_file_from_opts, input_mime_from_opts, FieldCursor, FieldError, CallType, UploadProtocol,
+          calltype_from_str, remove_json_null_values, ComplexType, JsonType, JsonTypeInfo};
+
+use std::default::Default;
+use std::str::FromStr;
+
+use oauth2::{Authenticator, DefaultAuthenticatorDelegate, FlowType};
+use serde_json as json;
+use clap::ArgMatches;
+
+enum DoitError {
+    IoError(String, io::Error),
+    ApiError(api::Error),
+}
+
+struct Engine<'n> {
+    opt: ArgMatches<'n>,
+    hub: api::CloudTrace<hyper::Client, Authenticator<DefaultAuthenticatorDelegate, JsonTokenStorage, hyper::Client>>,
+    gp: Vec<&'static str>,
+    gpm: Vec<(&'static str, &'static str)>,
+}
+
+
+impl<'n> Engine<'n> {
+    fn _projects_traces_batch_write(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec![]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::BatchWriteSpansRequest = json::value::from_value(object).unwrap();
+        let mut call = self.hub.projects().traces_batch_write(request, opt.value_of("name").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _projects_traces_spans_create(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    "status.message" => Some(("status.message", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "status.code" => Some(("status.code", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Pod })),
+                    "child-span-count" => Some(("childSpanCount", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Pod })),
+                    "display-name.value" => Some(("displayName.value", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "display-name.truncated-byte-count" => Some(("displayName.truncatedByteCount", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Pod })),
+                    "name" => Some(("name", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "links.dropped-links-count" => Some(("links.droppedLinksCount", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Pod })),
+                    "stack-trace.stack-trace-hash-id" => Some(("stackTrace.stackTraceHashId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "stack-trace.stack-frames.dropped-frames-count" => Some(("stackTrace.stackFrames.droppedFramesCount", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Pod })),
+                    "parent-span-id" => Some(("parentSpanId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "start-time" => Some(("startTime", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "span-id" => Some(("spanId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "attributes.dropped-attributes-count" => Some(("attributes.droppedAttributesCount", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Pod })),
+                    "time-events.dropped-message-events-count" => Some(("timeEvents.droppedMessageEventsCount", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Pod })),
+                    "time-events.dropped-annotations-count" => Some(("timeEvents.droppedAnnotationsCount", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Pod })),
+                    "end-time" => Some(("endTime", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "same-process-as-parent-span" => Some(("sameProcessAsParentSpan", JsonTypeInfo { jtype: JsonType::Boolean, ctype: ComplexType::Pod })),
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec!["attributes", "child-span-count", "code", "display-name", "dropped-annotations-count", "dropped-attributes-count", "dropped-frames-count", "dropped-links-count", "dropped-message-events-count", "end-time", "links", "message", "name", "parent-span-id", "same-process-as-parent-span", "span-id", "stack-frames", "stack-trace", "stack-trace-hash-id", "start-time", "status", "time-events", "truncated-byte-count", "value"]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::Span = json::value::from_value(object).unwrap();
+        let mut call = self.hub.projects().traces_spans_create(request, opt.value_of("name").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _doit(&self, dry_run: bool) -> Result<Result<(), DoitError>, Option<InvalidOptionsError>> {
+        let mut err = InvalidOptionsError::new();
+        let mut call_result: Result<(), DoitError> = Ok(());
+        let mut err_opt: Option<InvalidOptionsError> = None;
+        match self.opt.subcommand() {
+            ("projects", Some(opt)) => {
+                match opt.subcommand() {
+                    ("traces-batch-write", Some(opt)) => {
+                        call_result = self._projects_traces_batch_write(opt, dry_run, &mut err);
+                    },
+                    ("traces-spans-create", Some(opt)) => {
+                        call_result = self._projects_traces_spans_create(opt, dry_run, &mut err);
+                    },
+                    _ => {
+                        err.issues.push(CLIError::MissingMethodError("projects".to_string()));
+                        writeln!(io::stderr(), "{}\n", opt.usage()).ok();
+                    }
+                }
+            },
+            _ => {
+                err.issues.push(CLIError::MissingCommandError);
+                writeln!(io::stderr(), "{}\n", self.opt.usage()).ok();
+            }
+        }
+
+        if dry_run {
+            if err.issues.len() > 0 {
+                err_opt = Some(err);
+            }
+            Err(err_opt)
+        } else {
+            Ok(call_result)
+        }
+    }
+
+    // Please note that this call will fail if any part of the opt can't be handled
+    fn new(opt: ArgMatches<'n>) -> Result<Engine<'n>, InvalidOptionsError> {
+        let (config_dir, secret) = {
+            let config_dir = match cmn::assure_config_dir_exists(opt.value_of("folder").unwrap_or("~/.google-service-cli")) {
+                Err(e) => return Err(InvalidOptionsError::single(e, 3)),
+                Ok(p) => p,
+            };
+
+            match cmn::application_secret_from_directory(&config_dir, "cloudtrace2-secret.json",
+                                                         "{\"installed\":{\"auth_uri\":\"https://accounts.google.com/o/oauth2/auth\",\"client_secret\":\"hCsslbCUyfehWMmbkG8vTYxG\",\"token_uri\":\"https://accounts.google.com/o/oauth2/token\",\"client_email\":\"\",\"redirect_uris\":[\"urn:ietf:wg:oauth:2.0:oob\",\"oob\"],\"client_x509_cert_url\":\"\",\"client_id\":\"620010449518-9ngf7o4dhs0dka470npqvor6dc5lqb9b.apps.googleusercontent.com\",\"auth_provider_x509_cert_url\":\"https://www.googleapis.com/oauth2/v1/certs\"}}") {
+                Ok(secret) => (config_dir, secret),
+                Err(e) => return Err(InvalidOptionsError::single(e, 4))
+            }
+        };
+
+        let auth = Authenticator::new(  &secret, DefaultAuthenticatorDelegate,
+                                        if opt.is_present("debug-auth") {
+                                            hyper::Client::with_connector(mock::TeeConnector {
+                                                    connector: hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())
+                                                })
+                                        } else {
+                                            hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new()))
+                                        },
+                                        JsonTokenStorage {
+                                          program_name: "cloudtrace2",
+                                          db_dir: config_dir.clone(),
+                                        }, Some(FlowType::InstalledRedirect(54324)));
+
+        let client =
+            if opt.is_present("debug") {
+                hyper::Client::with_connector(mock::TeeConnector {
+                        connector: hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())
+                    })
+            } else {
+                hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new()))
+            };
+        let engine = Engine {
+            opt: opt,
+            hub: api::CloudTrace::new(client, auth),
+            gp: vec!["$-xgafv", "access-token", "alt", "bearer-token", "callback", "fields", "key", "oauth-token", "pp", "pretty-print", "quota-user", "upload-type", "upload-protocol"],
+            gpm: vec![
+                    ("$-xgafv", "$.xgafv"),
+                    ("access-token", "access_token"),
+                    ("bearer-token", "bearer_token"),
+                    ("oauth-token", "oauth_token"),
+                    ("pretty-print", "prettyPrint"),
+                    ("quota-user", "quotaUser"),
+                    ("upload-type", "uploadType"),
+                    ("upload-protocol", "upload_protocol"),
+                ]
+        };
+
+        match engine._doit(true) {
+            Err(Some(err)) => Err(err),
+            Err(None)      => Ok(engine),
+            Ok(_)          => unreachable!(),
+        }
+    }
+
+    fn doit(&self) -> Result<(), DoitError> {
+        match self._doit(false) {
+            Ok(res) => res,
+            Err(_) => unreachable!(),
+        }
+    }
+}
+
+fn main() {
+    let mut exit_status = 0i32;
+    let arg_data = [
+        ("projects", "methods: 'traces-batch-write' and 'traces-spans-create'", vec![
+            ("traces-batch-write",
+                    Some(r##"Sends new spans to new or existing traces. You cannot update
+        existing spans."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_cloudtrace2_cli/projects_traces-batch-write",
+                  vec![
+                    (Some(r##"name"##),
+                     None,
+                     Some(r##"Required. The name of the project where the spans belong. The format is
+        `projects/[PROJECT_ID]`."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("traces-spans-create",
+                    Some(r##"Creates a new span."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_cloudtrace2_cli/projects_traces-spans-create",
+                  vec![
+                    (Some(r##"name"##),
+                     None,
+                     Some(r##"The resource name of the span in the following format:
+        
+            projects/[PROJECT_ID]/traces/[TRACE_ID]/spans/SPAN_ID is a unique identifier for a trace within a project;
+        it is a 32-character hexadecimal encoding of a 16-byte array.
+        
+        [SPAN_ID] is a unique identifier for a span within a trace; it
+        is a 16-character hexadecimal encoding of an 8-byte array."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ]),
+        
+    ];
+    
+    let mut app = App::new("cloudtrace2")
+           .author("Sebastian Thiel <byronimo@gmail.com>")
+           .version("1.0.7+20171202")
+           .about("Sends application trace data to Stackdriver Trace for viewing. Trace data is collected for all App Engine applications by default. Trace data from other applications can be provided using this API.
+           ")
+           .after_help("All documentation details can be found at http://byron.github.io/google-apis-rs/google_cloudtrace2_cli")
+           .arg(Arg::with_name("url")
+                   .long("scope")
+                   .help("Specify the authentication a method should be executed in. Each scope requires the user to grant this application permission to use it.If unset, it defaults to the shortest scope url for a particular method.")
+                   .multiple(true)
+                   .takes_value(true))
+           .arg(Arg::with_name("folder")
+                   .long("config-dir")
+                   .help("A directory into which we will store our persistent data. Defaults to a user-writable directory that we will create during the first invocation.[default: ~/.google-service-cli")
+                   .multiple(false)
+                   .takes_value(true))
+           .arg(Arg::with_name("debug")
+                   .long("debug")
+                   .help("Output all server communication to standard error. `tx` and `rx` are placed into the same stream.")
+                   .multiple(false)
+                   .takes_value(false))
+           .arg(Arg::with_name("debug-auth")
+                   .long("debug-auth")
+                   .help("Output all communication related to authentication to standard error. `tx` and `rx` are placed into the same stream.")
+                   .multiple(false)
+                   .takes_value(false));
+           
+           for &(main_command_name, about, ref subcommands) in arg_data.iter() {
+               let mut mcmd = SubCommand::with_name(main_command_name).about(about);
+           
+               for &(sub_command_name, ref desc, url_info, ref args) in subcommands {
+                   let mut scmd = SubCommand::with_name(sub_command_name);
+                   if let &Some(desc) = desc {
+                       scmd = scmd.about(desc);
+                   }
+                   scmd = scmd.after_help(url_info);
+           
+                   for &(ref arg_name, ref flag, ref desc, ref required, ref multi) in args {
+                       let arg_name_str =
+                           match (arg_name, flag) {
+                                   (&Some(an), _       ) => an,
+                                   (_        , &Some(f)) => f,
+                                    _                    => unreachable!(),
+                            };
+                       let mut arg = Arg::with_name(arg_name_str)
+                                         .empty_values(false);
+                       if let &Some(short_flag) = flag {
+                           arg = arg.short(short_flag);
+                       }
+                       if let &Some(desc) = desc {
+                           arg = arg.help(desc);
+                       }
+                       if arg_name.is_some() && flag.is_some() {
+                           arg = arg.takes_value(true);
+                       }
+                       if let &Some(required) = required {
+                           arg = arg.required(required);
+                       }
+                       if let &Some(multi) = multi {
+                           arg = arg.multiple(multi);
+                       }
+                       scmd = scmd.arg(arg);
+                   }
+                   mcmd = mcmd.subcommand(scmd);
+               }
+               app = app.subcommand(mcmd);
+           }
+           
+        let matches = app.get_matches();
+
+    let debug = matches.is_present("debug");
+    match Engine::new(matches) {
+        Err(err) => {
+            exit_status = err.exit_code;
+            writeln!(io::stderr(), "{}", err).ok();
+        },
+        Ok(engine) => {
+            if let Err(doit_err) = engine.doit() {
+                exit_status = 1;
+                match doit_err {
+                    DoitError::IoError(path, err) => {
+                        writeln!(io::stderr(), "Failed to open output file '{}': {}", path, err).ok();
+                    },
+                    DoitError::ApiError(err) => {
+                        if debug {
+                            writeln!(io::stderr(), "{:#?}", err).ok();
+                        } else {
+                            writeln!(io::stderr(), "{}", err).ok();
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    std::process::exit(exit_status);
+}

--- a/gen/cloudtrace2/Cargo.toml
+++ b/gen/cloudtrace2/Cargo.toml
@@ -1,0 +1,31 @@
+# DO NOT EDIT !
+# This file was generated automatically from 'src/mako/Cargo.toml.mako'
+# DO NOT EDIT !
+[package]
+
+name = "google-cloudtrace2"
+version = "1.0.7+20171202"
+authors = ["Sebastian Thiel <byronimo@gmail.com>"]
+description = "A complete library to interact with Cloud Trace (protocol v2)"
+repository = "https://github.com/Byron/google-apis-rs/tree/master/gen/cloudtrace2"
+homepage = "https://cloud.google.com/trace"
+documentation = "https://docs.rs/google-cloudtrace2/1.0.7+20171202"
+license = "MIT"
+keywords = ["cloudtrace", "google", "protocol", "web", "api"]
+
+
+[dev-dependencies]
+hyper-rustls = "^0.6"
+
+[dependencies]
+hyper = "^ 0.10"
+mime = "^ 0.2.0"
+serde = "^ 1.0"
+serde_json = "^ 1.0"
+serde_derive = "^ 1.0"
+yup-oauth2 = "^ 1.0"
+url = "= 0.5"
+
+[features]
+
+

--- a/gen/cloudtrace2/LICENSE.md
+++ b/gen/cloudtrace2/LICENSE.md
@@ -1,0 +1,30 @@
+<!---
+DO NOT EDIT !
+This file was generated automatically from 'src/mako/LICENSE.md.mako'
+DO NOT EDIT !
+-->
+The MIT License (MIT)
+=====================
+
+Copyright © `2015-2016` `Sebastian Thiel`
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the “Software”), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.

--- a/gen/cloudtrace2/README.md
+++ b/gen/cloudtrace2/README.md
@@ -1,0 +1,180 @@
+<!---
+DO NOT EDIT !
+This file was generated automatically from 'src/mako/api/README.md.mako'
+DO NOT EDIT !
+-->
+The `google-cloudtrace2` library allows access to all features of the *Google Cloud Trace* service.
+
+This documentation was generated from *Cloud Trace* crate version *1.0.7+20171202*, where *20171202* is the exact revision of the *cloudtrace:v2* schema built by the [mako](http://www.makotemplates.org/) code generator *v1.0.7*.
+
+Everything else about the *Cloud Trace* *v2* API can be found at the
+[official documentation site](https://cloud.google.com/trace).
+# Features
+
+Handle the following *Resources* with ease from the central [hub](https://docs.rs/google-cloudtrace2/1.0.7+20171202/google_cloudtrace2/struct.CloudTrace.html) ... 
+
+* projects
+ * [*traces batch write*](https://docs.rs/google-cloudtrace2/1.0.7+20171202/google_cloudtrace2/struct.ProjectTraceBatchWriteCall.html) and [*traces spans create*](https://docs.rs/google-cloudtrace2/1.0.7+20171202/google_cloudtrace2/struct.ProjectTraceSpanCreateCall.html)
+
+
+
+
+# Structure of this Library
+
+The API is structured into the following primary items:
+
+* **[Hub](https://docs.rs/google-cloudtrace2/1.0.7+20171202/google_cloudtrace2/struct.CloudTrace.html)**
+    * a central object to maintain state and allow accessing all *Activities*
+    * creates [*Method Builders*](https://docs.rs/google-cloudtrace2/1.0.7+20171202/google_cloudtrace2/trait.MethodsBuilder.html) which in turn
+      allow access to individual [*Call Builders*](https://docs.rs/google-cloudtrace2/1.0.7+20171202/google_cloudtrace2/trait.CallBuilder.html)
+* **[Resources](https://docs.rs/google-cloudtrace2/1.0.7+20171202/google_cloudtrace2/trait.Resource.html)**
+    * primary types that you can apply *Activities* to
+    * a collection of properties and *Parts*
+    * **[Parts](https://docs.rs/google-cloudtrace2/1.0.7+20171202/google_cloudtrace2/trait.Part.html)**
+        * a collection of properties
+        * never directly used in *Activities*
+* **[Activities](https://docs.rs/google-cloudtrace2/1.0.7+20171202/google_cloudtrace2/trait.CallBuilder.html)**
+    * operations to apply to *Resources*
+
+All *structures* are marked with applicable traits to further categorize them and ease browsing.
+
+Generally speaking, you can invoke *Activities* like this:
+
+```Rust,ignore
+let r = hub.resource().activity(...).doit()
+```
+
+Or specifically ...
+
+```ignore
+let r = hub.projects().traces_spans_create(...).doit()
+```
+
+The `resource()` and `activity(...)` calls create [builders][builder-pattern]. The second one dealing with `Activities` 
+supports various methods to configure the impending operation (not shown here). It is made such that all required arguments have to be 
+specified right away (i.e. `(...)`), whereas all optional ones can be [build up][builder-pattern] as desired.
+The `doit()` method performs the actual communication with the server and returns the respective result.
+
+# Usage
+
+## Setting up your Project
+
+To use this library, you would put the following lines into your `Cargo.toml` file:
+
+```toml
+[dependencies]
+google-cloudtrace2 = "*"
+```
+
+## A complete example
+
+```Rust
+extern crate hyper;
+extern crate hyper_rustls;
+extern crate yup_oauth2 as oauth2;
+extern crate google_cloudtrace2 as cloudtrace2;
+use cloudtrace2::Span;
+use cloudtrace2::{Result, Error};
+use std::default::Default;
+use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+use cloudtrace2::CloudTrace;
+
+// Get an ApplicationSecret instance by some means. It contains the `client_id` and 
+// `client_secret`, among other things.
+let secret: ApplicationSecret = Default::default();
+// Instantiate the authenticator. It will choose a suitable authentication flow for you, 
+// unless you replace  `None` with the desired Flow.
+// Provide your own `AuthenticatorDelegate` to adjust the way it operates and get feedback about 
+// what's going on. You probably want to bring in your own `TokenStorage` to persist tokens and
+// retrieve them from storage.
+let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+                              hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+                              <MemoryStorage as Default>::default(), None);
+let mut hub = CloudTrace::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+// As the method needs a request, you would usually fill it with the desired information
+// into the respective structure. Some of the parts shown here might not be applicable !
+// Values shown here are possibly random and not representative !
+let mut req = Span::default();
+
+// You can configure optional parameters by calling the respective setters at will, and
+// execute the final call using `doit()`.
+// Values shown here are possibly random and not representative !
+let result = hub.projects().traces_spans_create(req, "name")
+             .doit();
+
+match result {
+    Err(e) => match e {
+        // The Error enum provides details about what exactly happened.
+        // You can also just use its `Debug`, `Display` or `Error` traits
+         Error::HttpError(_)
+        |Error::MissingAPIKey
+        |Error::MissingToken(_)
+        |Error::Cancelled
+        |Error::UploadSizeLimitExceeded(_, _)
+        |Error::Failure(_)
+        |Error::BadRequest(_)
+        |Error::FieldClash(_)
+        |Error::JsonDecodeError(_, _) => println!("{}", e),
+    },
+    Ok(res) => println!("Success: {:?}", res),
+}
+
+```
+## Handling Errors
+
+All errors produced by the system are provided either as [Result](https://docs.rs/google-cloudtrace2/1.0.7+20171202/google_cloudtrace2/enum.Result.html) enumeration as return value of 
+the doit() methods, or handed as possibly intermediate results to either the 
+[Hub Delegate](https://docs.rs/google-cloudtrace2/1.0.7+20171202/google_cloudtrace2/trait.Delegate.html), or the [Authenticator Delegate](https://docs.rs/yup-oauth2/*/yup_oauth2/trait.AuthenticatorDelegate.html).
+
+When delegates handle errors or intermediate values, they may have a chance to instruct the system to retry. This 
+makes the system potentially resilient to all kinds of errors.
+
+## Uploads and Downloads
+If a method supports downloads, the response body, which is part of the [Result](https://docs.rs/google-cloudtrace2/1.0.7+20171202/google_cloudtrace2/enum.Result.html), should be
+read by you to obtain the media.
+If such a method also supports a [Response Result](https://docs.rs/google-cloudtrace2/1.0.7+20171202/google_cloudtrace2/trait.ResponseResult.html), it will return that by default.
+You can see it as meta-data for the actual media. To trigger a media download, you will have to set up the builder by making
+this call: `.param("alt", "media")`.
+
+Methods supporting uploads can do so using up to 2 different protocols: 
+*simple* and *resumable*. The distinctiveness of each is represented by customized 
+`doit(...)` methods, which are then named `upload(...)` and `upload_resumable(...)` respectively.
+
+## Customization and Callbacks
+
+You may alter the way an `doit()` method is called by providing a [delegate](https://docs.rs/google-cloudtrace2/1.0.7+20171202/google_cloudtrace2/trait.Delegate.html) to the 
+[Method Builder](https://docs.rs/google-cloudtrace2/1.0.7+20171202/google_cloudtrace2/trait.CallBuilder.html) before making the final `doit()` call. 
+Respective methods will be called to provide progress information, as well as determine whether the system should 
+retry on failure.
+
+The [delegate trait](https://docs.rs/google-cloudtrace2/1.0.7+20171202/google_cloudtrace2/trait.Delegate.html) is default-implemented, allowing you to customize it with minimal effort.
+
+## Optional Parts in Server-Requests
+
+All structures provided by this library are made to be [enocodable](https://docs.rs/google-cloudtrace2/1.0.7+20171202/google_cloudtrace2/trait.RequestValue.html) and 
+[decodable](https://docs.rs/google-cloudtrace2/1.0.7+20171202/google_cloudtrace2/trait.ResponseResult.html) via *json*. Optionals are used to indicate that partial requests are responses 
+are valid.
+Most optionals are are considered [Parts](https://docs.rs/google-cloudtrace2/1.0.7+20171202/google_cloudtrace2/trait.Part.html) which are identifiable by name, which will be sent to 
+the server to indicate either the set parts of the request or the desired parts in the response.
+
+## Builder Arguments
+
+Using [method builders](https://docs.rs/google-cloudtrace2/1.0.7+20171202/google_cloudtrace2/trait.CallBuilder.html), you are able to prepare an action call by repeatedly calling it's methods.
+These will always take a single argument, for which the following statements are true.
+
+* [PODs][wiki-pod] are handed by copy
+* strings are passed as `&str`
+* [request values](https://docs.rs/google-cloudtrace2/1.0.7+20171202/google_cloudtrace2/trait.RequestValue.html) are moved
+
+Arguments will always be copied or cloned into the builder, to make them independent of their original life times.
+
+[wiki-pod]: http://en.wikipedia.org/wiki/Plain_old_data_structure
+[builder-pattern]: http://en.wikipedia.org/wiki/Builder_pattern
+[google-go-api]: https://github.com/google/google-api-go-client
+
+# License
+The **cloudtrace2** library was generated by Sebastian Thiel, and is placed 
+under the *MIT* license.
+You can read the full text at the repository's [license file][repo-license].
+
+[repo-license]: https://github.com/Byron/google-apis-rsblob/master/LICENSE.md

--- a/gen/cloudtrace2/src/cmn.rs
+++ b/gen/cloudtrace2/src/cmn.rs
@@ -1,0 +1,753 @@
+// COPY OF 'src/rust/api/cmn.rs'
+// DO NOT EDIT
+use std::io::{self, Read, Seek, Cursor, Write, SeekFrom};
+use std;
+use std::fmt::{self, Display};
+use std::str::FromStr;
+use std::error;
+use std::thread::sleep;
+use std::time::Duration;
+
+use mime::{Mime, TopLevel, SubLevel, Attr, Value};
+use oauth2::{TokenType, Retry, self};
+use hyper;
+use hyper::header::{ContentType, ContentLength, Headers, UserAgent, Authorization, Header,
+                    HeaderFormat, Bearer};
+use hyper::http::h1::LINE_ENDING;
+use hyper::method::Method;
+use hyper::status::StatusCode;
+
+use serde_json as json;
+
+/// Identifies the Hub. There is only one per library, this trait is supposed
+/// to make intended use more explicit.
+/// The hub allows to access all resource methods more easily.
+pub trait Hub {}
+
+/// Identifies types for building methods of a particular resource type
+pub trait MethodsBuilder {}
+
+/// Identifies types which represent builders for a particular resource method
+pub trait CallBuilder {}
+
+/// Identifies types which can be inserted and deleted.
+/// Types with this trait are most commonly used by clients of this API.
+pub trait Resource {}
+
+/// Identifies types which are used in API responses.
+pub trait ResponseResult {}
+
+/// Identifies types which are used in API requests.
+pub trait RequestValue {}
+
+/// Identifies types which are not actually used by the API
+/// This might be a bug within the google API schema.
+pub trait UnusedType {}
+
+/// Identifies types which are only used as part of other types, which
+/// usually are carrying the `Resource` trait.
+pub trait Part {}
+
+/// Identifies types which are only used by other types internally.
+/// They have no special meaning, this trait just marks them for completeness.
+pub trait NestedType {}
+
+/// A utility to specify reader types which provide seeking capabilities too
+pub trait ReadSeek: Seek + Read {}
+impl<T: Seek + Read> ReadSeek for T {}
+
+/// A trait for all types that can convert themselves into a *parts* string
+pub trait ToParts {
+    fn to_parts(&self) -> String;
+}
+
+/// A utility type which can decode a server response that indicates error
+#[derive(Deserialize)]
+pub struct JsonServerError {
+    pub error: String,
+    pub error_description: Option<String>
+}
+
+/// A utility to represent detailed errors we might see in case there are BadRequests.
+/// The latter happen if the sent parameters or request structures are unsound
+#[derive(Deserialize, Serialize, Debug)]
+pub struct ErrorResponse {
+    error: ServerError,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct ServerError {
+    errors: Vec<ServerMessage>,
+    code: u16,
+    message: String,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct ServerMessage {
+    domain: String,
+    reason: String,
+    message: String,
+    #[serde(rename="locationType")]
+    location_type: Option<String>,
+    location: Option<String>
+}
+
+#[derive(Copy, Clone)]
+pub struct DummyNetworkStream;
+
+impl Read for DummyNetworkStream {
+    fn read(&mut self, _: &mut [u8]) -> io::Result<usize> {
+        Ok(0)
+    }
+}
+
+impl Write for DummyNetworkStream {
+    fn write(&mut self, _: &[u8]) -> io::Result<usize> {
+        Ok(0)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl hyper::net::NetworkStream for DummyNetworkStream {
+    fn peer_addr(&mut self) -> io::Result<std::net::SocketAddr> {
+        Ok("127.0.0.1:1337".parse().unwrap())
+    }
+
+    fn set_read_timeout(&self, _dur: Option<Duration>) -> io::Result<()> {
+        Ok(())
+    }
+
+    fn set_write_timeout(&self, _dur: Option<Duration>) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+
+/// A trait specifying functionality to help controlling any request performed by the API.
+/// The trait has a conservative default implementation.
+///
+/// It contains methods to deal with all common issues, as well with the ones related to
+/// uploading media
+pub trait Delegate {
+
+    /// Called at the beginning of any API request. The delegate should store the method
+    /// information if he is interesting in knowing more context when further calls to it
+    /// are made.
+    /// The matching `finished()` call will always be made, no matter whether or not the API
+    /// request was successful. That way, the delegate may easily maintain a clean state
+    /// between various API calls.
+    fn begin(&mut self, MethodInfo) {}
+
+    /// Called whenever there is an [HttpError](http://hyperium.github.io/hyper/hyper/error/enum.HttpError.html), usually if there are network problems.
+    ///
+    /// If you choose to retry after a duration, the duration should be chosen using the
+    /// [exponential backoff algorithm](http://en.wikipedia.org/wiki/Exponential_backoff).
+    ///
+    /// Return retry information.
+    fn http_error(&mut self, &hyper::Error) -> Retry {
+        Retry::Abort
+    }
+
+    /// Called whenever there is the need for your applications API key after
+    /// the official authenticator implementation didn't provide one, for some reason.
+    /// If this method returns None as well, the underlying operation will fail
+    fn api_key(&mut self) -> Option<String> {
+        None
+    }
+
+    /// Called whenever the Authenticator didn't yield a token. The delegate
+    /// may attempt to provide one, or just take it as a general information about the
+    /// impending failure.
+    /// The given Error provides information about why the token couldn't be acquired in the
+    /// first place
+    fn token(&mut self, err: &error::Error) -> Option<oauth2::Token> {
+        let _ = err;
+        None
+    }
+
+    /// Called during resumable uploads to provide a URL for the impending upload.
+    /// It was saved after a previous call to `store_upload_url(...)`, and if not None,
+    /// will be used instead of asking the server for a new upload URL.
+    /// This is useful in case a previous resumable upload was aborted/canceled, but should now
+    /// be resumed.
+    /// The returned URL will be used exactly once - if it fails again and the delegate allows
+    /// to retry, we will ask the server for a new upload URL.
+    fn upload_url(&mut self) -> Option<String> {
+        None
+    }
+
+    /// Called after we have retrieved a new upload URL for a resumable upload to store it
+    /// in case we fail or cancel. That way, we can attempt to resume the upload later,
+    /// see `upload_url()`.
+    /// It will also be called with None after a successful upload, which allows the delegate
+    /// to forget the URL. That way, we will not attempt to resume an upload that has already
+    /// finished.
+    fn store_upload_url(&mut self, url: Option<&str>) {
+        let _ = url;
+    }
+
+    /// Called whenever a server response could not be decoded from json.
+    /// It's for informational purposes only, the caller will return with an error
+    /// accordingly.
+    ///
+    /// # Arguments
+    ///
+    /// * `json_encoded_value` - The json-encoded value which failed to decode.
+    /// * `json_decode_error`  - The decoder error
+    fn response_json_decode_error(&mut self, json_encoded_value: &str, json_decode_error: &json::Error) {
+        let _ = json_encoded_value;
+        let _ = json_decode_error;
+    }
+
+    /// Called whenever the http request returns with a non-success status code.
+    /// This can involve authentication issues, or anything else that very much
+    /// depends on the used API method.
+    /// The delegate should check the status, header and decoded json error to decide
+    /// whether to retry or not. In the latter case, the underlying call will fail.
+    ///
+    /// If you choose to retry after a duration, the duration should be chosen using the
+    /// [exponential backoff algorithm](http://en.wikipedia.org/wiki/Exponential_backoff).
+    fn http_failure(&mut self, _: &hyper::client::Response, Option<JsonServerError>, _: Option<ServerError>) -> Retry {
+        Retry::Abort
+    }
+
+    /// Called prior to sending the main request of the given method. It can be used to time
+    /// the call or to print progress information.
+    /// It's also useful as you can be sure that a request will definitely be made.
+    fn pre_request(&mut self) { }
+
+    /// Return the size of each chunk of a resumable upload.
+    /// Must be a power of two, with 1<<18 being the smallest allowed chunk size.
+    /// Will be called once before starting any resumable upload.
+    fn chunk_size(&mut self) -> u64 {
+        1 << 23
+    }
+
+    /// Called before the given chunk is uploaded to the server.
+    /// If true is returned, the upload will be interrupted.
+    /// However, it may be resumable if you stored the upload URL in a previous call
+    /// to `store_upload_url()`
+    fn cancel_chunk_upload(&mut self, chunk: &ContentRange) -> bool {
+        let _ = chunk;
+        false
+    }
+
+    /// Called before the API request method returns, in every case. It can be used to clean up
+    /// internal state between calls to the API.
+    /// This call always has a matching call to `begin(...)`.
+    ///
+    /// # Arguments
+    ///
+    /// * `is_success` - a true value indicates the operation was successful. If false, you should
+    ///                  discard all values stored during `store_upload_url`.
+    fn finished(&mut self, is_success: bool) {
+        let _ = is_success;
+    }
+}
+
+/// A delegate with a conservative default implementation, which is used if no other delegate is
+/// set.
+#[derive(Default)]
+pub struct DefaultDelegate;
+
+impl Delegate for DefaultDelegate {}
+
+
+#[derive(Debug)]
+pub enum Error {
+    /// The http connection failed
+    HttpError(hyper::Error),
+
+    /// An attempt was made to upload a resource with size stored in field `.0`
+    /// even though the maximum upload size is what is stored in field `.1`.
+    UploadSizeLimitExceeded(u64, u64),
+
+    /// Represents information about a request that was not understood by the server.
+    /// Details are included.
+    BadRequest(ErrorResponse),
+
+    /// We needed an API key for authentication, but didn't obtain one.
+    /// Neither through the authenticator, nor through the Delegate.
+    MissingAPIKey,
+
+    /// We required a Token, but didn't get one from the Authenticator
+    MissingToken(Box<error::Error>),
+
+    /// The delgate instructed to cancel the operation
+    Cancelled,
+
+    /// An additional, free form field clashed with one of the built-in optional ones
+    FieldClash(&'static str),
+
+    /// Shows that we failed to decode the server response.
+    /// This can happen if the protocol changes in conjunction with strict json decoding.
+    JsonDecodeError(String, json::Error),
+
+    /// Indicates an HTTP repsonse with a non-success status code
+    Failure(hyper::client::Response),
+}
+
+
+impl Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Error::HttpError(ref err) => err.fmt(f),
+            Error::UploadSizeLimitExceeded(ref resource_size, ref max_size) =>
+                writeln!(f, "The media size {} exceeds the maximum allowed upload size of {}"
+                         , resource_size, max_size),
+            Error::MissingAPIKey => {
+                (writeln!(f, "The application's API key was not found in the configuration")).ok();
+                writeln!(f, "It is used as there are no Scopes defined for this method.")
+            },
+            Error::BadRequest(ref err) => {
+                try!(writeln!(f, "Bad Request ({}): {}", err.error.code, err.error.message));
+                for err in err.error.errors.iter() {
+                    try!(writeln!(f, "    {}: {}, {}{}",
+                                            err.domain,
+                                            err.message,
+                                            err.reason,
+                                            match &err.location {
+                                                &Some(ref loc) => format!("@{}", loc),
+                                                &None => String::new(),
+                                            }));
+                }
+                Ok(())
+            },
+            Error::MissingToken(ref err) =>
+                writeln!(f, "Token retrieval failed with error: {}", err),
+            Error::Cancelled =>
+                writeln!(f, "Operation cancelled by delegate"),
+            Error::FieldClash(field) =>
+                writeln!(f, "The custom parameter '{}' is already provided natively by the CallBuilder.", field),
+            Error::JsonDecodeError(ref json_str, ref err)
+                => writeln!(f, "{}: {}", err, json_str),
+            Error::Failure(ref response) =>
+                writeln!(f, "Http status indicates failure: {:?}", response),
+        }
+    }
+}
+
+impl error::Error for Error {
+    fn description(&self) -> &str {
+        match *self {
+            Error::HttpError(ref err) => err.description(),
+            Error::JsonDecodeError(_, ref err) => err.description(),
+            _ => "NO DESCRIPTION POSSIBLE - use `Display.fmt()` instead"
+        }
+    }
+
+    fn cause(&self) -> Option<&error::Error> {
+        match *self {
+            Error::HttpError(ref err) => err.cause(),
+            Error::JsonDecodeError(_, ref err) => err.cause(),
+            _ => None
+        }
+    }
+}
+
+/// A universal result type used as return for all calls.
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Contains information about an API request.
+pub struct MethodInfo {
+    pub id: &'static str,
+    pub http_method: Method,
+}
+
+const BOUNDARY: &'static str = "MDuXWGyeE33QFXGchb2VFWc4Z7945d";
+
+/// Provides a `Read` interface that converts multiple parts into the protocol
+/// identified by [RFC2387](https://tools.ietf.org/html/rfc2387).
+/// **Note**: This implementation is just as rich as it needs to be to perform uploads
+/// to google APIs, and might not be a fully-featured implementation.
+#[derive(Default)]
+pub struct MultiPartReader<'a> {
+    raw_parts: Vec<(Headers, &'a mut Read)>,
+    current_part: Option<(Cursor<Vec<u8>>, &'a mut Read)>,
+    last_part_boundary: Option<Cursor<Vec<u8>>>,
+}
+
+impl<'a> MultiPartReader<'a> {
+
+    /// Reserve memory for exactly the given amount of parts
+    pub fn reserve_exact(&mut self, cap: usize) {
+        self.raw_parts.reserve_exact(cap);
+    }
+
+    /// Add a new part to the queue of parts to be read on the first `read` call.
+    ///
+    /// # Arguments
+    ///
+    /// `headers` - identifying the body of the part. It's similar to the header
+    ///             in an ordinary single-part call, and should thus contain the
+    ///             same information.
+    /// `reader`  - a reader providing the part's body
+    /// `size`    - the amount of bytes provided by the reader. It will be put onto the header as
+    ///             content-size.
+    /// `mime`    - It will be put onto the content type
+    pub fn add_part(&mut self, reader: &'a mut Read, size: u64, mime_type: Mime) -> &mut MultiPartReader<'a> {
+        let mut headers = Headers::new();
+        headers.set(ContentType(mime_type));
+        headers.set(ContentLength(size));
+        self.raw_parts.push((headers, reader));
+        self
+    }
+
+    /// Returns the mime-type representing our multi-part message.
+    /// Use it with the ContentType header.
+    pub fn mime_type(&self) -> Mime {
+        Mime(
+            TopLevel::Multipart,
+            SubLevel::Ext("Related".to_string()),
+            vec![(Attr::Ext("boundary".to_string()), Value::Ext(BOUNDARY.to_string()))],
+        )
+    }
+
+    /// Returns true if we are totally used
+    fn is_depleted(&self) -> bool {
+        self.raw_parts.len() == 0 && self.current_part.is_none() && self.last_part_boundary.is_none()
+    }
+
+    /// Returns true if we are handling our last part
+    fn is_last_part(&self) -> bool {
+        self.raw_parts.len() == 0 && self.current_part.is_some()
+    }
+}
+
+impl<'a> Read for MultiPartReader<'a> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        match (self.raw_parts.len(),
+               self.current_part.is_none(),
+               self.last_part_boundary.is_none()) {
+            (_, _, false) => {
+                let br = self.last_part_boundary.as_mut().unwrap().read(buf).unwrap_or(0);
+                if br < buf.len() {
+                    self.last_part_boundary = None;
+                }
+                return Ok(br)
+            },
+            (0, true, true) => return Ok(0),
+            (n, true, _) if n > 0 => {
+                let (headers, reader) = self.raw_parts.remove(0);
+                let mut c = Cursor::new(Vec::<u8>::new());
+                (write!(&mut c, "{}--{}{}{}{}", LINE_ENDING, BOUNDARY, LINE_ENDING,
+                                                headers, LINE_ENDING)).unwrap();
+                c.seek(SeekFrom::Start(0)).unwrap();
+                self.current_part = Some((c, reader));
+            }
+            _ => {},
+        }
+
+        // read headers as long as possible
+        let (hb, rr) = {
+            let &mut (ref mut c, ref mut reader) = self.current_part.as_mut().unwrap();
+            let b = c.read(buf).unwrap_or(0);
+            (b, reader.read(&mut buf[b..]))
+        };
+
+        match rr {
+            Ok(bytes_read) => {
+                if hb < buf.len() && bytes_read == 0 {
+                    if self.is_last_part() {
+                        // before clearing the last part, we will add the boundary that
+                        // will be written last
+                        self.last_part_boundary = Some(Cursor::new(
+                                                        format!("{}--{}--", LINE_ENDING, BOUNDARY).into_bytes()))
+                    }
+                    // We are depleted - this can trigger the next part to come in
+                    self.current_part = None;
+                }
+                let mut total_bytes_read = hb + bytes_read;
+                while total_bytes_read < buf.len() && !self.is_depleted() {
+                    match self.read(&mut buf[total_bytes_read ..]) {
+                        Ok(br) => total_bytes_read += br,
+                        Err(err) => return Err(err),
+                    }
+                }
+                Ok(total_bytes_read)
+            }
+            Err(err) => {
+                // fail permanently
+                self.current_part = None;
+                self.last_part_boundary = None;
+                self.raw_parts.clear();
+                Err(err)
+            }
+        }
+    }
+}
+
+/// The `X-Upload-Content-Type` header.
+///
+/// Generated via rustc --pretty expanded -Z unstable-options, and manually
+/// processed to be more readable.
+#[derive(PartialEq, Debug, Clone)]
+pub struct XUploadContentType(pub Mime);
+
+impl ::std::ops::Deref for XUploadContentType {
+    type Target = Mime;
+    fn deref<'a>(&'a self) -> &'a Mime { &self.0 }
+}
+impl ::std::ops::DerefMut for XUploadContentType {
+    fn deref_mut<'a>(&'a mut self) -> &'a mut Mime { &mut self.0 }
+}
+impl Header for XUploadContentType {
+    fn header_name() -> &'static str { "X-Upload-Content-Type" }
+    fn parse_header(raw: &[Vec<u8>]) -> hyper::error::Result<Self> {
+        hyper::header::parsing::from_one_raw_str(raw).map(XUploadContentType)
+    }
+}
+impl HeaderFormat for XUploadContentType {
+    fn fmt_header(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        Display::fmt(&**self, f)
+    }
+}
+impl Display for XUploadContentType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(&**self, f)
+    }
+}
+
+#[derive(Clone, PartialEq, Debug)]
+pub struct Chunk {
+    pub first: u64,
+    pub last: u64
+}
+
+impl fmt::Display for Chunk {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        (write!(fmt, "{}-{}", self.first, self.last)).ok();
+        Ok(())
+    }
+}
+
+impl FromStr for Chunk {
+    type Err = &'static str;
+
+    /// NOTE: only implements `%i-%i`, not `*`
+    fn from_str(s: &str) -> std::result::Result<Chunk, &'static str> {
+        let parts: Vec<&str> = s.split('-').collect();
+        if parts.len() != 2 {
+            return Err("Expected two parts: %i-%i")
+        }
+        Ok(
+            Chunk {
+                first: match FromStr::from_str(parts[0]) {
+                    Ok(d) => d,
+                    _ => return Err("Couldn't parse 'first' as digit")
+                },
+                last: match FromStr::from_str(parts[1]) {
+                    Ok(d) => d,
+                    _ => return Err("Couldn't parse 'last' as digit")
+                }
+            }
+        )
+    }
+}
+
+/// Implements the Content-Range header, for serialization only
+#[derive(Clone, PartialEq, Debug)]
+pub struct ContentRange {
+    pub range: Option<Chunk>,
+    pub total_length: u64,
+}
+
+impl Header for ContentRange {
+    fn header_name() -> &'static str {
+        "Content-Range"
+    }
+
+    /// We are not parsable, as parsing is done by the `Range` header
+    fn parse_header(_: &[Vec<u8>]) -> hyper::error::Result<Self> {
+        Err(hyper::error::Error::Method)
+    }
+}
+
+
+impl HeaderFormat for ContentRange {
+    fn fmt_header(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        try!(fmt.write_str("bytes "));
+        match self.range {
+            Some(ref c) => try!(c.fmt(fmt)),
+            None => try!(fmt.write_str("*"))
+        }
+        (write!(fmt, "/{}", self.total_length)).ok();
+        Ok(())
+    }
+}
+
+#[derive(Clone, PartialEq, Debug)]
+pub struct RangeResponseHeader(pub Chunk);
+
+impl Header for RangeResponseHeader {
+    fn header_name() -> &'static str {
+        "Range"
+    }
+
+    fn parse_header(raw: &[Vec<u8>]) -> hyper::error::Result<Self> {
+        if raw.len() > 0 {
+            let v = &raw[0];
+            if let Ok(s) = std::str::from_utf8(v) {
+                const PREFIX: &'static str = "bytes ";
+                if s.starts_with(PREFIX) {
+                    if let Ok(c) = <Chunk as FromStr>::from_str(&s[PREFIX.len()..]) {
+                        return  Ok(RangeResponseHeader(c))
+                    }
+                }
+            }
+        }
+        Err(hyper::error::Error::Method)
+    }
+}
+
+impl HeaderFormat for RangeResponseHeader {
+    /// No implmentation necessary, we just need to parse
+    fn fmt_header(&self, _: &mut fmt::Formatter) -> fmt::Result {
+        Err(fmt::Error)
+    }
+}
+
+/// A utility type to perform a resumable upload from start to end.
+pub struct ResumableUploadHelper<'a, A: 'a> {
+    pub client: &'a mut hyper::client::Client,
+    pub delegate: &'a mut Delegate,
+    pub start_at: Option<u64>,
+    pub auth: &'a mut A,
+    pub user_agent: &'a str,
+    pub auth_header: Authorization<Bearer>,
+    pub url: &'a str,
+    pub reader: &'a mut ReadSeek,
+    pub media_type: Mime,
+    pub content_length: u64
+}
+
+impl<'a, A> ResumableUploadHelper<'a, A>
+    where A: oauth2::GetToken {
+
+    fn query_transfer_status(&mut self) -> std::result::Result<u64, hyper::Result<hyper::client::Response>> {
+        loop {
+            match self.client.post(self.url)
+                .header(UserAgent(self.user_agent.to_string()))
+                .header(ContentRange { range: None, total_length: self.content_length })
+                .header(self.auth_header.clone())
+                .send() {
+                Ok(r) => {
+                    // 308 = resume-incomplete == PermanentRedirect
+                    let headers = r.headers.clone();
+                    let h: &RangeResponseHeader = match headers.get() {
+                        Some(hh) if r.status == StatusCode::PermanentRedirect => hh,
+                        None|Some(_) => {
+                            if let Retry::After(d) = self.delegate.http_failure(&r, None, None) {
+                                sleep(d);
+                                continue;
+                            }
+                            return Err(Ok(r))
+                        }
+                    };
+                    return Ok(h.0.last)
+                }
+                Err(err) => {
+                    if let Retry::After(d) = self.delegate.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    return Err(Err(err))
+                }
+            }
+        }
+    }
+
+    /// returns None if operation was cancelled by delegate, or the HttpResult.
+    /// It can be that we return the result just because we didn't understand the status code -
+    /// caller should check for status himself before assuming it's OK to use
+    pub fn upload(&mut self) -> Option<hyper::Result<hyper::client::Response>> {
+        let mut start = match self.start_at {
+            Some(s) => s,
+            None => match self.query_transfer_status() {
+                Ok(s) => s,
+                Err(result) => return Some(result)
+            }
+        };
+
+        const MIN_CHUNK_SIZE: u64 = 1 << 18;
+        let chunk_size = match self.delegate.chunk_size() {
+            cs if cs > MIN_CHUNK_SIZE => cs,
+            _ => MIN_CHUNK_SIZE
+        };
+
+        self.reader.seek(SeekFrom::Start(start)).unwrap();
+        loop {
+            let request_size = match self.content_length - start {
+                rs if rs > chunk_size => chunk_size,
+                rs => rs
+            };
+
+            let mut section_reader = self.reader.take(request_size);
+            let range_header = ContentRange {
+                range: Some(Chunk {first: start, last: start + request_size - 1}),
+                total_length: self.content_length
+            };
+            start += request_size;
+            if self.delegate.cancel_chunk_upload(&range_header) {
+                return None
+            }
+            let res = self.client.post(self.url)
+                                 .header(range_header)
+                                 .header(ContentType(self.media_type.clone()))
+                                 .header(UserAgent(self.user_agent.to_string()))
+                                 .body(&mut section_reader)
+                                 .send();
+            match res {
+                Ok(mut res) => {
+                    if res.status == StatusCode::PermanentRedirect  {
+                        continue
+                    }
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let Retry::After(d) = self.delegate.http_failure(&res,
+                                                        json::from_str(&json_err).ok(),
+                                                        json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                    }
+                    return Some(Ok(res))
+                },
+                Err(err) => {
+                    if let Retry::After(d) = self.delegate.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    return Some(Err(err))
+                }
+            }
+        }
+    }
+}
+
+// Copy of src/rust/cli/cmn.rs
+// TODO(ST): Allow sharing common code between program types
+pub fn remove_json_null_values(value: &mut json::value::Value) {
+    match *value {
+        json::value::Value::Object(ref mut map) => {
+            let mut for_removal = Vec::new();
+
+            for (key, mut value) in map.iter_mut() {
+                if value.is_null() {
+                    for_removal.push(key.clone());
+                } else {
+                    remove_json_null_values(&mut value);
+                }
+            }
+
+            for key in &for_removal {
+                map.remove(key);
+            }
+        }
+        _ => {}
+    }
+}

--- a/gen/cloudtrace2/src/lib.rs
+++ b/gen/cloudtrace2/src/lib.rs
@@ -1,0 +1,1530 @@
+// DO NOT EDIT !
+// This file was generated automatically from 'src/mako/api/lib.rs.mako'
+// DO NOT EDIT !
+
+//! This documentation was generated from *Cloud Trace* crate version *1.0.7+20171202*, where *20171202* is the exact revision of the *cloudtrace:v2* schema built by the [mako](http://www.makotemplates.org/) code generator *v1.0.7*.
+//! 
+//! Everything else about the *Cloud Trace* *v2* API can be found at the
+//! [official documentation site](https://cloud.google.com/trace).
+//! The original source code is [on github](https://github.com/Byron/google-apis-rs/tree/master/gen/cloudtrace2).
+//! # Features
+//! 
+//! Handle the following *Resources* with ease from the central [hub](struct.CloudTrace.html) ... 
+//! 
+//! * projects
+//!  * [*traces batch write*](struct.ProjectTraceBatchWriteCall.html) and [*traces spans create*](struct.ProjectTraceSpanCreateCall.html)
+//! 
+//! 
+//! 
+//! 
+//! Not what you are looking for ? Find all other Google APIs in their Rust [documentation index](http://byron.github.io/google-apis-rs).
+//! 
+//! # Structure of this Library
+//! 
+//! The API is structured into the following primary items:
+//! 
+//! * **[Hub](struct.CloudTrace.html)**
+//!     * a central object to maintain state and allow accessing all *Activities*
+//!     * creates [*Method Builders*](trait.MethodsBuilder.html) which in turn
+//!       allow access to individual [*Call Builders*](trait.CallBuilder.html)
+//! * **[Resources](trait.Resource.html)**
+//!     * primary types that you can apply *Activities* to
+//!     * a collection of properties and *Parts*
+//!     * **[Parts](trait.Part.html)**
+//!         * a collection of properties
+//!         * never directly used in *Activities*
+//! * **[Activities](trait.CallBuilder.html)**
+//!     * operations to apply to *Resources*
+//! 
+//! All *structures* are marked with applicable traits to further categorize them and ease browsing.
+//! 
+//! Generally speaking, you can invoke *Activities* like this:
+//! 
+//! ```Rust,ignore
+//! let r = hub.resource().activity(...).doit()
+//! ```
+//! 
+//! Or specifically ...
+//! 
+//! ```ignore
+//! let r = hub.projects().traces_spans_create(...).doit()
+//! ```
+//! 
+//! The `resource()` and `activity(...)` calls create [builders][builder-pattern]. The second one dealing with `Activities` 
+//! supports various methods to configure the impending operation (not shown here). It is made such that all required arguments have to be 
+//! specified right away (i.e. `(...)`), whereas all optional ones can be [build up][builder-pattern] as desired.
+//! The `doit()` method performs the actual communication with the server and returns the respective result.
+//! 
+//! # Usage
+//! 
+//! ## Setting up your Project
+//! 
+//! To use this library, you would put the following lines into your `Cargo.toml` file:
+//! 
+//! ```toml
+//! [dependencies]
+//! google-cloudtrace2 = "*"
+//! ```
+//! 
+//! ## A complete example
+//! 
+//! ```test_harness,no_run
+//! extern crate hyper;
+//! extern crate hyper_rustls;
+//! extern crate yup_oauth2 as oauth2;
+//! extern crate google_cloudtrace2 as cloudtrace2;
+//! use cloudtrace2::Span;
+//! use cloudtrace2::{Result, Error};
+//! # #[test] fn egal() {
+//! use std::default::Default;
+//! use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+//! use cloudtrace2::CloudTrace;
+//! 
+//! // Get an ApplicationSecret instance by some means. It contains the `client_id` and 
+//! // `client_secret`, among other things.
+//! let secret: ApplicationSecret = Default::default();
+//! // Instantiate the authenticator. It will choose a suitable authentication flow for you, 
+//! // unless you replace  `None` with the desired Flow.
+//! // Provide your own `AuthenticatorDelegate` to adjust the way it operates and get feedback about 
+//! // what's going on. You probably want to bring in your own `TokenStorage` to persist tokens and
+//! // retrieve them from storage.
+//! let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+//!                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+//!                               <MemoryStorage as Default>::default(), None);
+//! let mut hub = CloudTrace::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+//! // As the method needs a request, you would usually fill it with the desired information
+//! // into the respective structure. Some of the parts shown here might not be applicable !
+//! // Values shown here are possibly random and not representative !
+//! let mut req = Span::default();
+//! 
+//! // You can configure optional parameters by calling the respective setters at will, and
+//! // execute the final call using `doit()`.
+//! // Values shown here are possibly random and not representative !
+//! let result = hub.projects().traces_spans_create(req, "name")
+//!              .doit();
+//! 
+//! match result {
+//!     Err(e) => match e {
+//!         // The Error enum provides details about what exactly happened.
+//!         // You can also just use its `Debug`, `Display` or `Error` traits
+//!          Error::HttpError(_)
+//!         |Error::MissingAPIKey
+//!         |Error::MissingToken(_)
+//!         |Error::Cancelled
+//!         |Error::UploadSizeLimitExceeded(_, _)
+//!         |Error::Failure(_)
+//!         |Error::BadRequest(_)
+//!         |Error::FieldClash(_)
+//!         |Error::JsonDecodeError(_, _) => println!("{}", e),
+//!     },
+//!     Ok(res) => println!("Success: {:?}", res),
+//! }
+//! # }
+//! ```
+//! ## Handling Errors
+//! 
+//! All errors produced by the system are provided either as [Result](enum.Result.html) enumeration as return value of 
+//! the doit() methods, or handed as possibly intermediate results to either the 
+//! [Hub Delegate](trait.Delegate.html), or the [Authenticator Delegate](https://docs.rs/yup-oauth2/*/yup_oauth2/trait.AuthenticatorDelegate.html).
+//! 
+//! When delegates handle errors or intermediate values, they may have a chance to instruct the system to retry. This 
+//! makes the system potentially resilient to all kinds of errors.
+//! 
+//! ## Uploads and Downloads
+//! If a method supports downloads, the response body, which is part of the [Result](enum.Result.html), should be
+//! read by you to obtain the media.
+//! If such a method also supports a [Response Result](trait.ResponseResult.html), it will return that by default.
+//! You can see it as meta-data for the actual media. To trigger a media download, you will have to set up the builder by making
+//! this call: `.param("alt", "media")`.
+//! 
+//! Methods supporting uploads can do so using up to 2 different protocols: 
+//! *simple* and *resumable*. The distinctiveness of each is represented by customized 
+//! `doit(...)` methods, which are then named `upload(...)` and `upload_resumable(...)` respectively.
+//! 
+//! ## Customization and Callbacks
+//! 
+//! You may alter the way an `doit()` method is called by providing a [delegate](trait.Delegate.html) to the 
+//! [Method Builder](trait.CallBuilder.html) before making the final `doit()` call. 
+//! Respective methods will be called to provide progress information, as well as determine whether the system should 
+//! retry on failure.
+//! 
+//! The [delegate trait](trait.Delegate.html) is default-implemented, allowing you to customize it with minimal effort.
+//! 
+//! ## Optional Parts in Server-Requests
+//! 
+//! All structures provided by this library are made to be [enocodable](trait.RequestValue.html) and 
+//! [decodable](trait.ResponseResult.html) via *json*. Optionals are used to indicate that partial requests are responses 
+//! are valid.
+//! Most optionals are are considered [Parts](trait.Part.html) which are identifiable by name, which will be sent to 
+//! the server to indicate either the set parts of the request or the desired parts in the response.
+//! 
+//! ## Builder Arguments
+//! 
+//! Using [method builders](trait.CallBuilder.html), you are able to prepare an action call by repeatedly calling it's methods.
+//! These will always take a single argument, for which the following statements are true.
+//! 
+//! * [PODs][wiki-pod] are handed by copy
+//! * strings are passed as `&str`
+//! * [request values](trait.RequestValue.html) are moved
+//! 
+//! Arguments will always be copied or cloned into the builder, to make them independent of their original life times.
+//! 
+//! [wiki-pod]: http://en.wikipedia.org/wiki/Plain_old_data_structure
+//! [builder-pattern]: http://en.wikipedia.org/wiki/Builder_pattern
+//! [google-go-api]: https://github.com/google/google-api-go-client
+//! 
+//! 
+
+// Unused attributes happen thanks to defined, but unused structures
+// We don't warn about this, as depending on the API, some data structures or facilities are never used.
+// Instead of pre-determining this, we just disable the lint. It's manually tuned to not have any
+// unused imports in fully featured APIs. Same with unused_mut ... .
+#![allow(unused_imports, unused_mut, dead_code)]
+
+// DO NOT EDIT !
+// This file was generated automatically from 'src/mako/api/lib.rs.mako'
+// DO NOT EDIT !
+
+#[macro_use]
+extern crate serde_derive;
+
+extern crate hyper;
+extern crate serde;
+extern crate serde_json;
+extern crate yup_oauth2 as oauth2;
+extern crate mime;
+extern crate url;
+
+mod cmn;
+
+use std::collections::HashMap;
+use std::cell::RefCell;
+use std::borrow::BorrowMut;
+use std::default::Default;
+use std::collections::BTreeMap;
+use serde_json as json;
+use std::io;
+use std::fs;
+use std::mem;
+use std::thread::sleep;
+use std::time::Duration;
+
+pub use cmn::{MultiPartReader, ToParts, MethodInfo, Result, Error, CallBuilder, Hub, ReadSeek, Part,
+              ResponseResult, RequestValue, NestedType, Delegate, DefaultDelegate, MethodsBuilder,
+              Resource, ErrorResponse, remove_json_null_values};
+
+
+// ##############
+// UTILITIES ###
+// ############
+
+/// Identifies the an OAuth2 authorization scope.
+/// A scope is needed when requesting an
+/// [authorization token](https://developers.google.com/youtube/v3/guides/authentication).
+#[derive(PartialEq, Eq, Hash)]
+pub enum Scope {
+    /// View and manage your data across Google Cloud Platform services
+    CloudPlatform,
+
+    /// Write Trace data for a project or application
+    TraceAppend,
+}
+
+impl AsRef<str> for Scope {
+    fn as_ref(&self) -> &str {
+        match *self {
+            Scope::CloudPlatform => "https://www.googleapis.com/auth/cloud-platform",
+            Scope::TraceAppend => "https://www.googleapis.com/auth/trace.append",
+        }
+    }
+}
+
+impl Default for Scope {
+    fn default() -> Scope {
+        Scope::TraceAppend
+    }
+}
+
+
+
+// ########
+// HUB ###
+// ######
+
+/// Central instance to access all CloudTrace related resource activities
+///
+/// # Examples
+///
+/// Instantiate a new hub
+///
+/// ```test_harness,no_run
+/// extern crate hyper;
+/// extern crate hyper_rustls;
+/// extern crate yup_oauth2 as oauth2;
+/// extern crate google_cloudtrace2 as cloudtrace2;
+/// use cloudtrace2::Span;
+/// use cloudtrace2::{Result, Error};
+/// # #[test] fn egal() {
+/// use std::default::Default;
+/// use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// use cloudtrace2::CloudTrace;
+/// 
+/// // Get an ApplicationSecret instance by some means. It contains the `client_id` and 
+/// // `client_secret`, among other things.
+/// let secret: ApplicationSecret = Default::default();
+/// // Instantiate the authenticator. It will choose a suitable authentication flow for you, 
+/// // unless you replace  `None` with the desired Flow.
+/// // Provide your own `AuthenticatorDelegate` to adjust the way it operates and get feedback about 
+/// // what's going on. You probably want to bring in your own `TokenStorage` to persist tokens and
+/// // retrieve them from storage.
+/// let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+///                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+///                               <MemoryStorage as Default>::default(), None);
+/// let mut hub = CloudTrace::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = Span::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.projects().traces_spans_create(req, "name")
+///              .doit();
+/// 
+/// match result {
+///     Err(e) => match e {
+///         // The Error enum provides details about what exactly happened.
+///         // You can also just use its `Debug`, `Display` or `Error` traits
+///          Error::HttpError(_)
+///         |Error::MissingAPIKey
+///         |Error::MissingToken(_)
+///         |Error::Cancelled
+///         |Error::UploadSizeLimitExceeded(_, _)
+///         |Error::Failure(_)
+///         |Error::BadRequest(_)
+///         |Error::FieldClash(_)
+///         |Error::JsonDecodeError(_, _) => println!("{}", e),
+///     },
+///     Ok(res) => println!("Success: {:?}", res),
+/// }
+/// # }
+/// ```
+pub struct CloudTrace<C, A> {
+    client: RefCell<C>,
+    auth: RefCell<A>,
+    _user_agent: String,
+    _base_url: String,
+    _root_url: String,
+}
+
+impl<'a, C, A> Hub for CloudTrace<C, A> {}
+
+impl<'a, C, A> CloudTrace<C, A>
+    where  C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+    pub fn new(client: C, authenticator: A) -> CloudTrace<C, A> {
+        CloudTrace {
+            client: RefCell::new(client),
+            auth: RefCell::new(authenticator),
+            _user_agent: "google-api-rust-client/1.0.7".to_string(),
+            _base_url: "https://cloudtrace.googleapis.com/".to_string(),
+            _root_url: "https://cloudtrace.googleapis.com/".to_string(),
+        }
+    }
+
+    pub fn projects(&'a self) -> ProjectMethods<'a, C, A> {
+        ProjectMethods { hub: &self }
+    }
+
+    /// Set the user-agent header field to use in all requests to the server.
+    /// It defaults to `google-api-rust-client/1.0.7`.
+    ///
+    /// Returns the previously set user-agent.
+    pub fn user_agent(&mut self, agent_name: String) -> String {
+        mem::replace(&mut self._user_agent, agent_name)
+    }
+
+    /// Set the base url to use in all requests to the server.
+    /// It defaults to `https://cloudtrace.googleapis.com/`.
+    ///
+    /// Returns the previously set base url.
+    pub fn base_url(&mut self, new_base_url: String) -> String {
+        mem::replace(&mut self._base_url, new_base_url)
+    }
+
+    /// Set the root url to use in all requests to the server.
+    /// It defaults to `https://cloudtrace.googleapis.com/`.
+    ///
+    /// Returns the previously set root url.
+    pub fn root_url(&mut self, new_root_url: String) -> String {
+        mem::replace(&mut self._root_url, new_root_url)
+    }
+}
+
+
+// ############
+// SCHEMAS ###
+// ##########
+/// A call stack appearing in a trace.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct StackTrace {
+    /// The hash ID is used to conserve network bandwidth for duplicate
+    /// stack traces within a single trace.
+    /// 
+    /// Often multiple spans will have identical stack traces.
+    /// The first occurrence of a stack trace should contain both the
+    /// `stackFrame` content and a value in `stackTraceHashId`.
+    /// 
+    /// Subsequent spans within the same request can refer
+    /// to that stack trace by only setting `stackTraceHashId`.
+    #[serde(rename="stackTraceHashId")]
+    pub stack_trace_hash_id: Option<String>,
+    /// Stack frames in this stack trace. A maximum of 128 frames are allowed.
+    #[serde(rename="stackFrames")]
+    pub stack_frames: Option<StackFrames>,
+}
+
+impl Part for StackTrace {}
+
+
+/// A span represents a single operation within a trace. Spans can be
+/// nested to form a trace tree. Often, a trace contains a root span
+/// that describes the end-to-end latency, and one or more subspans for
+/// its sub-operations. A trace can also contain multiple root spans,
+/// or none at all. Spans do not need to be contiguous&mdash;there may be
+/// gaps or overlaps between spans in a trace.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [traces spans create projects](struct.ProjectTraceSpanCreateCall.html) (request|response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Span {
+    /// An optional final status for this span.
+    pub status: Option<Status>,
+    /// An optional number of child spans that were generated while this span
+    /// was active. If set, allows implementation to detect missing child spans.
+    #[serde(rename="childSpanCount")]
+    pub child_span_count: Option<i32>,
+    /// A description of the span's operation (up to 128 bytes).
+    /// Stackdriver Trace displays the description in the
+    /// {% dynamic print site_values.console_name %}.
+    /// For example, the display name can be a qualified method name or a file name
+    /// and a line number where the operation is called. A best practice is to use
+    /// the same display name within an application and at the same call point.
+    /// This makes it easier to correlate spans in different traces.
+    #[serde(rename="displayName")]
+    pub display_name: Option<TruncatableString>,
+    /// The resource name of the span in the following format:
+    /// 
+    ///     projects/[PROJECT_ID]/traces/[TRACE_ID]/spans/SPAN_ID is a unique identifier for a trace within a project;
+    /// it is a 32-character hexadecimal encoding of a 16-byte array.
+    /// 
+    /// [SPAN_ID] is a unique identifier for a span within a trace; it
+    /// is a 16-character hexadecimal encoding of an 8-byte array.
+    pub name: Option<String>,
+    /// Links associated with the span. You can have up to 128 links per Span.
+    pub links: Option<Links>,
+    /// Stack trace captured at the start of the span.
+    #[serde(rename="stackTrace")]
+    pub stack_trace: Option<StackTrace>,
+    /// The [SPAN_ID] of this span's parent span. If this is a root span,
+    /// then this field must be empty.
+    #[serde(rename="parentSpanId")]
+    pub parent_span_id: Option<String>,
+    /// The start time of the span. On the client side, this is the time kept by
+    /// the local machine where the span execution starts. On the server side, this
+    /// is the time when the server's application handler starts running.
+    #[serde(rename="startTime")]
+    pub start_time: Option<String>,
+    /// A set of attributes on the span. You can have up to 32 attributes per
+    /// span.
+    pub attributes: Option<Attributes>,
+    /// The [SPAN_ID] portion of the span's resource name.
+    #[serde(rename="spanId")]
+    pub span_id: Option<String>,
+    /// A set of time events. You can have up to 32 annotations and 128 message
+    /// events per span.
+    #[serde(rename="timeEvents")]
+    pub time_events: Option<TimeEvents>,
+    /// The end time of the span. On the client side, this is the time kept by
+    /// the local machine where the span execution ends. On the server side, this
+    /// is the time when the server application handler stops running.
+    #[serde(rename="endTime")]
+    pub end_time: Option<String>,
+    /// (Optional) Set this parameter to indicate whether this span is in
+    /// the same process as its parent. If you do not set this parameter,
+    /// Stackdriver Trace is unable to take advantage of this helpful
+    /// information.
+    #[serde(rename="sameProcessAsParentSpan")]
+    pub same_process_as_parent_span: Option<bool>,
+}
+
+impl RequestValue for Span {}
+impl ResponseResult for Span {}
+
+
+/// Represents a single stack frame in a stack trace.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct StackFrame {
+    /// The version of the deployed source code (up to 128 bytes).
+    #[serde(rename="sourceVersion")]
+    pub source_version: Option<TruncatableString>,
+    /// The column number where the function call appears, if available.
+    /// This is important in JavaScript because of its anonymous functions.
+    #[serde(rename="columnNumber")]
+    pub column_number: Option<String>,
+    /// The fully-qualified name that uniquely identifies the function or
+    /// method that is active in this frame (up to 1024 bytes).
+    #[serde(rename="functionName")]
+    pub function_name: Option<TruncatableString>,
+    /// The binary module from where the code was loaded.
+    #[serde(rename="loadModule")]
+    pub load_module: Option<Module>,
+    /// The line number in `file_name` where the function call appears.
+    #[serde(rename="lineNumber")]
+    pub line_number: Option<String>,
+    /// An un-mangled function name, if `function_name` is
+    /// [mangled](http://www.avabodh.com/cxxin/namemangling.html). The name can
+    /// be fully-qualified (up to 1024 bytes).
+    #[serde(rename="originalFunctionName")]
+    pub original_function_name: Option<TruncatableString>,
+    /// The name of the source file where the function call appears (up to 256
+    /// bytes).
+    #[serde(rename="fileName")]
+    pub file_name: Option<TruncatableString>,
+}
+
+impl Part for StackFrame {}
+
+
+/// Represents a string that might be shortened to a specified length.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct TruncatableString {
+    /// The shortened string. For example, if the original string is 500
+    /// bytes long and the limit of the string is 128 bytes, then
+    /// `value` contains the first 128 bytes of the 500-byte string.
+    /// 
+    /// Truncation always happens on a UTF8 character boundary. If there
+    /// are multi-byte characters in the string, then the length of the
+    /// shortened string might be less than the size limit.
+    pub value: Option<String>,
+    /// The number of bytes removed from the original string. If this
+    /// value is 0, then the string was not shortened.
+    #[serde(rename="truncatedByteCount")]
+    pub truncated_byte_count: Option<i32>,
+}
+
+impl Part for TruncatableString {}
+
+
+/// A set of attributes, each in the format `[KEY]:[VALUE]`.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Attributes {
+    /// The number of attributes that were discarded. Attributes can be discarded
+    /// because their keys are too long or because there are too many attributes.
+    /// If this value is 0 then all attributes are valid.
+    #[serde(rename="droppedAttributesCount")]
+    pub dropped_attributes_count: Option<i32>,
+    /// The set of attributes. Each attribute's key can be up to 128 bytes
+    /// long. The value can be a string up to 256 bytes, an integer, or the
+    /// Boolean values `true` and `false`. For example:
+    /// 
+    ///     "/instance_id": "my-instance"
+    ///     "/http/user_agent": ""
+    ///     "/http/request_bytes": 300
+    ///     "abc.com/myattribute": true
+    #[serde(rename="attributeMap")]
+    pub attribute_map: Option<HashMap<String, AttributeValue>>,
+}
+
+impl Part for Attributes {}
+
+
+/// A collection of `TimeEvent`s. A `TimeEvent` is a time-stamped annotation
+/// on the span, consisting of either user-supplied key:value pairs, or
+/// details of a message sent/received between Spans.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct TimeEvents {
+    /// The number of dropped message events in all the included time events.
+    /// If the value is 0, then no message events were dropped.
+    #[serde(rename="droppedMessageEventsCount")]
+    pub dropped_message_events_count: Option<i32>,
+    /// A collection of `TimeEvent`s.
+    #[serde(rename="timeEvent")]
+    pub time_event: Option<Vec<TimeEvent>>,
+    /// The number of dropped annotations in all the included time events.
+    /// If the value is 0, then no annotations were dropped.
+    #[serde(rename="droppedAnnotationsCount")]
+    pub dropped_annotations_count: Option<i32>,
+}
+
+impl Part for TimeEvents {}
+
+
+/// An event describing a message sent/received between Spans.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct MessageEvent {
+    /// The number of uncompressed bytes sent or received.
+    #[serde(rename="uncompressedSizeBytes")]
+    pub uncompressed_size_bytes: Option<String>,
+    /// Type of MessageEvent. Indicates whether the message was sent or
+    /// received.
+    #[serde(rename="type")]
+    pub type_: Option<String>,
+    /// An identifier for the MessageEvent's message that can be used to match
+    /// SENT and RECEIVED MessageEvents. It is recommended to be unique within
+    /// a Span.
+    pub id: Option<String>,
+    /// The number of compressed bytes sent or received. If missing assumed to
+    /// be the same size as uncompressed.
+    #[serde(rename="compressedSizeBytes")]
+    pub compressed_size_bytes: Option<String>,
+}
+
+impl Part for MessageEvent {}
+
+
+/// The request message for the `BatchWriteSpans` method.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [traces batch write projects](struct.ProjectTraceBatchWriteCall.html) (request)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct BatchWriteSpansRequest {
+    /// A list of new spans. The span names must not match existing
+    /// spans, or the results are undefined.
+    pub spans: Option<Vec<Span>>,
+}
+
+impl RequestValue for BatchWriteSpansRequest {}
+
+
+/// A generic empty message that you can re-use to avoid defining duplicated
+/// empty messages in your APIs. A typical example is to use it as the request
+/// or the response type of an API method. For instance:
+/// 
+///     service Foo {
+///       rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
+///     }
+/// 
+/// The JSON representation for `Empty` is empty JSON object `{}`.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [traces batch write projects](struct.ProjectTraceBatchWriteCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Empty { _never_set: Option<bool> }
+
+impl ResponseResult for Empty {}
+
+
+/// The `Status` type defines a logical error model that is suitable for different
+/// programming environments, including REST APIs and RPC APIs. It is used by
+/// [gRPC](https://github.com/grpc). The error model is designed to be:
+/// 
+/// - Simple to use and understand for most users
+/// - Flexible enough to meet unexpected needs
+/// 
+/// # Overview
+/// 
+/// The `Status` message contains three pieces of data: error code, error message,
+/// and error details. The error code should be an enum value of
+/// google.rpc.Code, but it may accept additional error codes if needed.  The
+/// error message should be a developer-facing English message that helps
+/// developers *understand* and *resolve* the error. If a localized user-facing
+/// error message is needed, put the localized message in the error details or
+/// localize it in the client. The optional error details may contain arbitrary
+/// information about the error. There is a predefined set of error detail types
+/// in the package `google.rpc` that can be used for common error conditions.
+/// 
+/// # Language mapping
+/// 
+/// The `Status` message is the logical representation of the error model, but it
+/// is not necessarily the actual wire format. When the `Status` message is
+/// exposed in different client libraries and different wire protocols, it can be
+/// mapped differently. For example, it will likely be mapped to some exceptions
+/// in Java, but more likely mapped to some error codes in C.
+/// 
+/// # Other uses
+/// 
+/// The error model and the `Status` message can be used in a variety of
+/// environments, either with or without APIs, to provide a
+/// consistent developer experience across different environments.
+/// 
+/// Example uses of this error model include:
+/// 
+/// - Partial errors. If a service needs to return partial errors to the client,
+///     it may embed the `Status` in the normal response to indicate the partial
+///     errors.
+/// 
+/// - Workflow errors. A typical workflow has multiple steps. Each step may
+///     have a `Status` message for error reporting.
+/// 
+/// - Batch operations. If a client uses batch request and batch response, the
+///     `Status` message should be used directly inside batch response, one for
+///     each error sub-response.
+/// 
+/// - Asynchronous operations. If an API call embeds asynchronous operation
+///     results in its response, the status of those operations should be
+///     represented directly using the `Status` message.
+/// 
+/// - Logging. If some API errors are stored in logs, the message `Status` could
+///     be used directly after any stripping needed for security/privacy reasons.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Status {
+    /// A developer-facing error message, which should be in English. Any
+    /// user-facing error message should be localized and sent in the
+    /// google.rpc.Status.details field, or localized by the client.
+    pub message: Option<String>,
+    /// The status code, which should be an enum value of google.rpc.Code.
+    pub code: Option<i32>,
+    /// A list of messages that carry the error details.  There is a common set of
+    /// message types for APIs to use.
+    pub details: Option<Vec<HashMap<String, String>>>,
+}
+
+impl Part for Status {}
+
+
+/// The allowed types for [VALUE] in a `[KEY]:[VALUE]` attribute.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct AttributeValue {
+    /// A string up to 256 bytes long.
+    #[serde(rename="stringValue")]
+    pub string_value: Option<TruncatableString>,
+    /// A 64-bit signed integer.
+    #[serde(rename="intValue")]
+    pub int_value: Option<String>,
+    /// A Boolean value represented by `true` or `false`.
+    #[serde(rename="boolValue")]
+    pub bool_value: Option<bool>,
+}
+
+impl Part for AttributeValue {}
+
+
+/// A collection of links, which are references from this span to a span
+/// in the same or different trace.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Links {
+    /// The number of dropped links after the maximum size was enforced. If
+    /// this value is 0, then no links were dropped.
+    #[serde(rename="droppedLinksCount")]
+    pub dropped_links_count: Option<i32>,
+    /// A collection of links.
+    pub link: Option<Vec<Link>>,
+}
+
+impl Part for Links {}
+
+
+/// A time-stamped annotation or message event in the Span.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct TimeEvent {
+    /// An event describing a message sent/received between Spans.
+    #[serde(rename="messageEvent")]
+    pub message_event: Option<MessageEvent>,
+    /// Text annotation with a set of attributes.
+    pub annotation: Option<Annotation>,
+    /// The timestamp indicating the time the event occurred.
+    pub time: Option<String>,
+}
+
+impl Part for TimeEvent {}
+
+
+/// A collection of stack frames, which can be truncated.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct StackFrames {
+    /// Stack frames in this call stack.
+    pub frame: Option<Vec<StackFrame>>,
+    /// The number of stack frames that were dropped because there
+    /// were too many stack frames.
+    /// If this value is 0, then no stack frames were dropped.
+    #[serde(rename="droppedFramesCount")]
+    pub dropped_frames_count: Option<i32>,
+}
+
+impl Part for StackFrames {}
+
+
+/// Binary module.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Module {
+    /// A unique identifier for the module, usually a hash of its
+    /// contents (up to 128 bytes).
+    #[serde(rename="buildId")]
+    pub build_id: Option<TruncatableString>,
+    /// For example: main binary, kernel modules, and dynamic libraries
+    /// such as libc.so, sharedlib.so (up to 256 bytes).
+    pub module: Option<TruncatableString>,
+}
+
+impl Part for Module {}
+
+
+/// A pointer from the current span to another span in the same trace or in a
+/// different trace. For example, this can be used in batching operations,
+/// where a single batch handler processes multiple requests from different
+/// traces or when the handler receives a request from a different project.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Link {
+    /// A set of attributes on the link. You have have up to  32 attributes per
+    /// link.
+    pub attributes: Option<Attributes>,
+    /// The [TRACE_ID] for a trace within a project.
+    #[serde(rename="traceId")]
+    pub trace_id: Option<String>,
+    /// The relationship of the current span relative to the linked span.
+    #[serde(rename="type")]
+    pub type_: Option<String>,
+    /// The [SPAN_ID] for a span within a trace.
+    #[serde(rename="spanId")]
+    pub span_id: Option<String>,
+}
+
+impl Part for Link {}
+
+
+/// Text annotation with a set of attributes.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Annotation {
+    /// A set of attributes on the annotation. You can have up to 4 attributes
+    /// per Annotation.
+    pub attributes: Option<Attributes>,
+    /// A user-supplied message describing the event. The maximum length for
+    /// the description is 256 bytes.
+    pub description: Option<TruncatableString>,
+}
+
+impl Part for Annotation {}
+
+
+
+// ###################
+// MethodBuilders ###
+// #################
+
+/// A builder providing access to all methods supported on *project* resources.
+/// It is not used directly, but through the `CloudTrace` hub.
+///
+/// # Example
+///
+/// Instantiate a resource builder
+///
+/// ```test_harness,no_run
+/// extern crate hyper;
+/// extern crate hyper_rustls;
+/// extern crate yup_oauth2 as oauth2;
+/// extern crate google_cloudtrace2 as cloudtrace2;
+/// 
+/// # #[test] fn egal() {
+/// use std::default::Default;
+/// use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// use cloudtrace2::CloudTrace;
+/// 
+/// let secret: ApplicationSecret = Default::default();
+/// let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+///                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+///                               <MemoryStorage as Default>::default(), None);
+/// let mut hub = CloudTrace::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // Usually you wouldn't bind this to a variable, but keep calling *CallBuilders*
+/// // like `traces_batch_write(...)` and `traces_spans_create(...)`
+/// // to build up your call.
+/// let rb = hub.projects();
+/// # }
+/// ```
+pub struct ProjectMethods<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a CloudTrace<C, A>,
+}
+
+impl<'a, C, A> MethodsBuilder for ProjectMethods<'a, C, A> {}
+
+impl<'a, C, A> ProjectMethods<'a, C, A> {
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Creates a new span.
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    /// * `name` - The resource name of the span in the following format:
+    ///                projects/[PROJECT_ID]/traces/[TRACE_ID]/spans/SPAN_ID is a unique identifier for a trace within a project;
+    ///            it is a 32-character hexadecimal encoding of a 16-byte array.
+    ///            [SPAN_ID] is a unique identifier for a span within a trace; it
+    ///            is a 16-character hexadecimal encoding of an 8-byte array.
+    pub fn traces_spans_create(&self, request: Span, name: &str) -> ProjectTraceSpanCreateCall<'a, C, A> {
+        ProjectTraceSpanCreateCall {
+            hub: self.hub,
+            _request: request,
+            _name: name.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Sends new spans to new or existing traces. You cannot update
+    /// existing spans.
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    /// * `name` - Required. The name of the project where the spans belong. The format is
+    ///            `projects/[PROJECT_ID]`.
+    pub fn traces_batch_write(&self, request: BatchWriteSpansRequest, name: &str) -> ProjectTraceBatchWriteCall<'a, C, A> {
+        ProjectTraceBatchWriteCall {
+            hub: self.hub,
+            _request: request,
+            _name: name.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+}
+
+
+
+
+
+// ###################
+// CallBuilders   ###
+// #################
+
+/// Creates a new span.
+///
+/// A builder for the *traces.spans.create* method supported by a *project* resource.
+/// It is not used directly, but through a `ProjectMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_cloudtrace2 as cloudtrace2;
+/// use cloudtrace2::Span;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use cloudtrace2::CloudTrace;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = CloudTrace::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = Span::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.projects().traces_spans_create(req, "name")
+///              .doit();
+/// # }
+/// ```
+pub struct ProjectTraceSpanCreateCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a CloudTrace<C, A>,
+    _request: Span,
+    _name: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for ProjectTraceSpanCreateCall<'a, C, A> {}
+
+impl<'a, C, A> ProjectTraceSpanCreateCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, Span)> {
+        use url::percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "cloudtrace.projects.traces.spans.create",
+                               http_method: hyper::method::Method::Post });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((4 + self._additional_params.len()));
+        params.push(("name", self._name.to_string()));
+        for &field in ["alt", "name"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v2/{+name}/spans";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{+name}", "name")].iter() {
+            let mut replace_with = String::new();
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = value.to_string();
+                    break;
+                }
+            }
+            if find_this.as_bytes()[1] == '+' as u8 {
+                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET);
+            }
+            url = url.replace(find_this, &replace_with);
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["name"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Post, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: Span) -> ProjectTraceSpanCreateCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// The resource name of the span in the following format:
+    /// 
+    ///     projects/[PROJECT_ID]/traces/[TRACE_ID]/spans/SPAN_ID is a unique identifier for a trace within a project;
+    /// it is a 32-character hexadecimal encoding of a 16-byte array.
+    /// 
+    /// [SPAN_ID] is a unique identifier for a span within a trace; it
+    /// is a 16-character hexadecimal encoding of an 8-byte array.
+    ///
+    /// Sets the *name* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn name(mut self, new_value: &str) -> ProjectTraceSpanCreateCall<'a, C, A> {
+        self._name = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> ProjectTraceSpanCreateCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> ProjectTraceSpanCreateCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> ProjectTraceSpanCreateCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Sends new spans to new or existing traces. You cannot update
+/// existing spans.
+///
+/// A builder for the *traces.batchWrite* method supported by a *project* resource.
+/// It is not used directly, but through a `ProjectMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_cloudtrace2 as cloudtrace2;
+/// use cloudtrace2::BatchWriteSpansRequest;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use cloudtrace2::CloudTrace;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = CloudTrace::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = BatchWriteSpansRequest::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.projects().traces_batch_write(req, "name")
+///              .doit();
+/// # }
+/// ```
+pub struct ProjectTraceBatchWriteCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a CloudTrace<C, A>,
+    _request: BatchWriteSpansRequest,
+    _name: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for ProjectTraceBatchWriteCall<'a, C, A> {}
+
+impl<'a, C, A> ProjectTraceBatchWriteCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, Empty)> {
+        use url::percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "cloudtrace.projects.traces.batchWrite",
+                               http_method: hyper::method::Method::Post });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((4 + self._additional_params.len()));
+        params.push(("name", self._name.to_string()));
+        for &field in ["alt", "name"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v2/{+name}/traces:batchWrite";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{+name}", "name")].iter() {
+            let mut replace_with = String::new();
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = value.to_string();
+                    break;
+                }
+            }
+            if find_this.as_bytes()[1] == '+' as u8 {
+                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET);
+            }
+            url = url.replace(find_this, &replace_with);
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["name"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Post, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: BatchWriteSpansRequest) -> ProjectTraceBatchWriteCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// Required. The name of the project where the spans belong. The format is
+    /// `projects/[PROJECT_ID]`.
+    ///
+    /// Sets the *name* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn name(mut self, new_value: &str) -> ProjectTraceBatchWriteCall<'a, C, A> {
+        self._name = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> ProjectTraceBatchWriteCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> ProjectTraceBatchWriteCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> ProjectTraceBatchWriteCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+

--- a/gen/consumersurveys2-cli/Cargo.toml
+++ b/gen/consumersurveys2-cli/Cargo.toml
@@ -1,0 +1,39 @@
+# DO NOT EDIT !
+# This file was generated automatically from 'src/mako/Cargo.toml.mako'
+# DO NOT EDIT !
+[package]
+
+name = "google-consumersurveys2-cli"
+version = "1.0.7+20170407"
+authors = ["Sebastian Thiel <byronimo@gmail.com>"]
+description = "A complete library to interact with Consumer Surveys (protocol v2)"
+repository = "https://github.com/Byron/google-apis-rs/tree/master/gen/consumersurveys2-cli"
+documentation = "http://byron.github.io/google-apis-rs/google_consumersurveys2_cli"
+license = "MIT"
+keywords = ["consumersurveys", "google", "cli"]
+
+[[bin]]
+name = "consumersurveys2"
+
+[dev-dependencies]
+hyper-rustls = "^0.6"
+
+[dependencies]
+hyper = "^ 0.10"
+mime = "^ 0.2.0"
+serde = "^ 1.0"
+serde_json = "^ 1.0"
+serde_derive = "^ 1.0"
+yup-oauth2 = "^ 1.0"
+strsim = "^0.5"
+hyper-rustls = "^0.6"
+yup-hyper-mock = "^2.0"
+clap = "^2.0"
+
+[features]
+
+
+
+[dependencies.google-consumersurveys2]
+path = "../consumersurveys2"
+version = "1.0.7+20170407"

--- a/gen/consumersurveys2-cli/LICENSE.md
+++ b/gen/consumersurveys2-cli/LICENSE.md
@@ -1,0 +1,30 @@
+<!---
+DO NOT EDIT !
+This file was generated automatically from 'src/mako/LICENSE.md.mako'
+DO NOT EDIT !
+-->
+The MIT License (MIT)
+=====================
+
+Copyright © `2015-2016` `Sebastian Thiel`
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the “Software”), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.

--- a/gen/consumersurveys2-cli/README.md
+++ b/gen/consumersurveys2-cli/README.md
@@ -1,0 +1,123 @@
+<!---
+DO NOT EDIT !
+This file was generated automatically from 'src/mako/cli/README.md.mako'
+DO NOT EDIT !
+-->
+The `consumersurveys2` command-line interface *(CLI)* allows to use most features of the *Google Consumer Surveys* service from the comfort of your terminal.
+
+By default all output is printed to standard out, but flags can be set to direct it into a file independent of your shell's
+capabilities. Errors will be printed to standard error, and cause the program's exit code to be non-zero.
+
+If data-structures are requested, these will be returned as pretty-printed JSON, to be useful as input to other tools.
+
+# Installation and Source Code
+
+Install the command-line interface with cargo using:
+
+```bash
+cargo install google-consumersurveys2-cli
+```
+
+Find the source code [on github](https://github.com/Byron/google-apis-rs/tree/master/gen/consumersurveys2-cli).
+
+# Usage
+
+This documentation was generated from the *Consumer Surveys* API at revision *20170407*. The CLI is at version *1.0.7*.
+
+```bash
+consumersurveys2 [options]
+        mobileapppanels
+                get <panel-id> [-p <v>]... [-o <out>]
+                list [-p <v>]... [-o <out>]
+                update <panel-id> (-r <kv>)... [-p <v>]... [-o <out>]
+        results
+                get <survey-url-id> (-r <kv>)... [-p <v>]... [-o <out>]
+        surveys
+                delete <survey-url-id> [-p <v>]... [-o <out>]
+                get <survey-url-id> [-p <v>]... [-o <out>]
+                insert (-r <kv>)... [-p <v>]... [-o <out>]
+                list [-p <v>]... [-o <out>]
+                start <resource-id> (-r <kv>)... [-p <v>]... [-o <out>]
+                stop <resource-id> [-p <v>]... [-o <out>]
+                update <survey-url-id> (-r <kv>)... [-p <v>]... [-o <out>]
+  consumersurveys2 --help
+
+Configuration:
+  [--scope <url>]...
+            Specify the authentication a method should be executed in. Each scope
+            requires the user to grant this application permission to use it.
+            If unset, it defaults to the shortest scope url for a particular method.
+  --config-dir <folder>
+            A directory into which we will store our persistent data. Defaults to
+            a user-writable directory that we will create during the first invocation.
+            [default: ~/.google-service-cli]
+  --debug
+            Output all server communication to standard error. `tx` and `rx` are placed
+            into the same stream.
+  --debug-auth
+            Output all communication related to authentication to standard error. `tx`
+            and `rx` are placed into the same stream.
+
+```
+
+# Configuration
+
+The program will store all persistent data in the `~/.google-service-cli` directory in *JSON* files prefixed with `consumersurveys2-`.  You can change the directory used to store configuration with the `--config-dir` flag on a per-invocation basis.
+
+More information about the various kinds of persistent data are given in the following paragraphs.
+
+# Authentication
+
+Most APIs require a user to authenticate any request. If this is the case, the [scope][scopes] determines the 
+set of permissions granted. The granularity of these is usually no more than *read-only* or *full-access*.
+
+If not set, the system will automatically select the smallest feasible scope, e.g. when invoking a
+method that is read-only, it will ask only for a read-only scope. 
+You may use the `--scope` flag to specify a scope directly. 
+All applicable scopes are documented in the respective method's CLI documentation.
+
+The first time a scope is used, the user is asked for permission. Follow the instructions given 
+by the CLI to grant permissions, or to decline.
+
+If a scope was authenticated by the user, the respective information will be stored as *JSON* in the configuration
+directory, e.g. `~/.google-service-cli/consumersurveys2-token-<scope-hash>.json`. No manual management of these tokens
+is necessary.
+
+To revoke granted authentication, please refer to the [official documentation][revoke-access].
+
+# Application Secrets
+
+In order to allow any application to use Google services, it will need to be registered using the 
+[Google Developer Console][google-dev-console]. APIs the application may use are then enabled for it
+one by one. Most APIs can be used for free and have a daily quota.
+
+To allow more comfortable usage of the CLI without forcing anyone to register an own application, the CLI
+comes with a default application secret that is configured accordingly. This also means that heavy usage
+all around the world may deplete the daily quota.
+
+You can workaround this limitation by putting your own secrets file at this location: 
+`~/.google-service-cli/consumersurveys2-secret.json`, assuming that the required *consumersurveys* API 
+was enabled for it. Such a secret file can be downloaded in the *Google Developer Console* at 
+*APIs & auth -> Credentials -> Download JSON* and used as is.
+
+Learn more about how to setup Google projects and enable APIs using the [official documentation][google-project-new].
+
+
+# Debugging
+
+Even though the CLI does its best to provide usable error messages, sometimes it might be desirable to know
+what exactly led to a particular issue. This is done by allowing all client-server communication to be 
+output to standard error *as-is*.
+
+The `--debug` flag will print all client-server communication to standard error, whereas the `--debug-auth` flag
+will cause all communication related to authentication to standard error.
+If the `--debug` flag is set, error-results will be debug-printed, possibly yielding more information about the 
+issue at hand.
+
+You may consider redirecting standard error into a file for ease of use, e.g. `consumersurveys2 --debug <resource> <method> [options] 2>debug.txt`.
+
+
+[scopes]: https://developers.google.com/+/api/oauth#scopes
+[revoke-access]: http://webapps.stackexchange.com/a/30849
+[google-dev-console]: https://console.developers.google.com/
+[google-project-new]: https://developers.google.com/console/help/new/

--- a/gen/consumersurveys2-cli/mkdocs.yml
+++ b/gen/consumersurveys2-cli/mkdocs.yml
@@ -1,0 +1,27 @@
+site_name: Consumer Surveys v1.0.7+20170407
+site_url: http://byron.github.io/google-apis-rs/google-consumersurveys2-cli
+site_description: A complete library to interact with Consumer Surveys (protocol v2)
+
+repo_url: https://github.com/Byron/google-apis-rs/tree/master/gen/consumersurveys2-cli
+
+docs_dir: docs
+site_dir: build_html
+
+pages:
+- ['index.md', 'Home']
+- ['mobileapppanels_get.md', 'Mobileapppanels', 'Get']
+- ['mobileapppanels_list.md', 'Mobileapppanels', 'List']
+- ['mobileapppanels_update.md', 'Mobileapppanels', 'Update']
+- ['results_get.md', 'Results', 'Get']
+- ['surveys_delete.md', 'Surveys', 'Delete']
+- ['surveys_get.md', 'Surveys', 'Get']
+- ['surveys_insert.md', 'Surveys', 'Insert']
+- ['surveys_list.md', 'Surveys', 'List']
+- ['surveys_start.md', 'Surveys', 'Start']
+- ['surveys_stop.md', 'Surveys', 'Stop']
+- ['surveys_update.md', 'Surveys', 'Update']
+
+theme: readthedocs
+
+copyright: Copyright &copy; 2015-2016, `Sebastian Thiel`
+

--- a/gen/consumersurveys2-cli/src/cmn.rs
+++ b/gen/consumersurveys2-cli/src/cmn.rs
@@ -1,0 +1,799 @@
+// COPY OF 'src/rust/cli/cmn.rs'
+// DO NOT EDIT
+use oauth2::{ApplicationSecret, ConsoleApplicationSecret, TokenStorage, Token};
+use serde_json as json;
+use serde_json::value::Value;
+use mime::Mime;
+use clap::{App, SubCommand};
+use strsim;
+
+use std::fs;
+use std::env;
+use std::io;
+use std::error::Error as StdError;
+use std::fmt;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+use std::string::ToString;
+use std::io::{Write, Read, stdout};
+
+use std::default::Default;
+
+const FIELD_SEP: char = '.';
+
+
+pub enum ComplexType {
+    Pod,
+    Vec,
+    Map,
+}
+
+// Null,
+// Bool(bool),
+// I64(i64),
+// U64(u64),
+// F64(f64),
+// String(String),
+
+pub enum JsonType {
+    Boolean,
+    Int,
+    Uint,
+    Float,
+    String,
+}
+
+pub struct JsonTypeInfo {
+    pub jtype: JsonType,
+    pub ctype: ComplexType,
+}
+
+// Based on @erickt user comment. Thanks for the idea !
+// Remove all keys whose values are null from given value (changed in place)
+pub fn remove_json_null_values(value: &mut Value) {
+    match *value {
+        Value::Object(ref mut map) => {
+            let mut for_removal = Vec::new();
+
+            for (key, mut value) in map.iter_mut() {
+                if value.is_null() {
+                    for_removal.push(key.clone());
+                } else {
+                    remove_json_null_values(&mut value);
+                }
+            }
+
+            for key in &for_removal {
+                map.remove(key);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn did_you_mean<'a>(v: &str, possible_values: &[&'a str]) -> Option<&'a str> {
+
+    let mut candidate: Option<(f64, &str)> = None;
+    for pv in possible_values {
+        let confidence = strsim::jaro_winkler(v, pv);
+        if confidence > 0.8 &&
+           (candidate.is_none() || (candidate.as_ref().unwrap().0 < confidence)) {
+            candidate = Some((confidence, pv));
+        }
+    }
+    match candidate {
+        None => None,
+        Some((_, candidate)) => Some(candidate),
+    }
+}
+
+pub enum CallType {
+    Upload(UploadProtocol),
+    Standard,
+}
+
+arg_enum!{
+    pub enum UploadProtocol {
+        Simple,
+        Resumable
+    }
+}
+
+impl AsRef<str> for UploadProtocol {
+    fn as_ref(&self) -> &str {
+        match *self {
+            UploadProtocol::Simple => "simple",
+            UploadProtocol::Resumable => "resumable",
+        }
+    }
+}
+
+impl AsRef<str> for CallType {
+    fn as_ref(&self) -> &str {
+        match *self {
+            CallType::Upload(ref proto) => proto.as_ref(),
+            CallType::Standard => "standard-request",
+        }
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct FieldCursor(Vec<String>);
+
+impl ToString for  FieldCursor {
+    fn to_string(&self) -> String {
+        self.0.join(".")
+    }
+}
+
+impl From<&'static str> for FieldCursor {
+    fn from(value: &'static str) -> FieldCursor {
+        let mut res = FieldCursor::default();
+        res.set(value).unwrap();
+        res
+    }
+}
+
+fn assure_entry<'a, 'b>(m: &'a mut json::Map<String, Value>, k: &'b String) -> &'a mut Value {
+    if m.contains_key(k) {
+        return m.get_mut(k).expect("value to exist");
+    }
+    m.insert(k.to_owned(), Value::Object(Default::default()));
+    m.get_mut(k).expect("value to exist")
+}
+
+impl FieldCursor {
+    pub fn set(&mut self, value: &str) -> Result<(), CLIError> {
+        if value.len() == 0 {
+            return Err(CLIError::Field(FieldError::Empty));
+        }
+
+        let mut first_is_field_sep = false;
+        let mut char_count: usize = 0;
+        let mut last_c = FIELD_SEP;
+        let mut num_conscutive_field_seps = 0;
+
+        let mut field = String::new();
+        let mut fields = self.0.clone();
+
+        let push_field = |fs: &mut Vec<String>, f: &mut String| {
+            if f.len() > 0 {
+                fs.push(f.clone());
+                f.truncate(0);
+            }
+        };
+
+        for (cid, c) in value.chars().enumerate() {
+            char_count += 1;
+
+            if c == FIELD_SEP {
+                if cid == 0 {
+                    first_is_field_sep = true;
+                }
+                num_conscutive_field_seps += 1;
+                if cid > 0 && last_c == FIELD_SEP {
+                    if fields.pop().is_none() {
+                        return Err(CLIError::Field(FieldError::PopOnEmpty(value.to_string())));
+                    }
+                } else {
+                    push_field(&mut fields, &mut field);
+                }
+            } else {
+                num_conscutive_field_seps = 0;
+                if cid == 1 {
+                    if first_is_field_sep {
+                        fields.truncate(0);
+                    }
+                }
+                field.push(c);
+            }
+
+            last_c = c;
+        }
+
+        push_field(&mut fields, &mut field);
+
+        if char_count == 1 && first_is_field_sep {
+            fields.truncate(0);
+        }
+        if char_count > 1 && num_conscutive_field_seps == 1 {
+            return Err(CLIError::Field(FieldError::TrailingFieldSep(value.to_string())));
+        }
+
+        self.0 = fields;
+        Ok(())
+    }
+
+    pub fn did_you_mean(value: &str, possible_values: &[&str]) -> Option<String> {
+        if value.len() == 0 {
+            return None;
+        }
+
+        let mut last_c = FIELD_SEP;
+
+        let mut field = String::new();
+        let mut output = String::new();
+
+        let push_field = |fs: &mut String, f: &mut String| {
+            if f.len() > 0 {
+                fs.push_str(match did_you_mean(&f, possible_values) {
+                    Some(candidate) => candidate,
+                    None => &f,
+                });
+                f.truncate(0);
+            }
+        };
+
+        for (cid, c) in value.chars().enumerate() {
+            if c == FIELD_SEP {
+                if last_c != FIELD_SEP {
+                    push_field(&mut output, &mut field);
+                }
+                output.push(c);
+            } else {
+                field.push(c);
+            }
+
+            last_c = c;
+        }
+
+        push_field(&mut output, &mut field);
+
+        if &output == value {
+            None
+        } else {
+            Some(output)
+        }
+    }
+
+    pub fn set_json_value(&self,
+                          mut object: &mut Value,
+                          value: &str,
+                          type_info: JsonTypeInfo,
+                          err: &mut InvalidOptionsError,
+                          orig_cursor: &FieldCursor) {
+        assert!(self.0.len() > 0);
+
+        for field in &self.0[..self.0.len() - 1] {
+            let tmp = object;
+            object = match *tmp {
+                Value::Object(ref mut mapping) => {
+                    assure_entry(mapping, &field)
+                }
+                _ => panic!("We don't expect non-object Values here ..."),
+            };
+        }
+
+        match *object {
+            Value::Object(ref mut mapping) => {
+                let field = &self.0[self.0.len() - 1];
+                let to_jval = |value: &str,
+                               jtype: JsonType,
+                               err: &mut InvalidOptionsError|
+                               -> Value {
+                    match jtype {
+                        JsonType::Boolean =>
+                            Value::Bool(arg_from_str(value, err, &field, "boolean")),
+                        JsonType::Int =>
+                            Value::Number(json::Number::from_f64(arg_from_str(value,
+                                                                              err,
+                                                                              &field,
+                                                                              "int"))
+                                              .expect("valid f64")),
+                        JsonType::Uint =>
+                            Value::Number(json::Number::from_f64(arg_from_str(value,
+                                                                              err,
+                                                                              &field,
+                                                                              "uint"))
+                                              .expect("valid f64")),
+                        JsonType::Float =>
+                            Value::Number(json::Number::from_f64(arg_from_str(value,
+                                                                              err,
+                                                                              &field,
+                                                                              "float"))
+                                              .expect("valid f64")),
+                        JsonType::String => Value::String(value.to_owned()),
+                    }
+                };
+
+                match type_info.ctype {
+                    ComplexType::Pod => {
+                        if mapping.insert(field.to_owned(), to_jval(value, type_info.jtype, err))
+                                  .is_some() {
+                            err.issues.push(CLIError::Field(FieldError::Duplicate(orig_cursor.to_string())));
+                        }
+                    }
+                    ComplexType::Vec => {
+                        match *assure_entry(mapping, field) {
+                            Value::Array(ref mut values) =>
+                                values.push(to_jval(value, type_info.jtype, err)),
+                            _ => unreachable!(),
+                        }
+                    }
+                    ComplexType::Map => {
+                        let (key, value) = parse_kv_arg(value, err, true);
+                        let jval = to_jval(value.unwrap_or(""), type_info.jtype, err);
+
+                        match *assure_entry(mapping, &field) {
+
+                            Value::Object(ref mut value_map) => {
+                                if value_map.insert(key.to_owned(), jval).is_some() {
+                                    err.issues.push(CLIError::Field(FieldError::Duplicate(orig_cursor.to_string())));
+                                }
+                            }
+                            _ => unreachable!(),
+                        }
+                    }
+                }
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    pub fn num_fields(&self) -> usize {
+        self.0.len()
+    }
+}
+
+pub fn parse_kv_arg<'a>(kv: &'a str,
+                        err: &mut InvalidOptionsError,
+                        for_hashmap: bool)
+                        -> (&'a str, Option<&'a str>) {
+    let mut add_err = || {
+        err.issues.push(CLIError::InvalidKeyValueSyntax(kv.to_string(), for_hashmap))
+    };
+    match kv.find('=') {
+        None => {
+            add_err();
+            return (kv, None);
+        }
+        Some(pos) => {
+            let key = &kv[..pos];
+            if kv.len() <= pos + 1 {
+                add_err();
+                return (key, Some(""));
+            }
+            (key, Some(&kv[pos + 1..]))
+        }
+    }
+}
+
+pub fn calltype_from_str(name: &str,
+                         valid_protocols: Vec<String>,
+                         err: &mut InvalidOptionsError)
+                         -> CallType {
+    CallType::Upload(match UploadProtocol::from_str(name) {
+        Ok(up) => up,
+        Err(msg) => {
+            err.issues.push(CLIError::InvalidUploadProtocol(name.to_string(), valid_protocols));
+            UploadProtocol::Simple
+        }
+    })
+}
+
+pub fn input_file_from_opts(file_path: &str, err: &mut InvalidOptionsError) -> Option<fs::File> {
+    match fs::File::open(file_path) {
+        Ok(f) => Some(f),
+        Err(io_err) => {
+            err.issues.push(CLIError::Input(InputError::Io((file_path.to_string(), io_err))));
+            None
+        }
+    }
+}
+
+pub fn input_mime_from_opts(mime: &str, err: &mut InvalidOptionsError) -> Option<Mime> {
+    match mime.parse() {
+        Ok(m) => Some(m),
+        Err(_) => {
+            err.issues.push(CLIError::Input(InputError::Mime(mime.to_string())));
+            None
+        }
+    }
+}
+
+pub fn writer_from_opts(arg: Option<&str>) -> Result<Box<Write>, io::Error> {
+    let f = arg.unwrap_or("-");
+    match f {
+        "-" => Ok(Box::new(stdout())),
+        _ => match fs::OpenOptions::new().create(true).write(true).open(f) {
+            Ok(f) => Ok(Box::new(f)),
+            Err(io_err) => Err(io_err),
+        },
+    }
+}
+
+
+pub fn arg_from_str<'a, T>(arg: &str,
+                           err: &mut InvalidOptionsError,
+                           arg_name: &'a str,
+                           arg_type: &'a str)
+                           -> T
+    where T: FromStr + Default,
+          <T as FromStr>::Err: fmt::Display
+{
+    match FromStr::from_str(arg) {
+        Err(perr) => {
+            err.issues.push(CLIError::ParseError(arg_name.to_owned(),
+                                                 arg_type.to_owned(),
+                                                 arg.to_string(),
+                                                 format!("{}", perr)));
+            Default::default()
+        }
+        Ok(v) => v,
+    }
+}
+
+pub struct JsonTokenStorage {
+    pub program_name: &'static str,
+    pub db_dir: String,
+}
+
+impl JsonTokenStorage {
+    fn path(&self, scope_hash: u64) -> PathBuf {
+        Path::new(&self.db_dir).join(&format!("{}-token-{}.json", self.program_name, scope_hash))
+    }
+}
+
+
+#[derive(Debug)]
+pub enum TokenStorageError {
+    Json(json::Error),
+    Io(io::Error),
+}
+
+impl fmt::Display for TokenStorageError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            TokenStorageError::Json(ref err) => writeln!(f, "Could not serialize secrets: {}", err),
+            TokenStorageError::Io(ref err) => writeln!(f, "Failed to write secret token: {}", err),
+        }
+    }
+}
+
+impl StdError for TokenStorageError {
+    fn description(&self) -> &str {
+        "Failure when getting or setting the token storage"
+    }
+}
+
+
+impl TokenStorage for JsonTokenStorage {
+    type Error = TokenStorageError;
+
+    // NOTE: logging might be interesting, currently we swallow all errors
+    fn set(&mut self,
+           scope_hash: u64,
+           _: &Vec<&str>,
+           token: Option<Token>)
+           -> Result<(), TokenStorageError> {
+        match token {
+            None => {
+                match fs::remove_file(self.path(scope_hash)) {
+                    Err(err) => match err.kind() {
+                        io::ErrorKind::NotFound => Ok(()),
+                        _ => Err(TokenStorageError::Io(err)),
+                    },
+                    Ok(_) => Ok(()),
+                }
+            }
+            Some(token) => {
+                match fs::OpenOptions::new().create(true).write(true).open(&self.path(scope_hash)) {
+                    Ok(mut f) => {
+                        match json::to_writer_pretty(&mut f, &token) {
+                            Ok(_) => Ok(()),
+                            Err(serde_err) => Err(TokenStorageError::Json(serde_err)),
+                        }
+                    }
+                    Err(io_err) => Err(TokenStorageError::Io(io_err)),
+                }
+            }
+        }
+    }
+
+    fn get(&self, scope_hash: u64, _: &Vec<&str>) -> Result<Option<Token>, TokenStorageError> {
+        match fs::File::open(&self.path(scope_hash)) {
+            Ok(f) => {
+                match json::de::from_reader(f) {
+                    Ok(token) => Ok(Some(token)),
+                    Err(err) => Err(TokenStorageError::Json(err)),
+                }
+            }
+            Err(io_err) => {
+                match io_err.kind() {
+                    io::ErrorKind::NotFound => Ok(None),
+                    _ => Err(TokenStorageError::Io(io_err)),
+                }
+            }
+        }
+    }
+}
+
+
+#[derive(Debug)]
+pub enum ApplicationSecretError {
+    DecoderError((String, json::Error)),
+    FormatError(String),
+}
+
+impl fmt::Display for ApplicationSecretError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            ApplicationSecretError::DecoderError((ref path, ref err)) =>
+                writeln!(f,
+                         "Could not decode file at '{}' with error: {}.",
+                         path,
+                         err),
+            ApplicationSecretError::FormatError(ref path) =>
+                writeln!(f,
+                         "'installed' field is unset in secret file at '{}'.",
+                         path),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum ConfigurationError {
+    DirectoryCreationFailed((String, io::Error)),
+    DirectoryUnset,
+    HomeExpansionFailed(String),
+    Secret(ApplicationSecretError),
+    Io((String, io::Error)),
+}
+
+impl fmt::Display for ConfigurationError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            ConfigurationError::DirectoryCreationFailed((ref dir, ref err)) =>
+                writeln!(f,
+                         "Directory '{}' could not be created with error: {}.",
+                         dir,
+                         err),
+            ConfigurationError::DirectoryUnset => writeln!(f, "--config-dir was unset or empty."),
+            ConfigurationError::HomeExpansionFailed(ref dir) =>
+                writeln!(f,
+                         "Couldn't find HOME directory of current user, failed to expand '{}'.",
+                         dir),
+            ConfigurationError::Secret(ref err) => writeln!(f, "Secret -> {}", err),
+            ConfigurationError::Io((ref path, ref err)) =>
+                writeln!(f,
+                         "IO operation failed on path '{}' with error: {}.",
+                         path,
+                         err),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum InputError {
+    Io((String, io::Error)),
+    Mime(String),
+}
+
+impl fmt::Display for InputError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            InputError::Io((ref file_path, ref io_err)) =>
+                writeln!(f,
+                         "Failed to open '{}' for reading with error: {}.",
+                         file_path,
+                         io_err),
+            InputError::Mime(ref mime) => writeln!(f, "'{}' is not a known mime-type.", mime),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum FieldError {
+    PopOnEmpty(String),
+    TrailingFieldSep(String),
+    Unknown(String, Option<String>, Option<String>),
+    Duplicate(String),
+    Empty,
+}
+
+
+impl fmt::Display for FieldError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            FieldError::PopOnEmpty(ref field) =>
+                writeln!(f, "'{}': Cannot move up on empty field cursor.", field),
+            FieldError::TrailingFieldSep(ref field) =>
+                writeln!(f,
+                         "'{}': Single field separator may not be last character.",
+                         field),
+            FieldError::Unknown(ref field, ref suggestion, ref value) => {
+                let suffix = match *suggestion {
+                    Some(ref s) => {
+                        let kv = match *value {
+                            Some(ref v) => format!("{}={}", s, v),
+                            None => s.clone(),
+                        };
+                        format!(" Did you mean '{}' ?", kv)
+                    }
+                    None => String::new(),
+                };
+                writeln!(f, "Field '{}' does not exist.{}", field, suffix)
+            }
+            FieldError::Duplicate(ref cursor) =>
+                writeln!(f, "Value at '{}' was already set", cursor),
+            FieldError::Empty => writeln!(f, "Field names must not be empty."),
+        }
+    }
+}
+
+
+#[derive(Debug)]
+pub enum CLIError {
+    Configuration(ConfigurationError),
+    ParseError(String, String, String, String),
+    UnknownParameter(String, Vec<&'static str>),
+    InvalidUploadProtocol(String, Vec<String>),
+    InvalidKeyValueSyntax(String, bool),
+    Input(InputError),
+    Field(FieldError),
+    MissingCommandError,
+    MissingMethodError(String),
+}
+
+impl fmt::Display for CLIError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            CLIError::Configuration(ref err) => write!(f, "Configuration -> {}", err),
+            CLIError::Input(ref err) => write!(f, "Input -> {}", err),
+            CLIError::Field(ref err) => write!(f, "Field -> {}", err),
+            CLIError::InvalidUploadProtocol(ref proto_name, ref valid_names) =>
+                writeln!(f,
+                         "'{}' is not a valid upload protocol. Choose from one of {}.",
+                         proto_name,
+                         valid_names.join(", ")),
+            CLIError::ParseError(ref arg_name, ref type_name, ref value, ref err_desc) =>
+                writeln!(f,
+                         "Failed to parse argument '{}' with value '{}' as {} with error: {}.",
+                         arg_name,
+                         value,
+                         type_name,
+                         err_desc),
+            CLIError::UnknownParameter(ref param_name, ref possible_values) => {
+                let suffix = match did_you_mean(param_name, &possible_values) {
+                    Some(v) => format!(" Did you mean '{}' ?", v),
+                    None => String::new(),
+                };
+                write!(f, "Parameter '{}' is unknown.{}\n", param_name, suffix)
+            }
+            CLIError::InvalidKeyValueSyntax(ref kv, is_hashmap) => {
+                let hashmap_info = if is_hashmap {
+                    "hashmap "
+                } else {
+                    ""
+                };
+                writeln!(f,
+                         "'{}' does not match {}pattern <key>=<value>.",
+                         kv,
+                         hashmap_info)
+            }
+            CLIError::MissingCommandError => writeln!(f, "Please specify the main sub-command."),
+            CLIError::MissingMethodError(ref cmd) =>
+                writeln!(f,
+                         "Please specify the method to call on the '{}' command.",
+                         cmd),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct InvalidOptionsError {
+    pub issues: Vec<CLIError>,
+    pub exit_code: i32,
+}
+
+impl fmt::Display for InvalidOptionsError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        for issue in &self.issues {
+            try!(issue.fmt(f));
+        }
+        Ok(())
+    }
+}
+
+impl InvalidOptionsError {
+    pub fn single(err: CLIError, exit_code: i32) -> InvalidOptionsError {
+        InvalidOptionsError {
+            issues: vec![err],
+            exit_code: exit_code,
+        }
+    }
+
+    pub fn new() -> InvalidOptionsError {
+        InvalidOptionsError {
+            issues: Vec::new(),
+            exit_code: 1,
+        }
+    }
+}
+
+pub fn assure_config_dir_exists(dir: &str) -> Result<String, CLIError> {
+    let trdir = dir.trim();
+    if trdir.len() == 0 {
+        return Err(CLIError::Configuration(ConfigurationError::DirectoryUnset));
+    }
+
+    let expanded_config_dir = if trdir.as_bytes()[0] == b'~' {
+        match env::var("HOME").ok().or(env::var("UserProfile").ok()) {
+            None => return Err(CLIError::Configuration(ConfigurationError::HomeExpansionFailed(trdir.to_string()))),
+            Some(mut user) => {
+                user.push_str(&trdir[1..]);
+                user
+            }
+        }
+    } else {
+        trdir.to_string()
+    };
+
+    if let Err(err) = fs::create_dir(&expanded_config_dir) {
+        if err.kind() != io::ErrorKind::AlreadyExists {
+            return Err(CLIError::Configuration(
+                    ConfigurationError::DirectoryCreationFailed((expanded_config_dir, err))));
+        }
+    }
+
+    Ok(expanded_config_dir)
+}
+
+pub fn application_secret_from_directory(dir: &str,
+                                         secret_basename: &str,
+                                         json_console_secret: &str)
+                                         -> Result<ApplicationSecret, CLIError> {
+    let secret_path = Path::new(dir).join(secret_basename);
+    let secret_str = || secret_path.as_path().to_str().unwrap().to_string();
+    let secret_io_error = |io_err: io::Error| {
+        Err(CLIError::Configuration(ConfigurationError::Io((secret_str(), io_err))))
+    };
+
+    for _ in 0..2 {
+        match fs::File::open(&secret_path) {
+            Err(mut err) => {
+                if err.kind() == io::ErrorKind::NotFound {
+                    // Write our built-in one - user may adjust the written file at will
+
+                    err = match fs::OpenOptions::new()
+                                    .create(true)
+                                    .write(true)
+                                    .open(&secret_path) {
+                        Err(cfe) => cfe,
+                        Ok(mut f) => {
+                            // Assure we convert 'ugly' json string into pretty one
+                            let console_secret: ConsoleApplicationSecret =
+                                json::from_str(json_console_secret).unwrap();
+                            match json::to_writer_pretty(&mut f, &console_secret) {
+                                Err(serde_err) =>
+                                    panic!("Unexpected serde error: {:#?}", serde_err),
+                                Ok(_) => continue,
+                            }
+                        }
+                    };
+                    // fall through to IO error handling
+                }
+                return secret_io_error(err);
+            }
+            Ok(f) => {
+                match json::de::from_reader::<_, ConsoleApplicationSecret>(f) {
+                    Err(json_err) =>
+                        return Err(CLIError::Configuration(
+                            ConfigurationError::Secret(
+                                ApplicationSecretError::DecoderError(
+                                                (secret_str(), json_err)
+                                              )))),
+                    Ok(console_secret) => match console_secret.installed {
+                        Some(secret) => return Ok(secret),
+                        None => return Err(
+                                        CLIError::Configuration(
+                                        ConfigurationError::Secret(
+                                        ApplicationSecretError::FormatError(secret_str())
+                                        ))),
+                    },
+                }
+            }
+        }
+    }
+    unreachable!();
+}

--- a/gen/consumersurveys2-cli/src/main.rs
+++ b/gen/consumersurveys2-cli/src/main.rs
@@ -1,0 +1,1362 @@
+// DO NOT EDIT !
+// This file was generated automatically from 'src/mako/cli/main.rs.mako'
+// DO NOT EDIT !
+#![allow(unused_variables, unused_imports, dead_code, unused_mut)]
+
+#[macro_use]
+extern crate clap;
+extern crate yup_oauth2 as oauth2;
+extern crate yup_hyper_mock as mock;
+extern crate hyper_rustls;
+extern crate serde;
+extern crate serde_json;
+extern crate hyper;
+extern crate mime;
+extern crate strsim;
+extern crate google_consumersurveys2 as api;
+
+use std::env;
+use std::io::{self, Write};
+use clap::{App, SubCommand, Arg};
+
+mod cmn;
+
+use cmn::{InvalidOptionsError, CLIError, JsonTokenStorage, arg_from_str, writer_from_opts, parse_kv_arg,
+          input_file_from_opts, input_mime_from_opts, FieldCursor, FieldError, CallType, UploadProtocol,
+          calltype_from_str, remove_json_null_values, ComplexType, JsonType, JsonTypeInfo};
+
+use std::default::Default;
+use std::str::FromStr;
+
+use oauth2::{Authenticator, DefaultAuthenticatorDelegate, FlowType};
+use serde_json as json;
+use clap::ArgMatches;
+
+enum DoitError {
+    IoError(String, io::Error),
+    ApiError(api::Error),
+}
+
+struct Engine<'n> {
+    opt: ArgMatches<'n>,
+    hub: api::ConsumerSurveys<hyper::Client, Authenticator<DefaultAuthenticatorDelegate, JsonTokenStorage, hyper::Client>>,
+    gp: Vec<&'static str>,
+    gpm: Vec<(&'static str, &'static str)>,
+}
+
+
+impl<'n> Engine<'n> {
+    fn _mobileapppanels_get(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let mut call = self.hub.mobileapppanels().get(opt.value_of("panel-id").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _mobileapppanels_list(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let mut call = self.hub.mobileapppanels().list();
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                "token" => {
+                    call = call.token(value.unwrap_or(""));
+                },
+                "start-index" => {
+                    call = call.start_index(arg_from_str(value.unwrap_or("-0"), err, "start-index", "integer"));
+                },
+                "max-results" => {
+                    call = call.max_results(arg_from_str(value.unwrap_or("-0"), err, "max-results", "integer"));
+                },
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v.extend(["token", "start-index", "max-results"].iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _mobileapppanels_update(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    "owners" => Some(("owners", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Vec })),
+                    "mobile-app-panel-id" => Some(("mobileAppPanelId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "name" => Some(("name", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "language" => Some(("language", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "country" => Some(("country", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "is-public-panel" => Some(("isPublicPanel", JsonTypeInfo { jtype: JsonType::Boolean, ctype: ComplexType::Pod })),
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec!["country", "is-public-panel", "language", "mobile-app-panel-id", "name", "owners"]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::MobileAppPanel = json::value::from_value(object).unwrap();
+        let mut call = self.hub.mobileapppanels().update(request, opt.value_of("panel-id").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _results_get(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    "result-mask.projection" => Some(("resultMask.projection", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec!["projection", "result-mask"]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::ResultsGetRequest = json::value::from_value(object).unwrap();
+        let mut download_mode = false;
+        let mut call = self.hub.results().get(request, opt.value_of("survey-url-id").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            if key == "alt" && value.unwrap_or("unset") == "media" {
+                                download_mode = true;
+                            }
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    if !download_mode {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    } else {
+                    io::copy(&mut response, &mut ostream).unwrap();
+                    ostream.flush().unwrap();
+                    }
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _surveys_delete(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let mut call = self.hub.surveys().delete(opt.value_of("survey-url-id").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _surveys_get(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let mut call = self.hub.surveys().get(opt.value_of("survey-url-id").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _surveys_insert(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    "owners" => Some(("owners", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Vec })),
+                    "description" => Some(("description", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "title" => Some(("title", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "customer-data" => Some(("customerData", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "state" => Some(("state", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "audience.country-subdivision" => Some(("audience.countrySubdivision", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "audience.mobile-app-panel-id" => Some(("audience.mobileAppPanelId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "audience.country" => Some(("audience.country", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "audience.ages" => Some(("audience.ages", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Vec })),
+                    "audience.population-source" => Some(("audience.populationSource", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "audience.languages" => Some(("audience.languages", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Vec })),
+                    "audience.gender" => Some(("audience.gender", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "cost.nanos" => Some(("cost.nanos", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "cost.currency-code" => Some(("cost.currencyCode", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "cost.cost-per-response-nanos" => Some(("cost.costPerResponseNanos", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "cost.max-cost-per-response-nanos" => Some(("cost.maxCostPerResponseNanos", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "survey-url-id" => Some(("surveyUrlId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "wanted-response-count" => Some(("wantedResponseCount", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Pod })),
+                    "rejection-reason.explanation" => Some(("rejectionReason.explanation", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "rejection-reason.type" => Some(("rejectionReason.type", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec!["ages", "audience", "cost", "cost-per-response-nanos", "country", "country-subdivision", "currency-code", "customer-data", "description", "explanation", "gender", "languages", "max-cost-per-response-nanos", "mobile-app-panel-id", "nanos", "owners", "population-source", "rejection-reason", "state", "survey-url-id", "title", "type", "wanted-response-count"]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::Survey = json::value::from_value(object).unwrap();
+        let mut call = self.hub.surveys().insert(request);
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _surveys_list(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let mut call = self.hub.surveys().list();
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                "token" => {
+                    call = call.token(value.unwrap_or(""));
+                },
+                "start-index" => {
+                    call = call.start_index(arg_from_str(value.unwrap_or("-0"), err, "start-index", "integer"));
+                },
+                "max-results" => {
+                    call = call.max_results(arg_from_str(value.unwrap_or("-0"), err, "max-results", "integer"));
+                },
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v.extend(["token", "start-index", "max-results"].iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _surveys_start(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    "max-cost-per-response-nanos" => Some(("maxCostPerResponseNanos", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec!["max-cost-per-response-nanos"]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::SurveysStartRequest = json::value::from_value(object).unwrap();
+        let mut call = self.hub.surveys().start(request, opt.value_of("resource-id").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _surveys_stop(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let mut call = self.hub.surveys().stop(opt.value_of("resource-id").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _surveys_update(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    "owners" => Some(("owners", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Vec })),
+                    "description" => Some(("description", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "title" => Some(("title", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "customer-data" => Some(("customerData", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "state" => Some(("state", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "audience.country-subdivision" => Some(("audience.countrySubdivision", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "audience.mobile-app-panel-id" => Some(("audience.mobileAppPanelId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "audience.country" => Some(("audience.country", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "audience.ages" => Some(("audience.ages", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Vec })),
+                    "audience.population-source" => Some(("audience.populationSource", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "audience.languages" => Some(("audience.languages", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Vec })),
+                    "audience.gender" => Some(("audience.gender", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "cost.nanos" => Some(("cost.nanos", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "cost.currency-code" => Some(("cost.currencyCode", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "cost.cost-per-response-nanos" => Some(("cost.costPerResponseNanos", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "cost.max-cost-per-response-nanos" => Some(("cost.maxCostPerResponseNanos", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "survey-url-id" => Some(("surveyUrlId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "wanted-response-count" => Some(("wantedResponseCount", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Pod })),
+                    "rejection-reason.explanation" => Some(("rejectionReason.explanation", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "rejection-reason.type" => Some(("rejectionReason.type", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec!["ages", "audience", "cost", "cost-per-response-nanos", "country", "country-subdivision", "currency-code", "customer-data", "description", "explanation", "gender", "languages", "max-cost-per-response-nanos", "mobile-app-panel-id", "nanos", "owners", "population-source", "rejection-reason", "state", "survey-url-id", "title", "type", "wanted-response-count"]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::Survey = json::value::from_value(object).unwrap();
+        let mut call = self.hub.surveys().update(request, opt.value_of("survey-url-id").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _doit(&self, dry_run: bool) -> Result<Result<(), DoitError>, Option<InvalidOptionsError>> {
+        let mut err = InvalidOptionsError::new();
+        let mut call_result: Result<(), DoitError> = Ok(());
+        let mut err_opt: Option<InvalidOptionsError> = None;
+        match self.opt.subcommand() {
+            ("mobileapppanels", Some(opt)) => {
+                match opt.subcommand() {
+                    ("get", Some(opt)) => {
+                        call_result = self._mobileapppanels_get(opt, dry_run, &mut err);
+                    },
+                    ("list", Some(opt)) => {
+                        call_result = self._mobileapppanels_list(opt, dry_run, &mut err);
+                    },
+                    ("update", Some(opt)) => {
+                        call_result = self._mobileapppanels_update(opt, dry_run, &mut err);
+                    },
+                    _ => {
+                        err.issues.push(CLIError::MissingMethodError("mobileapppanels".to_string()));
+                        writeln!(io::stderr(), "{}\n", opt.usage()).ok();
+                    }
+                }
+            },
+            ("results", Some(opt)) => {
+                match opt.subcommand() {
+                    ("get", Some(opt)) => {
+                        call_result = self._results_get(opt, dry_run, &mut err);
+                    },
+                    _ => {
+                        err.issues.push(CLIError::MissingMethodError("results".to_string()));
+                        writeln!(io::stderr(), "{}\n", opt.usage()).ok();
+                    }
+                }
+            },
+            ("surveys", Some(opt)) => {
+                match opt.subcommand() {
+                    ("delete", Some(opt)) => {
+                        call_result = self._surveys_delete(opt, dry_run, &mut err);
+                    },
+                    ("get", Some(opt)) => {
+                        call_result = self._surveys_get(opt, dry_run, &mut err);
+                    },
+                    ("insert", Some(opt)) => {
+                        call_result = self._surveys_insert(opt, dry_run, &mut err);
+                    },
+                    ("list", Some(opt)) => {
+                        call_result = self._surveys_list(opt, dry_run, &mut err);
+                    },
+                    ("start", Some(opt)) => {
+                        call_result = self._surveys_start(opt, dry_run, &mut err);
+                    },
+                    ("stop", Some(opt)) => {
+                        call_result = self._surveys_stop(opt, dry_run, &mut err);
+                    },
+                    ("update", Some(opt)) => {
+                        call_result = self._surveys_update(opt, dry_run, &mut err);
+                    },
+                    _ => {
+                        err.issues.push(CLIError::MissingMethodError("surveys".to_string()));
+                        writeln!(io::stderr(), "{}\n", opt.usage()).ok();
+                    }
+                }
+            },
+            _ => {
+                err.issues.push(CLIError::MissingCommandError);
+                writeln!(io::stderr(), "{}\n", self.opt.usage()).ok();
+            }
+        }
+
+        if dry_run {
+            if err.issues.len() > 0 {
+                err_opt = Some(err);
+            }
+            Err(err_opt)
+        } else {
+            Ok(call_result)
+        }
+    }
+
+    // Please note that this call will fail if any part of the opt can't be handled
+    fn new(opt: ArgMatches<'n>) -> Result<Engine<'n>, InvalidOptionsError> {
+        let (config_dir, secret) = {
+            let config_dir = match cmn::assure_config_dir_exists(opt.value_of("folder").unwrap_or("~/.google-service-cli")) {
+                Err(e) => return Err(InvalidOptionsError::single(e, 3)),
+                Ok(p) => p,
+            };
+
+            match cmn::application_secret_from_directory(&config_dir, "consumersurveys2-secret.json",
+                                                         "{\"installed\":{\"auth_uri\":\"https://accounts.google.com/o/oauth2/auth\",\"client_secret\":\"hCsslbCUyfehWMmbkG8vTYxG\",\"token_uri\":\"https://accounts.google.com/o/oauth2/token\",\"client_email\":\"\",\"redirect_uris\":[\"urn:ietf:wg:oauth:2.0:oob\",\"oob\"],\"client_x509_cert_url\":\"\",\"client_id\":\"620010449518-9ngf7o4dhs0dka470npqvor6dc5lqb9b.apps.googleusercontent.com\",\"auth_provider_x509_cert_url\":\"https://www.googleapis.com/oauth2/v1/certs\"}}") {
+                Ok(secret) => (config_dir, secret),
+                Err(e) => return Err(InvalidOptionsError::single(e, 4))
+            }
+        };
+
+        let auth = Authenticator::new(  &secret, DefaultAuthenticatorDelegate,
+                                        if opt.is_present("debug-auth") {
+                                            hyper::Client::with_connector(mock::TeeConnector {
+                                                    connector: hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())
+                                                })
+                                        } else {
+                                            hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new()))
+                                        },
+                                        JsonTokenStorage {
+                                          program_name: "consumersurveys2",
+                                          db_dir: config_dir.clone(),
+                                        }, Some(FlowType::InstalledRedirect(54324)));
+
+        let client =
+            if opt.is_present("debug") {
+                hyper::Client::with_connector(mock::TeeConnector {
+                        connector: hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())
+                    })
+            } else {
+                hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new()))
+            };
+        let engine = Engine {
+            opt: opt,
+            hub: api::ConsumerSurveys::new(client, auth),
+            gp: vec!["alt", "fields", "key", "oauth-token", "pretty-print", "quota-user", "user-ip"],
+            gpm: vec![
+                    ("oauth-token", "oauth_token"),
+                    ("pretty-print", "prettyPrint"),
+                    ("quota-user", "quotaUser"),
+                    ("user-ip", "userIp"),
+                ]
+        };
+
+        match engine._doit(true) {
+            Err(Some(err)) => Err(err),
+            Err(None)      => Ok(engine),
+            Ok(_)          => unreachable!(),
+        }
+    }
+
+    fn doit(&self) -> Result<(), DoitError> {
+        match self._doit(false) {
+            Ok(res) => res,
+            Err(_) => unreachable!(),
+        }
+    }
+}
+
+fn main() {
+    let mut exit_status = 0i32;
+    let arg_data = [
+        ("mobileapppanels", "methods: 'get', 'list' and 'update'", vec![
+            ("get",
+                    Some(r##"Retrieves a MobileAppPanel that is available to the authenticated user."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_consumersurveys2_cli/mobileapppanels_get",
+                  vec![
+                    (Some(r##"panel-id"##),
+                     None,
+                     Some(r##"External URL ID for the panel."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("list",
+                    Some(r##"Lists the MobileAppPanels available to the authenticated user."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_consumersurveys2_cli/mobileapppanels_list",
+                  vec![
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("update",
+                    Some(r##"Updates a MobileAppPanel. Currently the only property that can be updated is the owners property."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_consumersurveys2_cli/mobileapppanels_update",
+                  vec![
+                    (Some(r##"panel-id"##),
+                     None,
+                     Some(r##"External URL ID for the panel."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ]),
+        
+        ("results", "methods: 'get'", vec![
+            ("get",
+                    Some(r##"Retrieves any survey results that have been produced so far. Results are formatted as an Excel file. You must add "?alt=media" to the URL as an argument to get results."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_consumersurveys2_cli/results_get",
+                  vec![
+                    (Some(r##"survey-url-id"##),
+                     None,
+                     Some(r##"External URL ID for the survey."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ]),
+        
+        ("surveys", "methods: 'delete', 'get', 'insert', 'list', 'start', 'stop' and 'update'", vec![
+            ("delete",
+                    Some(r##"Removes a survey from view in all user GET requests."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_consumersurveys2_cli/surveys_delete",
+                  vec![
+                    (Some(r##"survey-url-id"##),
+                     None,
+                     Some(r##"External URL ID for the survey."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("get",
+                    Some(r##"Retrieves information about the specified survey."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_consumersurveys2_cli/surveys_get",
+                  vec![
+                    (Some(r##"survey-url-id"##),
+                     None,
+                     Some(r##"External URL ID for the survey."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("insert",
+                    Some(r##"Creates a survey."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_consumersurveys2_cli/surveys_insert",
+                  vec![
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("list",
+                    Some(r##"Lists the surveys owned by the authenticated user."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_consumersurveys2_cli/surveys_list",
+                  vec![
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("start",
+                    Some(r##"Begins running a survey."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_consumersurveys2_cli/surveys_start",
+                  vec![
+                    (Some(r##"resource-id"##),
+                     None,
+                     None,
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("stop",
+                    Some(r##"Stops a running survey."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_consumersurveys2_cli/surveys_stop",
+                  vec![
+                    (Some(r##"resource-id"##),
+                     None,
+                     None,
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("update",
+                    Some(r##"Updates a survey. Currently the only property that can be updated is the owners property."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_consumersurveys2_cli/surveys_update",
+                  vec![
+                    (Some(r##"survey-url-id"##),
+                     None,
+                     Some(r##"External URL ID for the survey."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ]),
+        
+    ];
+    
+    let mut app = App::new("consumersurveys2")
+           .author("Sebastian Thiel <byronimo@gmail.com>")
+           .version("1.0.7+20170407")
+           .about("Creates and conducts surveys, lists the surveys that an authenticated user owns, and retrieves survey results and information about specified surveys.")
+           .after_help("All documentation details can be found at http://byron.github.io/google-apis-rs/google_consumersurveys2_cli")
+           .arg(Arg::with_name("url")
+                   .long("scope")
+                   .help("Specify the authentication a method should be executed in. Each scope requires the user to grant this application permission to use it.If unset, it defaults to the shortest scope url for a particular method.")
+                   .multiple(true)
+                   .takes_value(true))
+           .arg(Arg::with_name("folder")
+                   .long("config-dir")
+                   .help("A directory into which we will store our persistent data. Defaults to a user-writable directory that we will create during the first invocation.[default: ~/.google-service-cli")
+                   .multiple(false)
+                   .takes_value(true))
+           .arg(Arg::with_name("debug")
+                   .long("debug")
+                   .help("Output all server communication to standard error. `tx` and `rx` are placed into the same stream.")
+                   .multiple(false)
+                   .takes_value(false))
+           .arg(Arg::with_name("debug-auth")
+                   .long("debug-auth")
+                   .help("Output all communication related to authentication to standard error. `tx` and `rx` are placed into the same stream.")
+                   .multiple(false)
+                   .takes_value(false));
+           
+           for &(main_command_name, about, ref subcommands) in arg_data.iter() {
+               let mut mcmd = SubCommand::with_name(main_command_name).about(about);
+           
+               for &(sub_command_name, ref desc, url_info, ref args) in subcommands {
+                   let mut scmd = SubCommand::with_name(sub_command_name);
+                   if let &Some(desc) = desc {
+                       scmd = scmd.about(desc);
+                   }
+                   scmd = scmd.after_help(url_info);
+           
+                   for &(ref arg_name, ref flag, ref desc, ref required, ref multi) in args {
+                       let arg_name_str =
+                           match (arg_name, flag) {
+                                   (&Some(an), _       ) => an,
+                                   (_        , &Some(f)) => f,
+                                    _                    => unreachable!(),
+                            };
+                       let mut arg = Arg::with_name(arg_name_str)
+                                         .empty_values(false);
+                       if let &Some(short_flag) = flag {
+                           arg = arg.short(short_flag);
+                       }
+                       if let &Some(desc) = desc {
+                           arg = arg.help(desc);
+                       }
+                       if arg_name.is_some() && flag.is_some() {
+                           arg = arg.takes_value(true);
+                       }
+                       if let &Some(required) = required {
+                           arg = arg.required(required);
+                       }
+                       if let &Some(multi) = multi {
+                           arg = arg.multiple(multi);
+                       }
+                       scmd = scmd.arg(arg);
+                   }
+                   mcmd = mcmd.subcommand(scmd);
+               }
+               app = app.subcommand(mcmd);
+           }
+           
+        let matches = app.get_matches();
+
+    let debug = matches.is_present("debug");
+    match Engine::new(matches) {
+        Err(err) => {
+            exit_status = err.exit_code;
+            writeln!(io::stderr(), "{}", err).ok();
+        },
+        Ok(engine) => {
+            if let Err(doit_err) = engine.doit() {
+                exit_status = 1;
+                match doit_err {
+                    DoitError::IoError(path, err) => {
+                        writeln!(io::stderr(), "Failed to open output file '{}': {}", path, err).ok();
+                    },
+                    DoitError::ApiError(err) => {
+                        if debug {
+                            writeln!(io::stderr(), "{:#?}", err).ok();
+                        } else {
+                            writeln!(io::stderr(), "{}", err).ok();
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    std::process::exit(exit_status);
+}

--- a/gen/consumersurveys2/Cargo.toml
+++ b/gen/consumersurveys2/Cargo.toml
@@ -1,0 +1,30 @@
+# DO NOT EDIT !
+# This file was generated automatically from 'src/mako/Cargo.toml.mako'
+# DO NOT EDIT !
+[package]
+
+name = "google-consumersurveys2"
+version = "1.0.7+20170407"
+authors = ["Sebastian Thiel <byronimo@gmail.com>"]
+description = "A complete library to interact with Consumer Surveys (protocol v2)"
+repository = "https://github.com/Byron/google-apis-rs/tree/master/gen/consumersurveys2"
+documentation = "https://docs.rs/google-consumersurveys2/1.0.7+20170407"
+license = "MIT"
+keywords = ["consumersurveys", "google", "protocol", "web", "api"]
+
+
+[dev-dependencies]
+hyper-rustls = "^0.6"
+
+[dependencies]
+hyper = "^ 0.10"
+mime = "^ 0.2.0"
+serde = "^ 1.0"
+serde_json = "^ 1.0"
+serde_derive = "^ 1.0"
+yup-oauth2 = "^ 1.0"
+url = "= 0.5"
+
+[features]
+
+

--- a/gen/consumersurveys2/LICENSE.md
+++ b/gen/consumersurveys2/LICENSE.md
@@ -1,0 +1,30 @@
+<!---
+DO NOT EDIT !
+This file was generated automatically from 'src/mako/LICENSE.md.mako'
+DO NOT EDIT !
+-->
+The MIT License (MIT)
+=====================
+
+Copyright © `2015-2016` `Sebastian Thiel`
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the “Software”), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.

--- a/gen/consumersurveys2/README.md
+++ b/gen/consumersurveys2/README.md
@@ -1,0 +1,188 @@
+<!---
+DO NOT EDIT !
+This file was generated automatically from 'src/mako/api/README.md.mako'
+DO NOT EDIT !
+-->
+The `google-consumersurveys2` library allows access to all features of the *Google Consumer Surveys* service.
+
+This documentation was generated from *Consumer Surveys* crate version *1.0.7+20170407*, where *20170407* is the exact revision of the *consumersurveys:v2* schema built by the [mako](http://www.makotemplates.org/) code generator *v1.0.7*.
+# Features
+
+Handle the following *Resources* with ease from the central [hub](https://docs.rs/google-consumersurveys2/1.0.7+20170407/google_consumersurveys2/struct.ConsumerSurveys.html) ... 
+
+* mobileapppanels
+ * [*get*](https://docs.rs/google-consumersurveys2/1.0.7+20170407/google_consumersurveys2/struct.MobileapppanelGetCall.html), [*list*](https://docs.rs/google-consumersurveys2/1.0.7+20170407/google_consumersurveys2/struct.MobileapppanelListCall.html) and [*update*](https://docs.rs/google-consumersurveys2/1.0.7+20170407/google_consumersurveys2/struct.MobileapppanelUpdateCall.html)
+* results
+ * [*get*](https://docs.rs/google-consumersurveys2/1.0.7+20170407/google_consumersurveys2/struct.ResultGetCall.html)
+* [surveys](https://docs.rs/google-consumersurveys2/1.0.7+20170407/google_consumersurveys2/struct.Survey.html)
+ * [*delete*](https://docs.rs/google-consumersurveys2/1.0.7+20170407/google_consumersurveys2/struct.SurveyDeleteCall.html), [*get*](https://docs.rs/google-consumersurveys2/1.0.7+20170407/google_consumersurveys2/struct.SurveyGetCall.html), [*insert*](https://docs.rs/google-consumersurveys2/1.0.7+20170407/google_consumersurveys2/struct.SurveyInsertCall.html), [*list*](https://docs.rs/google-consumersurveys2/1.0.7+20170407/google_consumersurveys2/struct.SurveyListCall.html), [*start*](https://docs.rs/google-consumersurveys2/1.0.7+20170407/google_consumersurveys2/struct.SurveyStartCall.html), [*stop*](https://docs.rs/google-consumersurveys2/1.0.7+20170407/google_consumersurveys2/struct.SurveyStopCall.html) and [*update*](https://docs.rs/google-consumersurveys2/1.0.7+20170407/google_consumersurveys2/struct.SurveyUpdateCall.html)
+
+
+Download supported by ...
+
+* [*get results*](https://docs.rs/google-consumersurveys2/1.0.7+20170407/google_consumersurveys2/struct.ResultGetCall.html)
+
+
+
+# Structure of this Library
+
+The API is structured into the following primary items:
+
+* **[Hub](https://docs.rs/google-consumersurveys2/1.0.7+20170407/google_consumersurveys2/struct.ConsumerSurveys.html)**
+    * a central object to maintain state and allow accessing all *Activities*
+    * creates [*Method Builders*](https://docs.rs/google-consumersurveys2/1.0.7+20170407/google_consumersurveys2/trait.MethodsBuilder.html) which in turn
+      allow access to individual [*Call Builders*](https://docs.rs/google-consumersurveys2/1.0.7+20170407/google_consumersurveys2/trait.CallBuilder.html)
+* **[Resources](https://docs.rs/google-consumersurveys2/1.0.7+20170407/google_consumersurveys2/trait.Resource.html)**
+    * primary types that you can apply *Activities* to
+    * a collection of properties and *Parts*
+    * **[Parts](https://docs.rs/google-consumersurveys2/1.0.7+20170407/google_consumersurveys2/trait.Part.html)**
+        * a collection of properties
+        * never directly used in *Activities*
+* **[Activities](https://docs.rs/google-consumersurveys2/1.0.7+20170407/google_consumersurveys2/trait.CallBuilder.html)**
+    * operations to apply to *Resources*
+
+All *structures* are marked with applicable traits to further categorize them and ease browsing.
+
+Generally speaking, you can invoke *Activities* like this:
+
+```Rust,ignore
+let r = hub.resource().activity(...).doit()
+```
+
+Or specifically ...
+
+```ignore
+let r = hub.surveys().delete(...).doit()
+let r = hub.surveys().insert(...).doit()
+let r = hub.surveys().list(...).doit()
+let r = hub.surveys().update(...).doit()
+let r = hub.surveys().get(...).doit()
+let r = hub.surveys().stop(...).doit()
+let r = hub.surveys().start(...).doit()
+```
+
+The `resource()` and `activity(...)` calls create [builders][builder-pattern]. The second one dealing with `Activities` 
+supports various methods to configure the impending operation (not shown here). It is made such that all required arguments have to be 
+specified right away (i.e. `(...)`), whereas all optional ones can be [build up][builder-pattern] as desired.
+The `doit()` method performs the actual communication with the server and returns the respective result.
+
+# Usage
+
+## Setting up your Project
+
+To use this library, you would put the following lines into your `Cargo.toml` file:
+
+```toml
+[dependencies]
+google-consumersurveys2 = "*"
+```
+
+## A complete example
+
+```Rust
+extern crate hyper;
+extern crate hyper_rustls;
+extern crate yup_oauth2 as oauth2;
+extern crate google_consumersurveys2 as consumersurveys2;
+use consumersurveys2::{Result, Error};
+use std::default::Default;
+use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+use consumersurveys2::ConsumerSurveys;
+
+// Get an ApplicationSecret instance by some means. It contains the `client_id` and 
+// `client_secret`, among other things.
+let secret: ApplicationSecret = Default::default();
+// Instantiate the authenticator. It will choose a suitable authentication flow for you, 
+// unless you replace  `None` with the desired Flow.
+// Provide your own `AuthenticatorDelegate` to adjust the way it operates and get feedback about 
+// what's going on. You probably want to bring in your own `TokenStorage` to persist tokens and
+// retrieve them from storage.
+let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+                              hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+                              <MemoryStorage as Default>::default(), None);
+let mut hub = ConsumerSurveys::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+// You can configure optional parameters by calling the respective setters at will, and
+// execute the final call using `doit()`.
+// Values shown here are possibly random and not representative !
+let result = hub.surveys().list()
+             .token("eirmod")
+             .start_index(53)
+             .max_results(36)
+             .doit();
+
+match result {
+    Err(e) => match e {
+        // The Error enum provides details about what exactly happened.
+        // You can also just use its `Debug`, `Display` or `Error` traits
+         Error::HttpError(_)
+        |Error::MissingAPIKey
+        |Error::MissingToken(_)
+        |Error::Cancelled
+        |Error::UploadSizeLimitExceeded(_, _)
+        |Error::Failure(_)
+        |Error::BadRequest(_)
+        |Error::FieldClash(_)
+        |Error::JsonDecodeError(_, _) => println!("{}", e),
+    },
+    Ok(res) => println!("Success: {:?}", res),
+}
+
+```
+## Handling Errors
+
+All errors produced by the system are provided either as [Result](https://docs.rs/google-consumersurveys2/1.0.7+20170407/google_consumersurveys2/enum.Result.html) enumeration as return value of 
+the doit() methods, or handed as possibly intermediate results to either the 
+[Hub Delegate](https://docs.rs/google-consumersurveys2/1.0.7+20170407/google_consumersurveys2/trait.Delegate.html), or the [Authenticator Delegate](https://docs.rs/yup-oauth2/*/yup_oauth2/trait.AuthenticatorDelegate.html).
+
+When delegates handle errors or intermediate values, they may have a chance to instruct the system to retry. This 
+makes the system potentially resilient to all kinds of errors.
+
+## Uploads and Downloads
+If a method supports downloads, the response body, which is part of the [Result](https://docs.rs/google-consumersurveys2/1.0.7+20170407/google_consumersurveys2/enum.Result.html), should be
+read by you to obtain the media.
+If such a method also supports a [Response Result](https://docs.rs/google-consumersurveys2/1.0.7+20170407/google_consumersurveys2/trait.ResponseResult.html), it will return that by default.
+You can see it as meta-data for the actual media. To trigger a media download, you will have to set up the builder by making
+this call: `.param("alt", "media")`.
+
+Methods supporting uploads can do so using up to 2 different protocols: 
+*simple* and *resumable*. The distinctiveness of each is represented by customized 
+`doit(...)` methods, which are then named `upload(...)` and `upload_resumable(...)` respectively.
+
+## Customization and Callbacks
+
+You may alter the way an `doit()` method is called by providing a [delegate](https://docs.rs/google-consumersurveys2/1.0.7+20170407/google_consumersurveys2/trait.Delegate.html) to the 
+[Method Builder](https://docs.rs/google-consumersurveys2/1.0.7+20170407/google_consumersurveys2/trait.CallBuilder.html) before making the final `doit()` call. 
+Respective methods will be called to provide progress information, as well as determine whether the system should 
+retry on failure.
+
+The [delegate trait](https://docs.rs/google-consumersurveys2/1.0.7+20170407/google_consumersurveys2/trait.Delegate.html) is default-implemented, allowing you to customize it with minimal effort.
+
+## Optional Parts in Server-Requests
+
+All structures provided by this library are made to be [enocodable](https://docs.rs/google-consumersurveys2/1.0.7+20170407/google_consumersurveys2/trait.RequestValue.html) and 
+[decodable](https://docs.rs/google-consumersurveys2/1.0.7+20170407/google_consumersurveys2/trait.ResponseResult.html) via *json*. Optionals are used to indicate that partial requests are responses 
+are valid.
+Most optionals are are considered [Parts](https://docs.rs/google-consumersurveys2/1.0.7+20170407/google_consumersurveys2/trait.Part.html) which are identifiable by name, which will be sent to 
+the server to indicate either the set parts of the request or the desired parts in the response.
+
+## Builder Arguments
+
+Using [method builders](https://docs.rs/google-consumersurveys2/1.0.7+20170407/google_consumersurveys2/trait.CallBuilder.html), you are able to prepare an action call by repeatedly calling it's methods.
+These will always take a single argument, for which the following statements are true.
+
+* [PODs][wiki-pod] are handed by copy
+* strings are passed as `&str`
+* [request values](https://docs.rs/google-consumersurveys2/1.0.7+20170407/google_consumersurveys2/trait.RequestValue.html) are moved
+
+Arguments will always be copied or cloned into the builder, to make them independent of their original life times.
+
+[wiki-pod]: http://en.wikipedia.org/wiki/Plain_old_data_structure
+[builder-pattern]: http://en.wikipedia.org/wiki/Builder_pattern
+[google-go-api]: https://github.com/google/google-api-go-client
+
+# License
+The **consumersurveys2** library was generated by Sebastian Thiel, and is placed 
+under the *MIT* license.
+You can read the full text at the repository's [license file][repo-license].
+
+[repo-license]: https://github.com/Byron/google-apis-rsblob/master/LICENSE.md

--- a/gen/consumersurveys2/src/cmn.rs
+++ b/gen/consumersurveys2/src/cmn.rs
@@ -1,0 +1,753 @@
+// COPY OF 'src/rust/api/cmn.rs'
+// DO NOT EDIT
+use std::io::{self, Read, Seek, Cursor, Write, SeekFrom};
+use std;
+use std::fmt::{self, Display};
+use std::str::FromStr;
+use std::error;
+use std::thread::sleep;
+use std::time::Duration;
+
+use mime::{Mime, TopLevel, SubLevel, Attr, Value};
+use oauth2::{TokenType, Retry, self};
+use hyper;
+use hyper::header::{ContentType, ContentLength, Headers, UserAgent, Authorization, Header,
+                    HeaderFormat, Bearer};
+use hyper::http::h1::LINE_ENDING;
+use hyper::method::Method;
+use hyper::status::StatusCode;
+
+use serde_json as json;
+
+/// Identifies the Hub. There is only one per library, this trait is supposed
+/// to make intended use more explicit.
+/// The hub allows to access all resource methods more easily.
+pub trait Hub {}
+
+/// Identifies types for building methods of a particular resource type
+pub trait MethodsBuilder {}
+
+/// Identifies types which represent builders for a particular resource method
+pub trait CallBuilder {}
+
+/// Identifies types which can be inserted and deleted.
+/// Types with this trait are most commonly used by clients of this API.
+pub trait Resource {}
+
+/// Identifies types which are used in API responses.
+pub trait ResponseResult {}
+
+/// Identifies types which are used in API requests.
+pub trait RequestValue {}
+
+/// Identifies types which are not actually used by the API
+/// This might be a bug within the google API schema.
+pub trait UnusedType {}
+
+/// Identifies types which are only used as part of other types, which
+/// usually are carrying the `Resource` trait.
+pub trait Part {}
+
+/// Identifies types which are only used by other types internally.
+/// They have no special meaning, this trait just marks them for completeness.
+pub trait NestedType {}
+
+/// A utility to specify reader types which provide seeking capabilities too
+pub trait ReadSeek: Seek + Read {}
+impl<T: Seek + Read> ReadSeek for T {}
+
+/// A trait for all types that can convert themselves into a *parts* string
+pub trait ToParts {
+    fn to_parts(&self) -> String;
+}
+
+/// A utility type which can decode a server response that indicates error
+#[derive(Deserialize)]
+pub struct JsonServerError {
+    pub error: String,
+    pub error_description: Option<String>
+}
+
+/// A utility to represent detailed errors we might see in case there are BadRequests.
+/// The latter happen if the sent parameters or request structures are unsound
+#[derive(Deserialize, Serialize, Debug)]
+pub struct ErrorResponse {
+    error: ServerError,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct ServerError {
+    errors: Vec<ServerMessage>,
+    code: u16,
+    message: String,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct ServerMessage {
+    domain: String,
+    reason: String,
+    message: String,
+    #[serde(rename="locationType")]
+    location_type: Option<String>,
+    location: Option<String>
+}
+
+#[derive(Copy, Clone)]
+pub struct DummyNetworkStream;
+
+impl Read for DummyNetworkStream {
+    fn read(&mut self, _: &mut [u8]) -> io::Result<usize> {
+        Ok(0)
+    }
+}
+
+impl Write for DummyNetworkStream {
+    fn write(&mut self, _: &[u8]) -> io::Result<usize> {
+        Ok(0)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl hyper::net::NetworkStream for DummyNetworkStream {
+    fn peer_addr(&mut self) -> io::Result<std::net::SocketAddr> {
+        Ok("127.0.0.1:1337".parse().unwrap())
+    }
+
+    fn set_read_timeout(&self, _dur: Option<Duration>) -> io::Result<()> {
+        Ok(())
+    }
+
+    fn set_write_timeout(&self, _dur: Option<Duration>) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+
+/// A trait specifying functionality to help controlling any request performed by the API.
+/// The trait has a conservative default implementation.
+///
+/// It contains methods to deal with all common issues, as well with the ones related to
+/// uploading media
+pub trait Delegate {
+
+    /// Called at the beginning of any API request. The delegate should store the method
+    /// information if he is interesting in knowing more context when further calls to it
+    /// are made.
+    /// The matching `finished()` call will always be made, no matter whether or not the API
+    /// request was successful. That way, the delegate may easily maintain a clean state
+    /// between various API calls.
+    fn begin(&mut self, MethodInfo) {}
+
+    /// Called whenever there is an [HttpError](http://hyperium.github.io/hyper/hyper/error/enum.HttpError.html), usually if there are network problems.
+    ///
+    /// If you choose to retry after a duration, the duration should be chosen using the
+    /// [exponential backoff algorithm](http://en.wikipedia.org/wiki/Exponential_backoff).
+    ///
+    /// Return retry information.
+    fn http_error(&mut self, &hyper::Error) -> Retry {
+        Retry::Abort
+    }
+
+    /// Called whenever there is the need for your applications API key after
+    /// the official authenticator implementation didn't provide one, for some reason.
+    /// If this method returns None as well, the underlying operation will fail
+    fn api_key(&mut self) -> Option<String> {
+        None
+    }
+
+    /// Called whenever the Authenticator didn't yield a token. The delegate
+    /// may attempt to provide one, or just take it as a general information about the
+    /// impending failure.
+    /// The given Error provides information about why the token couldn't be acquired in the
+    /// first place
+    fn token(&mut self, err: &error::Error) -> Option<oauth2::Token> {
+        let _ = err;
+        None
+    }
+
+    /// Called during resumable uploads to provide a URL for the impending upload.
+    /// It was saved after a previous call to `store_upload_url(...)`, and if not None,
+    /// will be used instead of asking the server for a new upload URL.
+    /// This is useful in case a previous resumable upload was aborted/canceled, but should now
+    /// be resumed.
+    /// The returned URL will be used exactly once - if it fails again and the delegate allows
+    /// to retry, we will ask the server for a new upload URL.
+    fn upload_url(&mut self) -> Option<String> {
+        None
+    }
+
+    /// Called after we have retrieved a new upload URL for a resumable upload to store it
+    /// in case we fail or cancel. That way, we can attempt to resume the upload later,
+    /// see `upload_url()`.
+    /// It will also be called with None after a successful upload, which allows the delegate
+    /// to forget the URL. That way, we will not attempt to resume an upload that has already
+    /// finished.
+    fn store_upload_url(&mut self, url: Option<&str>) {
+        let _ = url;
+    }
+
+    /// Called whenever a server response could not be decoded from json.
+    /// It's for informational purposes only, the caller will return with an error
+    /// accordingly.
+    ///
+    /// # Arguments
+    ///
+    /// * `json_encoded_value` - The json-encoded value which failed to decode.
+    /// * `json_decode_error`  - The decoder error
+    fn response_json_decode_error(&mut self, json_encoded_value: &str, json_decode_error: &json::Error) {
+        let _ = json_encoded_value;
+        let _ = json_decode_error;
+    }
+
+    /// Called whenever the http request returns with a non-success status code.
+    /// This can involve authentication issues, or anything else that very much
+    /// depends on the used API method.
+    /// The delegate should check the status, header and decoded json error to decide
+    /// whether to retry or not. In the latter case, the underlying call will fail.
+    ///
+    /// If you choose to retry after a duration, the duration should be chosen using the
+    /// [exponential backoff algorithm](http://en.wikipedia.org/wiki/Exponential_backoff).
+    fn http_failure(&mut self, _: &hyper::client::Response, Option<JsonServerError>, _: Option<ServerError>) -> Retry {
+        Retry::Abort
+    }
+
+    /// Called prior to sending the main request of the given method. It can be used to time
+    /// the call or to print progress information.
+    /// It's also useful as you can be sure that a request will definitely be made.
+    fn pre_request(&mut self) { }
+
+    /// Return the size of each chunk of a resumable upload.
+    /// Must be a power of two, with 1<<18 being the smallest allowed chunk size.
+    /// Will be called once before starting any resumable upload.
+    fn chunk_size(&mut self) -> u64 {
+        1 << 23
+    }
+
+    /// Called before the given chunk is uploaded to the server.
+    /// If true is returned, the upload will be interrupted.
+    /// However, it may be resumable if you stored the upload URL in a previous call
+    /// to `store_upload_url()`
+    fn cancel_chunk_upload(&mut self, chunk: &ContentRange) -> bool {
+        let _ = chunk;
+        false
+    }
+
+    /// Called before the API request method returns, in every case. It can be used to clean up
+    /// internal state between calls to the API.
+    /// This call always has a matching call to `begin(...)`.
+    ///
+    /// # Arguments
+    ///
+    /// * `is_success` - a true value indicates the operation was successful. If false, you should
+    ///                  discard all values stored during `store_upload_url`.
+    fn finished(&mut self, is_success: bool) {
+        let _ = is_success;
+    }
+}
+
+/// A delegate with a conservative default implementation, which is used if no other delegate is
+/// set.
+#[derive(Default)]
+pub struct DefaultDelegate;
+
+impl Delegate for DefaultDelegate {}
+
+
+#[derive(Debug)]
+pub enum Error {
+    /// The http connection failed
+    HttpError(hyper::Error),
+
+    /// An attempt was made to upload a resource with size stored in field `.0`
+    /// even though the maximum upload size is what is stored in field `.1`.
+    UploadSizeLimitExceeded(u64, u64),
+
+    /// Represents information about a request that was not understood by the server.
+    /// Details are included.
+    BadRequest(ErrorResponse),
+
+    /// We needed an API key for authentication, but didn't obtain one.
+    /// Neither through the authenticator, nor through the Delegate.
+    MissingAPIKey,
+
+    /// We required a Token, but didn't get one from the Authenticator
+    MissingToken(Box<error::Error>),
+
+    /// The delgate instructed to cancel the operation
+    Cancelled,
+
+    /// An additional, free form field clashed with one of the built-in optional ones
+    FieldClash(&'static str),
+
+    /// Shows that we failed to decode the server response.
+    /// This can happen if the protocol changes in conjunction with strict json decoding.
+    JsonDecodeError(String, json::Error),
+
+    /// Indicates an HTTP repsonse with a non-success status code
+    Failure(hyper::client::Response),
+}
+
+
+impl Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Error::HttpError(ref err) => err.fmt(f),
+            Error::UploadSizeLimitExceeded(ref resource_size, ref max_size) =>
+                writeln!(f, "The media size {} exceeds the maximum allowed upload size of {}"
+                         , resource_size, max_size),
+            Error::MissingAPIKey => {
+                (writeln!(f, "The application's API key was not found in the configuration")).ok();
+                writeln!(f, "It is used as there are no Scopes defined for this method.")
+            },
+            Error::BadRequest(ref err) => {
+                try!(writeln!(f, "Bad Request ({}): {}", err.error.code, err.error.message));
+                for err in err.error.errors.iter() {
+                    try!(writeln!(f, "    {}: {}, {}{}",
+                                            err.domain,
+                                            err.message,
+                                            err.reason,
+                                            match &err.location {
+                                                &Some(ref loc) => format!("@{}", loc),
+                                                &None => String::new(),
+                                            }));
+                }
+                Ok(())
+            },
+            Error::MissingToken(ref err) =>
+                writeln!(f, "Token retrieval failed with error: {}", err),
+            Error::Cancelled =>
+                writeln!(f, "Operation cancelled by delegate"),
+            Error::FieldClash(field) =>
+                writeln!(f, "The custom parameter '{}' is already provided natively by the CallBuilder.", field),
+            Error::JsonDecodeError(ref json_str, ref err)
+                => writeln!(f, "{}: {}", err, json_str),
+            Error::Failure(ref response) =>
+                writeln!(f, "Http status indicates failure: {:?}", response),
+        }
+    }
+}
+
+impl error::Error for Error {
+    fn description(&self) -> &str {
+        match *self {
+            Error::HttpError(ref err) => err.description(),
+            Error::JsonDecodeError(_, ref err) => err.description(),
+            _ => "NO DESCRIPTION POSSIBLE - use `Display.fmt()` instead"
+        }
+    }
+
+    fn cause(&self) -> Option<&error::Error> {
+        match *self {
+            Error::HttpError(ref err) => err.cause(),
+            Error::JsonDecodeError(_, ref err) => err.cause(),
+            _ => None
+        }
+    }
+}
+
+/// A universal result type used as return for all calls.
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Contains information about an API request.
+pub struct MethodInfo {
+    pub id: &'static str,
+    pub http_method: Method,
+}
+
+const BOUNDARY: &'static str = "MDuXWGyeE33QFXGchb2VFWc4Z7945d";
+
+/// Provides a `Read` interface that converts multiple parts into the protocol
+/// identified by [RFC2387](https://tools.ietf.org/html/rfc2387).
+/// **Note**: This implementation is just as rich as it needs to be to perform uploads
+/// to google APIs, and might not be a fully-featured implementation.
+#[derive(Default)]
+pub struct MultiPartReader<'a> {
+    raw_parts: Vec<(Headers, &'a mut Read)>,
+    current_part: Option<(Cursor<Vec<u8>>, &'a mut Read)>,
+    last_part_boundary: Option<Cursor<Vec<u8>>>,
+}
+
+impl<'a> MultiPartReader<'a> {
+
+    /// Reserve memory for exactly the given amount of parts
+    pub fn reserve_exact(&mut self, cap: usize) {
+        self.raw_parts.reserve_exact(cap);
+    }
+
+    /// Add a new part to the queue of parts to be read on the first `read` call.
+    ///
+    /// # Arguments
+    ///
+    /// `headers` - identifying the body of the part. It's similar to the header
+    ///             in an ordinary single-part call, and should thus contain the
+    ///             same information.
+    /// `reader`  - a reader providing the part's body
+    /// `size`    - the amount of bytes provided by the reader. It will be put onto the header as
+    ///             content-size.
+    /// `mime`    - It will be put onto the content type
+    pub fn add_part(&mut self, reader: &'a mut Read, size: u64, mime_type: Mime) -> &mut MultiPartReader<'a> {
+        let mut headers = Headers::new();
+        headers.set(ContentType(mime_type));
+        headers.set(ContentLength(size));
+        self.raw_parts.push((headers, reader));
+        self
+    }
+
+    /// Returns the mime-type representing our multi-part message.
+    /// Use it with the ContentType header.
+    pub fn mime_type(&self) -> Mime {
+        Mime(
+            TopLevel::Multipart,
+            SubLevel::Ext("Related".to_string()),
+            vec![(Attr::Ext("boundary".to_string()), Value::Ext(BOUNDARY.to_string()))],
+        )
+    }
+
+    /// Returns true if we are totally used
+    fn is_depleted(&self) -> bool {
+        self.raw_parts.len() == 0 && self.current_part.is_none() && self.last_part_boundary.is_none()
+    }
+
+    /// Returns true if we are handling our last part
+    fn is_last_part(&self) -> bool {
+        self.raw_parts.len() == 0 && self.current_part.is_some()
+    }
+}
+
+impl<'a> Read for MultiPartReader<'a> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        match (self.raw_parts.len(),
+               self.current_part.is_none(),
+               self.last_part_boundary.is_none()) {
+            (_, _, false) => {
+                let br = self.last_part_boundary.as_mut().unwrap().read(buf).unwrap_or(0);
+                if br < buf.len() {
+                    self.last_part_boundary = None;
+                }
+                return Ok(br)
+            },
+            (0, true, true) => return Ok(0),
+            (n, true, _) if n > 0 => {
+                let (headers, reader) = self.raw_parts.remove(0);
+                let mut c = Cursor::new(Vec::<u8>::new());
+                (write!(&mut c, "{}--{}{}{}{}", LINE_ENDING, BOUNDARY, LINE_ENDING,
+                                                headers, LINE_ENDING)).unwrap();
+                c.seek(SeekFrom::Start(0)).unwrap();
+                self.current_part = Some((c, reader));
+            }
+            _ => {},
+        }
+
+        // read headers as long as possible
+        let (hb, rr) = {
+            let &mut (ref mut c, ref mut reader) = self.current_part.as_mut().unwrap();
+            let b = c.read(buf).unwrap_or(0);
+            (b, reader.read(&mut buf[b..]))
+        };
+
+        match rr {
+            Ok(bytes_read) => {
+                if hb < buf.len() && bytes_read == 0 {
+                    if self.is_last_part() {
+                        // before clearing the last part, we will add the boundary that
+                        // will be written last
+                        self.last_part_boundary = Some(Cursor::new(
+                                                        format!("{}--{}--", LINE_ENDING, BOUNDARY).into_bytes()))
+                    }
+                    // We are depleted - this can trigger the next part to come in
+                    self.current_part = None;
+                }
+                let mut total_bytes_read = hb + bytes_read;
+                while total_bytes_read < buf.len() && !self.is_depleted() {
+                    match self.read(&mut buf[total_bytes_read ..]) {
+                        Ok(br) => total_bytes_read += br,
+                        Err(err) => return Err(err),
+                    }
+                }
+                Ok(total_bytes_read)
+            }
+            Err(err) => {
+                // fail permanently
+                self.current_part = None;
+                self.last_part_boundary = None;
+                self.raw_parts.clear();
+                Err(err)
+            }
+        }
+    }
+}
+
+/// The `X-Upload-Content-Type` header.
+///
+/// Generated via rustc --pretty expanded -Z unstable-options, and manually
+/// processed to be more readable.
+#[derive(PartialEq, Debug, Clone)]
+pub struct XUploadContentType(pub Mime);
+
+impl ::std::ops::Deref for XUploadContentType {
+    type Target = Mime;
+    fn deref<'a>(&'a self) -> &'a Mime { &self.0 }
+}
+impl ::std::ops::DerefMut for XUploadContentType {
+    fn deref_mut<'a>(&'a mut self) -> &'a mut Mime { &mut self.0 }
+}
+impl Header for XUploadContentType {
+    fn header_name() -> &'static str { "X-Upload-Content-Type" }
+    fn parse_header(raw: &[Vec<u8>]) -> hyper::error::Result<Self> {
+        hyper::header::parsing::from_one_raw_str(raw).map(XUploadContentType)
+    }
+}
+impl HeaderFormat for XUploadContentType {
+    fn fmt_header(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        Display::fmt(&**self, f)
+    }
+}
+impl Display for XUploadContentType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(&**self, f)
+    }
+}
+
+#[derive(Clone, PartialEq, Debug)]
+pub struct Chunk {
+    pub first: u64,
+    pub last: u64
+}
+
+impl fmt::Display for Chunk {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        (write!(fmt, "{}-{}", self.first, self.last)).ok();
+        Ok(())
+    }
+}
+
+impl FromStr for Chunk {
+    type Err = &'static str;
+
+    /// NOTE: only implements `%i-%i`, not `*`
+    fn from_str(s: &str) -> std::result::Result<Chunk, &'static str> {
+        let parts: Vec<&str> = s.split('-').collect();
+        if parts.len() != 2 {
+            return Err("Expected two parts: %i-%i")
+        }
+        Ok(
+            Chunk {
+                first: match FromStr::from_str(parts[0]) {
+                    Ok(d) => d,
+                    _ => return Err("Couldn't parse 'first' as digit")
+                },
+                last: match FromStr::from_str(parts[1]) {
+                    Ok(d) => d,
+                    _ => return Err("Couldn't parse 'last' as digit")
+                }
+            }
+        )
+    }
+}
+
+/// Implements the Content-Range header, for serialization only
+#[derive(Clone, PartialEq, Debug)]
+pub struct ContentRange {
+    pub range: Option<Chunk>,
+    pub total_length: u64,
+}
+
+impl Header for ContentRange {
+    fn header_name() -> &'static str {
+        "Content-Range"
+    }
+
+    /// We are not parsable, as parsing is done by the `Range` header
+    fn parse_header(_: &[Vec<u8>]) -> hyper::error::Result<Self> {
+        Err(hyper::error::Error::Method)
+    }
+}
+
+
+impl HeaderFormat for ContentRange {
+    fn fmt_header(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        try!(fmt.write_str("bytes "));
+        match self.range {
+            Some(ref c) => try!(c.fmt(fmt)),
+            None => try!(fmt.write_str("*"))
+        }
+        (write!(fmt, "/{}", self.total_length)).ok();
+        Ok(())
+    }
+}
+
+#[derive(Clone, PartialEq, Debug)]
+pub struct RangeResponseHeader(pub Chunk);
+
+impl Header for RangeResponseHeader {
+    fn header_name() -> &'static str {
+        "Range"
+    }
+
+    fn parse_header(raw: &[Vec<u8>]) -> hyper::error::Result<Self> {
+        if raw.len() > 0 {
+            let v = &raw[0];
+            if let Ok(s) = std::str::from_utf8(v) {
+                const PREFIX: &'static str = "bytes ";
+                if s.starts_with(PREFIX) {
+                    if let Ok(c) = <Chunk as FromStr>::from_str(&s[PREFIX.len()..]) {
+                        return  Ok(RangeResponseHeader(c))
+                    }
+                }
+            }
+        }
+        Err(hyper::error::Error::Method)
+    }
+}
+
+impl HeaderFormat for RangeResponseHeader {
+    /// No implmentation necessary, we just need to parse
+    fn fmt_header(&self, _: &mut fmt::Formatter) -> fmt::Result {
+        Err(fmt::Error)
+    }
+}
+
+/// A utility type to perform a resumable upload from start to end.
+pub struct ResumableUploadHelper<'a, A: 'a> {
+    pub client: &'a mut hyper::client::Client,
+    pub delegate: &'a mut Delegate,
+    pub start_at: Option<u64>,
+    pub auth: &'a mut A,
+    pub user_agent: &'a str,
+    pub auth_header: Authorization<Bearer>,
+    pub url: &'a str,
+    pub reader: &'a mut ReadSeek,
+    pub media_type: Mime,
+    pub content_length: u64
+}
+
+impl<'a, A> ResumableUploadHelper<'a, A>
+    where A: oauth2::GetToken {
+
+    fn query_transfer_status(&mut self) -> std::result::Result<u64, hyper::Result<hyper::client::Response>> {
+        loop {
+            match self.client.post(self.url)
+                .header(UserAgent(self.user_agent.to_string()))
+                .header(ContentRange { range: None, total_length: self.content_length })
+                .header(self.auth_header.clone())
+                .send() {
+                Ok(r) => {
+                    // 308 = resume-incomplete == PermanentRedirect
+                    let headers = r.headers.clone();
+                    let h: &RangeResponseHeader = match headers.get() {
+                        Some(hh) if r.status == StatusCode::PermanentRedirect => hh,
+                        None|Some(_) => {
+                            if let Retry::After(d) = self.delegate.http_failure(&r, None, None) {
+                                sleep(d);
+                                continue;
+                            }
+                            return Err(Ok(r))
+                        }
+                    };
+                    return Ok(h.0.last)
+                }
+                Err(err) => {
+                    if let Retry::After(d) = self.delegate.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    return Err(Err(err))
+                }
+            }
+        }
+    }
+
+    /// returns None if operation was cancelled by delegate, or the HttpResult.
+    /// It can be that we return the result just because we didn't understand the status code -
+    /// caller should check for status himself before assuming it's OK to use
+    pub fn upload(&mut self) -> Option<hyper::Result<hyper::client::Response>> {
+        let mut start = match self.start_at {
+            Some(s) => s,
+            None => match self.query_transfer_status() {
+                Ok(s) => s,
+                Err(result) => return Some(result)
+            }
+        };
+
+        const MIN_CHUNK_SIZE: u64 = 1 << 18;
+        let chunk_size = match self.delegate.chunk_size() {
+            cs if cs > MIN_CHUNK_SIZE => cs,
+            _ => MIN_CHUNK_SIZE
+        };
+
+        self.reader.seek(SeekFrom::Start(start)).unwrap();
+        loop {
+            let request_size = match self.content_length - start {
+                rs if rs > chunk_size => chunk_size,
+                rs => rs
+            };
+
+            let mut section_reader = self.reader.take(request_size);
+            let range_header = ContentRange {
+                range: Some(Chunk {first: start, last: start + request_size - 1}),
+                total_length: self.content_length
+            };
+            start += request_size;
+            if self.delegate.cancel_chunk_upload(&range_header) {
+                return None
+            }
+            let res = self.client.post(self.url)
+                                 .header(range_header)
+                                 .header(ContentType(self.media_type.clone()))
+                                 .header(UserAgent(self.user_agent.to_string()))
+                                 .body(&mut section_reader)
+                                 .send();
+            match res {
+                Ok(mut res) => {
+                    if res.status == StatusCode::PermanentRedirect  {
+                        continue
+                    }
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let Retry::After(d) = self.delegate.http_failure(&res,
+                                                        json::from_str(&json_err).ok(),
+                                                        json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                    }
+                    return Some(Ok(res))
+                },
+                Err(err) => {
+                    if let Retry::After(d) = self.delegate.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    return Some(Err(err))
+                }
+            }
+        }
+    }
+}
+
+// Copy of src/rust/cli/cmn.rs
+// TODO(ST): Allow sharing common code between program types
+pub fn remove_json_null_values(value: &mut json::value::Value) {
+    match *value {
+        json::value::Value::Object(ref mut map) => {
+            let mut for_removal = Vec::new();
+
+            for (key, mut value) in map.iter_mut() {
+                if value.is_null() {
+                    for_removal.push(key.clone());
+                } else {
+                    remove_json_null_values(&mut value);
+                }
+            }
+
+            for key in &for_removal {
+                map.remove(key);
+            }
+        }
+        _ => {}
+    }
+}

--- a/gen/consumersurveys2/src/lib.rs
+++ b/gen/consumersurveys2/src/lib.rs
@@ -1,0 +1,3991 @@
+// DO NOT EDIT !
+// This file was generated automatically from 'src/mako/api/lib.rs.mako'
+// DO NOT EDIT !
+
+//! This documentation was generated from *Consumer Surveys* crate version *1.0.7+20170407*, where *20170407* is the exact revision of the *consumersurveys:v2* schema built by the [mako](http://www.makotemplates.org/) code generator *v1.0.7*.
+//! The original source code is [on github](https://github.com/Byron/google-apis-rs/tree/master/gen/consumersurveys2).
+//! # Features
+//! 
+//! Handle the following *Resources* with ease from the central [hub](struct.ConsumerSurveys.html) ... 
+//! 
+//! * mobileapppanels
+//!  * [*get*](struct.MobileapppanelGetCall.html), [*list*](struct.MobileapppanelListCall.html) and [*update*](struct.MobileapppanelUpdateCall.html)
+//! * results
+//!  * [*get*](struct.ResultGetCall.html)
+//! * [surveys](struct.Survey.html)
+//!  * [*delete*](struct.SurveyDeleteCall.html), [*get*](struct.SurveyGetCall.html), [*insert*](struct.SurveyInsertCall.html), [*list*](struct.SurveyListCall.html), [*start*](struct.SurveyStartCall.html), [*stop*](struct.SurveyStopCall.html) and [*update*](struct.SurveyUpdateCall.html)
+//! 
+//! 
+//! Download supported by ...
+//! 
+//! * [*get results*](struct.ResultGetCall.html)
+//! 
+//! 
+//! 
+//! Not what you are looking for ? Find all other Google APIs in their Rust [documentation index](http://byron.github.io/google-apis-rs).
+//! 
+//! # Structure of this Library
+//! 
+//! The API is structured into the following primary items:
+//! 
+//! * **[Hub](struct.ConsumerSurveys.html)**
+//!     * a central object to maintain state and allow accessing all *Activities*
+//!     * creates [*Method Builders*](trait.MethodsBuilder.html) which in turn
+//!       allow access to individual [*Call Builders*](trait.CallBuilder.html)
+//! * **[Resources](trait.Resource.html)**
+//!     * primary types that you can apply *Activities* to
+//!     * a collection of properties and *Parts*
+//!     * **[Parts](trait.Part.html)**
+//!         * a collection of properties
+//!         * never directly used in *Activities*
+//! * **[Activities](trait.CallBuilder.html)**
+//!     * operations to apply to *Resources*
+//! 
+//! All *structures* are marked with applicable traits to further categorize them and ease browsing.
+//! 
+//! Generally speaking, you can invoke *Activities* like this:
+//! 
+//! ```Rust,ignore
+//! let r = hub.resource().activity(...).doit()
+//! ```
+//! 
+//! Or specifically ...
+//! 
+//! ```ignore
+//! let r = hub.surveys().delete(...).doit()
+//! let r = hub.surveys().insert(...).doit()
+//! let r = hub.surveys().list(...).doit()
+//! let r = hub.surveys().update(...).doit()
+//! let r = hub.surveys().get(...).doit()
+//! let r = hub.surveys().stop(...).doit()
+//! let r = hub.surveys().start(...).doit()
+//! ```
+//! 
+//! The `resource()` and `activity(...)` calls create [builders][builder-pattern]. The second one dealing with `Activities` 
+//! supports various methods to configure the impending operation (not shown here). It is made such that all required arguments have to be 
+//! specified right away (i.e. `(...)`), whereas all optional ones can be [build up][builder-pattern] as desired.
+//! The `doit()` method performs the actual communication with the server and returns the respective result.
+//! 
+//! # Usage
+//! 
+//! ## Setting up your Project
+//! 
+//! To use this library, you would put the following lines into your `Cargo.toml` file:
+//! 
+//! ```toml
+//! [dependencies]
+//! google-consumersurveys2 = "*"
+//! ```
+//! 
+//! ## A complete example
+//! 
+//! ```test_harness,no_run
+//! extern crate hyper;
+//! extern crate hyper_rustls;
+//! extern crate yup_oauth2 as oauth2;
+//! extern crate google_consumersurveys2 as consumersurveys2;
+//! use consumersurveys2::{Result, Error};
+//! # #[test] fn egal() {
+//! use std::default::Default;
+//! use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+//! use consumersurveys2::ConsumerSurveys;
+//! 
+//! // Get an ApplicationSecret instance by some means. It contains the `client_id` and 
+//! // `client_secret`, among other things.
+//! let secret: ApplicationSecret = Default::default();
+//! // Instantiate the authenticator. It will choose a suitable authentication flow for you, 
+//! // unless you replace  `None` with the desired Flow.
+//! // Provide your own `AuthenticatorDelegate` to adjust the way it operates and get feedback about 
+//! // what's going on. You probably want to bring in your own `TokenStorage` to persist tokens and
+//! // retrieve them from storage.
+//! let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+//!                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+//!                               <MemoryStorage as Default>::default(), None);
+//! let mut hub = ConsumerSurveys::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+//! // You can configure optional parameters by calling the respective setters at will, and
+//! // execute the final call using `doit()`.
+//! // Values shown here are possibly random and not representative !
+//! let result = hub.surveys().list()
+//!              .token("sed")
+//!              .start_index(16)
+//!              .max_results(83)
+//!              .doit();
+//! 
+//! match result {
+//!     Err(e) => match e {
+//!         // The Error enum provides details about what exactly happened.
+//!         // You can also just use its `Debug`, `Display` or `Error` traits
+//!          Error::HttpError(_)
+//!         |Error::MissingAPIKey
+//!         |Error::MissingToken(_)
+//!         |Error::Cancelled
+//!         |Error::UploadSizeLimitExceeded(_, _)
+//!         |Error::Failure(_)
+//!         |Error::BadRequest(_)
+//!         |Error::FieldClash(_)
+//!         |Error::JsonDecodeError(_, _) => println!("{}", e),
+//!     },
+//!     Ok(res) => println!("Success: {:?}", res),
+//! }
+//! # }
+//! ```
+//! ## Handling Errors
+//! 
+//! All errors produced by the system are provided either as [Result](enum.Result.html) enumeration as return value of 
+//! the doit() methods, or handed as possibly intermediate results to either the 
+//! [Hub Delegate](trait.Delegate.html), or the [Authenticator Delegate](https://docs.rs/yup-oauth2/*/yup_oauth2/trait.AuthenticatorDelegate.html).
+//! 
+//! When delegates handle errors or intermediate values, they may have a chance to instruct the system to retry. This 
+//! makes the system potentially resilient to all kinds of errors.
+//! 
+//! ## Uploads and Downloads
+//! If a method supports downloads, the response body, which is part of the [Result](enum.Result.html), should be
+//! read by you to obtain the media.
+//! If such a method also supports a [Response Result](trait.ResponseResult.html), it will return that by default.
+//! You can see it as meta-data for the actual media. To trigger a media download, you will have to set up the builder by making
+//! this call: `.param("alt", "media")`.
+//! 
+//! Methods supporting uploads can do so using up to 2 different protocols: 
+//! *simple* and *resumable*. The distinctiveness of each is represented by customized 
+//! `doit(...)` methods, which are then named `upload(...)` and `upload_resumable(...)` respectively.
+//! 
+//! ## Customization and Callbacks
+//! 
+//! You may alter the way an `doit()` method is called by providing a [delegate](trait.Delegate.html) to the 
+//! [Method Builder](trait.CallBuilder.html) before making the final `doit()` call. 
+//! Respective methods will be called to provide progress information, as well as determine whether the system should 
+//! retry on failure.
+//! 
+//! The [delegate trait](trait.Delegate.html) is default-implemented, allowing you to customize it with minimal effort.
+//! 
+//! ## Optional Parts in Server-Requests
+//! 
+//! All structures provided by this library are made to be [enocodable](trait.RequestValue.html) and 
+//! [decodable](trait.ResponseResult.html) via *json*. Optionals are used to indicate that partial requests are responses 
+//! are valid.
+//! Most optionals are are considered [Parts](trait.Part.html) which are identifiable by name, which will be sent to 
+//! the server to indicate either the set parts of the request or the desired parts in the response.
+//! 
+//! ## Builder Arguments
+//! 
+//! Using [method builders](trait.CallBuilder.html), you are able to prepare an action call by repeatedly calling it's methods.
+//! These will always take a single argument, for which the following statements are true.
+//! 
+//! * [PODs][wiki-pod] are handed by copy
+//! * strings are passed as `&str`
+//! * [request values](trait.RequestValue.html) are moved
+//! 
+//! Arguments will always be copied or cloned into the builder, to make them independent of their original life times.
+//! 
+//! [wiki-pod]: http://en.wikipedia.org/wiki/Plain_old_data_structure
+//! [builder-pattern]: http://en.wikipedia.org/wiki/Builder_pattern
+//! [google-go-api]: https://github.com/google/google-api-go-client
+//! 
+//! 
+
+// Unused attributes happen thanks to defined, but unused structures
+// We don't warn about this, as depending on the API, some data structures or facilities are never used.
+// Instead of pre-determining this, we just disable the lint. It's manually tuned to not have any
+// unused imports in fully featured APIs. Same with unused_mut ... .
+#![allow(unused_imports, unused_mut, dead_code)]
+
+// DO NOT EDIT !
+// This file was generated automatically from 'src/mako/api/lib.rs.mako'
+// DO NOT EDIT !
+
+#[macro_use]
+extern crate serde_derive;
+
+extern crate hyper;
+extern crate serde;
+extern crate serde_json;
+extern crate yup_oauth2 as oauth2;
+extern crate mime;
+extern crate url;
+
+mod cmn;
+
+use std::collections::HashMap;
+use std::cell::RefCell;
+use std::borrow::BorrowMut;
+use std::default::Default;
+use std::collections::BTreeMap;
+use serde_json as json;
+use std::io;
+use std::fs;
+use std::mem;
+use std::thread::sleep;
+use std::time::Duration;
+
+pub use cmn::{MultiPartReader, ToParts, MethodInfo, Result, Error, CallBuilder, Hub, ReadSeek, Part,
+              ResponseResult, RequestValue, NestedType, Delegate, DefaultDelegate, MethodsBuilder,
+              Resource, ErrorResponse, remove_json_null_values};
+
+
+// ##############
+// UTILITIES ###
+// ############
+
+/// Identifies the an OAuth2 authorization scope.
+/// A scope is needed when requesting an
+/// [authorization token](https://developers.google.com/youtube/v3/guides/authentication).
+#[derive(PartialEq, Eq, Hash)]
+pub enum Scope {
+    /// View your email address
+    UserinfoEmail,
+
+    /// View the results for your surveys
+    Readonly,
+
+    /// View and edit your surveys and results
+    Full,
+}
+
+impl AsRef<str> for Scope {
+    fn as_ref(&self) -> &str {
+        match *self {
+            Scope::UserinfoEmail => "https://www.googleapis.com/auth/userinfo.email",
+            Scope::Readonly => "https://www.googleapis.com/auth/consumersurveys.readonly",
+            Scope::Full => "https://www.googleapis.com/auth/consumersurveys",
+        }
+    }
+}
+
+impl Default for Scope {
+    fn default() -> Scope {
+        Scope::Readonly
+    }
+}
+
+
+
+// ########
+// HUB ###
+// ######
+
+/// Central instance to access all ConsumerSurveys related resource activities
+///
+/// # Examples
+///
+/// Instantiate a new hub
+///
+/// ```test_harness,no_run
+/// extern crate hyper;
+/// extern crate hyper_rustls;
+/// extern crate yup_oauth2 as oauth2;
+/// extern crate google_consumersurveys2 as consumersurveys2;
+/// use consumersurveys2::{Result, Error};
+/// # #[test] fn egal() {
+/// use std::default::Default;
+/// use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// use consumersurveys2::ConsumerSurveys;
+/// 
+/// // Get an ApplicationSecret instance by some means. It contains the `client_id` and 
+/// // `client_secret`, among other things.
+/// let secret: ApplicationSecret = Default::default();
+/// // Instantiate the authenticator. It will choose a suitable authentication flow for you, 
+/// // unless you replace  `None` with the desired Flow.
+/// // Provide your own `AuthenticatorDelegate` to adjust the way it operates and get feedback about 
+/// // what's going on. You probably want to bring in your own `TokenStorage` to persist tokens and
+/// // retrieve them from storage.
+/// let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+///                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+///                               <MemoryStorage as Default>::default(), None);
+/// let mut hub = ConsumerSurveys::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.surveys().list()
+///              .token("kasd")
+///              .start_index(79)
+///              .max_results(93)
+///              .doit();
+/// 
+/// match result {
+///     Err(e) => match e {
+///         // The Error enum provides details about what exactly happened.
+///         // You can also just use its `Debug`, `Display` or `Error` traits
+///          Error::HttpError(_)
+///         |Error::MissingAPIKey
+///         |Error::MissingToken(_)
+///         |Error::Cancelled
+///         |Error::UploadSizeLimitExceeded(_, _)
+///         |Error::Failure(_)
+///         |Error::BadRequest(_)
+///         |Error::FieldClash(_)
+///         |Error::JsonDecodeError(_, _) => println!("{}", e),
+///     },
+///     Ok(res) => println!("Success: {:?}", res),
+/// }
+/// # }
+/// ```
+pub struct ConsumerSurveys<C, A> {
+    client: RefCell<C>,
+    auth: RefCell<A>,
+    _user_agent: String,
+    _base_url: String,
+    _root_url: String,
+}
+
+impl<'a, C, A> Hub for ConsumerSurveys<C, A> {}
+
+impl<'a, C, A> ConsumerSurveys<C, A>
+    where  C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+    pub fn new(client: C, authenticator: A) -> ConsumerSurveys<C, A> {
+        ConsumerSurveys {
+            client: RefCell::new(client),
+            auth: RefCell::new(authenticator),
+            _user_agent: "google-api-rust-client/1.0.7".to_string(),
+            _base_url: "https://www.googleapis.com/consumersurveys/v2/".to_string(),
+            _root_url: "https://www.googleapis.com/".to_string(),
+        }
+    }
+
+    pub fn mobileapppanels(&'a self) -> MobileapppanelMethods<'a, C, A> {
+        MobileapppanelMethods { hub: &self }
+    }
+    pub fn results(&'a self) -> ResultMethods<'a, C, A> {
+        ResultMethods { hub: &self }
+    }
+    pub fn surveys(&'a self) -> SurveyMethods<'a, C, A> {
+        SurveyMethods { hub: &self }
+    }
+
+    /// Set the user-agent header field to use in all requests to the server.
+    /// It defaults to `google-api-rust-client/1.0.7`.
+    ///
+    /// Returns the previously set user-agent.
+    pub fn user_agent(&mut self, agent_name: String) -> String {
+        mem::replace(&mut self._user_agent, agent_name)
+    }
+
+    /// Set the base url to use in all requests to the server.
+    /// It defaults to `https://www.googleapis.com/consumersurveys/v2/`.
+    ///
+    /// Returns the previously set base url.
+    pub fn base_url(&mut self, new_base_url: String) -> String {
+        mem::replace(&mut self._base_url, new_base_url)
+    }
+
+    /// Set the root url to use in all requests to the server.
+    /// It defaults to `https://www.googleapis.com/`.
+    ///
+    /// Returns the previously set root url.
+    pub fn root_url(&mut self, new_root_url: String) -> String {
+        mem::replace(&mut self._root_url, new_root_url)
+    }
+}
+
+
+// ############
+// SCHEMAS ###
+// ##########
+/// There is no detailed description.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct SurveyRejection {
+    /// no description provided
+    pub explanation: Option<String>,
+    /// no description provided
+    #[serde(rename="type")]
+    pub type_: Option<String>,
+}
+
+impl Part for SurveyRejection {}
+
+
+/// There is no detailed description.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [get results](struct.ResultGetCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct SurveyResults {
+    /// no description provided
+    pub status: Option<String>,
+    /// no description provided
+    #[serde(rename="surveyUrlId")]
+    pub survey_url_id: Option<String>,
+}
+
+impl ResponseResult for SurveyResults {}
+
+
+/// There is no detailed description.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct TokenPagination {
+    /// no description provided
+    #[serde(rename="nextPageToken")]
+    pub next_page_token: Option<String>,
+    /// no description provided
+    #[serde(rename="previousPageToken")]
+    pub previous_page_token: Option<String>,
+}
+
+impl Part for TokenPagination {}
+
+
+/// There is no detailed description.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct FieldMask {
+    /// no description provided
+    pub fields: Option<Vec<FieldMask>>,
+    /// no description provided
+    pub id: Option<i32>,
+}
+
+impl Part for FieldMask {}
+
+
+/// There is no detailed description.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [start surveys](struct.SurveyStartCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct SurveysStartResponse {
+    /// Unique request ID used for logging and debugging. Please include in any error reporting or troubleshooting requests.
+    #[serde(rename="requestId")]
+    pub request_id: Option<String>,
+}
+
+impl ResponseResult for SurveysStartResponse {}
+
+
+/// There is no detailed description.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [list surveys](struct.SurveyListCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct SurveysListResponse {
+    /// no description provided
+    #[serde(rename="tokenPagination")]
+    pub token_pagination: Option<TokenPagination>,
+    /// no description provided
+    #[serde(rename="pageInfo")]
+    pub page_info: Option<PageInfo>,
+    /// An individual survey resource.
+    pub resources: Option<Vec<Survey>>,
+    /// Unique request ID used for logging and debugging. Please include in any error reporting or troubleshooting requests.
+    #[serde(rename="requestId")]
+    pub request_id: Option<String>,
+}
+
+impl ResponseResult for SurveysListResponse {}
+
+
+/// There is no detailed description.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [list mobileapppanels](struct.MobileapppanelListCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct MobileAppPanelsListResponse {
+    /// no description provided
+    #[serde(rename="tokenPagination")]
+    pub token_pagination: Option<TokenPagination>,
+    /// no description provided
+    #[serde(rename="pageInfo")]
+    pub page_info: Option<PageInfo>,
+    /// An individual predefined panel of Opinion Rewards mobile users.
+    pub resources: Option<Vec<MobileAppPanel>>,
+    /// Unique request ID used for logging and debugging. Please include in any error reporting or troubleshooting requests.
+    #[serde(rename="requestId")]
+    pub request_id: Option<String>,
+}
+
+impl ResponseResult for MobileAppPanelsListResponse {}
+
+
+/// There is no detailed description.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [start surveys](struct.SurveyStartCall.html) (request)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct SurveysStartRequest {
+    /// Threshold to start a survey automically if the quoted prices is less than or equal to this value. See Survey.Cost for more details.
+    #[serde(rename="maxCostPerResponseNanos")]
+    pub max_cost_per_response_nanos: Option<String>,
+}
+
+impl RequestValue for SurveysStartRequest {}
+
+
+/// There is no detailed description.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct SurveyCost {
+    /// no description provided
+    pub nanos: Option<String>,
+    /// no description provided
+    #[serde(rename="currencyCode")]
+    pub currency_code: Option<String>,
+    /// no description provided
+    #[serde(rename="costPerResponseNanos")]
+    pub cost_per_response_nanos: Option<String>,
+    /// no description provided
+    #[serde(rename="maxCostPerResponseNanos")]
+    pub max_cost_per_response_nanos: Option<String>,
+}
+
+impl Part for SurveyCost {}
+
+
+/// There is no detailed description.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct SurveyAudience {
+    /// no description provided
+    pub languages: Option<Vec<String>>,
+    /// no description provided
+    #[serde(rename="countrySubdivision")]
+    pub country_subdivision: Option<String>,
+    /// no description provided
+    #[serde(rename="mobileAppPanelId")]
+    pub mobile_app_panel_id: Option<String>,
+    /// no description provided
+    pub country: Option<String>,
+    /// no description provided
+    pub gender: Option<String>,
+    /// no description provided
+    pub ages: Option<Vec<String>>,
+    /// no description provided
+    #[serde(rename="populationSource")]
+    pub population_source: Option<String>,
+}
+
+impl Part for SurveyAudience {}
+
+
+/// There is no detailed description.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct SurveyQuestion {
+    /// no description provided
+    #[serde(rename="mustPickSuggestion")]
+    pub must_pick_suggestion: Option<bool>,
+    /// no description provided
+    #[serde(rename="thresholdAnswers")]
+    pub threshold_answers: Option<Vec<String>>,
+    /// no description provided
+    #[serde(rename="numStars")]
+    pub num_stars: Option<String>,
+    /// no description provided
+    #[serde(rename="lowValueLabel")]
+    pub low_value_label: Option<String>,
+    /// no description provided
+    #[serde(rename="videoId")]
+    pub video_id: Option<String>,
+    /// no description provided
+    pub answers: Option<Vec<String>>,
+    /// no description provided
+    #[serde(rename="hasOther")]
+    pub has_other: Option<bool>,
+    /// no description provided
+    pub images: Option<Vec<SurveyQuestionImage>>,
+    /// no description provided
+    #[serde(rename="unitOfMeasurementLabel")]
+    pub unit_of_measurement_label: Option<String>,
+    /// no description provided
+    #[serde(rename="lastAnswerPositionPinned")]
+    pub last_answer_position_pinned: Option<bool>,
+    /// no description provided
+    #[serde(rename="openTextSuggestions")]
+    pub open_text_suggestions: Option<Vec<String>>,
+    /// no description provided
+    #[serde(rename="highValueLabel")]
+    pub high_value_label: Option<String>,
+    /// no description provided
+    pub question: Option<String>,
+    /// no description provided
+    #[serde(rename="sentimentText")]
+    pub sentiment_text: Option<String>,
+    /// no description provided
+    #[serde(rename="singleLineResponse")]
+    pub single_line_response: Option<bool>,
+    /// no description provided
+    #[serde(rename="type")]
+    pub type_: Option<String>,
+    /// no description provided
+    #[serde(rename="answerOrder")]
+    pub answer_order: Option<String>,
+    /// no description provided
+    #[serde(rename="openTextPlaceholder")]
+    pub open_text_placeholder: Option<String>,
+}
+
+impl Part for SurveyQuestion {}
+
+
+/// There is no detailed description.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct SurveyQuestionImage {
+    /// no description provided
+    pub url: Option<String>,
+    /// no description provided
+    #[serde(rename="altText")]
+    pub alt_text: Option<String>,
+    /// no description provided
+    pub data: Option<String>,
+}
+
+impl Part for SurveyQuestionImage {}
+
+
+/// There is no detailed description.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [get results](struct.ResultGetCall.html) (request)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct ResultsGetRequest {
+    /// no description provided
+    #[serde(rename="resultMask")]
+    pub result_mask: Option<ResultsMask>,
+}
+
+impl RequestValue for ResultsGetRequest {}
+
+
+/// There is no detailed description.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct PageInfo {
+    /// no description provided
+    #[serde(rename="resultPerPage")]
+    pub result_per_page: Option<i32>,
+    /// no description provided
+    #[serde(rename="startIndex")]
+    pub start_index: Option<i32>,
+    /// no description provided
+    #[serde(rename="totalResults")]
+    pub total_results: Option<i32>,
+}
+
+impl Part for PageInfo {}
+
+
+/// There is no detailed description.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct ResultsMask {
+    /// no description provided
+    pub fields: Option<Vec<FieldMask>>,
+    /// no description provided
+    pub projection: Option<String>,
+}
+
+impl Part for ResultsMask {}
+
+
+/// There is no detailed description.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [delete surveys](struct.SurveyDeleteCall.html) (none)
+/// * [insert surveys](struct.SurveyInsertCall.html) (request|response)
+/// * [list surveys](struct.SurveyListCall.html) (none)
+/// * [update surveys](struct.SurveyUpdateCall.html) (request|response)
+/// * [get surveys](struct.SurveyGetCall.html) (response)
+/// * [stop surveys](struct.SurveyStopCall.html) (none)
+/// * [start surveys](struct.SurveyStartCall.html) (none)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Survey {
+    /// no description provided
+    pub owners: Option<Vec<String>>,
+    /// no description provided
+    pub description: Option<String>,
+    /// no description provided
+    pub title: Option<String>,
+    /// no description provided
+    #[serde(rename="customerData")]
+    pub customer_data: Option<String>,
+    /// no description provided
+    pub state: Option<String>,
+    /// no description provided
+    pub audience: Option<SurveyAudience>,
+    /// no description provided
+    pub cost: Option<SurveyCost>,
+    /// no description provided
+    #[serde(rename="surveyUrlId")]
+    pub survey_url_id: Option<String>,
+    /// no description provided
+    pub questions: Option<Vec<SurveyQuestion>>,
+    /// no description provided
+    #[serde(rename="wantedResponseCount")]
+    pub wanted_response_count: Option<i32>,
+    /// no description provided
+    #[serde(rename="rejectionReason")]
+    pub rejection_reason: Option<SurveyRejection>,
+}
+
+impl RequestValue for Survey {}
+impl Resource for Survey {}
+impl ResponseResult for Survey {}
+
+
+/// There is no detailed description.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [delete surveys](struct.SurveyDeleteCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct SurveysDeleteResponse {
+    /// Unique request ID used for logging and debugging. Please include in any error reporting or troubleshooting requests.
+    #[serde(rename="requestId")]
+    pub request_id: Option<String>,
+}
+
+impl ResponseResult for SurveysDeleteResponse {}
+
+
+/// There is no detailed description.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [update mobileapppanels](struct.MobileapppanelUpdateCall.html) (request|response)
+/// * [get mobileapppanels](struct.MobileapppanelGetCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct MobileAppPanel {
+    /// no description provided
+    pub owners: Option<Vec<String>>,
+    /// no description provided
+    #[serde(rename="mobileAppPanelId")]
+    pub mobile_app_panel_id: Option<String>,
+    /// no description provided
+    pub name: Option<String>,
+    /// no description provided
+    pub language: Option<String>,
+    /// no description provided
+    pub country: Option<String>,
+    /// no description provided
+    #[serde(rename="isPublicPanel")]
+    pub is_public_panel: Option<bool>,
+}
+
+impl RequestValue for MobileAppPanel {}
+impl Resource for MobileAppPanel {}
+impl ResponseResult for MobileAppPanel {}
+
+
+/// There is no detailed description.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [stop surveys](struct.SurveyStopCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct SurveysStopResponse {
+    /// Unique request ID used for logging and debugging. Please include in any error reporting or troubleshooting requests.
+    #[serde(rename="requestId")]
+    pub request_id: Option<String>,
+}
+
+impl ResponseResult for SurveysStopResponse {}
+
+
+
+// ###################
+// MethodBuilders ###
+// #################
+
+/// A builder providing access to all methods supported on *survey* resources.
+/// It is not used directly, but through the `ConsumerSurveys` hub.
+///
+/// # Example
+///
+/// Instantiate a resource builder
+///
+/// ```test_harness,no_run
+/// extern crate hyper;
+/// extern crate hyper_rustls;
+/// extern crate yup_oauth2 as oauth2;
+/// extern crate google_consumersurveys2 as consumersurveys2;
+/// 
+/// # #[test] fn egal() {
+/// use std::default::Default;
+/// use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// use consumersurveys2::ConsumerSurveys;
+/// 
+/// let secret: ApplicationSecret = Default::default();
+/// let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+///                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+///                               <MemoryStorage as Default>::default(), None);
+/// let mut hub = ConsumerSurveys::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // Usually you wouldn't bind this to a variable, but keep calling *CallBuilders*
+/// // like `delete(...)`, `get(...)`, `insert(...)`, `list(...)`, `start(...)`, `stop(...)` and `update(...)`
+/// // to build up your call.
+/// let rb = hub.surveys();
+/// # }
+/// ```
+pub struct SurveyMethods<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a ConsumerSurveys<C, A>,
+}
+
+impl<'a, C, A> MethodsBuilder for SurveyMethods<'a, C, A> {}
+
+impl<'a, C, A> SurveyMethods<'a, C, A> {
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Removes a survey from view in all user GET requests.
+    /// 
+    /// # Arguments
+    ///
+    /// * `surveyUrlId` - External URL ID for the survey.
+    pub fn delete(&self, survey_url_id: &str) -> SurveyDeleteCall<'a, C, A> {
+        SurveyDeleteCall {
+            hub: self.hub,
+            _survey_url_id: survey_url_id.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Creates a survey.
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    pub fn insert(&self, request: Survey) -> SurveyInsertCall<'a, C, A> {
+        SurveyInsertCall {
+            hub: self.hub,
+            _request: request,
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Lists the surveys owned by the authenticated user.
+    pub fn list(&self) -> SurveyListCall<'a, C, A> {
+        SurveyListCall {
+            hub: self.hub,
+            _token: Default::default(),
+            _start_index: Default::default(),
+            _max_results: Default::default(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Updates a survey. Currently the only property that can be updated is the owners property.
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    /// * `surveyUrlId` - External URL ID for the survey.
+    pub fn update(&self, request: Survey, survey_url_id: &str) -> SurveyUpdateCall<'a, C, A> {
+        SurveyUpdateCall {
+            hub: self.hub,
+            _request: request,
+            _survey_url_id: survey_url_id.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Retrieves information about the specified survey.
+    /// 
+    /// # Arguments
+    ///
+    /// * `surveyUrlId` - External URL ID for the survey.
+    pub fn get(&self, survey_url_id: &str) -> SurveyGetCall<'a, C, A> {
+        SurveyGetCall {
+            hub: self.hub,
+            _survey_url_id: survey_url_id.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Stops a running survey.
+    /// 
+    /// # Arguments
+    ///
+    /// * `resourceId` - No description provided.
+    pub fn stop(&self, resource_id: &str) -> SurveyStopCall<'a, C, A> {
+        SurveyStopCall {
+            hub: self.hub,
+            _resource_id: resource_id.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Begins running a survey.
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    /// * `resourceId` - No description provided.
+    pub fn start(&self, request: SurveysStartRequest, resource_id: &str) -> SurveyStartCall<'a, C, A> {
+        SurveyStartCall {
+            hub: self.hub,
+            _request: request,
+            _resource_id: resource_id.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+}
+
+
+
+/// A builder providing access to all methods supported on *result* resources.
+/// It is not used directly, but through the `ConsumerSurveys` hub.
+///
+/// # Example
+///
+/// Instantiate a resource builder
+///
+/// ```test_harness,no_run
+/// extern crate hyper;
+/// extern crate hyper_rustls;
+/// extern crate yup_oauth2 as oauth2;
+/// extern crate google_consumersurveys2 as consumersurveys2;
+/// 
+/// # #[test] fn egal() {
+/// use std::default::Default;
+/// use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// use consumersurveys2::ConsumerSurveys;
+/// 
+/// let secret: ApplicationSecret = Default::default();
+/// let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+///                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+///                               <MemoryStorage as Default>::default(), None);
+/// let mut hub = ConsumerSurveys::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // Usually you wouldn't bind this to a variable, but keep calling *CallBuilders*
+/// // like `get(...)`
+/// // to build up your call.
+/// let rb = hub.results();
+/// # }
+/// ```
+pub struct ResultMethods<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a ConsumerSurveys<C, A>,
+}
+
+impl<'a, C, A> MethodsBuilder for ResultMethods<'a, C, A> {}
+
+impl<'a, C, A> ResultMethods<'a, C, A> {
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Retrieves any survey results that have been produced so far. Results are formatted as an Excel file. You must add "?alt=media" to the URL as an argument to get results.
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    /// * `surveyUrlId` - External URL ID for the survey.
+    pub fn get(&self, request: ResultsGetRequest, survey_url_id: &str) -> ResultGetCall<'a, C, A> {
+        ResultGetCall {
+            hub: self.hub,
+            _request: request,
+            _survey_url_id: survey_url_id.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+}
+
+
+
+/// A builder providing access to all methods supported on *mobileapppanel* resources.
+/// It is not used directly, but through the `ConsumerSurveys` hub.
+///
+/// # Example
+///
+/// Instantiate a resource builder
+///
+/// ```test_harness,no_run
+/// extern crate hyper;
+/// extern crate hyper_rustls;
+/// extern crate yup_oauth2 as oauth2;
+/// extern crate google_consumersurveys2 as consumersurveys2;
+/// 
+/// # #[test] fn egal() {
+/// use std::default::Default;
+/// use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// use consumersurveys2::ConsumerSurveys;
+/// 
+/// let secret: ApplicationSecret = Default::default();
+/// let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+///                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+///                               <MemoryStorage as Default>::default(), None);
+/// let mut hub = ConsumerSurveys::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // Usually you wouldn't bind this to a variable, but keep calling *CallBuilders*
+/// // like `get(...)`, `list(...)` and `update(...)`
+/// // to build up your call.
+/// let rb = hub.mobileapppanels();
+/// # }
+/// ```
+pub struct MobileapppanelMethods<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a ConsumerSurveys<C, A>,
+}
+
+impl<'a, C, A> MethodsBuilder for MobileapppanelMethods<'a, C, A> {}
+
+impl<'a, C, A> MobileapppanelMethods<'a, C, A> {
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Updates a MobileAppPanel. Currently the only property that can be updated is the owners property.
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    /// * `panelId` - External URL ID for the panel.
+    pub fn update(&self, request: MobileAppPanel, panel_id: &str) -> MobileapppanelUpdateCall<'a, C, A> {
+        MobileapppanelUpdateCall {
+            hub: self.hub,
+            _request: request,
+            _panel_id: panel_id.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Retrieves a MobileAppPanel that is available to the authenticated user.
+    /// 
+    /// # Arguments
+    ///
+    /// * `panelId` - External URL ID for the panel.
+    pub fn get(&self, panel_id: &str) -> MobileapppanelGetCall<'a, C, A> {
+        MobileapppanelGetCall {
+            hub: self.hub,
+            _panel_id: panel_id.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Lists the MobileAppPanels available to the authenticated user.
+    pub fn list(&self) -> MobileapppanelListCall<'a, C, A> {
+        MobileapppanelListCall {
+            hub: self.hub,
+            _token: Default::default(),
+            _start_index: Default::default(),
+            _max_results: Default::default(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+}
+
+
+
+
+
+// ###################
+// CallBuilders   ###
+// #################
+
+/// Removes a survey from view in all user GET requests.
+///
+/// A builder for the *delete* method supported by a *survey* resource.
+/// It is not used directly, but through a `SurveyMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_consumersurveys2 as consumersurveys2;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use consumersurveys2::ConsumerSurveys;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = ConsumerSurveys::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.surveys().delete("surveyUrlId")
+///              .doit();
+/// # }
+/// ```
+pub struct SurveyDeleteCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a ConsumerSurveys<C, A>,
+    _survey_url_id: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for SurveyDeleteCall<'a, C, A> {}
+
+impl<'a, C, A> SurveyDeleteCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, SurveysDeleteResponse)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "consumersurveys.surveys.delete",
+                               http_method: hyper::method::Method::Delete });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((3 + self._additional_params.len()));
+        params.push(("surveyUrlId", self._survey_url_id.to_string()));
+        for &field in ["alt", "surveyUrlId"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "surveys/{surveyUrlId}";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::Full.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{surveyUrlId}", "surveyUrlId")].iter() {
+            let mut replace_with: Option<&str> = None;
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = Some(value);
+                    break;
+                }
+            }
+            url = url.replace(find_this, replace_with.expect("to find substitution value in params"));
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["surveyUrlId"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Delete, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    /// External URL ID for the survey.
+    ///
+    /// Sets the *survey url id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn survey_url_id(mut self, new_value: &str) -> SurveyDeleteCall<'a, C, A> {
+        self._survey_url_id = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> SurveyDeleteCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters. Overrides userIp if both are provided.
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *userIp* (query-string) - IP address of the site where the request originates. Use this if you want to enforce per-user limits.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for the response.
+    pub fn param<T>(mut self, name: T, value: T) -> SurveyDeleteCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::Full`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> SurveyDeleteCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Creates a survey.
+///
+/// A builder for the *insert* method supported by a *survey* resource.
+/// It is not used directly, but through a `SurveyMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_consumersurveys2 as consumersurveys2;
+/// use consumersurveys2::Survey;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use consumersurveys2::ConsumerSurveys;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = ConsumerSurveys::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = Survey::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.surveys().insert(req)
+///              .doit();
+/// # }
+/// ```
+pub struct SurveyInsertCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a ConsumerSurveys<C, A>,
+    _request: Survey,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for SurveyInsertCall<'a, C, A> {}
+
+impl<'a, C, A> SurveyInsertCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, Survey)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "consumersurveys.surveys.insert",
+                               http_method: hyper::method::Method::Post });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((3 + self._additional_params.len()));
+        for &field in ["alt"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "surveys";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::Full.as_ref().to_string(), ());
+        }
+
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Post, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: Survey) -> SurveyInsertCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> SurveyInsertCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters. Overrides userIp if both are provided.
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *userIp* (query-string) - IP address of the site where the request originates. Use this if you want to enforce per-user limits.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for the response.
+    pub fn param<T>(mut self, name: T, value: T) -> SurveyInsertCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::Full`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> SurveyInsertCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Lists the surveys owned by the authenticated user.
+///
+/// A builder for the *list* method supported by a *survey* resource.
+/// It is not used directly, but through a `SurveyMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_consumersurveys2 as consumersurveys2;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use consumersurveys2::ConsumerSurveys;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = ConsumerSurveys::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.surveys().list()
+///              .token("amet.")
+///              .start_index(20)
+///              .max_results(66)
+///              .doit();
+/// # }
+/// ```
+pub struct SurveyListCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a ConsumerSurveys<C, A>,
+    _token: Option<String>,
+    _start_index: Option<u32>,
+    _max_results: Option<u32>,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for SurveyListCall<'a, C, A> {}
+
+impl<'a, C, A> SurveyListCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, SurveysListResponse)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "consumersurveys.surveys.list",
+                               http_method: hyper::method::Method::Get });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((5 + self._additional_params.len()));
+        if let Some(value) = self._token {
+            params.push(("token", value.to_string()));
+        }
+        if let Some(value) = self._start_index {
+            params.push(("startIndex", value.to_string()));
+        }
+        if let Some(value) = self._max_results {
+            params.push(("maxResults", value.to_string()));
+        }
+        for &field in ["alt", "token", "startIndex", "maxResults"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "surveys";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::Readonly.as_ref().to_string(), ());
+        }
+
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Get, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *token* query property to the given value.
+    pub fn token(mut self, new_value: &str) -> SurveyListCall<'a, C, A> {
+        self._token = Some(new_value.to_string());
+        self
+    }
+    ///
+    /// Sets the *start index* query property to the given value.
+    pub fn start_index(mut self, new_value: u32) -> SurveyListCall<'a, C, A> {
+        self._start_index = Some(new_value);
+        self
+    }
+    ///
+    /// Sets the *max results* query property to the given value.
+    pub fn max_results(mut self, new_value: u32) -> SurveyListCall<'a, C, A> {
+        self._max_results = Some(new_value);
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> SurveyListCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters. Overrides userIp if both are provided.
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *userIp* (query-string) - IP address of the site where the request originates. Use this if you want to enforce per-user limits.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for the response.
+    pub fn param<T>(mut self, name: T, value: T) -> SurveyListCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::Readonly`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> SurveyListCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Updates a survey. Currently the only property that can be updated is the owners property.
+///
+/// A builder for the *update* method supported by a *survey* resource.
+/// It is not used directly, but through a `SurveyMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_consumersurveys2 as consumersurveys2;
+/// use consumersurveys2::Survey;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use consumersurveys2::ConsumerSurveys;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = ConsumerSurveys::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = Survey::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.surveys().update(req, "surveyUrlId")
+///              .doit();
+/// # }
+/// ```
+pub struct SurveyUpdateCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a ConsumerSurveys<C, A>,
+    _request: Survey,
+    _survey_url_id: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for SurveyUpdateCall<'a, C, A> {}
+
+impl<'a, C, A> SurveyUpdateCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, Survey)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "consumersurveys.surveys.update",
+                               http_method: hyper::method::Method::Put });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((4 + self._additional_params.len()));
+        params.push(("surveyUrlId", self._survey_url_id.to_string()));
+        for &field in ["alt", "surveyUrlId"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "surveys/{surveyUrlId}";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::Full.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{surveyUrlId}", "surveyUrlId")].iter() {
+            let mut replace_with: Option<&str> = None;
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = Some(value);
+                    break;
+                }
+            }
+            url = url.replace(find_this, replace_with.expect("to find substitution value in params"));
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["surveyUrlId"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Put, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: Survey) -> SurveyUpdateCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// External URL ID for the survey.
+    ///
+    /// Sets the *survey url id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn survey_url_id(mut self, new_value: &str) -> SurveyUpdateCall<'a, C, A> {
+        self._survey_url_id = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> SurveyUpdateCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters. Overrides userIp if both are provided.
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *userIp* (query-string) - IP address of the site where the request originates. Use this if you want to enforce per-user limits.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for the response.
+    pub fn param<T>(mut self, name: T, value: T) -> SurveyUpdateCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::Full`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> SurveyUpdateCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Retrieves information about the specified survey.
+///
+/// A builder for the *get* method supported by a *survey* resource.
+/// It is not used directly, but through a `SurveyMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_consumersurveys2 as consumersurveys2;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use consumersurveys2::ConsumerSurveys;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = ConsumerSurveys::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.surveys().get("surveyUrlId")
+///              .doit();
+/// # }
+/// ```
+pub struct SurveyGetCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a ConsumerSurveys<C, A>,
+    _survey_url_id: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for SurveyGetCall<'a, C, A> {}
+
+impl<'a, C, A> SurveyGetCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, Survey)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "consumersurveys.surveys.get",
+                               http_method: hyper::method::Method::Get });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((3 + self._additional_params.len()));
+        params.push(("surveyUrlId", self._survey_url_id.to_string()));
+        for &field in ["alt", "surveyUrlId"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "surveys/{surveyUrlId}";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::Readonly.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{surveyUrlId}", "surveyUrlId")].iter() {
+            let mut replace_with: Option<&str> = None;
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = Some(value);
+                    break;
+                }
+            }
+            url = url.replace(find_this, replace_with.expect("to find substitution value in params"));
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["surveyUrlId"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Get, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    /// External URL ID for the survey.
+    ///
+    /// Sets the *survey url id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn survey_url_id(mut self, new_value: &str) -> SurveyGetCall<'a, C, A> {
+        self._survey_url_id = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> SurveyGetCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters. Overrides userIp if both are provided.
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *userIp* (query-string) - IP address of the site where the request originates. Use this if you want to enforce per-user limits.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for the response.
+    pub fn param<T>(mut self, name: T, value: T) -> SurveyGetCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::Readonly`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> SurveyGetCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Stops a running survey.
+///
+/// A builder for the *stop* method supported by a *survey* resource.
+/// It is not used directly, but through a `SurveyMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_consumersurveys2 as consumersurveys2;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use consumersurveys2::ConsumerSurveys;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = ConsumerSurveys::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.surveys().stop("resourceId")
+///              .doit();
+/// # }
+/// ```
+pub struct SurveyStopCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a ConsumerSurveys<C, A>,
+    _resource_id: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for SurveyStopCall<'a, C, A> {}
+
+impl<'a, C, A> SurveyStopCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, SurveysStopResponse)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "consumersurveys.surveys.stop",
+                               http_method: hyper::method::Method::Post });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((3 + self._additional_params.len()));
+        params.push(("resourceId", self._resource_id.to_string()));
+        for &field in ["alt", "resourceId"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "surveys/{resourceId}/stop";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::Full.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{resourceId}", "resourceId")].iter() {
+            let mut replace_with: Option<&str> = None;
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = Some(value);
+                    break;
+                }
+            }
+            url = url.replace(find_this, replace_with.expect("to find substitution value in params"));
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["resourceId"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Post, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *resource id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn resource_id(mut self, new_value: &str) -> SurveyStopCall<'a, C, A> {
+        self._resource_id = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> SurveyStopCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters. Overrides userIp if both are provided.
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *userIp* (query-string) - IP address of the site where the request originates. Use this if you want to enforce per-user limits.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for the response.
+    pub fn param<T>(mut self, name: T, value: T) -> SurveyStopCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::Full`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> SurveyStopCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Begins running a survey.
+///
+/// A builder for the *start* method supported by a *survey* resource.
+/// It is not used directly, but through a `SurveyMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_consumersurveys2 as consumersurveys2;
+/// use consumersurveys2::SurveysStartRequest;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use consumersurveys2::ConsumerSurveys;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = ConsumerSurveys::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = SurveysStartRequest::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.surveys().start(req, "resourceId")
+///              .doit();
+/// # }
+/// ```
+pub struct SurveyStartCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a ConsumerSurveys<C, A>,
+    _request: SurveysStartRequest,
+    _resource_id: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for SurveyStartCall<'a, C, A> {}
+
+impl<'a, C, A> SurveyStartCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, SurveysStartResponse)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "consumersurveys.surveys.start",
+                               http_method: hyper::method::Method::Post });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((4 + self._additional_params.len()));
+        params.push(("resourceId", self._resource_id.to_string()));
+        for &field in ["alt", "resourceId"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "surveys/{resourceId}/start";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::Full.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{resourceId}", "resourceId")].iter() {
+            let mut replace_with: Option<&str> = None;
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = Some(value);
+                    break;
+                }
+            }
+            url = url.replace(find_this, replace_with.expect("to find substitution value in params"));
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["resourceId"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Post, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: SurveysStartRequest) -> SurveyStartCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    ///
+    /// Sets the *resource id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn resource_id(mut self, new_value: &str) -> SurveyStartCall<'a, C, A> {
+        self._resource_id = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> SurveyStartCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters. Overrides userIp if both are provided.
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *userIp* (query-string) - IP address of the site where the request originates. Use this if you want to enforce per-user limits.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for the response.
+    pub fn param<T>(mut self, name: T, value: T) -> SurveyStartCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::Full`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> SurveyStartCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Retrieves any survey results that have been produced so far. Results are formatted as an Excel file. You must add "?alt=media" to the URL as an argument to get results.
+///
+/// This method supports **media download**. To enable it, adjust the builder like this:
+/// `.param("alt", "media")`.
+/// Please note that due to missing multi-part support on the server side, you will only receive the media,
+/// but not the `SurveyResults` structure that you would usually get. The latter will be a default value.
+///
+/// A builder for the *get* method supported by a *result* resource.
+/// It is not used directly, but through a `ResultMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_consumersurveys2 as consumersurveys2;
+/// use consumersurveys2::ResultsGetRequest;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use consumersurveys2::ConsumerSurveys;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = ConsumerSurveys::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = ResultsGetRequest::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.results().get(req, "surveyUrlId")
+///              .doit();
+/// # }
+/// ```
+pub struct ResultGetCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a ConsumerSurveys<C, A>,
+    _request: ResultsGetRequest,
+    _survey_url_id: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for ResultGetCall<'a, C, A> {}
+
+impl<'a, C, A> ResultGetCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, SurveyResults)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "consumersurveys.results.get",
+                               http_method: hyper::method::Method::Get });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((3 + self._additional_params.len()));
+        params.push(("surveyUrlId", self._survey_url_id.to_string()));
+        for &field in ["surveyUrlId"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        let (json_field_missing, enable_resource_parsing) = {
+            let mut enable = true;
+            let mut field_present = true;
+            for &(name, ref value) in params.iter() {
+                if name == "alt" {
+                    field_present = false;
+                    if <String as AsRef<str>>::as_ref(&value) != "json" {
+                        enable = false;
+                    }
+                    break;
+                }
+            }
+            (field_present, enable)
+        };
+        if json_field_missing {
+            params.push(("alt", "json".to_string()));
+        }
+
+        let mut url = self.hub._base_url.clone() + "surveys/{surveyUrlId}/results";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::Readonly.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{surveyUrlId}", "surveyUrlId")].iter() {
+            let mut replace_with: Option<&str> = None;
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = Some(value);
+                    break;
+                }
+            }
+            url = url.replace(find_this, replace_with.expect("to find substitution value in params"));
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["surveyUrlId"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Get, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = if enable_resource_parsing {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    } else { (res, Default::default()) };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: ResultsGetRequest) -> ResultGetCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// External URL ID for the survey.
+    ///
+    /// Sets the *survey url id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn survey_url_id(mut self, new_value: &str) -> ResultGetCall<'a, C, A> {
+        self._survey_url_id = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> ResultGetCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters. Overrides userIp if both are provided.
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *userIp* (query-string) - IP address of the site where the request originates. Use this if you want to enforce per-user limits.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for the response.
+    pub fn param<T>(mut self, name: T, value: T) -> ResultGetCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::Readonly`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> ResultGetCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Updates a MobileAppPanel. Currently the only property that can be updated is the owners property.
+///
+/// A builder for the *update* method supported by a *mobileapppanel* resource.
+/// It is not used directly, but through a `MobileapppanelMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_consumersurveys2 as consumersurveys2;
+/// use consumersurveys2::MobileAppPanel;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use consumersurveys2::ConsumerSurveys;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = ConsumerSurveys::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = MobileAppPanel::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.mobileapppanels().update(req, "panelId")
+///              .doit();
+/// # }
+/// ```
+pub struct MobileapppanelUpdateCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a ConsumerSurveys<C, A>,
+    _request: MobileAppPanel,
+    _panel_id: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for MobileapppanelUpdateCall<'a, C, A> {}
+
+impl<'a, C, A> MobileapppanelUpdateCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, MobileAppPanel)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "consumersurveys.mobileapppanels.update",
+                               http_method: hyper::method::Method::Put });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((4 + self._additional_params.len()));
+        params.push(("panelId", self._panel_id.to_string()));
+        for &field in ["alt", "panelId"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "mobileAppPanels/{panelId}";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::Full.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{panelId}", "panelId")].iter() {
+            let mut replace_with: Option<&str> = None;
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = Some(value);
+                    break;
+                }
+            }
+            url = url.replace(find_this, replace_with.expect("to find substitution value in params"));
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["panelId"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Put, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: MobileAppPanel) -> MobileapppanelUpdateCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// External URL ID for the panel.
+    ///
+    /// Sets the *panel id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn panel_id(mut self, new_value: &str) -> MobileapppanelUpdateCall<'a, C, A> {
+        self._panel_id = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> MobileapppanelUpdateCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters. Overrides userIp if both are provided.
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *userIp* (query-string) - IP address of the site where the request originates. Use this if you want to enforce per-user limits.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for the response.
+    pub fn param<T>(mut self, name: T, value: T) -> MobileapppanelUpdateCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::Full`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> MobileapppanelUpdateCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Retrieves a MobileAppPanel that is available to the authenticated user.
+///
+/// A builder for the *get* method supported by a *mobileapppanel* resource.
+/// It is not used directly, but through a `MobileapppanelMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_consumersurveys2 as consumersurveys2;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use consumersurveys2::ConsumerSurveys;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = ConsumerSurveys::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.mobileapppanels().get("panelId")
+///              .doit();
+/// # }
+/// ```
+pub struct MobileapppanelGetCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a ConsumerSurveys<C, A>,
+    _panel_id: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for MobileapppanelGetCall<'a, C, A> {}
+
+impl<'a, C, A> MobileapppanelGetCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, MobileAppPanel)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "consumersurveys.mobileapppanels.get",
+                               http_method: hyper::method::Method::Get });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((3 + self._additional_params.len()));
+        params.push(("panelId", self._panel_id.to_string()));
+        for &field in ["alt", "panelId"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "mobileAppPanels/{panelId}";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::Readonly.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{panelId}", "panelId")].iter() {
+            let mut replace_with: Option<&str> = None;
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = Some(value);
+                    break;
+                }
+            }
+            url = url.replace(find_this, replace_with.expect("to find substitution value in params"));
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["panelId"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Get, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    /// External URL ID for the panel.
+    ///
+    /// Sets the *panel id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn panel_id(mut self, new_value: &str) -> MobileapppanelGetCall<'a, C, A> {
+        self._panel_id = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> MobileapppanelGetCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters. Overrides userIp if both are provided.
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *userIp* (query-string) - IP address of the site where the request originates. Use this if you want to enforce per-user limits.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for the response.
+    pub fn param<T>(mut self, name: T, value: T) -> MobileapppanelGetCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::Readonly`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> MobileapppanelGetCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Lists the MobileAppPanels available to the authenticated user.
+///
+/// A builder for the *list* method supported by a *mobileapppanel* resource.
+/// It is not used directly, but through a `MobileapppanelMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_consumersurveys2 as consumersurveys2;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use consumersurveys2::ConsumerSurveys;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = ConsumerSurveys::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.mobileapppanels().list()
+///              .token("no")
+///              .start_index(80)
+///              .max_results(80)
+///              .doit();
+/// # }
+/// ```
+pub struct MobileapppanelListCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a ConsumerSurveys<C, A>,
+    _token: Option<String>,
+    _start_index: Option<u32>,
+    _max_results: Option<u32>,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for MobileapppanelListCall<'a, C, A> {}
+
+impl<'a, C, A> MobileapppanelListCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, MobileAppPanelsListResponse)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "consumersurveys.mobileapppanels.list",
+                               http_method: hyper::method::Method::Get });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((5 + self._additional_params.len()));
+        if let Some(value) = self._token {
+            params.push(("token", value.to_string()));
+        }
+        if let Some(value) = self._start_index {
+            params.push(("startIndex", value.to_string()));
+        }
+        if let Some(value) = self._max_results {
+            params.push(("maxResults", value.to_string()));
+        }
+        for &field in ["alt", "token", "startIndex", "maxResults"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "mobileAppPanels";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::Readonly.as_ref().to_string(), ());
+        }
+
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Get, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *token* query property to the given value.
+    pub fn token(mut self, new_value: &str) -> MobileapppanelListCall<'a, C, A> {
+        self._token = Some(new_value.to_string());
+        self
+    }
+    ///
+    /// Sets the *start index* query property to the given value.
+    pub fn start_index(mut self, new_value: u32) -> MobileapppanelListCall<'a, C, A> {
+        self._start_index = Some(new_value);
+        self
+    }
+    ///
+    /// Sets the *max results* query property to the given value.
+    pub fn max_results(mut self, new_value: u32) -> MobileapppanelListCall<'a, C, A> {
+        self._max_results = Some(new_value);
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> MobileapppanelListCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters. Overrides userIp if both are provided.
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *userIp* (query-string) - IP address of the site where the request originates. Use this if you want to enforce per-user limits.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for the response.
+    pub fn param<T>(mut self, name: T, value: T) -> MobileapppanelListCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::Readonly`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> MobileapppanelListCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+

--- a/gen/datastore1-cli/Cargo.toml
+++ b/gen/datastore1-cli/Cargo.toml
@@ -1,0 +1,40 @@
+# DO NOT EDIT !
+# This file was generated automatically from 'src/mako/Cargo.toml.mako'
+# DO NOT EDIT !
+[package]
+
+name = "google-datastore1-cli"
+version = "1.0.7+20171205"
+authors = ["Sebastian Thiel <byronimo@gmail.com>"]
+description = "A complete library to interact with datastore (protocol v1)"
+repository = "https://github.com/Byron/google-apis-rs/tree/master/gen/datastore1-cli"
+homepage = "https://cloud.google.com/datastore/"
+documentation = "http://byron.github.io/google-apis-rs/google_datastore1_cli"
+license = "MIT"
+keywords = ["datastore", "google", "cli"]
+
+[[bin]]
+name = "datastore1"
+
+[dev-dependencies]
+hyper-rustls = "^0.6"
+
+[dependencies]
+hyper = "^ 0.10"
+mime = "^ 0.2.0"
+serde = "^ 1.0"
+serde_json = "^ 1.0"
+serde_derive = "^ 1.0"
+yup-oauth2 = "^ 1.0"
+strsim = "^0.5"
+hyper-rustls = "^0.6"
+yup-hyper-mock = "^2.0"
+clap = "^2.0"
+
+[features]
+
+
+
+[dependencies.google-datastore1]
+path = "../datastore1"
+version = "1.0.7+20171205"

--- a/gen/datastore1-cli/LICENSE.md
+++ b/gen/datastore1-cli/LICENSE.md
@@ -1,0 +1,30 @@
+<!---
+DO NOT EDIT !
+This file was generated automatically from 'src/mako/LICENSE.md.mako'
+DO NOT EDIT !
+-->
+The MIT License (MIT)
+=====================
+
+Copyright © `2015-2016` `Sebastian Thiel`
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the “Software”), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.

--- a/gen/datastore1-cli/README.md
+++ b/gen/datastore1-cli/README.md
@@ -1,0 +1,124 @@
+<!---
+DO NOT EDIT !
+This file was generated automatically from 'src/mako/cli/README.md.mako'
+DO NOT EDIT !
+-->
+The `datastore1` command-line interface *(CLI)* allows to use most features of the *Google datastore* service from the comfort of your terminal.
+
+By default all output is printed to standard out, but flags can be set to direct it into a file independent of your shell's
+capabilities. Errors will be printed to standard error, and cause the program's exit code to be non-zero.
+
+If data-structures are requested, these will be returned as pretty-printed JSON, to be useful as input to other tools.
+
+Everything else about the *datastore* API can be found at the
+[official documentation site](https://cloud.google.com/datastore/).
+
+# Installation and Source Code
+
+Install the command-line interface with cargo using:
+
+```bash
+cargo install google-datastore1-cli
+```
+
+Find the source code [on github](https://github.com/Byron/google-apis-rs/tree/master/gen/datastore1-cli).
+
+# Usage
+
+This documentation was generated from the *datastore* API at revision *20171205*. The CLI is at version *1.0.7*.
+
+```bash
+datastore1 [options]
+        projects
+                allocate-ids <project-id> (-r <kv>)... [-p <v>]... [-o <out>]
+                begin-transaction <project-id> (-r <kv>)... [-p <v>]... [-o <out>]
+                commit <project-id> (-r <kv>)... [-p <v>]... [-o <out>]
+                lookup <project-id> (-r <kv>)... [-p <v>]... [-o <out>]
+                operations-cancel <name> [-p <v>]... [-o <out>]
+                operations-delete <name> [-p <v>]... [-o <out>]
+                operations-get <name> [-p <v>]... [-o <out>]
+                operations-list <name> [-p <v>]... [-o <out>]
+                reserve-ids <project-id> (-r <kv>)... [-p <v>]... [-o <out>]
+                rollback <project-id> (-r <kv>)... [-p <v>]... [-o <out>]
+                run-query <project-id> (-r <kv>)... [-p <v>]... [-o <out>]
+  datastore1 --help
+
+Configuration:
+  [--scope <url>]...
+            Specify the authentication a method should be executed in. Each scope
+            requires the user to grant this application permission to use it.
+            If unset, it defaults to the shortest scope url for a particular method.
+  --config-dir <folder>
+            A directory into which we will store our persistent data. Defaults to
+            a user-writable directory that we will create during the first invocation.
+            [default: ~/.google-service-cli]
+  --debug
+            Output all server communication to standard error. `tx` and `rx` are placed
+            into the same stream.
+  --debug-auth
+            Output all communication related to authentication to standard error. `tx`
+            and `rx` are placed into the same stream.
+
+```
+
+# Configuration
+
+The program will store all persistent data in the `~/.google-service-cli` directory in *JSON* files prefixed with `datastore1-`.  You can change the directory used to store configuration with the `--config-dir` flag on a per-invocation basis.
+
+More information about the various kinds of persistent data are given in the following paragraphs.
+
+# Authentication
+
+Most APIs require a user to authenticate any request. If this is the case, the [scope][scopes] determines the 
+set of permissions granted. The granularity of these is usually no more than *read-only* or *full-access*.
+
+If not set, the system will automatically select the smallest feasible scope, e.g. when invoking a
+method that is read-only, it will ask only for a read-only scope. 
+You may use the `--scope` flag to specify a scope directly. 
+All applicable scopes are documented in the respective method's CLI documentation.
+
+The first time a scope is used, the user is asked for permission. Follow the instructions given 
+by the CLI to grant permissions, or to decline.
+
+If a scope was authenticated by the user, the respective information will be stored as *JSON* in the configuration
+directory, e.g. `~/.google-service-cli/datastore1-token-<scope-hash>.json`. No manual management of these tokens
+is necessary.
+
+To revoke granted authentication, please refer to the [official documentation][revoke-access].
+
+# Application Secrets
+
+In order to allow any application to use Google services, it will need to be registered using the 
+[Google Developer Console][google-dev-console]. APIs the application may use are then enabled for it
+one by one. Most APIs can be used for free and have a daily quota.
+
+To allow more comfortable usage of the CLI without forcing anyone to register an own application, the CLI
+comes with a default application secret that is configured accordingly. This also means that heavy usage
+all around the world may deplete the daily quota.
+
+You can workaround this limitation by putting your own secrets file at this location: 
+`~/.google-service-cli/datastore1-secret.json`, assuming that the required *datastore* API 
+was enabled for it. Such a secret file can be downloaded in the *Google Developer Console* at 
+*APIs & auth -> Credentials -> Download JSON* and used as is.
+
+Learn more about how to setup Google projects and enable APIs using the [official documentation][google-project-new].
+
+
+# Debugging
+
+Even though the CLI does its best to provide usable error messages, sometimes it might be desirable to know
+what exactly led to a particular issue. This is done by allowing all client-server communication to be 
+output to standard error *as-is*.
+
+The `--debug` flag will print all client-server communication to standard error, whereas the `--debug-auth` flag
+will cause all communication related to authentication to standard error.
+If the `--debug` flag is set, error-results will be debug-printed, possibly yielding more information about the 
+issue at hand.
+
+You may consider redirecting standard error into a file for ease of use, e.g. `datastore1 --debug <resource> <method> [options] 2>debug.txt`.
+
+
+[scopes]: https://developers.google.com/+/api/oauth#scopes
+[revoke-access]: http://webapps.stackexchange.com/a/30849
+[google-dev-console]: https://console.developers.google.com/
+[google-project-new]: https://developers.google.com/console/help/new/

--- a/gen/datastore1-cli/mkdocs.yml
+++ b/gen/datastore1-cli/mkdocs.yml
@@ -1,0 +1,27 @@
+site_name: datastore v1.0.7+20171205
+site_url: http://byron.github.io/google-apis-rs/google-datastore1-cli
+site_description: A complete library to interact with datastore (protocol v1)
+
+repo_url: https://github.com/Byron/google-apis-rs/tree/master/gen/datastore1-cli
+
+docs_dir: docs
+site_dir: build_html
+
+pages:
+- ['index.md', 'Home']
+- ['projects_allocate-ids.md', 'Projects', 'Allocate Ids']
+- ['projects_begin-transaction.md', 'Projects', 'Begin Transaction']
+- ['projects_commit.md', 'Projects', 'Commit']
+- ['projects_lookup.md', 'Projects', 'Lookup']
+- ['projects_operations-cancel.md', 'Projects', 'Operations Cancel']
+- ['projects_operations-delete.md', 'Projects', 'Operations Delete']
+- ['projects_operations-get.md', 'Projects', 'Operations Get']
+- ['projects_operations-list.md', 'Projects', 'Operations List']
+- ['projects_reserve-ids.md', 'Projects', 'Reserve Ids']
+- ['projects_rollback.md', 'Projects', 'Rollback']
+- ['projects_run-query.md', 'Projects', 'Run Query']
+
+theme: readthedocs
+
+copyright: Copyright &copy; 2015-2016, `Sebastian Thiel`
+

--- a/gen/datastore1-cli/src/cmn.rs
+++ b/gen/datastore1-cli/src/cmn.rs
@@ -1,0 +1,799 @@
+// COPY OF 'src/rust/cli/cmn.rs'
+// DO NOT EDIT
+use oauth2::{ApplicationSecret, ConsoleApplicationSecret, TokenStorage, Token};
+use serde_json as json;
+use serde_json::value::Value;
+use mime::Mime;
+use clap::{App, SubCommand};
+use strsim;
+
+use std::fs;
+use std::env;
+use std::io;
+use std::error::Error as StdError;
+use std::fmt;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+use std::string::ToString;
+use std::io::{Write, Read, stdout};
+
+use std::default::Default;
+
+const FIELD_SEP: char = '.';
+
+
+pub enum ComplexType {
+    Pod,
+    Vec,
+    Map,
+}
+
+// Null,
+// Bool(bool),
+// I64(i64),
+// U64(u64),
+// F64(f64),
+// String(String),
+
+pub enum JsonType {
+    Boolean,
+    Int,
+    Uint,
+    Float,
+    String,
+}
+
+pub struct JsonTypeInfo {
+    pub jtype: JsonType,
+    pub ctype: ComplexType,
+}
+
+// Based on @erickt user comment. Thanks for the idea !
+// Remove all keys whose values are null from given value (changed in place)
+pub fn remove_json_null_values(value: &mut Value) {
+    match *value {
+        Value::Object(ref mut map) => {
+            let mut for_removal = Vec::new();
+
+            for (key, mut value) in map.iter_mut() {
+                if value.is_null() {
+                    for_removal.push(key.clone());
+                } else {
+                    remove_json_null_values(&mut value);
+                }
+            }
+
+            for key in &for_removal {
+                map.remove(key);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn did_you_mean<'a>(v: &str, possible_values: &[&'a str]) -> Option<&'a str> {
+
+    let mut candidate: Option<(f64, &str)> = None;
+    for pv in possible_values {
+        let confidence = strsim::jaro_winkler(v, pv);
+        if confidence > 0.8 &&
+           (candidate.is_none() || (candidate.as_ref().unwrap().0 < confidence)) {
+            candidate = Some((confidence, pv));
+        }
+    }
+    match candidate {
+        None => None,
+        Some((_, candidate)) => Some(candidate),
+    }
+}
+
+pub enum CallType {
+    Upload(UploadProtocol),
+    Standard,
+}
+
+arg_enum!{
+    pub enum UploadProtocol {
+        Simple,
+        Resumable
+    }
+}
+
+impl AsRef<str> for UploadProtocol {
+    fn as_ref(&self) -> &str {
+        match *self {
+            UploadProtocol::Simple => "simple",
+            UploadProtocol::Resumable => "resumable",
+        }
+    }
+}
+
+impl AsRef<str> for CallType {
+    fn as_ref(&self) -> &str {
+        match *self {
+            CallType::Upload(ref proto) => proto.as_ref(),
+            CallType::Standard => "standard-request",
+        }
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct FieldCursor(Vec<String>);
+
+impl ToString for  FieldCursor {
+    fn to_string(&self) -> String {
+        self.0.join(".")
+    }
+}
+
+impl From<&'static str> for FieldCursor {
+    fn from(value: &'static str) -> FieldCursor {
+        let mut res = FieldCursor::default();
+        res.set(value).unwrap();
+        res
+    }
+}
+
+fn assure_entry<'a, 'b>(m: &'a mut json::Map<String, Value>, k: &'b String) -> &'a mut Value {
+    if m.contains_key(k) {
+        return m.get_mut(k).expect("value to exist");
+    }
+    m.insert(k.to_owned(), Value::Object(Default::default()));
+    m.get_mut(k).expect("value to exist")
+}
+
+impl FieldCursor {
+    pub fn set(&mut self, value: &str) -> Result<(), CLIError> {
+        if value.len() == 0 {
+            return Err(CLIError::Field(FieldError::Empty));
+        }
+
+        let mut first_is_field_sep = false;
+        let mut char_count: usize = 0;
+        let mut last_c = FIELD_SEP;
+        let mut num_conscutive_field_seps = 0;
+
+        let mut field = String::new();
+        let mut fields = self.0.clone();
+
+        let push_field = |fs: &mut Vec<String>, f: &mut String| {
+            if f.len() > 0 {
+                fs.push(f.clone());
+                f.truncate(0);
+            }
+        };
+
+        for (cid, c) in value.chars().enumerate() {
+            char_count += 1;
+
+            if c == FIELD_SEP {
+                if cid == 0 {
+                    first_is_field_sep = true;
+                }
+                num_conscutive_field_seps += 1;
+                if cid > 0 && last_c == FIELD_SEP {
+                    if fields.pop().is_none() {
+                        return Err(CLIError::Field(FieldError::PopOnEmpty(value.to_string())));
+                    }
+                } else {
+                    push_field(&mut fields, &mut field);
+                }
+            } else {
+                num_conscutive_field_seps = 0;
+                if cid == 1 {
+                    if first_is_field_sep {
+                        fields.truncate(0);
+                    }
+                }
+                field.push(c);
+            }
+
+            last_c = c;
+        }
+
+        push_field(&mut fields, &mut field);
+
+        if char_count == 1 && first_is_field_sep {
+            fields.truncate(0);
+        }
+        if char_count > 1 && num_conscutive_field_seps == 1 {
+            return Err(CLIError::Field(FieldError::TrailingFieldSep(value.to_string())));
+        }
+
+        self.0 = fields;
+        Ok(())
+    }
+
+    pub fn did_you_mean(value: &str, possible_values: &[&str]) -> Option<String> {
+        if value.len() == 0 {
+            return None;
+        }
+
+        let mut last_c = FIELD_SEP;
+
+        let mut field = String::new();
+        let mut output = String::new();
+
+        let push_field = |fs: &mut String, f: &mut String| {
+            if f.len() > 0 {
+                fs.push_str(match did_you_mean(&f, possible_values) {
+                    Some(candidate) => candidate,
+                    None => &f,
+                });
+                f.truncate(0);
+            }
+        };
+
+        for (cid, c) in value.chars().enumerate() {
+            if c == FIELD_SEP {
+                if last_c != FIELD_SEP {
+                    push_field(&mut output, &mut field);
+                }
+                output.push(c);
+            } else {
+                field.push(c);
+            }
+
+            last_c = c;
+        }
+
+        push_field(&mut output, &mut field);
+
+        if &output == value {
+            None
+        } else {
+            Some(output)
+        }
+    }
+
+    pub fn set_json_value(&self,
+                          mut object: &mut Value,
+                          value: &str,
+                          type_info: JsonTypeInfo,
+                          err: &mut InvalidOptionsError,
+                          orig_cursor: &FieldCursor) {
+        assert!(self.0.len() > 0);
+
+        for field in &self.0[..self.0.len() - 1] {
+            let tmp = object;
+            object = match *tmp {
+                Value::Object(ref mut mapping) => {
+                    assure_entry(mapping, &field)
+                }
+                _ => panic!("We don't expect non-object Values here ..."),
+            };
+        }
+
+        match *object {
+            Value::Object(ref mut mapping) => {
+                let field = &self.0[self.0.len() - 1];
+                let to_jval = |value: &str,
+                               jtype: JsonType,
+                               err: &mut InvalidOptionsError|
+                               -> Value {
+                    match jtype {
+                        JsonType::Boolean =>
+                            Value::Bool(arg_from_str(value, err, &field, "boolean")),
+                        JsonType::Int =>
+                            Value::Number(json::Number::from_f64(arg_from_str(value,
+                                                                              err,
+                                                                              &field,
+                                                                              "int"))
+                                              .expect("valid f64")),
+                        JsonType::Uint =>
+                            Value::Number(json::Number::from_f64(arg_from_str(value,
+                                                                              err,
+                                                                              &field,
+                                                                              "uint"))
+                                              .expect("valid f64")),
+                        JsonType::Float =>
+                            Value::Number(json::Number::from_f64(arg_from_str(value,
+                                                                              err,
+                                                                              &field,
+                                                                              "float"))
+                                              .expect("valid f64")),
+                        JsonType::String => Value::String(value.to_owned()),
+                    }
+                };
+
+                match type_info.ctype {
+                    ComplexType::Pod => {
+                        if mapping.insert(field.to_owned(), to_jval(value, type_info.jtype, err))
+                                  .is_some() {
+                            err.issues.push(CLIError::Field(FieldError::Duplicate(orig_cursor.to_string())));
+                        }
+                    }
+                    ComplexType::Vec => {
+                        match *assure_entry(mapping, field) {
+                            Value::Array(ref mut values) =>
+                                values.push(to_jval(value, type_info.jtype, err)),
+                            _ => unreachable!(),
+                        }
+                    }
+                    ComplexType::Map => {
+                        let (key, value) = parse_kv_arg(value, err, true);
+                        let jval = to_jval(value.unwrap_or(""), type_info.jtype, err);
+
+                        match *assure_entry(mapping, &field) {
+
+                            Value::Object(ref mut value_map) => {
+                                if value_map.insert(key.to_owned(), jval).is_some() {
+                                    err.issues.push(CLIError::Field(FieldError::Duplicate(orig_cursor.to_string())));
+                                }
+                            }
+                            _ => unreachable!(),
+                        }
+                    }
+                }
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    pub fn num_fields(&self) -> usize {
+        self.0.len()
+    }
+}
+
+pub fn parse_kv_arg<'a>(kv: &'a str,
+                        err: &mut InvalidOptionsError,
+                        for_hashmap: bool)
+                        -> (&'a str, Option<&'a str>) {
+    let mut add_err = || {
+        err.issues.push(CLIError::InvalidKeyValueSyntax(kv.to_string(), for_hashmap))
+    };
+    match kv.find('=') {
+        None => {
+            add_err();
+            return (kv, None);
+        }
+        Some(pos) => {
+            let key = &kv[..pos];
+            if kv.len() <= pos + 1 {
+                add_err();
+                return (key, Some(""));
+            }
+            (key, Some(&kv[pos + 1..]))
+        }
+    }
+}
+
+pub fn calltype_from_str(name: &str,
+                         valid_protocols: Vec<String>,
+                         err: &mut InvalidOptionsError)
+                         -> CallType {
+    CallType::Upload(match UploadProtocol::from_str(name) {
+        Ok(up) => up,
+        Err(msg) => {
+            err.issues.push(CLIError::InvalidUploadProtocol(name.to_string(), valid_protocols));
+            UploadProtocol::Simple
+        }
+    })
+}
+
+pub fn input_file_from_opts(file_path: &str, err: &mut InvalidOptionsError) -> Option<fs::File> {
+    match fs::File::open(file_path) {
+        Ok(f) => Some(f),
+        Err(io_err) => {
+            err.issues.push(CLIError::Input(InputError::Io((file_path.to_string(), io_err))));
+            None
+        }
+    }
+}
+
+pub fn input_mime_from_opts(mime: &str, err: &mut InvalidOptionsError) -> Option<Mime> {
+    match mime.parse() {
+        Ok(m) => Some(m),
+        Err(_) => {
+            err.issues.push(CLIError::Input(InputError::Mime(mime.to_string())));
+            None
+        }
+    }
+}
+
+pub fn writer_from_opts(arg: Option<&str>) -> Result<Box<Write>, io::Error> {
+    let f = arg.unwrap_or("-");
+    match f {
+        "-" => Ok(Box::new(stdout())),
+        _ => match fs::OpenOptions::new().create(true).write(true).open(f) {
+            Ok(f) => Ok(Box::new(f)),
+            Err(io_err) => Err(io_err),
+        },
+    }
+}
+
+
+pub fn arg_from_str<'a, T>(arg: &str,
+                           err: &mut InvalidOptionsError,
+                           arg_name: &'a str,
+                           arg_type: &'a str)
+                           -> T
+    where T: FromStr + Default,
+          <T as FromStr>::Err: fmt::Display
+{
+    match FromStr::from_str(arg) {
+        Err(perr) => {
+            err.issues.push(CLIError::ParseError(arg_name.to_owned(),
+                                                 arg_type.to_owned(),
+                                                 arg.to_string(),
+                                                 format!("{}", perr)));
+            Default::default()
+        }
+        Ok(v) => v,
+    }
+}
+
+pub struct JsonTokenStorage {
+    pub program_name: &'static str,
+    pub db_dir: String,
+}
+
+impl JsonTokenStorage {
+    fn path(&self, scope_hash: u64) -> PathBuf {
+        Path::new(&self.db_dir).join(&format!("{}-token-{}.json", self.program_name, scope_hash))
+    }
+}
+
+
+#[derive(Debug)]
+pub enum TokenStorageError {
+    Json(json::Error),
+    Io(io::Error),
+}
+
+impl fmt::Display for TokenStorageError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            TokenStorageError::Json(ref err) => writeln!(f, "Could not serialize secrets: {}", err),
+            TokenStorageError::Io(ref err) => writeln!(f, "Failed to write secret token: {}", err),
+        }
+    }
+}
+
+impl StdError for TokenStorageError {
+    fn description(&self) -> &str {
+        "Failure when getting or setting the token storage"
+    }
+}
+
+
+impl TokenStorage for JsonTokenStorage {
+    type Error = TokenStorageError;
+
+    // NOTE: logging might be interesting, currently we swallow all errors
+    fn set(&mut self,
+           scope_hash: u64,
+           _: &Vec<&str>,
+           token: Option<Token>)
+           -> Result<(), TokenStorageError> {
+        match token {
+            None => {
+                match fs::remove_file(self.path(scope_hash)) {
+                    Err(err) => match err.kind() {
+                        io::ErrorKind::NotFound => Ok(()),
+                        _ => Err(TokenStorageError::Io(err)),
+                    },
+                    Ok(_) => Ok(()),
+                }
+            }
+            Some(token) => {
+                match fs::OpenOptions::new().create(true).write(true).open(&self.path(scope_hash)) {
+                    Ok(mut f) => {
+                        match json::to_writer_pretty(&mut f, &token) {
+                            Ok(_) => Ok(()),
+                            Err(serde_err) => Err(TokenStorageError::Json(serde_err)),
+                        }
+                    }
+                    Err(io_err) => Err(TokenStorageError::Io(io_err)),
+                }
+            }
+        }
+    }
+
+    fn get(&self, scope_hash: u64, _: &Vec<&str>) -> Result<Option<Token>, TokenStorageError> {
+        match fs::File::open(&self.path(scope_hash)) {
+            Ok(f) => {
+                match json::de::from_reader(f) {
+                    Ok(token) => Ok(Some(token)),
+                    Err(err) => Err(TokenStorageError::Json(err)),
+                }
+            }
+            Err(io_err) => {
+                match io_err.kind() {
+                    io::ErrorKind::NotFound => Ok(None),
+                    _ => Err(TokenStorageError::Io(io_err)),
+                }
+            }
+        }
+    }
+}
+
+
+#[derive(Debug)]
+pub enum ApplicationSecretError {
+    DecoderError((String, json::Error)),
+    FormatError(String),
+}
+
+impl fmt::Display for ApplicationSecretError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            ApplicationSecretError::DecoderError((ref path, ref err)) =>
+                writeln!(f,
+                         "Could not decode file at '{}' with error: {}.",
+                         path,
+                         err),
+            ApplicationSecretError::FormatError(ref path) =>
+                writeln!(f,
+                         "'installed' field is unset in secret file at '{}'.",
+                         path),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum ConfigurationError {
+    DirectoryCreationFailed((String, io::Error)),
+    DirectoryUnset,
+    HomeExpansionFailed(String),
+    Secret(ApplicationSecretError),
+    Io((String, io::Error)),
+}
+
+impl fmt::Display for ConfigurationError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            ConfigurationError::DirectoryCreationFailed((ref dir, ref err)) =>
+                writeln!(f,
+                         "Directory '{}' could not be created with error: {}.",
+                         dir,
+                         err),
+            ConfigurationError::DirectoryUnset => writeln!(f, "--config-dir was unset or empty."),
+            ConfigurationError::HomeExpansionFailed(ref dir) =>
+                writeln!(f,
+                         "Couldn't find HOME directory of current user, failed to expand '{}'.",
+                         dir),
+            ConfigurationError::Secret(ref err) => writeln!(f, "Secret -> {}", err),
+            ConfigurationError::Io((ref path, ref err)) =>
+                writeln!(f,
+                         "IO operation failed on path '{}' with error: {}.",
+                         path,
+                         err),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum InputError {
+    Io((String, io::Error)),
+    Mime(String),
+}
+
+impl fmt::Display for InputError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            InputError::Io((ref file_path, ref io_err)) =>
+                writeln!(f,
+                         "Failed to open '{}' for reading with error: {}.",
+                         file_path,
+                         io_err),
+            InputError::Mime(ref mime) => writeln!(f, "'{}' is not a known mime-type.", mime),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum FieldError {
+    PopOnEmpty(String),
+    TrailingFieldSep(String),
+    Unknown(String, Option<String>, Option<String>),
+    Duplicate(String),
+    Empty,
+}
+
+
+impl fmt::Display for FieldError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            FieldError::PopOnEmpty(ref field) =>
+                writeln!(f, "'{}': Cannot move up on empty field cursor.", field),
+            FieldError::TrailingFieldSep(ref field) =>
+                writeln!(f,
+                         "'{}': Single field separator may not be last character.",
+                         field),
+            FieldError::Unknown(ref field, ref suggestion, ref value) => {
+                let suffix = match *suggestion {
+                    Some(ref s) => {
+                        let kv = match *value {
+                            Some(ref v) => format!("{}={}", s, v),
+                            None => s.clone(),
+                        };
+                        format!(" Did you mean '{}' ?", kv)
+                    }
+                    None => String::new(),
+                };
+                writeln!(f, "Field '{}' does not exist.{}", field, suffix)
+            }
+            FieldError::Duplicate(ref cursor) =>
+                writeln!(f, "Value at '{}' was already set", cursor),
+            FieldError::Empty => writeln!(f, "Field names must not be empty."),
+        }
+    }
+}
+
+
+#[derive(Debug)]
+pub enum CLIError {
+    Configuration(ConfigurationError),
+    ParseError(String, String, String, String),
+    UnknownParameter(String, Vec<&'static str>),
+    InvalidUploadProtocol(String, Vec<String>),
+    InvalidKeyValueSyntax(String, bool),
+    Input(InputError),
+    Field(FieldError),
+    MissingCommandError,
+    MissingMethodError(String),
+}
+
+impl fmt::Display for CLIError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            CLIError::Configuration(ref err) => write!(f, "Configuration -> {}", err),
+            CLIError::Input(ref err) => write!(f, "Input -> {}", err),
+            CLIError::Field(ref err) => write!(f, "Field -> {}", err),
+            CLIError::InvalidUploadProtocol(ref proto_name, ref valid_names) =>
+                writeln!(f,
+                         "'{}' is not a valid upload protocol. Choose from one of {}.",
+                         proto_name,
+                         valid_names.join(", ")),
+            CLIError::ParseError(ref arg_name, ref type_name, ref value, ref err_desc) =>
+                writeln!(f,
+                         "Failed to parse argument '{}' with value '{}' as {} with error: {}.",
+                         arg_name,
+                         value,
+                         type_name,
+                         err_desc),
+            CLIError::UnknownParameter(ref param_name, ref possible_values) => {
+                let suffix = match did_you_mean(param_name, &possible_values) {
+                    Some(v) => format!(" Did you mean '{}' ?", v),
+                    None => String::new(),
+                };
+                write!(f, "Parameter '{}' is unknown.{}\n", param_name, suffix)
+            }
+            CLIError::InvalidKeyValueSyntax(ref kv, is_hashmap) => {
+                let hashmap_info = if is_hashmap {
+                    "hashmap "
+                } else {
+                    ""
+                };
+                writeln!(f,
+                         "'{}' does not match {}pattern <key>=<value>.",
+                         kv,
+                         hashmap_info)
+            }
+            CLIError::MissingCommandError => writeln!(f, "Please specify the main sub-command."),
+            CLIError::MissingMethodError(ref cmd) =>
+                writeln!(f,
+                         "Please specify the method to call on the '{}' command.",
+                         cmd),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct InvalidOptionsError {
+    pub issues: Vec<CLIError>,
+    pub exit_code: i32,
+}
+
+impl fmt::Display for InvalidOptionsError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        for issue in &self.issues {
+            try!(issue.fmt(f));
+        }
+        Ok(())
+    }
+}
+
+impl InvalidOptionsError {
+    pub fn single(err: CLIError, exit_code: i32) -> InvalidOptionsError {
+        InvalidOptionsError {
+            issues: vec![err],
+            exit_code: exit_code,
+        }
+    }
+
+    pub fn new() -> InvalidOptionsError {
+        InvalidOptionsError {
+            issues: Vec::new(),
+            exit_code: 1,
+        }
+    }
+}
+
+pub fn assure_config_dir_exists(dir: &str) -> Result<String, CLIError> {
+    let trdir = dir.trim();
+    if trdir.len() == 0 {
+        return Err(CLIError::Configuration(ConfigurationError::DirectoryUnset));
+    }
+
+    let expanded_config_dir = if trdir.as_bytes()[0] == b'~' {
+        match env::var("HOME").ok().or(env::var("UserProfile").ok()) {
+            None => return Err(CLIError::Configuration(ConfigurationError::HomeExpansionFailed(trdir.to_string()))),
+            Some(mut user) => {
+                user.push_str(&trdir[1..]);
+                user
+            }
+        }
+    } else {
+        trdir.to_string()
+    };
+
+    if let Err(err) = fs::create_dir(&expanded_config_dir) {
+        if err.kind() != io::ErrorKind::AlreadyExists {
+            return Err(CLIError::Configuration(
+                    ConfigurationError::DirectoryCreationFailed((expanded_config_dir, err))));
+        }
+    }
+
+    Ok(expanded_config_dir)
+}
+
+pub fn application_secret_from_directory(dir: &str,
+                                         secret_basename: &str,
+                                         json_console_secret: &str)
+                                         -> Result<ApplicationSecret, CLIError> {
+    let secret_path = Path::new(dir).join(secret_basename);
+    let secret_str = || secret_path.as_path().to_str().unwrap().to_string();
+    let secret_io_error = |io_err: io::Error| {
+        Err(CLIError::Configuration(ConfigurationError::Io((secret_str(), io_err))))
+    };
+
+    for _ in 0..2 {
+        match fs::File::open(&secret_path) {
+            Err(mut err) => {
+                if err.kind() == io::ErrorKind::NotFound {
+                    // Write our built-in one - user may adjust the written file at will
+
+                    err = match fs::OpenOptions::new()
+                                    .create(true)
+                                    .write(true)
+                                    .open(&secret_path) {
+                        Err(cfe) => cfe,
+                        Ok(mut f) => {
+                            // Assure we convert 'ugly' json string into pretty one
+                            let console_secret: ConsoleApplicationSecret =
+                                json::from_str(json_console_secret).unwrap();
+                            match json::to_writer_pretty(&mut f, &console_secret) {
+                                Err(serde_err) =>
+                                    panic!("Unexpected serde error: {:#?}", serde_err),
+                                Ok(_) => continue,
+                            }
+                        }
+                    };
+                    // fall through to IO error handling
+                }
+                return secret_io_error(err);
+            }
+            Ok(f) => {
+                match json::de::from_reader::<_, ConsoleApplicationSecret>(f) {
+                    Err(json_err) =>
+                        return Err(CLIError::Configuration(
+                            ConfigurationError::Secret(
+                                ApplicationSecretError::DecoderError(
+                                                (secret_str(), json_err)
+                                              )))),
+                    Ok(console_secret) => match console_secret.installed {
+                        Some(secret) => return Ok(secret),
+                        None => return Err(
+                                        CLIError::Configuration(
+                                        ConfigurationError::Secret(
+                                        ApplicationSecretError::FormatError(secret_str())
+                                        ))),
+                    },
+                }
+            }
+        }
+    }
+    unreachable!();
+}

--- a/gen/datastore1-cli/src/main.rs
+++ b/gen/datastore1-cli/src/main.rs
@@ -1,0 +1,1433 @@
+// DO NOT EDIT !
+// This file was generated automatically from 'src/mako/cli/main.rs.mako'
+// DO NOT EDIT !
+#![allow(unused_variables, unused_imports, dead_code, unused_mut)]
+
+#[macro_use]
+extern crate clap;
+extern crate yup_oauth2 as oauth2;
+extern crate yup_hyper_mock as mock;
+extern crate hyper_rustls;
+extern crate serde;
+extern crate serde_json;
+extern crate hyper;
+extern crate mime;
+extern crate strsim;
+extern crate google_datastore1 as api;
+
+use std::env;
+use std::io::{self, Write};
+use clap::{App, SubCommand, Arg};
+
+mod cmn;
+
+use cmn::{InvalidOptionsError, CLIError, JsonTokenStorage, arg_from_str, writer_from_opts, parse_kv_arg,
+          input_file_from_opts, input_mime_from_opts, FieldCursor, FieldError, CallType, UploadProtocol,
+          calltype_from_str, remove_json_null_values, ComplexType, JsonType, JsonTypeInfo};
+
+use std::default::Default;
+use std::str::FromStr;
+
+use oauth2::{Authenticator, DefaultAuthenticatorDelegate, FlowType};
+use serde_json as json;
+use clap::ArgMatches;
+
+enum DoitError {
+    IoError(String, io::Error),
+    ApiError(api::Error),
+}
+
+struct Engine<'n> {
+    opt: ArgMatches<'n>,
+    hub: api::Datastore<hyper::Client, Authenticator<DefaultAuthenticatorDelegate, JsonTokenStorage, hyper::Client>>,
+    gp: Vec<&'static str>,
+    gpm: Vec<(&'static str, &'static str)>,
+}
+
+
+impl<'n> Engine<'n> {
+    fn _projects_allocate_ids(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec![]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::AllocateIdsRequest = json::value::from_value(object).unwrap();
+        let mut call = self.hub.projects().allocate_ids(request, opt.value_of("project-id").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _projects_begin_transaction(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    "transaction-options.read-write.previous-transaction" => Some(("transactionOptions.readWrite.previousTransaction", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec!["previous-transaction", "read-write", "transaction-options"]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::BeginTransactionRequest = json::value::from_value(object).unwrap();
+        let mut call = self.hub.projects().begin_transaction(request, opt.value_of("project-id").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _projects_commit(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    "transaction" => Some(("transaction", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "mode" => Some(("mode", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec!["mode", "transaction"]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::CommitRequest = json::value::from_value(object).unwrap();
+        let mut call = self.hub.projects().commit(request, opt.value_of("project-id").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _projects_lookup(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    "read-options.transaction" => Some(("readOptions.transaction", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "read-options.read-consistency" => Some(("readOptions.readConsistency", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec!["read-consistency", "read-options", "transaction"]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::LookupRequest = json::value::from_value(object).unwrap();
+        let mut call = self.hub.projects().lookup(request, opt.value_of("project-id").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _projects_operations_cancel(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let mut call = self.hub.projects().operations_cancel(opt.value_of("name").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _projects_operations_delete(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let mut call = self.hub.projects().operations_delete(opt.value_of("name").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _projects_operations_get(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let mut call = self.hub.projects().operations_get(opt.value_of("name").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _projects_operations_list(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let mut call = self.hub.projects().operations_list(opt.value_of("name").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                "page-token" => {
+                    call = call.page_token(value.unwrap_or(""));
+                },
+                "page-size" => {
+                    call = call.page_size(arg_from_str(value.unwrap_or("-0"), err, "page-size", "integer"));
+                },
+                "filter" => {
+                    call = call.filter(value.unwrap_or(""));
+                },
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v.extend(["filter", "page-token", "page-size"].iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _projects_reserve_ids(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    "database-id" => Some(("databaseId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec!["database-id"]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::ReserveIdsRequest = json::value::from_value(object).unwrap();
+        let mut call = self.hub.projects().reserve_ids(request, opt.value_of("project-id").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _projects_rollback(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    "transaction" => Some(("transaction", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec!["transaction"]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::RollbackRequest = json::value::from_value(object).unwrap();
+        let mut call = self.hub.projects().rollback(request, opt.value_of("project-id").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _projects_run_query(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    "query.filter.composite-filter.op" => Some(("query.filter.compositeFilter.op", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "query.filter.property-filter.property.name" => Some(("query.filter.propertyFilter.property.name", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "query.filter.property-filter.value.entity-value.key.partition-id.project-id" => Some(("query.filter.propertyFilter.value.entityValue.key.partitionId.projectId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "query.filter.property-filter.value.entity-value.key.partition-id.namespace-id" => Some(("query.filter.propertyFilter.value.entityValue.key.partitionId.namespaceId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "query.filter.property-filter.value.timestamp-value" => Some(("query.filter.propertyFilter.value.timestampValue", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "query.filter.property-filter.value.null-value" => Some(("query.filter.propertyFilter.value.nullValue", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "query.filter.property-filter.value.double-value" => Some(("query.filter.propertyFilter.value.doubleValue", JsonTypeInfo { jtype: JsonType::Float, ctype: ComplexType::Pod })),
+                    "query.filter.property-filter.value.meaning" => Some(("query.filter.propertyFilter.value.meaning", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Pod })),
+                    "query.filter.property-filter.value.exclude-from-indexes" => Some(("query.filter.propertyFilter.value.excludeFromIndexes", JsonTypeInfo { jtype: JsonType::Boolean, ctype: ComplexType::Pod })),
+                    "query.filter.property-filter.value.key-value.partition-id.project-id" => Some(("query.filter.propertyFilter.value.keyValue.partitionId.projectId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "query.filter.property-filter.value.key-value.partition-id.namespace-id" => Some(("query.filter.propertyFilter.value.keyValue.partitionId.namespaceId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "query.filter.property-filter.value.blob-value" => Some(("query.filter.propertyFilter.value.blobValue", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "query.filter.property-filter.value.string-value" => Some(("query.filter.propertyFilter.value.stringValue", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "query.filter.property-filter.value.boolean-value" => Some(("query.filter.propertyFilter.value.booleanValue", JsonTypeInfo { jtype: JsonType::Boolean, ctype: ComplexType::Pod })),
+                    "query.filter.property-filter.value.integer-value" => Some(("query.filter.propertyFilter.value.integerValue", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "query.filter.property-filter.value.geo-point-value.latitude" => Some(("query.filter.propertyFilter.value.geoPointValue.latitude", JsonTypeInfo { jtype: JsonType::Float, ctype: ComplexType::Pod })),
+                    "query.filter.property-filter.value.geo-point-value.longitude" => Some(("query.filter.propertyFilter.value.geoPointValue.longitude", JsonTypeInfo { jtype: JsonType::Float, ctype: ComplexType::Pod })),
+                    "query.filter.property-filter.op" => Some(("query.filter.propertyFilter.op", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "query.start-cursor" => Some(("query.startCursor", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "query.end-cursor" => Some(("query.endCursor", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "query.limit" => Some(("query.limit", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Pod })),
+                    "query.offset" => Some(("query.offset", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Pod })),
+                    "partition-id.project-id" => Some(("partitionId.projectId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "partition-id.namespace-id" => Some(("partitionId.namespaceId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "gql-query.query-string" => Some(("gqlQuery.queryString", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "gql-query.allow-literals" => Some(("gqlQuery.allowLiterals", JsonTypeInfo { jtype: JsonType::Boolean, ctype: ComplexType::Pod })),
+                    "read-options.transaction" => Some(("readOptions.transaction", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "read-options.read-consistency" => Some(("readOptions.readConsistency", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec!["allow-literals", "blob-value", "boolean-value", "composite-filter", "double-value", "end-cursor", "entity-value", "exclude-from-indexes", "filter", "geo-point-value", "gql-query", "integer-value", "key", "key-value", "latitude", "limit", "longitude", "meaning", "name", "namespace-id", "null-value", "offset", "op", "partition-id", "project-id", "property", "property-filter", "query", "query-string", "read-consistency", "read-options", "start-cursor", "string-value", "timestamp-value", "transaction", "value"]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::RunQueryRequest = json::value::from_value(object).unwrap();
+        let mut call = self.hub.projects().run_query(request, opt.value_of("project-id").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _doit(&self, dry_run: bool) -> Result<Result<(), DoitError>, Option<InvalidOptionsError>> {
+        let mut err = InvalidOptionsError::new();
+        let mut call_result: Result<(), DoitError> = Ok(());
+        let mut err_opt: Option<InvalidOptionsError> = None;
+        match self.opt.subcommand() {
+            ("projects", Some(opt)) => {
+                match opt.subcommand() {
+                    ("allocate-ids", Some(opt)) => {
+                        call_result = self._projects_allocate_ids(opt, dry_run, &mut err);
+                    },
+                    ("begin-transaction", Some(opt)) => {
+                        call_result = self._projects_begin_transaction(opt, dry_run, &mut err);
+                    },
+                    ("commit", Some(opt)) => {
+                        call_result = self._projects_commit(opt, dry_run, &mut err);
+                    },
+                    ("lookup", Some(opt)) => {
+                        call_result = self._projects_lookup(opt, dry_run, &mut err);
+                    },
+                    ("operations-cancel", Some(opt)) => {
+                        call_result = self._projects_operations_cancel(opt, dry_run, &mut err);
+                    },
+                    ("operations-delete", Some(opt)) => {
+                        call_result = self._projects_operations_delete(opt, dry_run, &mut err);
+                    },
+                    ("operations-get", Some(opt)) => {
+                        call_result = self._projects_operations_get(opt, dry_run, &mut err);
+                    },
+                    ("operations-list", Some(opt)) => {
+                        call_result = self._projects_operations_list(opt, dry_run, &mut err);
+                    },
+                    ("reserve-ids", Some(opt)) => {
+                        call_result = self._projects_reserve_ids(opt, dry_run, &mut err);
+                    },
+                    ("rollback", Some(opt)) => {
+                        call_result = self._projects_rollback(opt, dry_run, &mut err);
+                    },
+                    ("run-query", Some(opt)) => {
+                        call_result = self._projects_run_query(opt, dry_run, &mut err);
+                    },
+                    _ => {
+                        err.issues.push(CLIError::MissingMethodError("projects".to_string()));
+                        writeln!(io::stderr(), "{}\n", opt.usage()).ok();
+                    }
+                }
+            },
+            _ => {
+                err.issues.push(CLIError::MissingCommandError);
+                writeln!(io::stderr(), "{}\n", self.opt.usage()).ok();
+            }
+        }
+
+        if dry_run {
+            if err.issues.len() > 0 {
+                err_opt = Some(err);
+            }
+            Err(err_opt)
+        } else {
+            Ok(call_result)
+        }
+    }
+
+    // Please note that this call will fail if any part of the opt can't be handled
+    fn new(opt: ArgMatches<'n>) -> Result<Engine<'n>, InvalidOptionsError> {
+        let (config_dir, secret) = {
+            let config_dir = match cmn::assure_config_dir_exists(opt.value_of("folder").unwrap_or("~/.google-service-cli")) {
+                Err(e) => return Err(InvalidOptionsError::single(e, 3)),
+                Ok(p) => p,
+            };
+
+            match cmn::application_secret_from_directory(&config_dir, "datastore1-secret.json",
+                                                         "{\"installed\":{\"auth_uri\":\"https://accounts.google.com/o/oauth2/auth\",\"client_secret\":\"hCsslbCUyfehWMmbkG8vTYxG\",\"token_uri\":\"https://accounts.google.com/o/oauth2/token\",\"client_email\":\"\",\"redirect_uris\":[\"urn:ietf:wg:oauth:2.0:oob\",\"oob\"],\"client_x509_cert_url\":\"\",\"client_id\":\"620010449518-9ngf7o4dhs0dka470npqvor6dc5lqb9b.apps.googleusercontent.com\",\"auth_provider_x509_cert_url\":\"https://www.googleapis.com/oauth2/v1/certs\"}}") {
+                Ok(secret) => (config_dir, secret),
+                Err(e) => return Err(InvalidOptionsError::single(e, 4))
+            }
+        };
+
+        let auth = Authenticator::new(  &secret, DefaultAuthenticatorDelegate,
+                                        if opt.is_present("debug-auth") {
+                                            hyper::Client::with_connector(mock::TeeConnector {
+                                                    connector: hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())
+                                                })
+                                        } else {
+                                            hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new()))
+                                        },
+                                        JsonTokenStorage {
+                                          program_name: "datastore1",
+                                          db_dir: config_dir.clone(),
+                                        }, Some(FlowType::InstalledRedirect(54324)));
+
+        let client =
+            if opt.is_present("debug") {
+                hyper::Client::with_connector(mock::TeeConnector {
+                        connector: hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())
+                    })
+            } else {
+                hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new()))
+            };
+        let engine = Engine {
+            opt: opt,
+            hub: api::Datastore::new(client, auth),
+            gp: vec!["$-xgafv", "access-token", "alt", "bearer-token", "callback", "fields", "key", "oauth-token", "pp", "pretty-print", "quota-user", "upload-type", "upload-protocol"],
+            gpm: vec![
+                    ("$-xgafv", "$.xgafv"),
+                    ("access-token", "access_token"),
+                    ("bearer-token", "bearer_token"),
+                    ("oauth-token", "oauth_token"),
+                    ("pretty-print", "prettyPrint"),
+                    ("quota-user", "quotaUser"),
+                    ("upload-type", "uploadType"),
+                    ("upload-protocol", "upload_protocol"),
+                ]
+        };
+
+        match engine._doit(true) {
+            Err(Some(err)) => Err(err),
+            Err(None)      => Ok(engine),
+            Ok(_)          => unreachable!(),
+        }
+    }
+
+    fn doit(&self) -> Result<(), DoitError> {
+        match self._doit(false) {
+            Ok(res) => res,
+            Err(_) => unreachable!(),
+        }
+    }
+}
+
+fn main() {
+    let mut exit_status = 0i32;
+    let arg_data = [
+        ("projects", "methods: 'allocate-ids', 'begin-transaction', 'commit', 'lookup', 'operations-cancel', 'operations-delete', 'operations-get', 'operations-list', 'reserve-ids', 'rollback' and 'run-query'", vec![
+            ("allocate-ids",
+                    Some(r##"Allocates IDs for the given keys, which is useful for referencing an entity
+        before it is inserted."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_datastore1_cli/projects_allocate-ids",
+                  vec![
+                    (Some(r##"project-id"##),
+                     None,
+                     Some(r##"The ID of the project against which to make the request."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("begin-transaction",
+                    Some(r##"Begins a new transaction."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_datastore1_cli/projects_begin-transaction",
+                  vec![
+                    (Some(r##"project-id"##),
+                     None,
+                     Some(r##"The ID of the project against which to make the request."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("commit",
+                    Some(r##"Commits a transaction, optionally creating, deleting or modifying some
+        entities."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_datastore1_cli/projects_commit",
+                  vec![
+                    (Some(r##"project-id"##),
+                     None,
+                     Some(r##"The ID of the project against which to make the request."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("lookup",
+                    Some(r##"Looks up entities by key."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_datastore1_cli/projects_lookup",
+                  vec![
+                    (Some(r##"project-id"##),
+                     None,
+                     Some(r##"The ID of the project against which to make the request."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("operations-cancel",
+                    Some(r##"Starts asynchronous cancellation on a long-running operation.  The server
+        makes a best effort to cancel the operation, but success is not
+        guaranteed.  If the server doesn't support this method, it returns
+        `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
+        Operations.GetOperation or
+        other methods to check whether the cancellation succeeded or whether the
+        operation completed despite cancellation. On successful cancellation,
+        the operation is not deleted; instead, it becomes an operation with
+        an Operation.error value with a google.rpc.Status.code of 1,
+        corresponding to `Code.CANCELLED`."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_datastore1_cli/projects_operations-cancel",
+                  vec![
+                    (Some(r##"name"##),
+                     None,
+                     Some(r##"The name of the operation resource to be cancelled."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("operations-delete",
+                    Some(r##"Deletes a long-running operation. This method indicates that the client is
+        no longer interested in the operation result. It does not cancel the
+        operation. If the server doesn't support this method, it returns
+        `google.rpc.Code.UNIMPLEMENTED`."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_datastore1_cli/projects_operations-delete",
+                  vec![
+                    (Some(r##"name"##),
+                     None,
+                     Some(r##"The name of the operation resource to be deleted."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("operations-get",
+                    Some(r##"Gets the latest state of a long-running operation.  Clients can use this
+        method to poll the operation result at intervals as recommended by the API
+        service."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_datastore1_cli/projects_operations-get",
+                  vec![
+                    (Some(r##"name"##),
+                     None,
+                     Some(r##"The name of the operation resource."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("operations-list",
+                    Some(r##"Lists operations that match the specified filter in the request. If the
+        server doesn't support this method, it returns `UNIMPLEMENTED`.
+        
+        NOTE: the `name` binding allows API services to override the binding
+        to use different resource name schemes, such as `users/*/operations`. To
+        override the binding, API services can add a binding such as
+        `"/v1/{name=users/*}/operations"` to their service configuration.
+        For backwards compatibility, the default name includes the operations
+        collection id, however overriding users must ensure the name binding
+        is the parent resource, without the operations collection id."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_datastore1_cli/projects_operations-list",
+                  vec![
+                    (Some(r##"name"##),
+                     None,
+                     Some(r##"The name of the operation's parent resource."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("reserve-ids",
+                    Some(r##"Prevents the supplied keys' IDs from being auto-allocated by Cloud
+        Datastore."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_datastore1_cli/projects_reserve-ids",
+                  vec![
+                    (Some(r##"project-id"##),
+                     None,
+                     Some(r##"The ID of the project against which to make the request."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("rollback",
+                    Some(r##"Rolls back a transaction."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_datastore1_cli/projects_rollback",
+                  vec![
+                    (Some(r##"project-id"##),
+                     None,
+                     Some(r##"The ID of the project against which to make the request."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("run-query",
+                    Some(r##"Queries for entities."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_datastore1_cli/projects_run-query",
+                  vec![
+                    (Some(r##"project-id"##),
+                     None,
+                     Some(r##"The ID of the project against which to make the request."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ]),
+        
+    ];
+    
+    let mut app = App::new("datastore1")
+           .author("Sebastian Thiel <byronimo@gmail.com>")
+           .version("1.0.7+20171205")
+           .about("Accesses the schemaless NoSQL database to provide fully managed, robust, scalable storage for your application.
+           ")
+           .after_help("All documentation details can be found at http://byron.github.io/google-apis-rs/google_datastore1_cli")
+           .arg(Arg::with_name("url")
+                   .long("scope")
+                   .help("Specify the authentication a method should be executed in. Each scope requires the user to grant this application permission to use it.If unset, it defaults to the shortest scope url for a particular method.")
+                   .multiple(true)
+                   .takes_value(true))
+           .arg(Arg::with_name("folder")
+                   .long("config-dir")
+                   .help("A directory into which we will store our persistent data. Defaults to a user-writable directory that we will create during the first invocation.[default: ~/.google-service-cli")
+                   .multiple(false)
+                   .takes_value(true))
+           .arg(Arg::with_name("debug")
+                   .long("debug")
+                   .help("Output all server communication to standard error. `tx` and `rx` are placed into the same stream.")
+                   .multiple(false)
+                   .takes_value(false))
+           .arg(Arg::with_name("debug-auth")
+                   .long("debug-auth")
+                   .help("Output all communication related to authentication to standard error. `tx` and `rx` are placed into the same stream.")
+                   .multiple(false)
+                   .takes_value(false));
+           
+           for &(main_command_name, about, ref subcommands) in arg_data.iter() {
+               let mut mcmd = SubCommand::with_name(main_command_name).about(about);
+           
+               for &(sub_command_name, ref desc, url_info, ref args) in subcommands {
+                   let mut scmd = SubCommand::with_name(sub_command_name);
+                   if let &Some(desc) = desc {
+                       scmd = scmd.about(desc);
+                   }
+                   scmd = scmd.after_help(url_info);
+           
+                   for &(ref arg_name, ref flag, ref desc, ref required, ref multi) in args {
+                       let arg_name_str =
+                           match (arg_name, flag) {
+                                   (&Some(an), _       ) => an,
+                                   (_        , &Some(f)) => f,
+                                    _                    => unreachable!(),
+                            };
+                       let mut arg = Arg::with_name(arg_name_str)
+                                         .empty_values(false);
+                       if let &Some(short_flag) = flag {
+                           arg = arg.short(short_flag);
+                       }
+                       if let &Some(desc) = desc {
+                           arg = arg.help(desc);
+                       }
+                       if arg_name.is_some() && flag.is_some() {
+                           arg = arg.takes_value(true);
+                       }
+                       if let &Some(required) = required {
+                           arg = arg.required(required);
+                       }
+                       if let &Some(multi) = multi {
+                           arg = arg.multiple(multi);
+                       }
+                       scmd = scmd.arg(arg);
+                   }
+                   mcmd = mcmd.subcommand(scmd);
+               }
+               app = app.subcommand(mcmd);
+           }
+           
+        let matches = app.get_matches();
+
+    let debug = matches.is_present("debug");
+    match Engine::new(matches) {
+        Err(err) => {
+            exit_status = err.exit_code;
+            writeln!(io::stderr(), "{}", err).ok();
+        },
+        Ok(engine) => {
+            if let Err(doit_err) = engine.doit() {
+                exit_status = 1;
+                match doit_err {
+                    DoitError::IoError(path, err) => {
+                        writeln!(io::stderr(), "Failed to open output file '{}': {}", path, err).ok();
+                    },
+                    DoitError::ApiError(err) => {
+                        if debug {
+                            writeln!(io::stderr(), "{:#?}", err).ok();
+                        } else {
+                            writeln!(io::stderr(), "{}", err).ok();
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    std::process::exit(exit_status);
+}

--- a/gen/datastore1/Cargo.toml
+++ b/gen/datastore1/Cargo.toml
@@ -1,0 +1,31 @@
+# DO NOT EDIT !
+# This file was generated automatically from 'src/mako/Cargo.toml.mako'
+# DO NOT EDIT !
+[package]
+
+name = "google-datastore1"
+version = "1.0.7+20171205"
+authors = ["Sebastian Thiel <byronimo@gmail.com>"]
+description = "A complete library to interact with datastore (protocol v1)"
+repository = "https://github.com/Byron/google-apis-rs/tree/master/gen/datastore1"
+homepage = "https://cloud.google.com/datastore/"
+documentation = "https://docs.rs/google-datastore1/1.0.7+20171205"
+license = "MIT"
+keywords = ["datastore", "google", "protocol", "web", "api"]
+
+
+[dev-dependencies]
+hyper-rustls = "^0.6"
+
+[dependencies]
+hyper = "^ 0.10"
+mime = "^ 0.2.0"
+serde = "^ 1.0"
+serde_json = "^ 1.0"
+serde_derive = "^ 1.0"
+yup-oauth2 = "^ 1.0"
+url = "= 0.5"
+
+[features]
+
+

--- a/gen/datastore1/LICENSE.md
+++ b/gen/datastore1/LICENSE.md
@@ -1,0 +1,30 @@
+<!---
+DO NOT EDIT !
+This file was generated automatically from 'src/mako/LICENSE.md.mako'
+DO NOT EDIT !
+-->
+The MIT License (MIT)
+=====================
+
+Copyright © `2015-2016` `Sebastian Thiel`
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the “Software”), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.

--- a/gen/datastore1/README.md
+++ b/gen/datastore1/README.md
@@ -1,0 +1,175 @@
+<!---
+DO NOT EDIT !
+This file was generated automatically from 'src/mako/api/README.md.mako'
+DO NOT EDIT !
+-->
+The `google-datastore1` library allows access to all features of the *Google datastore* service.
+
+This documentation was generated from *datastore* crate version *1.0.7+20171205*, where *20171205* is the exact revision of the *datastore:v1* schema built by the [mako](http://www.makotemplates.org/) code generator *v1.0.7*.
+
+Everything else about the *datastore* *v1* API can be found at the
+[official documentation site](https://cloud.google.com/datastore/).
+# Features
+
+Handle the following *Resources* with ease from the central [hub](https://docs.rs/google-datastore1/1.0.7+20171205/google_datastore1/struct.Datastore.html) ... 
+
+* projects
+ * [*allocate ids*](https://docs.rs/google-datastore1/1.0.7+20171205/google_datastore1/struct.ProjectAllocateIdCall.html), [*begin transaction*](https://docs.rs/google-datastore1/1.0.7+20171205/google_datastore1/struct.ProjectBeginTransactionCall.html), [*commit*](https://docs.rs/google-datastore1/1.0.7+20171205/google_datastore1/struct.ProjectCommitCall.html), [*lookup*](https://docs.rs/google-datastore1/1.0.7+20171205/google_datastore1/struct.ProjectLookupCall.html), [*operations cancel*](https://docs.rs/google-datastore1/1.0.7+20171205/google_datastore1/struct.ProjectOperationCancelCall.html), [*operations delete*](https://docs.rs/google-datastore1/1.0.7+20171205/google_datastore1/struct.ProjectOperationDeleteCall.html), [*operations get*](https://docs.rs/google-datastore1/1.0.7+20171205/google_datastore1/struct.ProjectOperationGetCall.html), [*operations list*](https://docs.rs/google-datastore1/1.0.7+20171205/google_datastore1/struct.ProjectOperationListCall.html), [*reserve ids*](https://docs.rs/google-datastore1/1.0.7+20171205/google_datastore1/struct.ProjectReserveIdCall.html), [*rollback*](https://docs.rs/google-datastore1/1.0.7+20171205/google_datastore1/struct.ProjectRollbackCall.html) and [*run query*](https://docs.rs/google-datastore1/1.0.7+20171205/google_datastore1/struct.ProjectRunQueryCall.html)
+
+
+
+
+# Structure of this Library
+
+The API is structured into the following primary items:
+
+* **[Hub](https://docs.rs/google-datastore1/1.0.7+20171205/google_datastore1/struct.Datastore.html)**
+    * a central object to maintain state and allow accessing all *Activities*
+    * creates [*Method Builders*](https://docs.rs/google-datastore1/1.0.7+20171205/google_datastore1/trait.MethodsBuilder.html) which in turn
+      allow access to individual [*Call Builders*](https://docs.rs/google-datastore1/1.0.7+20171205/google_datastore1/trait.CallBuilder.html)
+* **[Resources](https://docs.rs/google-datastore1/1.0.7+20171205/google_datastore1/trait.Resource.html)**
+    * primary types that you can apply *Activities* to
+    * a collection of properties and *Parts*
+    * **[Parts](https://docs.rs/google-datastore1/1.0.7+20171205/google_datastore1/trait.Part.html)**
+        * a collection of properties
+        * never directly used in *Activities*
+* **[Activities](https://docs.rs/google-datastore1/1.0.7+20171205/google_datastore1/trait.CallBuilder.html)**
+    * operations to apply to *Resources*
+
+All *structures* are marked with applicable traits to further categorize them and ease browsing.
+
+Generally speaking, you can invoke *Activities* like this:
+
+```Rust,ignore
+let r = hub.resource().activity(...).doit()
+```
+
+Or specifically ...
+
+```ignore
+let r = hub.projects().operations_delete(...).doit()
+let r = hub.projects().operations_cancel(...).doit()
+```
+
+The `resource()` and `activity(...)` calls create [builders][builder-pattern]. The second one dealing with `Activities` 
+supports various methods to configure the impending operation (not shown here). It is made such that all required arguments have to be 
+specified right away (i.e. `(...)`), whereas all optional ones can be [build up][builder-pattern] as desired.
+The `doit()` method performs the actual communication with the server and returns the respective result.
+
+# Usage
+
+## Setting up your Project
+
+To use this library, you would put the following lines into your `Cargo.toml` file:
+
+```toml
+[dependencies]
+google-datastore1 = "*"
+```
+
+## A complete example
+
+```Rust
+extern crate hyper;
+extern crate hyper_rustls;
+extern crate yup_oauth2 as oauth2;
+extern crate google_datastore1 as datastore1;
+use datastore1::{Result, Error};
+use std::default::Default;
+use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+use datastore1::Datastore;
+
+// Get an ApplicationSecret instance by some means. It contains the `client_id` and 
+// `client_secret`, among other things.
+let secret: ApplicationSecret = Default::default();
+// Instantiate the authenticator. It will choose a suitable authentication flow for you, 
+// unless you replace  `None` with the desired Flow.
+// Provide your own `AuthenticatorDelegate` to adjust the way it operates and get feedback about 
+// what's going on. You probably want to bring in your own `TokenStorage` to persist tokens and
+// retrieve them from storage.
+let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+                              hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+                              <MemoryStorage as Default>::default(), None);
+let mut hub = Datastore::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+// You can configure optional parameters by calling the respective setters at will, and
+// execute the final call using `doit()`.
+// Values shown here are possibly random and not representative !
+let result = hub.projects().operations_delete("name")
+             .doit();
+
+match result {
+    Err(e) => match e {
+        // The Error enum provides details about what exactly happened.
+        // You can also just use its `Debug`, `Display` or `Error` traits
+         Error::HttpError(_)
+        |Error::MissingAPIKey
+        |Error::MissingToken(_)
+        |Error::Cancelled
+        |Error::UploadSizeLimitExceeded(_, _)
+        |Error::Failure(_)
+        |Error::BadRequest(_)
+        |Error::FieldClash(_)
+        |Error::JsonDecodeError(_, _) => println!("{}", e),
+    },
+    Ok(res) => println!("Success: {:?}", res),
+}
+
+```
+## Handling Errors
+
+All errors produced by the system are provided either as [Result](https://docs.rs/google-datastore1/1.0.7+20171205/google_datastore1/enum.Result.html) enumeration as return value of 
+the doit() methods, or handed as possibly intermediate results to either the 
+[Hub Delegate](https://docs.rs/google-datastore1/1.0.7+20171205/google_datastore1/trait.Delegate.html), or the [Authenticator Delegate](https://docs.rs/yup-oauth2/*/yup_oauth2/trait.AuthenticatorDelegate.html).
+
+When delegates handle errors or intermediate values, they may have a chance to instruct the system to retry. This 
+makes the system potentially resilient to all kinds of errors.
+
+## Uploads and Downloads
+If a method supports downloads, the response body, which is part of the [Result](https://docs.rs/google-datastore1/1.0.7+20171205/google_datastore1/enum.Result.html), should be
+read by you to obtain the media.
+If such a method also supports a [Response Result](https://docs.rs/google-datastore1/1.0.7+20171205/google_datastore1/trait.ResponseResult.html), it will return that by default.
+You can see it as meta-data for the actual media. To trigger a media download, you will have to set up the builder by making
+this call: `.param("alt", "media")`.
+
+Methods supporting uploads can do so using up to 2 different protocols: 
+*simple* and *resumable*. The distinctiveness of each is represented by customized 
+`doit(...)` methods, which are then named `upload(...)` and `upload_resumable(...)` respectively.
+
+## Customization and Callbacks
+
+You may alter the way an `doit()` method is called by providing a [delegate](https://docs.rs/google-datastore1/1.0.7+20171205/google_datastore1/trait.Delegate.html) to the 
+[Method Builder](https://docs.rs/google-datastore1/1.0.7+20171205/google_datastore1/trait.CallBuilder.html) before making the final `doit()` call. 
+Respective methods will be called to provide progress information, as well as determine whether the system should 
+retry on failure.
+
+The [delegate trait](https://docs.rs/google-datastore1/1.0.7+20171205/google_datastore1/trait.Delegate.html) is default-implemented, allowing you to customize it with minimal effort.
+
+## Optional Parts in Server-Requests
+
+All structures provided by this library are made to be [enocodable](https://docs.rs/google-datastore1/1.0.7+20171205/google_datastore1/trait.RequestValue.html) and 
+[decodable](https://docs.rs/google-datastore1/1.0.7+20171205/google_datastore1/trait.ResponseResult.html) via *json*. Optionals are used to indicate that partial requests are responses 
+are valid.
+Most optionals are are considered [Parts](https://docs.rs/google-datastore1/1.0.7+20171205/google_datastore1/trait.Part.html) which are identifiable by name, which will be sent to 
+the server to indicate either the set parts of the request or the desired parts in the response.
+
+## Builder Arguments
+
+Using [method builders](https://docs.rs/google-datastore1/1.0.7+20171205/google_datastore1/trait.CallBuilder.html), you are able to prepare an action call by repeatedly calling it's methods.
+These will always take a single argument, for which the following statements are true.
+
+* [PODs][wiki-pod] are handed by copy
+* strings are passed as `&str`
+* [request values](https://docs.rs/google-datastore1/1.0.7+20171205/google_datastore1/trait.RequestValue.html) are moved
+
+Arguments will always be copied or cloned into the builder, to make them independent of their original life times.
+
+[wiki-pod]: http://en.wikipedia.org/wiki/Plain_old_data_structure
+[builder-pattern]: http://en.wikipedia.org/wiki/Builder_pattern
+[google-go-api]: https://github.com/google/google-api-go-client
+
+# License
+The **datastore1** library was generated by Sebastian Thiel, and is placed 
+under the *MIT* license.
+You can read the full text at the repository's [license file][repo-license].
+
+[repo-license]: https://github.com/Byron/google-apis-rsblob/master/LICENSE.md

--- a/gen/datastore1/src/cmn.rs
+++ b/gen/datastore1/src/cmn.rs
@@ -1,0 +1,753 @@
+// COPY OF 'src/rust/api/cmn.rs'
+// DO NOT EDIT
+use std::io::{self, Read, Seek, Cursor, Write, SeekFrom};
+use std;
+use std::fmt::{self, Display};
+use std::str::FromStr;
+use std::error;
+use std::thread::sleep;
+use std::time::Duration;
+
+use mime::{Mime, TopLevel, SubLevel, Attr, Value};
+use oauth2::{TokenType, Retry, self};
+use hyper;
+use hyper::header::{ContentType, ContentLength, Headers, UserAgent, Authorization, Header,
+                    HeaderFormat, Bearer};
+use hyper::http::h1::LINE_ENDING;
+use hyper::method::Method;
+use hyper::status::StatusCode;
+
+use serde_json as json;
+
+/// Identifies the Hub. There is only one per library, this trait is supposed
+/// to make intended use more explicit.
+/// The hub allows to access all resource methods more easily.
+pub trait Hub {}
+
+/// Identifies types for building methods of a particular resource type
+pub trait MethodsBuilder {}
+
+/// Identifies types which represent builders for a particular resource method
+pub trait CallBuilder {}
+
+/// Identifies types which can be inserted and deleted.
+/// Types with this trait are most commonly used by clients of this API.
+pub trait Resource {}
+
+/// Identifies types which are used in API responses.
+pub trait ResponseResult {}
+
+/// Identifies types which are used in API requests.
+pub trait RequestValue {}
+
+/// Identifies types which are not actually used by the API
+/// This might be a bug within the google API schema.
+pub trait UnusedType {}
+
+/// Identifies types which are only used as part of other types, which
+/// usually are carrying the `Resource` trait.
+pub trait Part {}
+
+/// Identifies types which are only used by other types internally.
+/// They have no special meaning, this trait just marks them for completeness.
+pub trait NestedType {}
+
+/// A utility to specify reader types which provide seeking capabilities too
+pub trait ReadSeek: Seek + Read {}
+impl<T: Seek + Read> ReadSeek for T {}
+
+/// A trait for all types that can convert themselves into a *parts* string
+pub trait ToParts {
+    fn to_parts(&self) -> String;
+}
+
+/// A utility type which can decode a server response that indicates error
+#[derive(Deserialize)]
+pub struct JsonServerError {
+    pub error: String,
+    pub error_description: Option<String>
+}
+
+/// A utility to represent detailed errors we might see in case there are BadRequests.
+/// The latter happen if the sent parameters or request structures are unsound
+#[derive(Deserialize, Serialize, Debug)]
+pub struct ErrorResponse {
+    error: ServerError,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct ServerError {
+    errors: Vec<ServerMessage>,
+    code: u16,
+    message: String,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct ServerMessage {
+    domain: String,
+    reason: String,
+    message: String,
+    #[serde(rename="locationType")]
+    location_type: Option<String>,
+    location: Option<String>
+}
+
+#[derive(Copy, Clone)]
+pub struct DummyNetworkStream;
+
+impl Read for DummyNetworkStream {
+    fn read(&mut self, _: &mut [u8]) -> io::Result<usize> {
+        Ok(0)
+    }
+}
+
+impl Write for DummyNetworkStream {
+    fn write(&mut self, _: &[u8]) -> io::Result<usize> {
+        Ok(0)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl hyper::net::NetworkStream for DummyNetworkStream {
+    fn peer_addr(&mut self) -> io::Result<std::net::SocketAddr> {
+        Ok("127.0.0.1:1337".parse().unwrap())
+    }
+
+    fn set_read_timeout(&self, _dur: Option<Duration>) -> io::Result<()> {
+        Ok(())
+    }
+
+    fn set_write_timeout(&self, _dur: Option<Duration>) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+
+/// A trait specifying functionality to help controlling any request performed by the API.
+/// The trait has a conservative default implementation.
+///
+/// It contains methods to deal with all common issues, as well with the ones related to
+/// uploading media
+pub trait Delegate {
+
+    /// Called at the beginning of any API request. The delegate should store the method
+    /// information if he is interesting in knowing more context when further calls to it
+    /// are made.
+    /// The matching `finished()` call will always be made, no matter whether or not the API
+    /// request was successful. That way, the delegate may easily maintain a clean state
+    /// between various API calls.
+    fn begin(&mut self, MethodInfo) {}
+
+    /// Called whenever there is an [HttpError](http://hyperium.github.io/hyper/hyper/error/enum.HttpError.html), usually if there are network problems.
+    ///
+    /// If you choose to retry after a duration, the duration should be chosen using the
+    /// [exponential backoff algorithm](http://en.wikipedia.org/wiki/Exponential_backoff).
+    ///
+    /// Return retry information.
+    fn http_error(&mut self, &hyper::Error) -> Retry {
+        Retry::Abort
+    }
+
+    /// Called whenever there is the need for your applications API key after
+    /// the official authenticator implementation didn't provide one, for some reason.
+    /// If this method returns None as well, the underlying operation will fail
+    fn api_key(&mut self) -> Option<String> {
+        None
+    }
+
+    /// Called whenever the Authenticator didn't yield a token. The delegate
+    /// may attempt to provide one, or just take it as a general information about the
+    /// impending failure.
+    /// The given Error provides information about why the token couldn't be acquired in the
+    /// first place
+    fn token(&mut self, err: &error::Error) -> Option<oauth2::Token> {
+        let _ = err;
+        None
+    }
+
+    /// Called during resumable uploads to provide a URL for the impending upload.
+    /// It was saved after a previous call to `store_upload_url(...)`, and if not None,
+    /// will be used instead of asking the server for a new upload URL.
+    /// This is useful in case a previous resumable upload was aborted/canceled, but should now
+    /// be resumed.
+    /// The returned URL will be used exactly once - if it fails again and the delegate allows
+    /// to retry, we will ask the server for a new upload URL.
+    fn upload_url(&mut self) -> Option<String> {
+        None
+    }
+
+    /// Called after we have retrieved a new upload URL for a resumable upload to store it
+    /// in case we fail or cancel. That way, we can attempt to resume the upload later,
+    /// see `upload_url()`.
+    /// It will also be called with None after a successful upload, which allows the delegate
+    /// to forget the URL. That way, we will not attempt to resume an upload that has already
+    /// finished.
+    fn store_upload_url(&mut self, url: Option<&str>) {
+        let _ = url;
+    }
+
+    /// Called whenever a server response could not be decoded from json.
+    /// It's for informational purposes only, the caller will return with an error
+    /// accordingly.
+    ///
+    /// # Arguments
+    ///
+    /// * `json_encoded_value` - The json-encoded value which failed to decode.
+    /// * `json_decode_error`  - The decoder error
+    fn response_json_decode_error(&mut self, json_encoded_value: &str, json_decode_error: &json::Error) {
+        let _ = json_encoded_value;
+        let _ = json_decode_error;
+    }
+
+    /// Called whenever the http request returns with a non-success status code.
+    /// This can involve authentication issues, or anything else that very much
+    /// depends on the used API method.
+    /// The delegate should check the status, header and decoded json error to decide
+    /// whether to retry or not. In the latter case, the underlying call will fail.
+    ///
+    /// If you choose to retry after a duration, the duration should be chosen using the
+    /// [exponential backoff algorithm](http://en.wikipedia.org/wiki/Exponential_backoff).
+    fn http_failure(&mut self, _: &hyper::client::Response, Option<JsonServerError>, _: Option<ServerError>) -> Retry {
+        Retry::Abort
+    }
+
+    /// Called prior to sending the main request of the given method. It can be used to time
+    /// the call or to print progress information.
+    /// It's also useful as you can be sure that a request will definitely be made.
+    fn pre_request(&mut self) { }
+
+    /// Return the size of each chunk of a resumable upload.
+    /// Must be a power of two, with 1<<18 being the smallest allowed chunk size.
+    /// Will be called once before starting any resumable upload.
+    fn chunk_size(&mut self) -> u64 {
+        1 << 23
+    }
+
+    /// Called before the given chunk is uploaded to the server.
+    /// If true is returned, the upload will be interrupted.
+    /// However, it may be resumable if you stored the upload URL in a previous call
+    /// to `store_upload_url()`
+    fn cancel_chunk_upload(&mut self, chunk: &ContentRange) -> bool {
+        let _ = chunk;
+        false
+    }
+
+    /// Called before the API request method returns, in every case. It can be used to clean up
+    /// internal state between calls to the API.
+    /// This call always has a matching call to `begin(...)`.
+    ///
+    /// # Arguments
+    ///
+    /// * `is_success` - a true value indicates the operation was successful. If false, you should
+    ///                  discard all values stored during `store_upload_url`.
+    fn finished(&mut self, is_success: bool) {
+        let _ = is_success;
+    }
+}
+
+/// A delegate with a conservative default implementation, which is used if no other delegate is
+/// set.
+#[derive(Default)]
+pub struct DefaultDelegate;
+
+impl Delegate for DefaultDelegate {}
+
+
+#[derive(Debug)]
+pub enum Error {
+    /// The http connection failed
+    HttpError(hyper::Error),
+
+    /// An attempt was made to upload a resource with size stored in field `.0`
+    /// even though the maximum upload size is what is stored in field `.1`.
+    UploadSizeLimitExceeded(u64, u64),
+
+    /// Represents information about a request that was not understood by the server.
+    /// Details are included.
+    BadRequest(ErrorResponse),
+
+    /// We needed an API key for authentication, but didn't obtain one.
+    /// Neither through the authenticator, nor through the Delegate.
+    MissingAPIKey,
+
+    /// We required a Token, but didn't get one from the Authenticator
+    MissingToken(Box<error::Error>),
+
+    /// The delgate instructed to cancel the operation
+    Cancelled,
+
+    /// An additional, free form field clashed with one of the built-in optional ones
+    FieldClash(&'static str),
+
+    /// Shows that we failed to decode the server response.
+    /// This can happen if the protocol changes in conjunction with strict json decoding.
+    JsonDecodeError(String, json::Error),
+
+    /// Indicates an HTTP repsonse with a non-success status code
+    Failure(hyper::client::Response),
+}
+
+
+impl Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Error::HttpError(ref err) => err.fmt(f),
+            Error::UploadSizeLimitExceeded(ref resource_size, ref max_size) =>
+                writeln!(f, "The media size {} exceeds the maximum allowed upload size of {}"
+                         , resource_size, max_size),
+            Error::MissingAPIKey => {
+                (writeln!(f, "The application's API key was not found in the configuration")).ok();
+                writeln!(f, "It is used as there are no Scopes defined for this method.")
+            },
+            Error::BadRequest(ref err) => {
+                try!(writeln!(f, "Bad Request ({}): {}", err.error.code, err.error.message));
+                for err in err.error.errors.iter() {
+                    try!(writeln!(f, "    {}: {}, {}{}",
+                                            err.domain,
+                                            err.message,
+                                            err.reason,
+                                            match &err.location {
+                                                &Some(ref loc) => format!("@{}", loc),
+                                                &None => String::new(),
+                                            }));
+                }
+                Ok(())
+            },
+            Error::MissingToken(ref err) =>
+                writeln!(f, "Token retrieval failed with error: {}", err),
+            Error::Cancelled =>
+                writeln!(f, "Operation cancelled by delegate"),
+            Error::FieldClash(field) =>
+                writeln!(f, "The custom parameter '{}' is already provided natively by the CallBuilder.", field),
+            Error::JsonDecodeError(ref json_str, ref err)
+                => writeln!(f, "{}: {}", err, json_str),
+            Error::Failure(ref response) =>
+                writeln!(f, "Http status indicates failure: {:?}", response),
+        }
+    }
+}
+
+impl error::Error for Error {
+    fn description(&self) -> &str {
+        match *self {
+            Error::HttpError(ref err) => err.description(),
+            Error::JsonDecodeError(_, ref err) => err.description(),
+            _ => "NO DESCRIPTION POSSIBLE - use `Display.fmt()` instead"
+        }
+    }
+
+    fn cause(&self) -> Option<&error::Error> {
+        match *self {
+            Error::HttpError(ref err) => err.cause(),
+            Error::JsonDecodeError(_, ref err) => err.cause(),
+            _ => None
+        }
+    }
+}
+
+/// A universal result type used as return for all calls.
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Contains information about an API request.
+pub struct MethodInfo {
+    pub id: &'static str,
+    pub http_method: Method,
+}
+
+const BOUNDARY: &'static str = "MDuXWGyeE33QFXGchb2VFWc4Z7945d";
+
+/// Provides a `Read` interface that converts multiple parts into the protocol
+/// identified by [RFC2387](https://tools.ietf.org/html/rfc2387).
+/// **Note**: This implementation is just as rich as it needs to be to perform uploads
+/// to google APIs, and might not be a fully-featured implementation.
+#[derive(Default)]
+pub struct MultiPartReader<'a> {
+    raw_parts: Vec<(Headers, &'a mut Read)>,
+    current_part: Option<(Cursor<Vec<u8>>, &'a mut Read)>,
+    last_part_boundary: Option<Cursor<Vec<u8>>>,
+}
+
+impl<'a> MultiPartReader<'a> {
+
+    /// Reserve memory for exactly the given amount of parts
+    pub fn reserve_exact(&mut self, cap: usize) {
+        self.raw_parts.reserve_exact(cap);
+    }
+
+    /// Add a new part to the queue of parts to be read on the first `read` call.
+    ///
+    /// # Arguments
+    ///
+    /// `headers` - identifying the body of the part. It's similar to the header
+    ///             in an ordinary single-part call, and should thus contain the
+    ///             same information.
+    /// `reader`  - a reader providing the part's body
+    /// `size`    - the amount of bytes provided by the reader. It will be put onto the header as
+    ///             content-size.
+    /// `mime`    - It will be put onto the content type
+    pub fn add_part(&mut self, reader: &'a mut Read, size: u64, mime_type: Mime) -> &mut MultiPartReader<'a> {
+        let mut headers = Headers::new();
+        headers.set(ContentType(mime_type));
+        headers.set(ContentLength(size));
+        self.raw_parts.push((headers, reader));
+        self
+    }
+
+    /// Returns the mime-type representing our multi-part message.
+    /// Use it with the ContentType header.
+    pub fn mime_type(&self) -> Mime {
+        Mime(
+            TopLevel::Multipart,
+            SubLevel::Ext("Related".to_string()),
+            vec![(Attr::Ext("boundary".to_string()), Value::Ext(BOUNDARY.to_string()))],
+        )
+    }
+
+    /// Returns true if we are totally used
+    fn is_depleted(&self) -> bool {
+        self.raw_parts.len() == 0 && self.current_part.is_none() && self.last_part_boundary.is_none()
+    }
+
+    /// Returns true if we are handling our last part
+    fn is_last_part(&self) -> bool {
+        self.raw_parts.len() == 0 && self.current_part.is_some()
+    }
+}
+
+impl<'a> Read for MultiPartReader<'a> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        match (self.raw_parts.len(),
+               self.current_part.is_none(),
+               self.last_part_boundary.is_none()) {
+            (_, _, false) => {
+                let br = self.last_part_boundary.as_mut().unwrap().read(buf).unwrap_or(0);
+                if br < buf.len() {
+                    self.last_part_boundary = None;
+                }
+                return Ok(br)
+            },
+            (0, true, true) => return Ok(0),
+            (n, true, _) if n > 0 => {
+                let (headers, reader) = self.raw_parts.remove(0);
+                let mut c = Cursor::new(Vec::<u8>::new());
+                (write!(&mut c, "{}--{}{}{}{}", LINE_ENDING, BOUNDARY, LINE_ENDING,
+                                                headers, LINE_ENDING)).unwrap();
+                c.seek(SeekFrom::Start(0)).unwrap();
+                self.current_part = Some((c, reader));
+            }
+            _ => {},
+        }
+
+        // read headers as long as possible
+        let (hb, rr) = {
+            let &mut (ref mut c, ref mut reader) = self.current_part.as_mut().unwrap();
+            let b = c.read(buf).unwrap_or(0);
+            (b, reader.read(&mut buf[b..]))
+        };
+
+        match rr {
+            Ok(bytes_read) => {
+                if hb < buf.len() && bytes_read == 0 {
+                    if self.is_last_part() {
+                        // before clearing the last part, we will add the boundary that
+                        // will be written last
+                        self.last_part_boundary = Some(Cursor::new(
+                                                        format!("{}--{}--", LINE_ENDING, BOUNDARY).into_bytes()))
+                    }
+                    // We are depleted - this can trigger the next part to come in
+                    self.current_part = None;
+                }
+                let mut total_bytes_read = hb + bytes_read;
+                while total_bytes_read < buf.len() && !self.is_depleted() {
+                    match self.read(&mut buf[total_bytes_read ..]) {
+                        Ok(br) => total_bytes_read += br,
+                        Err(err) => return Err(err),
+                    }
+                }
+                Ok(total_bytes_read)
+            }
+            Err(err) => {
+                // fail permanently
+                self.current_part = None;
+                self.last_part_boundary = None;
+                self.raw_parts.clear();
+                Err(err)
+            }
+        }
+    }
+}
+
+/// The `X-Upload-Content-Type` header.
+///
+/// Generated via rustc --pretty expanded -Z unstable-options, and manually
+/// processed to be more readable.
+#[derive(PartialEq, Debug, Clone)]
+pub struct XUploadContentType(pub Mime);
+
+impl ::std::ops::Deref for XUploadContentType {
+    type Target = Mime;
+    fn deref<'a>(&'a self) -> &'a Mime { &self.0 }
+}
+impl ::std::ops::DerefMut for XUploadContentType {
+    fn deref_mut<'a>(&'a mut self) -> &'a mut Mime { &mut self.0 }
+}
+impl Header for XUploadContentType {
+    fn header_name() -> &'static str { "X-Upload-Content-Type" }
+    fn parse_header(raw: &[Vec<u8>]) -> hyper::error::Result<Self> {
+        hyper::header::parsing::from_one_raw_str(raw).map(XUploadContentType)
+    }
+}
+impl HeaderFormat for XUploadContentType {
+    fn fmt_header(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        Display::fmt(&**self, f)
+    }
+}
+impl Display for XUploadContentType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(&**self, f)
+    }
+}
+
+#[derive(Clone, PartialEq, Debug)]
+pub struct Chunk {
+    pub first: u64,
+    pub last: u64
+}
+
+impl fmt::Display for Chunk {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        (write!(fmt, "{}-{}", self.first, self.last)).ok();
+        Ok(())
+    }
+}
+
+impl FromStr for Chunk {
+    type Err = &'static str;
+
+    /// NOTE: only implements `%i-%i`, not `*`
+    fn from_str(s: &str) -> std::result::Result<Chunk, &'static str> {
+        let parts: Vec<&str> = s.split('-').collect();
+        if parts.len() != 2 {
+            return Err("Expected two parts: %i-%i")
+        }
+        Ok(
+            Chunk {
+                first: match FromStr::from_str(parts[0]) {
+                    Ok(d) => d,
+                    _ => return Err("Couldn't parse 'first' as digit")
+                },
+                last: match FromStr::from_str(parts[1]) {
+                    Ok(d) => d,
+                    _ => return Err("Couldn't parse 'last' as digit")
+                }
+            }
+        )
+    }
+}
+
+/// Implements the Content-Range header, for serialization only
+#[derive(Clone, PartialEq, Debug)]
+pub struct ContentRange {
+    pub range: Option<Chunk>,
+    pub total_length: u64,
+}
+
+impl Header for ContentRange {
+    fn header_name() -> &'static str {
+        "Content-Range"
+    }
+
+    /// We are not parsable, as parsing is done by the `Range` header
+    fn parse_header(_: &[Vec<u8>]) -> hyper::error::Result<Self> {
+        Err(hyper::error::Error::Method)
+    }
+}
+
+
+impl HeaderFormat for ContentRange {
+    fn fmt_header(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        try!(fmt.write_str("bytes "));
+        match self.range {
+            Some(ref c) => try!(c.fmt(fmt)),
+            None => try!(fmt.write_str("*"))
+        }
+        (write!(fmt, "/{}", self.total_length)).ok();
+        Ok(())
+    }
+}
+
+#[derive(Clone, PartialEq, Debug)]
+pub struct RangeResponseHeader(pub Chunk);
+
+impl Header for RangeResponseHeader {
+    fn header_name() -> &'static str {
+        "Range"
+    }
+
+    fn parse_header(raw: &[Vec<u8>]) -> hyper::error::Result<Self> {
+        if raw.len() > 0 {
+            let v = &raw[0];
+            if let Ok(s) = std::str::from_utf8(v) {
+                const PREFIX: &'static str = "bytes ";
+                if s.starts_with(PREFIX) {
+                    if let Ok(c) = <Chunk as FromStr>::from_str(&s[PREFIX.len()..]) {
+                        return  Ok(RangeResponseHeader(c))
+                    }
+                }
+            }
+        }
+        Err(hyper::error::Error::Method)
+    }
+}
+
+impl HeaderFormat for RangeResponseHeader {
+    /// No implmentation necessary, we just need to parse
+    fn fmt_header(&self, _: &mut fmt::Formatter) -> fmt::Result {
+        Err(fmt::Error)
+    }
+}
+
+/// A utility type to perform a resumable upload from start to end.
+pub struct ResumableUploadHelper<'a, A: 'a> {
+    pub client: &'a mut hyper::client::Client,
+    pub delegate: &'a mut Delegate,
+    pub start_at: Option<u64>,
+    pub auth: &'a mut A,
+    pub user_agent: &'a str,
+    pub auth_header: Authorization<Bearer>,
+    pub url: &'a str,
+    pub reader: &'a mut ReadSeek,
+    pub media_type: Mime,
+    pub content_length: u64
+}
+
+impl<'a, A> ResumableUploadHelper<'a, A>
+    where A: oauth2::GetToken {
+
+    fn query_transfer_status(&mut self) -> std::result::Result<u64, hyper::Result<hyper::client::Response>> {
+        loop {
+            match self.client.post(self.url)
+                .header(UserAgent(self.user_agent.to_string()))
+                .header(ContentRange { range: None, total_length: self.content_length })
+                .header(self.auth_header.clone())
+                .send() {
+                Ok(r) => {
+                    // 308 = resume-incomplete == PermanentRedirect
+                    let headers = r.headers.clone();
+                    let h: &RangeResponseHeader = match headers.get() {
+                        Some(hh) if r.status == StatusCode::PermanentRedirect => hh,
+                        None|Some(_) => {
+                            if let Retry::After(d) = self.delegate.http_failure(&r, None, None) {
+                                sleep(d);
+                                continue;
+                            }
+                            return Err(Ok(r))
+                        }
+                    };
+                    return Ok(h.0.last)
+                }
+                Err(err) => {
+                    if let Retry::After(d) = self.delegate.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    return Err(Err(err))
+                }
+            }
+        }
+    }
+
+    /// returns None if operation was cancelled by delegate, or the HttpResult.
+    /// It can be that we return the result just because we didn't understand the status code -
+    /// caller should check for status himself before assuming it's OK to use
+    pub fn upload(&mut self) -> Option<hyper::Result<hyper::client::Response>> {
+        let mut start = match self.start_at {
+            Some(s) => s,
+            None => match self.query_transfer_status() {
+                Ok(s) => s,
+                Err(result) => return Some(result)
+            }
+        };
+
+        const MIN_CHUNK_SIZE: u64 = 1 << 18;
+        let chunk_size = match self.delegate.chunk_size() {
+            cs if cs > MIN_CHUNK_SIZE => cs,
+            _ => MIN_CHUNK_SIZE
+        };
+
+        self.reader.seek(SeekFrom::Start(start)).unwrap();
+        loop {
+            let request_size = match self.content_length - start {
+                rs if rs > chunk_size => chunk_size,
+                rs => rs
+            };
+
+            let mut section_reader = self.reader.take(request_size);
+            let range_header = ContentRange {
+                range: Some(Chunk {first: start, last: start + request_size - 1}),
+                total_length: self.content_length
+            };
+            start += request_size;
+            if self.delegate.cancel_chunk_upload(&range_header) {
+                return None
+            }
+            let res = self.client.post(self.url)
+                                 .header(range_header)
+                                 .header(ContentType(self.media_type.clone()))
+                                 .header(UserAgent(self.user_agent.to_string()))
+                                 .body(&mut section_reader)
+                                 .send();
+            match res {
+                Ok(mut res) => {
+                    if res.status == StatusCode::PermanentRedirect  {
+                        continue
+                    }
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let Retry::After(d) = self.delegate.http_failure(&res,
+                                                        json::from_str(&json_err).ok(),
+                                                        json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                    }
+                    return Some(Ok(res))
+                },
+                Err(err) => {
+                    if let Retry::After(d) = self.delegate.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    return Some(Err(err))
+                }
+            }
+        }
+    }
+}
+
+// Copy of src/rust/cli/cmn.rs
+// TODO(ST): Allow sharing common code between program types
+pub fn remove_json_null_values(value: &mut json::value::Value) {
+    match *value {
+        json::value::Value::Object(ref mut map) => {
+            let mut for_removal = Vec::new();
+
+            for (key, mut value) in map.iter_mut() {
+                if value.is_null() {
+                    for_removal.push(key.clone());
+                } else {
+                    remove_json_null_values(&mut value);
+                }
+            }
+
+            for key in &for_removal {
+                map.remove(key);
+            }
+        }
+        _ => {}
+    }
+}

--- a/gen/datastore1/src/lib.rs
+++ b/gen/datastore1/src/lib.rs
@@ -1,0 +1,4745 @@
+// DO NOT EDIT !
+// This file was generated automatically from 'src/mako/api/lib.rs.mako'
+// DO NOT EDIT !
+
+//! This documentation was generated from *datastore* crate version *1.0.7+20171205*, where *20171205* is the exact revision of the *datastore:v1* schema built by the [mako](http://www.makotemplates.org/) code generator *v1.0.7*.
+//! 
+//! Everything else about the *datastore* *v1* API can be found at the
+//! [official documentation site](https://cloud.google.com/datastore/).
+//! The original source code is [on github](https://github.com/Byron/google-apis-rs/tree/master/gen/datastore1).
+//! # Features
+//! 
+//! Handle the following *Resources* with ease from the central [hub](struct.Datastore.html) ... 
+//! 
+//! * projects
+//!  * [*allocate ids*](struct.ProjectAllocateIdCall.html), [*begin transaction*](struct.ProjectBeginTransactionCall.html), [*commit*](struct.ProjectCommitCall.html), [*lookup*](struct.ProjectLookupCall.html), [*operations cancel*](struct.ProjectOperationCancelCall.html), [*operations delete*](struct.ProjectOperationDeleteCall.html), [*operations get*](struct.ProjectOperationGetCall.html), [*operations list*](struct.ProjectOperationListCall.html), [*reserve ids*](struct.ProjectReserveIdCall.html), [*rollback*](struct.ProjectRollbackCall.html) and [*run query*](struct.ProjectRunQueryCall.html)
+//! 
+//! 
+//! 
+//! 
+//! Not what you are looking for ? Find all other Google APIs in their Rust [documentation index](http://byron.github.io/google-apis-rs).
+//! 
+//! # Structure of this Library
+//! 
+//! The API is structured into the following primary items:
+//! 
+//! * **[Hub](struct.Datastore.html)**
+//!     * a central object to maintain state and allow accessing all *Activities*
+//!     * creates [*Method Builders*](trait.MethodsBuilder.html) which in turn
+//!       allow access to individual [*Call Builders*](trait.CallBuilder.html)
+//! * **[Resources](trait.Resource.html)**
+//!     * primary types that you can apply *Activities* to
+//!     * a collection of properties and *Parts*
+//!     * **[Parts](trait.Part.html)**
+//!         * a collection of properties
+//!         * never directly used in *Activities*
+//! * **[Activities](trait.CallBuilder.html)**
+//!     * operations to apply to *Resources*
+//! 
+//! All *structures* are marked with applicable traits to further categorize them and ease browsing.
+//! 
+//! Generally speaking, you can invoke *Activities* like this:
+//! 
+//! ```Rust,ignore
+//! let r = hub.resource().activity(...).doit()
+//! ```
+//! 
+//! Or specifically ...
+//! 
+//! ```ignore
+//! let r = hub.projects().operations_delete(...).doit()
+//! let r = hub.projects().operations_cancel(...).doit()
+//! ```
+//! 
+//! The `resource()` and `activity(...)` calls create [builders][builder-pattern]. The second one dealing with `Activities` 
+//! supports various methods to configure the impending operation (not shown here). It is made such that all required arguments have to be 
+//! specified right away (i.e. `(...)`), whereas all optional ones can be [build up][builder-pattern] as desired.
+//! The `doit()` method performs the actual communication with the server and returns the respective result.
+//! 
+//! # Usage
+//! 
+//! ## Setting up your Project
+//! 
+//! To use this library, you would put the following lines into your `Cargo.toml` file:
+//! 
+//! ```toml
+//! [dependencies]
+//! google-datastore1 = "*"
+//! ```
+//! 
+//! ## A complete example
+//! 
+//! ```test_harness,no_run
+//! extern crate hyper;
+//! extern crate hyper_rustls;
+//! extern crate yup_oauth2 as oauth2;
+//! extern crate google_datastore1 as datastore1;
+//! use datastore1::{Result, Error};
+//! # #[test] fn egal() {
+//! use std::default::Default;
+//! use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+//! use datastore1::Datastore;
+//! 
+//! // Get an ApplicationSecret instance by some means. It contains the `client_id` and 
+//! // `client_secret`, among other things.
+//! let secret: ApplicationSecret = Default::default();
+//! // Instantiate the authenticator. It will choose a suitable authentication flow for you, 
+//! // unless you replace  `None` with the desired Flow.
+//! // Provide your own `AuthenticatorDelegate` to adjust the way it operates and get feedback about 
+//! // what's going on. You probably want to bring in your own `TokenStorage` to persist tokens and
+//! // retrieve them from storage.
+//! let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+//!                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+//!                               <MemoryStorage as Default>::default(), None);
+//! let mut hub = Datastore::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+//! // You can configure optional parameters by calling the respective setters at will, and
+//! // execute the final call using `doit()`.
+//! // Values shown here are possibly random and not representative !
+//! let result = hub.projects().operations_delete("name")
+//!              .doit();
+//! 
+//! match result {
+//!     Err(e) => match e {
+//!         // The Error enum provides details about what exactly happened.
+//!         // You can also just use its `Debug`, `Display` or `Error` traits
+//!          Error::HttpError(_)
+//!         |Error::MissingAPIKey
+//!         |Error::MissingToken(_)
+//!         |Error::Cancelled
+//!         |Error::UploadSizeLimitExceeded(_, _)
+//!         |Error::Failure(_)
+//!         |Error::BadRequest(_)
+//!         |Error::FieldClash(_)
+//!         |Error::JsonDecodeError(_, _) => println!("{}", e),
+//!     },
+//!     Ok(res) => println!("Success: {:?}", res),
+//! }
+//! # }
+//! ```
+//! ## Handling Errors
+//! 
+//! All errors produced by the system are provided either as [Result](enum.Result.html) enumeration as return value of 
+//! the doit() methods, or handed as possibly intermediate results to either the 
+//! [Hub Delegate](trait.Delegate.html), or the [Authenticator Delegate](https://docs.rs/yup-oauth2/*/yup_oauth2/trait.AuthenticatorDelegate.html).
+//! 
+//! When delegates handle errors or intermediate values, they may have a chance to instruct the system to retry. This 
+//! makes the system potentially resilient to all kinds of errors.
+//! 
+//! ## Uploads and Downloads
+//! If a method supports downloads, the response body, which is part of the [Result](enum.Result.html), should be
+//! read by you to obtain the media.
+//! If such a method also supports a [Response Result](trait.ResponseResult.html), it will return that by default.
+//! You can see it as meta-data for the actual media. To trigger a media download, you will have to set up the builder by making
+//! this call: `.param("alt", "media")`.
+//! 
+//! Methods supporting uploads can do so using up to 2 different protocols: 
+//! *simple* and *resumable*. The distinctiveness of each is represented by customized 
+//! `doit(...)` methods, which are then named `upload(...)` and `upload_resumable(...)` respectively.
+//! 
+//! ## Customization and Callbacks
+//! 
+//! You may alter the way an `doit()` method is called by providing a [delegate](trait.Delegate.html) to the 
+//! [Method Builder](trait.CallBuilder.html) before making the final `doit()` call. 
+//! Respective methods will be called to provide progress information, as well as determine whether the system should 
+//! retry on failure.
+//! 
+//! The [delegate trait](trait.Delegate.html) is default-implemented, allowing you to customize it with minimal effort.
+//! 
+//! ## Optional Parts in Server-Requests
+//! 
+//! All structures provided by this library are made to be [enocodable](trait.RequestValue.html) and 
+//! [decodable](trait.ResponseResult.html) via *json*. Optionals are used to indicate that partial requests are responses 
+//! are valid.
+//! Most optionals are are considered [Parts](trait.Part.html) which are identifiable by name, which will be sent to 
+//! the server to indicate either the set parts of the request or the desired parts in the response.
+//! 
+//! ## Builder Arguments
+//! 
+//! Using [method builders](trait.CallBuilder.html), you are able to prepare an action call by repeatedly calling it's methods.
+//! These will always take a single argument, for which the following statements are true.
+//! 
+//! * [PODs][wiki-pod] are handed by copy
+//! * strings are passed as `&str`
+//! * [request values](trait.RequestValue.html) are moved
+//! 
+//! Arguments will always be copied or cloned into the builder, to make them independent of their original life times.
+//! 
+//! [wiki-pod]: http://en.wikipedia.org/wiki/Plain_old_data_structure
+//! [builder-pattern]: http://en.wikipedia.org/wiki/Builder_pattern
+//! [google-go-api]: https://github.com/google/google-api-go-client
+//! 
+//! 
+
+// Unused attributes happen thanks to defined, but unused structures
+// We don't warn about this, as depending on the API, some data structures or facilities are never used.
+// Instead of pre-determining this, we just disable the lint. It's manually tuned to not have any
+// unused imports in fully featured APIs. Same with unused_mut ... .
+#![allow(unused_imports, unused_mut, dead_code)]
+
+// DO NOT EDIT !
+// This file was generated automatically from 'src/mako/api/lib.rs.mako'
+// DO NOT EDIT !
+
+#[macro_use]
+extern crate serde_derive;
+
+extern crate hyper;
+extern crate serde;
+extern crate serde_json;
+extern crate yup_oauth2 as oauth2;
+extern crate mime;
+extern crate url;
+
+mod cmn;
+
+use std::collections::HashMap;
+use std::cell::RefCell;
+use std::borrow::BorrowMut;
+use std::default::Default;
+use std::collections::BTreeMap;
+use serde_json as json;
+use std::io;
+use std::fs;
+use std::mem;
+use std::thread::sleep;
+use std::time::Duration;
+
+pub use cmn::{MultiPartReader, ToParts, MethodInfo, Result, Error, CallBuilder, Hub, ReadSeek, Part,
+              ResponseResult, RequestValue, NestedType, Delegate, DefaultDelegate, MethodsBuilder,
+              Resource, ErrorResponse, remove_json_null_values};
+
+
+// ##############
+// UTILITIES ###
+// ############
+
+/// Identifies the an OAuth2 authorization scope.
+/// A scope is needed when requesting an
+/// [authorization token](https://developers.google.com/youtube/v3/guides/authentication).
+#[derive(PartialEq, Eq, Hash)]
+pub enum Scope {
+    /// View and manage your Google Cloud Datastore data
+    Full,
+
+    /// View and manage your data across Google Cloud Platform services
+    CloudPlatform,
+}
+
+impl AsRef<str> for Scope {
+    fn as_ref(&self) -> &str {
+        match *self {
+            Scope::Full => "https://www.googleapis.com/auth/datastore",
+            Scope::CloudPlatform => "https://www.googleapis.com/auth/cloud-platform",
+        }
+    }
+}
+
+impl Default for Scope {
+    fn default() -> Scope {
+        Scope::Full
+    }
+}
+
+
+
+// ########
+// HUB ###
+// ######
+
+/// Central instance to access all Datastore related resource activities
+///
+/// # Examples
+///
+/// Instantiate a new hub
+///
+/// ```test_harness,no_run
+/// extern crate hyper;
+/// extern crate hyper_rustls;
+/// extern crate yup_oauth2 as oauth2;
+/// extern crate google_datastore1 as datastore1;
+/// use datastore1::{Result, Error};
+/// # #[test] fn egal() {
+/// use std::default::Default;
+/// use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// use datastore1::Datastore;
+/// 
+/// // Get an ApplicationSecret instance by some means. It contains the `client_id` and 
+/// // `client_secret`, among other things.
+/// let secret: ApplicationSecret = Default::default();
+/// // Instantiate the authenticator. It will choose a suitable authentication flow for you, 
+/// // unless you replace  `None` with the desired Flow.
+/// // Provide your own `AuthenticatorDelegate` to adjust the way it operates and get feedback about 
+/// // what's going on. You probably want to bring in your own `TokenStorage` to persist tokens and
+/// // retrieve them from storage.
+/// let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+///                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+///                               <MemoryStorage as Default>::default(), None);
+/// let mut hub = Datastore::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.projects().operations_delete("name")
+///              .doit();
+/// 
+/// match result {
+///     Err(e) => match e {
+///         // The Error enum provides details about what exactly happened.
+///         // You can also just use its `Debug`, `Display` or `Error` traits
+///          Error::HttpError(_)
+///         |Error::MissingAPIKey
+///         |Error::MissingToken(_)
+///         |Error::Cancelled
+///         |Error::UploadSizeLimitExceeded(_, _)
+///         |Error::Failure(_)
+///         |Error::BadRequest(_)
+///         |Error::FieldClash(_)
+///         |Error::JsonDecodeError(_, _) => println!("{}", e),
+///     },
+///     Ok(res) => println!("Success: {:?}", res),
+/// }
+/// # }
+/// ```
+pub struct Datastore<C, A> {
+    client: RefCell<C>,
+    auth: RefCell<A>,
+    _user_agent: String,
+    _base_url: String,
+    _root_url: String,
+}
+
+impl<'a, C, A> Hub for Datastore<C, A> {}
+
+impl<'a, C, A> Datastore<C, A>
+    where  C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+    pub fn new(client: C, authenticator: A) -> Datastore<C, A> {
+        Datastore {
+            client: RefCell::new(client),
+            auth: RefCell::new(authenticator),
+            _user_agent: "google-api-rust-client/1.0.7".to_string(),
+            _base_url: "https://datastore.googleapis.com/".to_string(),
+            _root_url: "https://datastore.googleapis.com/".to_string(),
+        }
+    }
+
+    pub fn projects(&'a self) -> ProjectMethods<'a, C, A> {
+        ProjectMethods { hub: &self }
+    }
+
+    /// Set the user-agent header field to use in all requests to the server.
+    /// It defaults to `google-api-rust-client/1.0.7`.
+    ///
+    /// Returns the previously set user-agent.
+    pub fn user_agent(&mut self, agent_name: String) -> String {
+        mem::replace(&mut self._user_agent, agent_name)
+    }
+
+    /// Set the base url to use in all requests to the server.
+    /// It defaults to `https://datastore.googleapis.com/`.
+    ///
+    /// Returns the previously set base url.
+    pub fn base_url(&mut self, new_base_url: String) -> String {
+        mem::replace(&mut self._base_url, new_base_url)
+    }
+
+    /// Set the root url to use in all requests to the server.
+    /// It defaults to `https://datastore.googleapis.com/`.
+    ///
+    /// Returns the previously set root url.
+    pub fn root_url(&mut self, new_root_url: String) -> String {
+        mem::replace(&mut self._root_url, new_root_url)
+    }
+}
+
+
+// ############
+// SCHEMAS ###
+// ##########
+/// A partition ID identifies a grouping of entities. The grouping is always
+/// by project and namespace, however the namespace ID may be empty.
+/// 
+/// A partition ID contains several dimensions:
+/// project ID and namespace ID.
+/// 
+/// Partition dimensions:
+/// 
+/// - May be `""`.
+/// - Must be valid UTF-8 bytes.
+/// - Must have values that match regex `[A-Za-z\d\.\-_]{1,100}`
+/// If the value of any dimension matches regex `__.*__`, the partition is
+/// reserved/read-only.
+/// A reserved/read-only partition ID is forbidden in certain documented
+/// contexts.
+/// 
+/// Foreign partition IDs (in which the project ID does
+/// not match the context project ID ) are discouraged.
+/// Reads and writes of foreign partition IDs may fail if the project is not in an active state.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct PartitionId {
+    /// The ID of the project to which the entities belong.
+    #[serde(rename="projectId")]
+    pub project_id: Option<String>,
+    /// If not empty, the ID of the namespace to which the entities belong.
+    #[serde(rename="namespaceId")]
+    pub namespace_id: Option<String>,
+}
+
+impl Part for PartitionId {}
+
+
+/// The request for Datastore.Lookup.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [lookup projects](struct.ProjectLookupCall.html) (request)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct LookupRequest {
+    /// Keys of entities to look up.
+    pub keys: Option<Vec<Key>>,
+    /// The options for this lookup request.
+    #[serde(rename="readOptions")]
+    pub read_options: Option<ReadOptions>,
+}
+
+impl RequestValue for LookupRequest {}
+
+
+/// The response for Datastore.BeginTransaction.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [begin transaction projects](struct.ProjectBeginTransactionCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct BeginTransactionResponse {
+    /// The transaction identifier (always present).
+    pub transaction: Option<String>,
+}
+
+impl ResponseResult for BeginTransactionResponse {}
+
+
+/// The request for Datastore.AllocateIds.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [allocate ids projects](struct.ProjectAllocateIdCall.html) (request)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct AllocateIdsRequest {
+    /// A list of keys with incomplete key paths for which to allocate IDs.
+    /// No key may be reserved/read-only.
+    pub keys: Option<Vec<Key>>,
+}
+
+impl RequestValue for AllocateIdsRequest {}
+
+
+/// The response for Datastore.RunQuery.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [run query projects](struct.ProjectRunQueryCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct RunQueryResponse {
+    /// The parsed form of the `GqlQuery` from the request, if it was set.
+    pub query: Option<Query>,
+    /// A batch of query results (always present).
+    pub batch: Option<QueryResultBatch>,
+}
+
+impl ResponseResult for RunQueryResponse {}
+
+
+/// A mutation to apply to an entity.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Mutation {
+    /// The entity to insert. The entity must not already exist.
+    /// The entity key's final path element may be incomplete.
+    pub insert: Option<Entity>,
+    /// The key of the entity to delete. The entity may or may not already exist.
+    /// Must have a complete key path and must not be reserved/read-only.
+    pub delete: Option<Key>,
+    /// The entity to update. The entity must already exist.
+    /// Must have a complete key path.
+    pub update: Option<Entity>,
+    /// The version of the entity that this mutation is being applied to. If this
+    /// does not match the current version on the server, the mutation conflicts.
+    #[serde(rename="baseVersion")]
+    pub base_version: Option<String>,
+    /// The entity to upsert. The entity may or may not already exist.
+    /// The entity key's final path element may be incomplete.
+    pub upsert: Option<Entity>,
+}
+
+impl Part for Mutation {}
+
+
+/// An array value.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct ArrayValue {
+    /// Values in the array.
+    /// The order of this array may not be preserved if it contains a mix of
+    /// indexed and unindexed values.
+    pub values: Option<Vec<Value>>,
+}
+
+impl Part for ArrayValue {}
+
+
+/// A generic empty message that you can re-use to avoid defining duplicated
+/// empty messages in your APIs. A typical example is to use it as the request
+/// or the response type of an API method. For instance:
+/// 
+///     service Foo {
+///       rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
+///     }
+/// 
+/// The JSON representation for `Empty` is empty JSON object `{}`.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [operations delete projects](struct.ProjectOperationDeleteCall.html) (response)
+/// * [operations cancel projects](struct.ProjectOperationCancelCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Empty { _never_set: Option<bool> }
+
+impl ResponseResult for Empty {}
+
+
+/// Options for beginning a new transaction.
+/// 
+/// Transactions can be created explicitly with calls to
+/// Datastore.BeginTransaction or implicitly by setting
+/// ReadOptions.new_transaction in read requests.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct TransactionOptions {
+    /// The transaction should allow both reads and writes.
+    #[serde(rename="readWrite")]
+    pub read_write: Option<ReadWrite>,
+    /// The transaction should only allow reads.
+    #[serde(rename="readOnly")]
+    pub read_only: Option<ReadOnly>,
+}
+
+impl Part for TransactionOptions {}
+
+
+/// A batch of results produced by a query.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct QueryResultBatch {
+    /// The state of the query after the current batch.
+    #[serde(rename="moreResults")]
+    pub more_results: Option<String>,
+    /// The result type for every entity in `entity_results`.
+    #[serde(rename="entityResultType")]
+    pub entity_result_type: Option<String>,
+    /// The version number of the snapshot this batch was returned from.
+    /// This applies to the range of results from the query's `start_cursor` (or
+    /// the beginning of the query if no cursor was given) to this batch's
+    /// `end_cursor` (not the query's `end_cursor`).
+    /// 
+    /// In a single transaction, subsequent query result batches for the same query
+    /// can have a greater snapshot version number. Each batch's snapshot version
+    /// is valid for all preceding batches.
+    /// The value will be zero for eventually consistent queries.
+    #[serde(rename="snapshotVersion")]
+    pub snapshot_version: Option<String>,
+    /// The number of results skipped, typically because of an offset.
+    #[serde(rename="skippedResults")]
+    pub skipped_results: Option<i32>,
+    /// A cursor that points to the position after the last result in the batch.
+    #[serde(rename="endCursor")]
+    pub end_cursor: Option<String>,
+    /// A cursor that points to the position after the last skipped result.
+    /// Will be set when `skipped_results` != 0.
+    #[serde(rename="skippedCursor")]
+    pub skipped_cursor: Option<String>,
+    /// The results for this batch.
+    #[serde(rename="entityResults")]
+    pub entity_results: Option<Vec<EntityResult>>,
+}
+
+impl Part for QueryResultBatch {}
+
+
+/// The response for Datastore.Commit.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [commit projects](struct.ProjectCommitCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct CommitResponse {
+    /// The result of performing the mutations.
+    /// The i-th mutation result corresponds to the i-th mutation in the request.
+    #[serde(rename="mutationResults")]
+    pub mutation_results: Option<Vec<MutationResult>>,
+    /// The number of index entries updated during the commit, or zero if none were
+    /// updated.
+    #[serde(rename="indexUpdates")]
+    pub index_updates: Option<i32>,
+}
+
+impl ResponseResult for CommitResponse {}
+
+
+/// The result of fetching an entity from Datastore.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct EntityResult {
+    /// A cursor that points to the position after the result entity.
+    /// Set only when the `EntityResult` is part of a `QueryResultBatch` message.
+    pub cursor: Option<String>,
+    /// The version of the entity, a strictly positive number that monotonically
+    /// increases with changes to the entity.
+    /// 
+    /// This field is set for `FULL` entity
+    /// results.
+    /// 
+    /// For missing entities in `LookupResponse`, this
+    /// is the version of the snapshot that was used to look up the entity, and it
+    /// is always set except for eventually consistent reads.
+    pub version: Option<String>,
+    /// The resulting entity.
+    pub entity: Option<Entity>,
+}
+
+impl Part for EntityResult {}
+
+
+/// The response for Datastore.Rollback.
+/// (an empty message).
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [rollback projects](struct.ProjectRollbackCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct RollbackResponse { _never_set: Option<bool> }
+
+impl ResponseResult for RollbackResponse {}
+
+
+/// The result of applying a mutation.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct MutationResult {
+    /// The version of the entity on the server after processing the mutation. If
+    /// the mutation doesn't change anything on the server, then the version will
+    /// be the version of the current entity or, if no entity is present, a version
+    /// that is strictly greater than the version of any previous entity and less
+    /// than the version of any possible future entity.
+    pub version: Option<String>,
+    /// Whether a conflict was detected for this mutation. Always false when a
+    /// conflict detection strategy field is not set in the mutation.
+    #[serde(rename="conflictDetected")]
+    pub conflict_detected: Option<bool>,
+    /// The automatically allocated key.
+    /// Set only when the mutation allocated a key.
+    pub key: Option<Key>,
+}
+
+impl Part for MutationResult {}
+
+
+/// A unique identifier for an entity.
+/// If a key's partition ID or any of its path kinds or names are
+/// reserved/read-only, the key is reserved/read-only.
+/// A reserved/read-only key is forbidden in certain documented contexts.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Key {
+    /// The entity path.
+    /// An entity path consists of one or more elements composed of a kind and a
+    /// string or numerical identifier, which identify entities. The first
+    /// element identifies a _root entity_, the second element identifies
+    /// a _child_ of the root entity, the third element identifies a child of the
+    /// second entity, and so forth. The entities identified by all prefixes of
+    /// the path are called the element's _ancestors_.
+    /// 
+    /// An entity path is always fully complete: *all* of the entity's ancestors
+    /// are required to be in the path along with the entity identifier itself.
+    /// The only exception is that in some documented cases, the identifier in the
+    /// last path element (for the entity) itself may be omitted. For example,
+    /// the last path element of the key of `Mutation.insert` may have no
+    /// identifier.
+    /// 
+    /// A path can never be empty, and a path can have at most 100 elements.
+    pub path: Option<Vec<PathElement>>,
+    /// Entities are partitioned into subsets, currently identified by a project
+    /// ID and namespace ID.
+    /// Queries are scoped to a single partition.
+    #[serde(rename="partitionId")]
+    pub partition_id: Option<PartitionId>,
+}
+
+impl Part for Key {}
+
+
+/// A [GQL query](https://cloud.google.com/datastore/docs/apis/gql/gql_reference).
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct GqlQuery {
+    /// A string of the format described
+    /// [here](https://cloud.google.com/datastore/docs/apis/gql/gql_reference).
+    #[serde(rename="queryString")]
+    pub query_string: Option<String>,
+    /// Numbered binding site @1 references the first numbered parameter,
+    /// effectively using 1-based indexing, rather than the usual 0.
+    /// 
+    /// For each binding site numbered i in `query_string`, there must be an i-th
+    /// numbered parameter. The inverse must also be true.
+    #[serde(rename="positionalBindings")]
+    pub positional_bindings: Option<Vec<GqlQueryParameter>>,
+    /// For each non-reserved named binding site in the query string, there must be
+    /// a named parameter with that name, but not necessarily the inverse.
+    /// 
+    /// Key must match regex `A-Za-z_$*`, must not match regex
+    /// `__.*__`, and must not be `""`.
+    #[serde(rename="namedBindings")]
+    pub named_bindings: Option<HashMap<String, GqlQueryParameter>>,
+    /// When false, the query string must not contain any literals and instead must
+    /// bind all values. For example,
+    /// `SELECT * FROM Kind WHERE a = 'string literal'` is not allowed, while
+    /// `SELECT * FROM Kind WHERE a = @value` is.
+    #[serde(rename="allowLiterals")]
+    pub allow_literals: Option<bool>,
+}
+
+impl Part for GqlQuery {}
+
+
+/// The `Status` type defines a logical error model that is suitable for different
+/// programming environments, including REST APIs and RPC APIs. It is used by
+/// [gRPC](https://github.com/grpc). The error model is designed to be:
+/// 
+/// - Simple to use and understand for most users
+/// - Flexible enough to meet unexpected needs
+/// 
+/// # Overview
+/// 
+/// The `Status` message contains three pieces of data: error code, error message,
+/// and error details. The error code should be an enum value of
+/// google.rpc.Code, but it may accept additional error codes if needed.  The
+/// error message should be a developer-facing English message that helps
+/// developers *understand* and *resolve* the error. If a localized user-facing
+/// error message is needed, put the localized message in the error details or
+/// localize it in the client. The optional error details may contain arbitrary
+/// information about the error. There is a predefined set of error detail types
+/// in the package `google.rpc` that can be used for common error conditions.
+/// 
+/// # Language mapping
+/// 
+/// The `Status` message is the logical representation of the error model, but it
+/// is not necessarily the actual wire format. When the `Status` message is
+/// exposed in different client libraries and different wire protocols, it can be
+/// mapped differently. For example, it will likely be mapped to some exceptions
+/// in Java, but more likely mapped to some error codes in C.
+/// 
+/// # Other uses
+/// 
+/// The error model and the `Status` message can be used in a variety of
+/// environments, either with or without APIs, to provide a
+/// consistent developer experience across different environments.
+/// 
+/// Example uses of this error model include:
+/// 
+/// - Partial errors. If a service needs to return partial errors to the client,
+///     it may embed the `Status` in the normal response to indicate the partial
+///     errors.
+/// 
+/// - Workflow errors. A typical workflow has multiple steps. Each step may
+///     have a `Status` message for error reporting.
+/// 
+/// - Batch operations. If a client uses batch request and batch response, the
+///     `Status` message should be used directly inside batch response, one for
+///     each error sub-response.
+/// 
+/// - Asynchronous operations. If an API call embeds asynchronous operation
+///     results in its response, the status of those operations should be
+///     represented directly using the `Status` message.
+/// 
+/// - Logging. If some API errors are stored in logs, the message `Status` could
+///     be used directly after any stripping needed for security/privacy reasons.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Status {
+    /// A developer-facing error message, which should be in English. Any
+    /// user-facing error message should be localized and sent in the
+    /// google.rpc.Status.details field, or localized by the client.
+    pub message: Option<String>,
+    /// The status code, which should be an enum value of google.rpc.Code.
+    pub code: Option<i32>,
+    /// A list of messages that carry the error details.  There is a common set of
+    /// message types for APIs to use.
+    pub details: Option<Vec<HashMap<String, String>>>,
+}
+
+impl Part for Status {}
+
+
+/// The request for Datastore.ReserveIds.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [reserve ids projects](struct.ProjectReserveIdCall.html) (request)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct ReserveIdsRequest {
+    /// A list of keys with complete key paths whose numeric IDs should not be
+    /// auto-allocated.
+    pub keys: Option<Vec<Key>>,
+    /// If not empty, the ID of the database against which to make the request.
+    #[serde(rename="databaseId")]
+    pub database_id: Option<String>,
+}
+
+impl RequestValue for ReserveIdsRequest {}
+
+
+/// The options shared by read requests.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct ReadOptions {
+    /// The identifier of the transaction in which to read. A
+    /// transaction identifier is returned by a call to
+    /// Datastore.BeginTransaction.
+    pub transaction: Option<String>,
+    /// The non-transactional read consistency to use.
+    /// Cannot be set to `STRONG` for global queries.
+    #[serde(rename="readConsistency")]
+    pub read_consistency: Option<String>,
+}
+
+impl Part for ReadOptions {}
+
+
+/// A filter on a specific property.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct PropertyFilter {
+    /// The property to filter by.
+    pub property: Option<PropertyReference>,
+    /// The value to compare the property to.
+    pub value: Option<Value>,
+    /// The operator to filter by.
+    pub op: Option<String>,
+}
+
+impl Part for PropertyFilter {}
+
+
+/// A binding parameter for a GQL query.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct GqlQueryParameter {
+    /// A query cursor. Query cursors are returned in query
+    /// result batches.
+    pub cursor: Option<String>,
+    /// A value parameter.
+    pub value: Option<Value>,
+}
+
+impl Part for GqlQueryParameter {}
+
+
+/// A representation of a kind.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct KindExpression {
+    /// The name of the kind.
+    pub name: Option<String>,
+}
+
+impl Part for KindExpression {}
+
+
+/// A filter that merges multiple other filters using the given operator.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct CompositeFilter {
+    /// The list of filters to combine.
+    /// Must contain at least one filter.
+    pub filters: Option<Vec<Filter>>,
+    /// The operator for combining multiple filters.
+    pub op: Option<String>,
+}
+
+impl Part for CompositeFilter {}
+
+
+/// A reference to a property relative to the kind expressions.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct PropertyReference {
+    /// The name of the property.
+    /// If name includes "."s, it may be interpreted as a property name path.
+    pub name: Option<String>,
+}
+
+impl Part for PropertyReference {}
+
+
+/// The response message for Operations.ListOperations.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [operations list projects](struct.ProjectOperationListCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct GoogleLongrunningListOperationsResponse {
+    /// The standard List next-page token.
+    #[serde(rename="nextPageToken")]
+    pub next_page_token: Option<String>,
+    /// A list of operations that matches the specified filter in the request.
+    pub operations: Option<Vec<GoogleLongrunningOperation>>,
+}
+
+impl ResponseResult for GoogleLongrunningListOperationsResponse {}
+
+
+/// A message that can hold any of the supported value types and associated
+/// metadata.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Value {
+    /// An entity value.
+    /// 
+    /// - May have no key.
+    /// - May have a key with an incomplete key path.
+    /// - May have a reserved/read-only key.
+    #[serde(rename="entityValue")]
+    pub entity_value: Option<Entity>,
+    /// A timestamp value.
+    /// When stored in the Datastore, precise only to microseconds;
+    /// any additional precision is rounded down.
+    #[serde(rename="timestampValue")]
+    pub timestamp_value: Option<String>,
+    /// A UTF-8 encoded string value.
+    /// When `exclude_from_indexes` is false (it is indexed) , may have at most 1500 bytes.
+    /// Otherwise, may be set to at least 1,000,000 bytes.
+    #[serde(rename="stringValue")]
+    pub string_value: Option<String>,
+    /// A double value.
+    #[serde(rename="doubleValue")]
+    pub double_value: Option<f64>,
+    /// The `meaning` field should only be populated for backwards compatibility.
+    pub meaning: Option<i32>,
+    /// If the value should be excluded from all indexes including those defined
+    /// explicitly.
+    #[serde(rename="excludeFromIndexes")]
+    pub exclude_from_indexes: Option<bool>,
+    /// A blob value.
+    /// May have at most 1,000,000 bytes.
+    /// When `exclude_from_indexes` is false, may have at most 1500 bytes.
+    /// In JSON requests, must be base64-encoded.
+    #[serde(rename="blobValue")]
+    pub blob_value: Option<String>,
+    /// A key value.
+    #[serde(rename="keyValue")]
+    pub key_value: Option<Key>,
+    /// A boolean value.
+    #[serde(rename="booleanValue")]
+    pub boolean_value: Option<bool>,
+    /// An array value.
+    /// Cannot contain another array value.
+    /// A `Value` instance that sets field `array_value` must not set fields
+    /// `meaning` or `exclude_from_indexes`.
+    #[serde(rename="arrayValue")]
+    pub array_value: Option<ArrayValue>,
+    /// An integer value.
+    #[serde(rename="integerValue")]
+    pub integer_value: Option<String>,
+    /// A geo point value representing a point on the surface of Earth.
+    #[serde(rename="geoPointValue")]
+    pub geo_point_value: Option<LatLng>,
+    /// A null value.
+    #[serde(rename="nullValue")]
+    pub null_value: Option<String>,
+}
+
+impl Part for Value {}
+
+
+/// A query for entities.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Query {
+    /// A starting point for the query results. Query cursors are
+    /// returned in query result batches and
+    /// [can only be used to continue the same query](https://cloud.google.com/datastore/docs/concepts/queries#cursors_limits_and_offsets).
+    #[serde(rename="startCursor")]
+    pub start_cursor: Option<String>,
+    /// The kinds to query (if empty, returns entities of all kinds).
+    /// Currently at most 1 kind may be specified.
+    pub kind: Option<Vec<KindExpression>>,
+    /// The projection to return. Defaults to returning all properties.
+    pub projection: Option<Vec<Projection>>,
+    /// The properties to make distinct. The query results will contain the first
+    /// result for each distinct combination of values for the given properties
+    /// (if empty, all results are returned).
+    #[serde(rename="distinctOn")]
+    pub distinct_on: Option<Vec<PropertyReference>>,
+    /// The filter to apply.
+    pub filter: Option<Filter>,
+    /// The maximum number of results to return. Applies after all other
+    /// constraints. Optional.
+    /// Unspecified is interpreted as no limit.
+    /// Must be >= 0 if specified.
+    pub limit: Option<i32>,
+    /// The number of results to skip. Applies before limit, but after all other
+    /// constraints. Optional. Must be >= 0 if specified.
+    pub offset: Option<i32>,
+    /// An ending point for the query results. Query cursors are
+    /// returned in query result batches and
+    /// [can only be used to limit the same query](https://cloud.google.com/datastore/docs/concepts/queries#cursors_limits_and_offsets).
+    #[serde(rename="endCursor")]
+    pub end_cursor: Option<String>,
+    /// The order to apply to the query results (if empty, order is unspecified).
+    pub order: Option<Vec<PropertyOrder>>,
+}
+
+impl Part for Query {}
+
+
+/// The request for Datastore.RunQuery.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [run query projects](struct.ProjectRunQueryCall.html) (request)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct RunQueryRequest {
+    /// The query to run.
+    pub query: Option<Query>,
+    /// Entities are partitioned into subsets, identified by a partition ID.
+    /// Queries are scoped to a single partition.
+    /// This partition ID is normalized with the standard default context
+    /// partition ID.
+    #[serde(rename="partitionId")]
+    pub partition_id: Option<PartitionId>,
+    /// The GQL query to run.
+    #[serde(rename="gqlQuery")]
+    pub gql_query: Option<GqlQuery>,
+    /// The options for this query.
+    #[serde(rename="readOptions")]
+    pub read_options: Option<ReadOptions>,
+}
+
+impl RequestValue for RunQueryRequest {}
+
+
+/// The response for Datastore.Lookup.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [lookup projects](struct.ProjectLookupCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct LookupResponse {
+    /// Entities found as `ResultType.FULL` entities. The order of results in this
+    /// field is undefined and has no relation to the order of the keys in the
+    /// input.
+    pub found: Option<Vec<EntityResult>>,
+    /// A list of keys that were not looked up due to resource constraints. The
+    /// order of results in this field is undefined and has no relation to the
+    /// order of the keys in the input.
+    pub deferred: Option<Vec<Key>>,
+    /// Entities not found as `ResultType.KEY_ONLY` entities. The order of results
+    /// in this field is undefined and has no relation to the order of the keys
+    /// in the input.
+    pub missing: Option<Vec<EntityResult>>,
+}
+
+impl ResponseResult for LookupResponse {}
+
+
+/// The response for Datastore.ReserveIds.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [reserve ids projects](struct.ProjectReserveIdCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct ReserveIdsResponse { _never_set: Option<bool> }
+
+impl ResponseResult for ReserveIdsResponse {}
+
+
+/// A holder for any type of filter.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Filter {
+    /// A composite filter.
+    #[serde(rename="compositeFilter")]
+    pub composite_filter: Option<CompositeFilter>,
+    /// A filter on a property.
+    #[serde(rename="propertyFilter")]
+    pub property_filter: Option<PropertyFilter>,
+}
+
+impl Part for Filter {}
+
+
+/// The request for Datastore.Commit.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [commit projects](struct.ProjectCommitCall.html) (request)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct CommitRequest {
+    /// The identifier of the transaction associated with the commit. A
+    /// transaction identifier is returned by a call to
+    /// Datastore.BeginTransaction.
+    pub transaction: Option<String>,
+    /// The type of commit to perform. Defaults to `TRANSACTIONAL`.
+    pub mode: Option<String>,
+    /// The mutations to perform.
+    /// 
+    /// When mode is `TRANSACTIONAL`, mutations affecting a single entity are
+    /// applied in order. The following sequences of mutations affecting a single
+    /// entity are not permitted in a single `Commit` request:
+    /// 
+    /// - `insert` followed by `insert`
+    /// - `update` followed by `insert`
+    /// - `upsert` followed by `insert`
+    /// - `delete` followed by `update`
+    /// 
+    /// When mode is `NON_TRANSACTIONAL`, no two mutations may affect a single
+    /// entity.
+    pub mutations: Option<Vec<Mutation>>,
+}
+
+impl RequestValue for CommitRequest {}
+
+
+/// A representation of a property in a projection.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Projection {
+    /// The property to project.
+    pub property: Option<PropertyReference>,
+}
+
+impl Part for Projection {}
+
+
+/// Options specific to read / write transactions.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct ReadWrite {
+    /// The transaction identifier of the transaction being retried.
+    #[serde(rename="previousTransaction")]
+    pub previous_transaction: Option<String>,
+}
+
+impl Part for ReadWrite {}
+
+
+/// This resource represents a long-running operation that is the result of a
+/// network API call.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [operations get projects](struct.ProjectOperationGetCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct GoogleLongrunningOperation {
+    /// The error result of the operation in case of failure or cancellation.
+    pub error: Option<Status>,
+    /// If the value is `false`, it means the operation is still in progress.
+    /// If `true`, the operation is completed, and either `error` or `response` is
+    /// available.
+    pub done: Option<bool>,
+    /// The normal response of the operation in case of success.  If the original
+    /// method returns no data on success, such as `Delete`, the response is
+    /// `google.protobuf.Empty`.  If the original method is standard
+    /// `Get`/`Create`/`Update`, the response should be the resource.  For other
+    /// methods, the response should have the type `XxxResponse`, where `Xxx`
+    /// is the original method name.  For example, if the original method name
+    /// is `TakeSnapshot()`, the inferred response type is
+    /// `TakeSnapshotResponse`.
+    pub response: Option<HashMap<String, String>>,
+    /// The server-assigned name, which is only unique within the same service that
+    /// originally returns it. If you use the default HTTP mapping, the
+    /// `name` should have the format of `operations/some/unique/name`.
+    pub name: Option<String>,
+    /// Service-specific metadata associated with the operation.  It typically
+    /// contains progress information and common metadata such as create time.
+    /// Some services might not provide such metadata.  Any method that returns a
+    /// long-running operation should document the metadata type, if any.
+    pub metadata: Option<HashMap<String, String>>,
+}
+
+impl ResponseResult for GoogleLongrunningOperation {}
+
+
+/// An object representing a latitude/longitude pair. This is expressed as a pair
+/// of doubles representing degrees latitude and degrees longitude. Unless
+/// specified otherwise, this must conform to the
+/// <a href="http://www.unoosa.org/pdf/icg/2012/template/WGS_84.pdf">WGS84
+/// standard</a>. Values must be within normalized ranges.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct LatLng {
+    /// The latitude in degrees. It must be in the range [-90.0, +90.0].
+    pub latitude: Option<f64>,
+    /// The longitude in degrees. It must be in the range [-180.0, +180.0].
+    pub longitude: Option<f64>,
+}
+
+impl Part for LatLng {}
+
+
+/// The response for Datastore.AllocateIds.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [allocate ids projects](struct.ProjectAllocateIdCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct AllocateIdsResponse {
+    /// The keys specified in the request (in the same order), each with
+    /// its key path completed with a newly allocated ID.
+    pub keys: Option<Vec<Key>>,
+}
+
+impl ResponseResult for AllocateIdsResponse {}
+
+
+/// A Datastore data object.
+/// 
+/// An entity is limited to 1 megabyte when stored. That _roughly_
+/// corresponds to a limit of 1 megabyte for the serialized form of this
+/// message.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Entity {
+    /// The entity's properties.
+    /// The map's keys are property names.
+    /// A property name matching regex `__.*__` is reserved.
+    /// A reserved property name is forbidden in certain documented contexts.
+    /// The name must not contain more than 500 characters.
+    /// The name cannot be `""`.
+    pub properties: Option<HashMap<String, Value>>,
+    /// The entity's key.
+    /// 
+    /// An entity must have a key, unless otherwise documented (for example,
+    /// an entity in `Value.entity_value` may have no key).
+    /// An entity's kind is its key path's last element's kind,
+    /// or null if it has no key.
+    pub key: Option<Key>,
+}
+
+impl Part for Entity {}
+
+
+/// The request for Datastore.Rollback.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [rollback projects](struct.ProjectRollbackCall.html) (request)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct RollbackRequest {
+    /// The transaction identifier, returned by a call to
+    /// Datastore.BeginTransaction.
+    pub transaction: Option<String>,
+}
+
+impl RequestValue for RollbackRequest {}
+
+
+/// Options specific to read-only transactions.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct ReadOnly { _never_set: Option<bool> }
+
+impl Part for ReadOnly {}
+
+
+/// The request for Datastore.BeginTransaction.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [begin transaction projects](struct.ProjectBeginTransactionCall.html) (request)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct BeginTransactionRequest {
+    /// Options for a new transaction.
+    #[serde(rename="transactionOptions")]
+    pub transaction_options: Option<TransactionOptions>,
+}
+
+impl RequestValue for BeginTransactionRequest {}
+
+
+/// The desired order for a specific property.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct PropertyOrder {
+    /// The direction to order by. Defaults to `ASCENDING`.
+    pub direction: Option<String>,
+    /// The property to order by.
+    pub property: Option<PropertyReference>,
+}
+
+impl Part for PropertyOrder {}
+
+
+/// A (kind, ID/name) pair used to construct a key path.
+/// 
+/// If either name or ID is set, the element is complete.
+/// If neither is set, the element is incomplete.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct PathElement {
+    /// The kind of the entity.
+    /// A kind matching regex `__.*__` is reserved/read-only.
+    /// A kind must not contain more than 1500 bytes when UTF-8 encoded.
+    /// Cannot be `""`.
+    pub kind: Option<String>,
+    /// The name of the entity.
+    /// A name matching regex `__.*__` is reserved/read-only.
+    /// A name must not be more than 1500 bytes when UTF-8 encoded.
+    /// Cannot be `""`.
+    pub name: Option<String>,
+    /// The auto-allocated ID of the entity.
+    /// Never equal to zero. Values less than zero are discouraged and may not
+    /// be supported in the future.
+    pub id: Option<String>,
+}
+
+impl Part for PathElement {}
+
+
+
+// ###################
+// MethodBuilders ###
+// #################
+
+/// A builder providing access to all methods supported on *project* resources.
+/// It is not used directly, but through the `Datastore` hub.
+///
+/// # Example
+///
+/// Instantiate a resource builder
+///
+/// ```test_harness,no_run
+/// extern crate hyper;
+/// extern crate hyper_rustls;
+/// extern crate yup_oauth2 as oauth2;
+/// extern crate google_datastore1 as datastore1;
+/// 
+/// # #[test] fn egal() {
+/// use std::default::Default;
+/// use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// use datastore1::Datastore;
+/// 
+/// let secret: ApplicationSecret = Default::default();
+/// let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+///                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+///                               <MemoryStorage as Default>::default(), None);
+/// let mut hub = Datastore::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // Usually you wouldn't bind this to a variable, but keep calling *CallBuilders*
+/// // like `allocate_ids(...)`, `begin_transaction(...)`, `commit(...)`, `lookup(...)`, `operations_cancel(...)`, `operations_delete(...)`, `operations_get(...)`, `operations_list(...)`, `reserve_ids(...)`, `rollback(...)` and `run_query(...)`
+/// // to build up your call.
+/// let rb = hub.projects();
+/// # }
+/// ```
+pub struct ProjectMethods<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a Datastore<C, A>,
+}
+
+impl<'a, C, A> MethodsBuilder for ProjectMethods<'a, C, A> {}
+
+impl<'a, C, A> ProjectMethods<'a, C, A> {
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Lists operations that match the specified filter in the request. If the
+    /// server doesn't support this method, it returns `UNIMPLEMENTED`.
+    /// 
+    /// NOTE: the `name` binding allows API services to override the binding
+    /// to use different resource name schemes, such as `users/*/operations`. To
+    /// override the binding, API services can add a binding such as
+    /// `"/v1/{name=users/*}/operations"` to their service configuration.
+    /// For backwards compatibility, the default name includes the operations
+    /// collection id, however overriding users must ensure the name binding
+    /// is the parent resource, without the operations collection id.
+    /// 
+    /// # Arguments
+    ///
+    /// * `name` - The name of the operation's parent resource.
+    pub fn operations_list(&self, name: &str) -> ProjectOperationListCall<'a, C, A> {
+        ProjectOperationListCall {
+            hub: self.hub,
+            _name: name.to_string(),
+            _page_token: Default::default(),
+            _page_size: Default::default(),
+            _filter: Default::default(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Queries for entities.
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    /// * `projectId` - The ID of the project against which to make the request.
+    pub fn run_query(&self, request: RunQueryRequest, project_id: &str) -> ProjectRunQueryCall<'a, C, A> {
+        ProjectRunQueryCall {
+            hub: self.hub,
+            _request: request,
+            _project_id: project_id.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Prevents the supplied keys' IDs from being auto-allocated by Cloud
+    /// Datastore.
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    /// * `projectId` - The ID of the project against which to make the request.
+    pub fn reserve_ids(&self, request: ReserveIdsRequest, project_id: &str) -> ProjectReserveIdCall<'a, C, A> {
+        ProjectReserveIdCall {
+            hub: self.hub,
+            _request: request,
+            _project_id: project_id.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Looks up entities by key.
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    /// * `projectId` - The ID of the project against which to make the request.
+    pub fn lookup(&self, request: LookupRequest, project_id: &str) -> ProjectLookupCall<'a, C, A> {
+        ProjectLookupCall {
+            hub: self.hub,
+            _request: request,
+            _project_id: project_id.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Commits a transaction, optionally creating, deleting or modifying some
+    /// entities.
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    /// * `projectId` - The ID of the project against which to make the request.
+    pub fn commit(&self, request: CommitRequest, project_id: &str) -> ProjectCommitCall<'a, C, A> {
+        ProjectCommitCall {
+            hub: self.hub,
+            _request: request,
+            _project_id: project_id.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Allocates IDs for the given keys, which is useful for referencing an entity
+    /// before it is inserted.
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    /// * `projectId` - The ID of the project against which to make the request.
+    pub fn allocate_ids(&self, request: AllocateIdsRequest, project_id: &str) -> ProjectAllocateIdCall<'a, C, A> {
+        ProjectAllocateIdCall {
+            hub: self.hub,
+            _request: request,
+            _project_id: project_id.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Deletes a long-running operation. This method indicates that the client is
+    /// no longer interested in the operation result. It does not cancel the
+    /// operation. If the server doesn't support this method, it returns
+    /// `google.rpc.Code.UNIMPLEMENTED`.
+    /// 
+    /// # Arguments
+    ///
+    /// * `name` - The name of the operation resource to be deleted.
+    pub fn operations_delete(&self, name: &str) -> ProjectOperationDeleteCall<'a, C, A> {
+        ProjectOperationDeleteCall {
+            hub: self.hub,
+            _name: name.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Gets the latest state of a long-running operation.  Clients can use this
+    /// method to poll the operation result at intervals as recommended by the API
+    /// service.
+    /// 
+    /// # Arguments
+    ///
+    /// * `name` - The name of the operation resource.
+    pub fn operations_get(&self, name: &str) -> ProjectOperationGetCall<'a, C, A> {
+        ProjectOperationGetCall {
+            hub: self.hub,
+            _name: name.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Starts asynchronous cancellation on a long-running operation.  The server
+    /// makes a best effort to cancel the operation, but success is not
+    /// guaranteed.  If the server doesn't support this method, it returns
+    /// `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
+    /// Operations.GetOperation or
+    /// other methods to check whether the cancellation succeeded or whether the
+    /// operation completed despite cancellation. On successful cancellation,
+    /// the operation is not deleted; instead, it becomes an operation with
+    /// an Operation.error value with a google.rpc.Status.code of 1,
+    /// corresponding to `Code.CANCELLED`.
+    /// 
+    /// # Arguments
+    ///
+    /// * `name` - The name of the operation resource to be cancelled.
+    pub fn operations_cancel(&self, name: &str) -> ProjectOperationCancelCall<'a, C, A> {
+        ProjectOperationCancelCall {
+            hub: self.hub,
+            _name: name.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Rolls back a transaction.
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    /// * `projectId` - The ID of the project against which to make the request.
+    pub fn rollback(&self, request: RollbackRequest, project_id: &str) -> ProjectRollbackCall<'a, C, A> {
+        ProjectRollbackCall {
+            hub: self.hub,
+            _request: request,
+            _project_id: project_id.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Begins a new transaction.
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    /// * `projectId` - The ID of the project against which to make the request.
+    pub fn begin_transaction(&self, request: BeginTransactionRequest, project_id: &str) -> ProjectBeginTransactionCall<'a, C, A> {
+        ProjectBeginTransactionCall {
+            hub: self.hub,
+            _request: request,
+            _project_id: project_id.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+}
+
+
+
+
+
+// ###################
+// CallBuilders   ###
+// #################
+
+/// Lists operations that match the specified filter in the request. If the
+/// server doesn't support this method, it returns `UNIMPLEMENTED`.
+/// 
+/// NOTE: the `name` binding allows API services to override the binding
+/// to use different resource name schemes, such as `users/*/operations`. To
+/// override the binding, API services can add a binding such as
+/// `"/v1/{name=users/*}/operations"` to their service configuration.
+/// For backwards compatibility, the default name includes the operations
+/// collection id, however overriding users must ensure the name binding
+/// is the parent resource, without the operations collection id.
+///
+/// A builder for the *operations.list* method supported by a *project* resource.
+/// It is not used directly, but through a `ProjectMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_datastore1 as datastore1;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use datastore1::Datastore;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = Datastore::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.projects().operations_list("name")
+///              .page_token("et")
+///              .page_size(-18)
+///              .filter("kasd")
+///              .doit();
+/// # }
+/// ```
+pub struct ProjectOperationListCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a Datastore<C, A>,
+    _name: String,
+    _page_token: Option<String>,
+    _page_size: Option<i32>,
+    _filter: Option<String>,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for ProjectOperationListCall<'a, C, A> {}
+
+impl<'a, C, A> ProjectOperationListCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, GoogleLongrunningListOperationsResponse)> {
+        use url::percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "datastore.projects.operations.list",
+                               http_method: hyper::method::Method::Get });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((6 + self._additional_params.len()));
+        params.push(("name", self._name.to_string()));
+        if let Some(value) = self._page_token {
+            params.push(("pageToken", value.to_string()));
+        }
+        if let Some(value) = self._page_size {
+            params.push(("pageSize", value.to_string()));
+        }
+        if let Some(value) = self._filter {
+            params.push(("filter", value.to_string()));
+        }
+        for &field in ["alt", "name", "pageToken", "pageSize", "filter"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1/{+name}/operations";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{+name}", "name")].iter() {
+            let mut replace_with = String::new();
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = value.to_string();
+                    break;
+                }
+            }
+            if find_this.as_bytes()[1] == '+' as u8 {
+                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET);
+            }
+            url = url.replace(find_this, &replace_with);
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["name"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Get, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    /// The name of the operation's parent resource.
+    ///
+    /// Sets the *name* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn name(mut self, new_value: &str) -> ProjectOperationListCall<'a, C, A> {
+        self._name = new_value.to_string();
+        self
+    }
+    /// The standard list page token.
+    ///
+    /// Sets the *page token* query property to the given value.
+    pub fn page_token(mut self, new_value: &str) -> ProjectOperationListCall<'a, C, A> {
+        self._page_token = Some(new_value.to_string());
+        self
+    }
+    /// The standard list page size.
+    ///
+    /// Sets the *page size* query property to the given value.
+    pub fn page_size(mut self, new_value: i32) -> ProjectOperationListCall<'a, C, A> {
+        self._page_size = Some(new_value);
+        self
+    }
+    /// The standard list filter.
+    ///
+    /// Sets the *filter* query property to the given value.
+    pub fn filter(mut self, new_value: &str) -> ProjectOperationListCall<'a, C, A> {
+        self._filter = Some(new_value.to_string());
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> ProjectOperationListCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> ProjectOperationListCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> ProjectOperationListCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Queries for entities.
+///
+/// A builder for the *runQuery* method supported by a *project* resource.
+/// It is not used directly, but through a `ProjectMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_datastore1 as datastore1;
+/// use datastore1::RunQueryRequest;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use datastore1::Datastore;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = Datastore::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = RunQueryRequest::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.projects().run_query(req, "projectId")
+///              .doit();
+/// # }
+/// ```
+pub struct ProjectRunQueryCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a Datastore<C, A>,
+    _request: RunQueryRequest,
+    _project_id: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for ProjectRunQueryCall<'a, C, A> {}
+
+impl<'a, C, A> ProjectRunQueryCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, RunQueryResponse)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "datastore.projects.runQuery",
+                               http_method: hyper::method::Method::Post });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((4 + self._additional_params.len()));
+        params.push(("projectId", self._project_id.to_string()));
+        for &field in ["alt", "projectId"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1/projects/{projectId}:runQuery";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{projectId}", "projectId")].iter() {
+            let mut replace_with: Option<&str> = None;
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = Some(value);
+                    break;
+                }
+            }
+            url = url.replace(find_this, replace_with.expect("to find substitution value in params"));
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["projectId"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Post, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: RunQueryRequest) -> ProjectRunQueryCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// The ID of the project against which to make the request.
+    ///
+    /// Sets the *project id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn project_id(mut self, new_value: &str) -> ProjectRunQueryCall<'a, C, A> {
+        self._project_id = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> ProjectRunQueryCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> ProjectRunQueryCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> ProjectRunQueryCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Prevents the supplied keys' IDs from being auto-allocated by Cloud
+/// Datastore.
+///
+/// A builder for the *reserveIds* method supported by a *project* resource.
+/// It is not used directly, but through a `ProjectMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_datastore1 as datastore1;
+/// use datastore1::ReserveIdsRequest;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use datastore1::Datastore;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = Datastore::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = ReserveIdsRequest::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.projects().reserve_ids(req, "projectId")
+///              .doit();
+/// # }
+/// ```
+pub struct ProjectReserveIdCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a Datastore<C, A>,
+    _request: ReserveIdsRequest,
+    _project_id: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for ProjectReserveIdCall<'a, C, A> {}
+
+impl<'a, C, A> ProjectReserveIdCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, ReserveIdsResponse)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "datastore.projects.reserveIds",
+                               http_method: hyper::method::Method::Post });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((4 + self._additional_params.len()));
+        params.push(("projectId", self._project_id.to_string()));
+        for &field in ["alt", "projectId"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1/projects/{projectId}:reserveIds";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{projectId}", "projectId")].iter() {
+            let mut replace_with: Option<&str> = None;
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = Some(value);
+                    break;
+                }
+            }
+            url = url.replace(find_this, replace_with.expect("to find substitution value in params"));
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["projectId"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Post, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: ReserveIdsRequest) -> ProjectReserveIdCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// The ID of the project against which to make the request.
+    ///
+    /// Sets the *project id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn project_id(mut self, new_value: &str) -> ProjectReserveIdCall<'a, C, A> {
+        self._project_id = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> ProjectReserveIdCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> ProjectReserveIdCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> ProjectReserveIdCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Looks up entities by key.
+///
+/// A builder for the *lookup* method supported by a *project* resource.
+/// It is not used directly, but through a `ProjectMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_datastore1 as datastore1;
+/// use datastore1::LookupRequest;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use datastore1::Datastore;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = Datastore::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = LookupRequest::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.projects().lookup(req, "projectId")
+///              .doit();
+/// # }
+/// ```
+pub struct ProjectLookupCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a Datastore<C, A>,
+    _request: LookupRequest,
+    _project_id: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for ProjectLookupCall<'a, C, A> {}
+
+impl<'a, C, A> ProjectLookupCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, LookupResponse)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "datastore.projects.lookup",
+                               http_method: hyper::method::Method::Post });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((4 + self._additional_params.len()));
+        params.push(("projectId", self._project_id.to_string()));
+        for &field in ["alt", "projectId"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1/projects/{projectId}:lookup";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{projectId}", "projectId")].iter() {
+            let mut replace_with: Option<&str> = None;
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = Some(value);
+                    break;
+                }
+            }
+            url = url.replace(find_this, replace_with.expect("to find substitution value in params"));
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["projectId"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Post, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: LookupRequest) -> ProjectLookupCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// The ID of the project against which to make the request.
+    ///
+    /// Sets the *project id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn project_id(mut self, new_value: &str) -> ProjectLookupCall<'a, C, A> {
+        self._project_id = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> ProjectLookupCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> ProjectLookupCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> ProjectLookupCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Commits a transaction, optionally creating, deleting or modifying some
+/// entities.
+///
+/// A builder for the *commit* method supported by a *project* resource.
+/// It is not used directly, but through a `ProjectMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_datastore1 as datastore1;
+/// use datastore1::CommitRequest;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use datastore1::Datastore;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = Datastore::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = CommitRequest::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.projects().commit(req, "projectId")
+///              .doit();
+/// # }
+/// ```
+pub struct ProjectCommitCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a Datastore<C, A>,
+    _request: CommitRequest,
+    _project_id: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for ProjectCommitCall<'a, C, A> {}
+
+impl<'a, C, A> ProjectCommitCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, CommitResponse)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "datastore.projects.commit",
+                               http_method: hyper::method::Method::Post });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((4 + self._additional_params.len()));
+        params.push(("projectId", self._project_id.to_string()));
+        for &field in ["alt", "projectId"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1/projects/{projectId}:commit";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{projectId}", "projectId")].iter() {
+            let mut replace_with: Option<&str> = None;
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = Some(value);
+                    break;
+                }
+            }
+            url = url.replace(find_this, replace_with.expect("to find substitution value in params"));
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["projectId"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Post, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: CommitRequest) -> ProjectCommitCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// The ID of the project against which to make the request.
+    ///
+    /// Sets the *project id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn project_id(mut self, new_value: &str) -> ProjectCommitCall<'a, C, A> {
+        self._project_id = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> ProjectCommitCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> ProjectCommitCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> ProjectCommitCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Allocates IDs for the given keys, which is useful for referencing an entity
+/// before it is inserted.
+///
+/// A builder for the *allocateIds* method supported by a *project* resource.
+/// It is not used directly, but through a `ProjectMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_datastore1 as datastore1;
+/// use datastore1::AllocateIdsRequest;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use datastore1::Datastore;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = Datastore::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = AllocateIdsRequest::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.projects().allocate_ids(req, "projectId")
+///              .doit();
+/// # }
+/// ```
+pub struct ProjectAllocateIdCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a Datastore<C, A>,
+    _request: AllocateIdsRequest,
+    _project_id: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for ProjectAllocateIdCall<'a, C, A> {}
+
+impl<'a, C, A> ProjectAllocateIdCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, AllocateIdsResponse)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "datastore.projects.allocateIds",
+                               http_method: hyper::method::Method::Post });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((4 + self._additional_params.len()));
+        params.push(("projectId", self._project_id.to_string()));
+        for &field in ["alt", "projectId"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1/projects/{projectId}:allocateIds";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{projectId}", "projectId")].iter() {
+            let mut replace_with: Option<&str> = None;
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = Some(value);
+                    break;
+                }
+            }
+            url = url.replace(find_this, replace_with.expect("to find substitution value in params"));
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["projectId"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Post, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: AllocateIdsRequest) -> ProjectAllocateIdCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// The ID of the project against which to make the request.
+    ///
+    /// Sets the *project id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn project_id(mut self, new_value: &str) -> ProjectAllocateIdCall<'a, C, A> {
+        self._project_id = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> ProjectAllocateIdCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> ProjectAllocateIdCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> ProjectAllocateIdCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Deletes a long-running operation. This method indicates that the client is
+/// no longer interested in the operation result. It does not cancel the
+/// operation. If the server doesn't support this method, it returns
+/// `google.rpc.Code.UNIMPLEMENTED`.
+///
+/// A builder for the *operations.delete* method supported by a *project* resource.
+/// It is not used directly, but through a `ProjectMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_datastore1 as datastore1;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use datastore1::Datastore;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = Datastore::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.projects().operations_delete("name")
+///              .doit();
+/// # }
+/// ```
+pub struct ProjectOperationDeleteCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a Datastore<C, A>,
+    _name: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for ProjectOperationDeleteCall<'a, C, A> {}
+
+impl<'a, C, A> ProjectOperationDeleteCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, Empty)> {
+        use url::percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "datastore.projects.operations.delete",
+                               http_method: hyper::method::Method::Delete });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((3 + self._additional_params.len()));
+        params.push(("name", self._name.to_string()));
+        for &field in ["alt", "name"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1/{+name}";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{+name}", "name")].iter() {
+            let mut replace_with = String::new();
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = value.to_string();
+                    break;
+                }
+            }
+            if find_this.as_bytes()[1] == '+' as u8 {
+                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET);
+            }
+            url = url.replace(find_this, &replace_with);
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["name"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Delete, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    /// The name of the operation resource to be deleted.
+    ///
+    /// Sets the *name* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn name(mut self, new_value: &str) -> ProjectOperationDeleteCall<'a, C, A> {
+        self._name = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> ProjectOperationDeleteCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> ProjectOperationDeleteCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> ProjectOperationDeleteCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Gets the latest state of a long-running operation.  Clients can use this
+/// method to poll the operation result at intervals as recommended by the API
+/// service.
+///
+/// A builder for the *operations.get* method supported by a *project* resource.
+/// It is not used directly, but through a `ProjectMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_datastore1 as datastore1;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use datastore1::Datastore;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = Datastore::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.projects().operations_get("name")
+///              .doit();
+/// # }
+/// ```
+pub struct ProjectOperationGetCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a Datastore<C, A>,
+    _name: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for ProjectOperationGetCall<'a, C, A> {}
+
+impl<'a, C, A> ProjectOperationGetCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, GoogleLongrunningOperation)> {
+        use url::percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "datastore.projects.operations.get",
+                               http_method: hyper::method::Method::Get });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((3 + self._additional_params.len()));
+        params.push(("name", self._name.to_string()));
+        for &field in ["alt", "name"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1/{+name}";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{+name}", "name")].iter() {
+            let mut replace_with = String::new();
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = value.to_string();
+                    break;
+                }
+            }
+            if find_this.as_bytes()[1] == '+' as u8 {
+                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET);
+            }
+            url = url.replace(find_this, &replace_with);
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["name"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Get, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    /// The name of the operation resource.
+    ///
+    /// Sets the *name* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn name(mut self, new_value: &str) -> ProjectOperationGetCall<'a, C, A> {
+        self._name = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> ProjectOperationGetCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> ProjectOperationGetCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> ProjectOperationGetCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Starts asynchronous cancellation on a long-running operation.  The server
+/// makes a best effort to cancel the operation, but success is not
+/// guaranteed.  If the server doesn't support this method, it returns
+/// `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
+/// Operations.GetOperation or
+/// other methods to check whether the cancellation succeeded or whether the
+/// operation completed despite cancellation. On successful cancellation,
+/// the operation is not deleted; instead, it becomes an operation with
+/// an Operation.error value with a google.rpc.Status.code of 1,
+/// corresponding to `Code.CANCELLED`.
+///
+/// A builder for the *operations.cancel* method supported by a *project* resource.
+/// It is not used directly, but through a `ProjectMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_datastore1 as datastore1;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use datastore1::Datastore;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = Datastore::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.projects().operations_cancel("name")
+///              .doit();
+/// # }
+/// ```
+pub struct ProjectOperationCancelCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a Datastore<C, A>,
+    _name: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for ProjectOperationCancelCall<'a, C, A> {}
+
+impl<'a, C, A> ProjectOperationCancelCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, Empty)> {
+        use url::percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "datastore.projects.operations.cancel",
+                               http_method: hyper::method::Method::Post });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((3 + self._additional_params.len()));
+        params.push(("name", self._name.to_string()));
+        for &field in ["alt", "name"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1/{+name}:cancel";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{+name}", "name")].iter() {
+            let mut replace_with = String::new();
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = value.to_string();
+                    break;
+                }
+            }
+            if find_this.as_bytes()[1] == '+' as u8 {
+                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET);
+            }
+            url = url.replace(find_this, &replace_with);
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["name"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Post, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    /// The name of the operation resource to be cancelled.
+    ///
+    /// Sets the *name* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn name(mut self, new_value: &str) -> ProjectOperationCancelCall<'a, C, A> {
+        self._name = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> ProjectOperationCancelCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> ProjectOperationCancelCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> ProjectOperationCancelCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Rolls back a transaction.
+///
+/// A builder for the *rollback* method supported by a *project* resource.
+/// It is not used directly, but through a `ProjectMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_datastore1 as datastore1;
+/// use datastore1::RollbackRequest;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use datastore1::Datastore;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = Datastore::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = RollbackRequest::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.projects().rollback(req, "projectId")
+///              .doit();
+/// # }
+/// ```
+pub struct ProjectRollbackCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a Datastore<C, A>,
+    _request: RollbackRequest,
+    _project_id: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for ProjectRollbackCall<'a, C, A> {}
+
+impl<'a, C, A> ProjectRollbackCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, RollbackResponse)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "datastore.projects.rollback",
+                               http_method: hyper::method::Method::Post });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((4 + self._additional_params.len()));
+        params.push(("projectId", self._project_id.to_string()));
+        for &field in ["alt", "projectId"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1/projects/{projectId}:rollback";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{projectId}", "projectId")].iter() {
+            let mut replace_with: Option<&str> = None;
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = Some(value);
+                    break;
+                }
+            }
+            url = url.replace(find_this, replace_with.expect("to find substitution value in params"));
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["projectId"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Post, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: RollbackRequest) -> ProjectRollbackCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// The ID of the project against which to make the request.
+    ///
+    /// Sets the *project id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn project_id(mut self, new_value: &str) -> ProjectRollbackCall<'a, C, A> {
+        self._project_id = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> ProjectRollbackCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> ProjectRollbackCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> ProjectRollbackCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Begins a new transaction.
+///
+/// A builder for the *beginTransaction* method supported by a *project* resource.
+/// It is not used directly, but through a `ProjectMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_datastore1 as datastore1;
+/// use datastore1::BeginTransactionRequest;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use datastore1::Datastore;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = Datastore::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = BeginTransactionRequest::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.projects().begin_transaction(req, "projectId")
+///              .doit();
+/// # }
+/// ```
+pub struct ProjectBeginTransactionCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a Datastore<C, A>,
+    _request: BeginTransactionRequest,
+    _project_id: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for ProjectBeginTransactionCall<'a, C, A> {}
+
+impl<'a, C, A> ProjectBeginTransactionCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, BeginTransactionResponse)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "datastore.projects.beginTransaction",
+                               http_method: hyper::method::Method::Post });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((4 + self._additional_params.len()));
+        params.push(("projectId", self._project_id.to_string()));
+        for &field in ["alt", "projectId"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1/projects/{projectId}:beginTransaction";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{projectId}", "projectId")].iter() {
+            let mut replace_with: Option<&str> = None;
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = Some(value);
+                    break;
+                }
+            }
+            url = url.replace(find_this, replace_with.expect("to find substitution value in params"));
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["projectId"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Post, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: BeginTransactionRequest) -> ProjectBeginTransactionCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// The ID of the project against which to make the request.
+    ///
+    /// Sets the *project id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn project_id(mut self, new_value: &str) -> ProjectBeginTransactionCall<'a, C, A> {
+        self._project_id = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> ProjectBeginTransactionCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> ProjectBeginTransactionCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> ProjectBeginTransactionCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+

--- a/gen/datastore1_beta3-cli/Cargo.toml
+++ b/gen/datastore1_beta3-cli/Cargo.toml
@@ -1,0 +1,40 @@
+# DO NOT EDIT !
+# This file was generated automatically from 'src/mako/Cargo.toml.mako'
+# DO NOT EDIT !
+[package]
+
+name = "google-datastore1_beta3-cli"
+version = "1.0.7+20171205"
+authors = ["Sebastian Thiel <byronimo@gmail.com>"]
+description = "A complete library to interact with datastore (protocol v1beta3)"
+repository = "https://github.com/Byron/google-apis-rs/tree/master/gen/datastore1_beta3-cli"
+homepage = "https://cloud.google.com/datastore/"
+documentation = "http://byron.github.io/google-apis-rs/google_datastore1_beta3_cli"
+license = "MIT"
+keywords = ["datastore", "google", "cli"]
+
+[[bin]]
+name = "datastore1-beta3"
+
+[dev-dependencies]
+hyper-rustls = "^0.6"
+
+[dependencies]
+hyper = "^ 0.10"
+mime = "^ 0.2.0"
+serde = "^ 1.0"
+serde_json = "^ 1.0"
+serde_derive = "^ 1.0"
+yup-oauth2 = "^ 1.0"
+strsim = "^0.5"
+hyper-rustls = "^0.6"
+yup-hyper-mock = "^2.0"
+clap = "^2.0"
+
+[features]
+
+
+
+[dependencies.google-datastore1_beta3]
+path = "../datastore1_beta3"
+version = "1.0.7+20171205"

--- a/gen/datastore1_beta3-cli/LICENSE.md
+++ b/gen/datastore1_beta3-cli/LICENSE.md
@@ -1,0 +1,30 @@
+<!---
+DO NOT EDIT !
+This file was generated automatically from 'src/mako/LICENSE.md.mako'
+DO NOT EDIT !
+-->
+The MIT License (MIT)
+=====================
+
+Copyright © `2015-2016` `Sebastian Thiel`
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the “Software”), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.

--- a/gen/datastore1_beta3-cli/README.md
+++ b/gen/datastore1_beta3-cli/README.md
@@ -1,0 +1,120 @@
+<!---
+DO NOT EDIT !
+This file was generated automatically from 'src/mako/cli/README.md.mako'
+DO NOT EDIT !
+-->
+The `datastore1-beta3` command-line interface *(CLI)* allows to use most features of the *Google datastore* service from the comfort of your terminal.
+
+By default all output is printed to standard out, but flags can be set to direct it into a file independent of your shell's
+capabilities. Errors will be printed to standard error, and cause the program's exit code to be non-zero.
+
+If data-structures are requested, these will be returned as pretty-printed JSON, to be useful as input to other tools.
+
+Everything else about the *datastore* API can be found at the
+[official documentation site](https://cloud.google.com/datastore/).
+
+# Installation and Source Code
+
+Install the command-line interface with cargo using:
+
+```bash
+cargo install google-datastore1_beta3-cli
+```
+
+Find the source code [on github](https://github.com/Byron/google-apis-rs/tree/master/gen/datastore1_beta3-cli).
+
+# Usage
+
+This documentation was generated from the *datastore* API at revision *20171205*. The CLI is at version *1.0.7*.
+
+```bash
+datastore1-beta3 [options]
+        projects
+                allocate-ids <project-id> (-r <kv>)... [-p <v>]... [-o <out>]
+                begin-transaction <project-id> (-r <kv>)... [-p <v>]... [-o <out>]
+                commit <project-id> (-r <kv>)... [-p <v>]... [-o <out>]
+                lookup <project-id> (-r <kv>)... [-p <v>]... [-o <out>]
+                reserve-ids <project-id> (-r <kv>)... [-p <v>]... [-o <out>]
+                rollback <project-id> (-r <kv>)... [-p <v>]... [-o <out>]
+                run-query <project-id> (-r <kv>)... [-p <v>]... [-o <out>]
+  datastore1-beta3 --help
+
+Configuration:
+  [--scope <url>]...
+            Specify the authentication a method should be executed in. Each scope
+            requires the user to grant this application permission to use it.
+            If unset, it defaults to the shortest scope url for a particular method.
+  --config-dir <folder>
+            A directory into which we will store our persistent data. Defaults to
+            a user-writable directory that we will create during the first invocation.
+            [default: ~/.google-service-cli]
+  --debug
+            Output all server communication to standard error. `tx` and `rx` are placed
+            into the same stream.
+  --debug-auth
+            Output all communication related to authentication to standard error. `tx`
+            and `rx` are placed into the same stream.
+
+```
+
+# Configuration
+
+The program will store all persistent data in the `~/.google-service-cli` directory in *JSON* files prefixed with `datastore1-beta3-`.  You can change the directory used to store configuration with the `--config-dir` flag on a per-invocation basis.
+
+More information about the various kinds of persistent data are given in the following paragraphs.
+
+# Authentication
+
+Most APIs require a user to authenticate any request. If this is the case, the [scope][scopes] determines the 
+set of permissions granted. The granularity of these is usually no more than *read-only* or *full-access*.
+
+If not set, the system will automatically select the smallest feasible scope, e.g. when invoking a
+method that is read-only, it will ask only for a read-only scope. 
+You may use the `--scope` flag to specify a scope directly. 
+All applicable scopes are documented in the respective method's CLI documentation.
+
+The first time a scope is used, the user is asked for permission. Follow the instructions given 
+by the CLI to grant permissions, or to decline.
+
+If a scope was authenticated by the user, the respective information will be stored as *JSON* in the configuration
+directory, e.g. `~/.google-service-cli/datastore1-beta3-token-<scope-hash>.json`. No manual management of these tokens
+is necessary.
+
+To revoke granted authentication, please refer to the [official documentation][revoke-access].
+
+# Application Secrets
+
+In order to allow any application to use Google services, it will need to be registered using the 
+[Google Developer Console][google-dev-console]. APIs the application may use are then enabled for it
+one by one. Most APIs can be used for free and have a daily quota.
+
+To allow more comfortable usage of the CLI without forcing anyone to register an own application, the CLI
+comes with a default application secret that is configured accordingly. This also means that heavy usage
+all around the world may deplete the daily quota.
+
+You can workaround this limitation by putting your own secrets file at this location: 
+`~/.google-service-cli/datastore1-beta3-secret.json`, assuming that the required *datastore* API 
+was enabled for it. Such a secret file can be downloaded in the *Google Developer Console* at 
+*APIs & auth -> Credentials -> Download JSON* and used as is.
+
+Learn more about how to setup Google projects and enable APIs using the [official documentation][google-project-new].
+
+
+# Debugging
+
+Even though the CLI does its best to provide usable error messages, sometimes it might be desirable to know
+what exactly led to a particular issue. This is done by allowing all client-server communication to be 
+output to standard error *as-is*.
+
+The `--debug` flag will print all client-server communication to standard error, whereas the `--debug-auth` flag
+will cause all communication related to authentication to standard error.
+If the `--debug` flag is set, error-results will be debug-printed, possibly yielding more information about the 
+issue at hand.
+
+You may consider redirecting standard error into a file for ease of use, e.g. `datastore1-beta3 --debug <resource> <method> [options] 2>debug.txt`.
+
+
+[scopes]: https://developers.google.com/+/api/oauth#scopes
+[revoke-access]: http://webapps.stackexchange.com/a/30849
+[google-dev-console]: https://console.developers.google.com/
+[google-project-new]: https://developers.google.com/console/help/new/

--- a/gen/datastore1_beta3-cli/mkdocs.yml
+++ b/gen/datastore1_beta3-cli/mkdocs.yml
@@ -1,0 +1,23 @@
+site_name: datastore v1.0.7+20171205
+site_url: http://byron.github.io/google-apis-rs/google-datastore1_beta3-cli
+site_description: A complete library to interact with datastore (protocol v1beta3)
+
+repo_url: https://github.com/Byron/google-apis-rs/tree/master/gen/datastore1_beta3-cli
+
+docs_dir: docs
+site_dir: build_html
+
+pages:
+- ['index.md', 'Home']
+- ['projects_allocate-ids.md', 'Projects', 'Allocate Ids']
+- ['projects_begin-transaction.md', 'Projects', 'Begin Transaction']
+- ['projects_commit.md', 'Projects', 'Commit']
+- ['projects_lookup.md', 'Projects', 'Lookup']
+- ['projects_reserve-ids.md', 'Projects', 'Reserve Ids']
+- ['projects_rollback.md', 'Projects', 'Rollback']
+- ['projects_run-query.md', 'Projects', 'Run Query']
+
+theme: readthedocs
+
+copyright: Copyright &copy; 2015-2016, `Sebastian Thiel`
+

--- a/gen/datastore1_beta3-cli/src/cmn.rs
+++ b/gen/datastore1_beta3-cli/src/cmn.rs
@@ -1,0 +1,799 @@
+// COPY OF 'src/rust/cli/cmn.rs'
+// DO NOT EDIT
+use oauth2::{ApplicationSecret, ConsoleApplicationSecret, TokenStorage, Token};
+use serde_json as json;
+use serde_json::value::Value;
+use mime::Mime;
+use clap::{App, SubCommand};
+use strsim;
+
+use std::fs;
+use std::env;
+use std::io;
+use std::error::Error as StdError;
+use std::fmt;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+use std::string::ToString;
+use std::io::{Write, Read, stdout};
+
+use std::default::Default;
+
+const FIELD_SEP: char = '.';
+
+
+pub enum ComplexType {
+    Pod,
+    Vec,
+    Map,
+}
+
+// Null,
+// Bool(bool),
+// I64(i64),
+// U64(u64),
+// F64(f64),
+// String(String),
+
+pub enum JsonType {
+    Boolean,
+    Int,
+    Uint,
+    Float,
+    String,
+}
+
+pub struct JsonTypeInfo {
+    pub jtype: JsonType,
+    pub ctype: ComplexType,
+}
+
+// Based on @erickt user comment. Thanks for the idea !
+// Remove all keys whose values are null from given value (changed in place)
+pub fn remove_json_null_values(value: &mut Value) {
+    match *value {
+        Value::Object(ref mut map) => {
+            let mut for_removal = Vec::new();
+
+            for (key, mut value) in map.iter_mut() {
+                if value.is_null() {
+                    for_removal.push(key.clone());
+                } else {
+                    remove_json_null_values(&mut value);
+                }
+            }
+
+            for key in &for_removal {
+                map.remove(key);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn did_you_mean<'a>(v: &str, possible_values: &[&'a str]) -> Option<&'a str> {
+
+    let mut candidate: Option<(f64, &str)> = None;
+    for pv in possible_values {
+        let confidence = strsim::jaro_winkler(v, pv);
+        if confidence > 0.8 &&
+           (candidate.is_none() || (candidate.as_ref().unwrap().0 < confidence)) {
+            candidate = Some((confidence, pv));
+        }
+    }
+    match candidate {
+        None => None,
+        Some((_, candidate)) => Some(candidate),
+    }
+}
+
+pub enum CallType {
+    Upload(UploadProtocol),
+    Standard,
+}
+
+arg_enum!{
+    pub enum UploadProtocol {
+        Simple,
+        Resumable
+    }
+}
+
+impl AsRef<str> for UploadProtocol {
+    fn as_ref(&self) -> &str {
+        match *self {
+            UploadProtocol::Simple => "simple",
+            UploadProtocol::Resumable => "resumable",
+        }
+    }
+}
+
+impl AsRef<str> for CallType {
+    fn as_ref(&self) -> &str {
+        match *self {
+            CallType::Upload(ref proto) => proto.as_ref(),
+            CallType::Standard => "standard-request",
+        }
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct FieldCursor(Vec<String>);
+
+impl ToString for  FieldCursor {
+    fn to_string(&self) -> String {
+        self.0.join(".")
+    }
+}
+
+impl From<&'static str> for FieldCursor {
+    fn from(value: &'static str) -> FieldCursor {
+        let mut res = FieldCursor::default();
+        res.set(value).unwrap();
+        res
+    }
+}
+
+fn assure_entry<'a, 'b>(m: &'a mut json::Map<String, Value>, k: &'b String) -> &'a mut Value {
+    if m.contains_key(k) {
+        return m.get_mut(k).expect("value to exist");
+    }
+    m.insert(k.to_owned(), Value::Object(Default::default()));
+    m.get_mut(k).expect("value to exist")
+}
+
+impl FieldCursor {
+    pub fn set(&mut self, value: &str) -> Result<(), CLIError> {
+        if value.len() == 0 {
+            return Err(CLIError::Field(FieldError::Empty));
+        }
+
+        let mut first_is_field_sep = false;
+        let mut char_count: usize = 0;
+        let mut last_c = FIELD_SEP;
+        let mut num_conscutive_field_seps = 0;
+
+        let mut field = String::new();
+        let mut fields = self.0.clone();
+
+        let push_field = |fs: &mut Vec<String>, f: &mut String| {
+            if f.len() > 0 {
+                fs.push(f.clone());
+                f.truncate(0);
+            }
+        };
+
+        for (cid, c) in value.chars().enumerate() {
+            char_count += 1;
+
+            if c == FIELD_SEP {
+                if cid == 0 {
+                    first_is_field_sep = true;
+                }
+                num_conscutive_field_seps += 1;
+                if cid > 0 && last_c == FIELD_SEP {
+                    if fields.pop().is_none() {
+                        return Err(CLIError::Field(FieldError::PopOnEmpty(value.to_string())));
+                    }
+                } else {
+                    push_field(&mut fields, &mut field);
+                }
+            } else {
+                num_conscutive_field_seps = 0;
+                if cid == 1 {
+                    if first_is_field_sep {
+                        fields.truncate(0);
+                    }
+                }
+                field.push(c);
+            }
+
+            last_c = c;
+        }
+
+        push_field(&mut fields, &mut field);
+
+        if char_count == 1 && first_is_field_sep {
+            fields.truncate(0);
+        }
+        if char_count > 1 && num_conscutive_field_seps == 1 {
+            return Err(CLIError::Field(FieldError::TrailingFieldSep(value.to_string())));
+        }
+
+        self.0 = fields;
+        Ok(())
+    }
+
+    pub fn did_you_mean(value: &str, possible_values: &[&str]) -> Option<String> {
+        if value.len() == 0 {
+            return None;
+        }
+
+        let mut last_c = FIELD_SEP;
+
+        let mut field = String::new();
+        let mut output = String::new();
+
+        let push_field = |fs: &mut String, f: &mut String| {
+            if f.len() > 0 {
+                fs.push_str(match did_you_mean(&f, possible_values) {
+                    Some(candidate) => candidate,
+                    None => &f,
+                });
+                f.truncate(0);
+            }
+        };
+
+        for (cid, c) in value.chars().enumerate() {
+            if c == FIELD_SEP {
+                if last_c != FIELD_SEP {
+                    push_field(&mut output, &mut field);
+                }
+                output.push(c);
+            } else {
+                field.push(c);
+            }
+
+            last_c = c;
+        }
+
+        push_field(&mut output, &mut field);
+
+        if &output == value {
+            None
+        } else {
+            Some(output)
+        }
+    }
+
+    pub fn set_json_value(&self,
+                          mut object: &mut Value,
+                          value: &str,
+                          type_info: JsonTypeInfo,
+                          err: &mut InvalidOptionsError,
+                          orig_cursor: &FieldCursor) {
+        assert!(self.0.len() > 0);
+
+        for field in &self.0[..self.0.len() - 1] {
+            let tmp = object;
+            object = match *tmp {
+                Value::Object(ref mut mapping) => {
+                    assure_entry(mapping, &field)
+                }
+                _ => panic!("We don't expect non-object Values here ..."),
+            };
+        }
+
+        match *object {
+            Value::Object(ref mut mapping) => {
+                let field = &self.0[self.0.len() - 1];
+                let to_jval = |value: &str,
+                               jtype: JsonType,
+                               err: &mut InvalidOptionsError|
+                               -> Value {
+                    match jtype {
+                        JsonType::Boolean =>
+                            Value::Bool(arg_from_str(value, err, &field, "boolean")),
+                        JsonType::Int =>
+                            Value::Number(json::Number::from_f64(arg_from_str(value,
+                                                                              err,
+                                                                              &field,
+                                                                              "int"))
+                                              .expect("valid f64")),
+                        JsonType::Uint =>
+                            Value::Number(json::Number::from_f64(arg_from_str(value,
+                                                                              err,
+                                                                              &field,
+                                                                              "uint"))
+                                              .expect("valid f64")),
+                        JsonType::Float =>
+                            Value::Number(json::Number::from_f64(arg_from_str(value,
+                                                                              err,
+                                                                              &field,
+                                                                              "float"))
+                                              .expect("valid f64")),
+                        JsonType::String => Value::String(value.to_owned()),
+                    }
+                };
+
+                match type_info.ctype {
+                    ComplexType::Pod => {
+                        if mapping.insert(field.to_owned(), to_jval(value, type_info.jtype, err))
+                                  .is_some() {
+                            err.issues.push(CLIError::Field(FieldError::Duplicate(orig_cursor.to_string())));
+                        }
+                    }
+                    ComplexType::Vec => {
+                        match *assure_entry(mapping, field) {
+                            Value::Array(ref mut values) =>
+                                values.push(to_jval(value, type_info.jtype, err)),
+                            _ => unreachable!(),
+                        }
+                    }
+                    ComplexType::Map => {
+                        let (key, value) = parse_kv_arg(value, err, true);
+                        let jval = to_jval(value.unwrap_or(""), type_info.jtype, err);
+
+                        match *assure_entry(mapping, &field) {
+
+                            Value::Object(ref mut value_map) => {
+                                if value_map.insert(key.to_owned(), jval).is_some() {
+                                    err.issues.push(CLIError::Field(FieldError::Duplicate(orig_cursor.to_string())));
+                                }
+                            }
+                            _ => unreachable!(),
+                        }
+                    }
+                }
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    pub fn num_fields(&self) -> usize {
+        self.0.len()
+    }
+}
+
+pub fn parse_kv_arg<'a>(kv: &'a str,
+                        err: &mut InvalidOptionsError,
+                        for_hashmap: bool)
+                        -> (&'a str, Option<&'a str>) {
+    let mut add_err = || {
+        err.issues.push(CLIError::InvalidKeyValueSyntax(kv.to_string(), for_hashmap))
+    };
+    match kv.find('=') {
+        None => {
+            add_err();
+            return (kv, None);
+        }
+        Some(pos) => {
+            let key = &kv[..pos];
+            if kv.len() <= pos + 1 {
+                add_err();
+                return (key, Some(""));
+            }
+            (key, Some(&kv[pos + 1..]))
+        }
+    }
+}
+
+pub fn calltype_from_str(name: &str,
+                         valid_protocols: Vec<String>,
+                         err: &mut InvalidOptionsError)
+                         -> CallType {
+    CallType::Upload(match UploadProtocol::from_str(name) {
+        Ok(up) => up,
+        Err(msg) => {
+            err.issues.push(CLIError::InvalidUploadProtocol(name.to_string(), valid_protocols));
+            UploadProtocol::Simple
+        }
+    })
+}
+
+pub fn input_file_from_opts(file_path: &str, err: &mut InvalidOptionsError) -> Option<fs::File> {
+    match fs::File::open(file_path) {
+        Ok(f) => Some(f),
+        Err(io_err) => {
+            err.issues.push(CLIError::Input(InputError::Io((file_path.to_string(), io_err))));
+            None
+        }
+    }
+}
+
+pub fn input_mime_from_opts(mime: &str, err: &mut InvalidOptionsError) -> Option<Mime> {
+    match mime.parse() {
+        Ok(m) => Some(m),
+        Err(_) => {
+            err.issues.push(CLIError::Input(InputError::Mime(mime.to_string())));
+            None
+        }
+    }
+}
+
+pub fn writer_from_opts(arg: Option<&str>) -> Result<Box<Write>, io::Error> {
+    let f = arg.unwrap_or("-");
+    match f {
+        "-" => Ok(Box::new(stdout())),
+        _ => match fs::OpenOptions::new().create(true).write(true).open(f) {
+            Ok(f) => Ok(Box::new(f)),
+            Err(io_err) => Err(io_err),
+        },
+    }
+}
+
+
+pub fn arg_from_str<'a, T>(arg: &str,
+                           err: &mut InvalidOptionsError,
+                           arg_name: &'a str,
+                           arg_type: &'a str)
+                           -> T
+    where T: FromStr + Default,
+          <T as FromStr>::Err: fmt::Display
+{
+    match FromStr::from_str(arg) {
+        Err(perr) => {
+            err.issues.push(CLIError::ParseError(arg_name.to_owned(),
+                                                 arg_type.to_owned(),
+                                                 arg.to_string(),
+                                                 format!("{}", perr)));
+            Default::default()
+        }
+        Ok(v) => v,
+    }
+}
+
+pub struct JsonTokenStorage {
+    pub program_name: &'static str,
+    pub db_dir: String,
+}
+
+impl JsonTokenStorage {
+    fn path(&self, scope_hash: u64) -> PathBuf {
+        Path::new(&self.db_dir).join(&format!("{}-token-{}.json", self.program_name, scope_hash))
+    }
+}
+
+
+#[derive(Debug)]
+pub enum TokenStorageError {
+    Json(json::Error),
+    Io(io::Error),
+}
+
+impl fmt::Display for TokenStorageError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            TokenStorageError::Json(ref err) => writeln!(f, "Could not serialize secrets: {}", err),
+            TokenStorageError::Io(ref err) => writeln!(f, "Failed to write secret token: {}", err),
+        }
+    }
+}
+
+impl StdError for TokenStorageError {
+    fn description(&self) -> &str {
+        "Failure when getting or setting the token storage"
+    }
+}
+
+
+impl TokenStorage for JsonTokenStorage {
+    type Error = TokenStorageError;
+
+    // NOTE: logging might be interesting, currently we swallow all errors
+    fn set(&mut self,
+           scope_hash: u64,
+           _: &Vec<&str>,
+           token: Option<Token>)
+           -> Result<(), TokenStorageError> {
+        match token {
+            None => {
+                match fs::remove_file(self.path(scope_hash)) {
+                    Err(err) => match err.kind() {
+                        io::ErrorKind::NotFound => Ok(()),
+                        _ => Err(TokenStorageError::Io(err)),
+                    },
+                    Ok(_) => Ok(()),
+                }
+            }
+            Some(token) => {
+                match fs::OpenOptions::new().create(true).write(true).open(&self.path(scope_hash)) {
+                    Ok(mut f) => {
+                        match json::to_writer_pretty(&mut f, &token) {
+                            Ok(_) => Ok(()),
+                            Err(serde_err) => Err(TokenStorageError::Json(serde_err)),
+                        }
+                    }
+                    Err(io_err) => Err(TokenStorageError::Io(io_err)),
+                }
+            }
+        }
+    }
+
+    fn get(&self, scope_hash: u64, _: &Vec<&str>) -> Result<Option<Token>, TokenStorageError> {
+        match fs::File::open(&self.path(scope_hash)) {
+            Ok(f) => {
+                match json::de::from_reader(f) {
+                    Ok(token) => Ok(Some(token)),
+                    Err(err) => Err(TokenStorageError::Json(err)),
+                }
+            }
+            Err(io_err) => {
+                match io_err.kind() {
+                    io::ErrorKind::NotFound => Ok(None),
+                    _ => Err(TokenStorageError::Io(io_err)),
+                }
+            }
+        }
+    }
+}
+
+
+#[derive(Debug)]
+pub enum ApplicationSecretError {
+    DecoderError((String, json::Error)),
+    FormatError(String),
+}
+
+impl fmt::Display for ApplicationSecretError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            ApplicationSecretError::DecoderError((ref path, ref err)) =>
+                writeln!(f,
+                         "Could not decode file at '{}' with error: {}.",
+                         path,
+                         err),
+            ApplicationSecretError::FormatError(ref path) =>
+                writeln!(f,
+                         "'installed' field is unset in secret file at '{}'.",
+                         path),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum ConfigurationError {
+    DirectoryCreationFailed((String, io::Error)),
+    DirectoryUnset,
+    HomeExpansionFailed(String),
+    Secret(ApplicationSecretError),
+    Io((String, io::Error)),
+}
+
+impl fmt::Display for ConfigurationError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            ConfigurationError::DirectoryCreationFailed((ref dir, ref err)) =>
+                writeln!(f,
+                         "Directory '{}' could not be created with error: {}.",
+                         dir,
+                         err),
+            ConfigurationError::DirectoryUnset => writeln!(f, "--config-dir was unset or empty."),
+            ConfigurationError::HomeExpansionFailed(ref dir) =>
+                writeln!(f,
+                         "Couldn't find HOME directory of current user, failed to expand '{}'.",
+                         dir),
+            ConfigurationError::Secret(ref err) => writeln!(f, "Secret -> {}", err),
+            ConfigurationError::Io((ref path, ref err)) =>
+                writeln!(f,
+                         "IO operation failed on path '{}' with error: {}.",
+                         path,
+                         err),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum InputError {
+    Io((String, io::Error)),
+    Mime(String),
+}
+
+impl fmt::Display for InputError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            InputError::Io((ref file_path, ref io_err)) =>
+                writeln!(f,
+                         "Failed to open '{}' for reading with error: {}.",
+                         file_path,
+                         io_err),
+            InputError::Mime(ref mime) => writeln!(f, "'{}' is not a known mime-type.", mime),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum FieldError {
+    PopOnEmpty(String),
+    TrailingFieldSep(String),
+    Unknown(String, Option<String>, Option<String>),
+    Duplicate(String),
+    Empty,
+}
+
+
+impl fmt::Display for FieldError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            FieldError::PopOnEmpty(ref field) =>
+                writeln!(f, "'{}': Cannot move up on empty field cursor.", field),
+            FieldError::TrailingFieldSep(ref field) =>
+                writeln!(f,
+                         "'{}': Single field separator may not be last character.",
+                         field),
+            FieldError::Unknown(ref field, ref suggestion, ref value) => {
+                let suffix = match *suggestion {
+                    Some(ref s) => {
+                        let kv = match *value {
+                            Some(ref v) => format!("{}={}", s, v),
+                            None => s.clone(),
+                        };
+                        format!(" Did you mean '{}' ?", kv)
+                    }
+                    None => String::new(),
+                };
+                writeln!(f, "Field '{}' does not exist.{}", field, suffix)
+            }
+            FieldError::Duplicate(ref cursor) =>
+                writeln!(f, "Value at '{}' was already set", cursor),
+            FieldError::Empty => writeln!(f, "Field names must not be empty."),
+        }
+    }
+}
+
+
+#[derive(Debug)]
+pub enum CLIError {
+    Configuration(ConfigurationError),
+    ParseError(String, String, String, String),
+    UnknownParameter(String, Vec<&'static str>),
+    InvalidUploadProtocol(String, Vec<String>),
+    InvalidKeyValueSyntax(String, bool),
+    Input(InputError),
+    Field(FieldError),
+    MissingCommandError,
+    MissingMethodError(String),
+}
+
+impl fmt::Display for CLIError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            CLIError::Configuration(ref err) => write!(f, "Configuration -> {}", err),
+            CLIError::Input(ref err) => write!(f, "Input -> {}", err),
+            CLIError::Field(ref err) => write!(f, "Field -> {}", err),
+            CLIError::InvalidUploadProtocol(ref proto_name, ref valid_names) =>
+                writeln!(f,
+                         "'{}' is not a valid upload protocol. Choose from one of {}.",
+                         proto_name,
+                         valid_names.join(", ")),
+            CLIError::ParseError(ref arg_name, ref type_name, ref value, ref err_desc) =>
+                writeln!(f,
+                         "Failed to parse argument '{}' with value '{}' as {} with error: {}.",
+                         arg_name,
+                         value,
+                         type_name,
+                         err_desc),
+            CLIError::UnknownParameter(ref param_name, ref possible_values) => {
+                let suffix = match did_you_mean(param_name, &possible_values) {
+                    Some(v) => format!(" Did you mean '{}' ?", v),
+                    None => String::new(),
+                };
+                write!(f, "Parameter '{}' is unknown.{}\n", param_name, suffix)
+            }
+            CLIError::InvalidKeyValueSyntax(ref kv, is_hashmap) => {
+                let hashmap_info = if is_hashmap {
+                    "hashmap "
+                } else {
+                    ""
+                };
+                writeln!(f,
+                         "'{}' does not match {}pattern <key>=<value>.",
+                         kv,
+                         hashmap_info)
+            }
+            CLIError::MissingCommandError => writeln!(f, "Please specify the main sub-command."),
+            CLIError::MissingMethodError(ref cmd) =>
+                writeln!(f,
+                         "Please specify the method to call on the '{}' command.",
+                         cmd),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct InvalidOptionsError {
+    pub issues: Vec<CLIError>,
+    pub exit_code: i32,
+}
+
+impl fmt::Display for InvalidOptionsError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        for issue in &self.issues {
+            try!(issue.fmt(f));
+        }
+        Ok(())
+    }
+}
+
+impl InvalidOptionsError {
+    pub fn single(err: CLIError, exit_code: i32) -> InvalidOptionsError {
+        InvalidOptionsError {
+            issues: vec![err],
+            exit_code: exit_code,
+        }
+    }
+
+    pub fn new() -> InvalidOptionsError {
+        InvalidOptionsError {
+            issues: Vec::new(),
+            exit_code: 1,
+        }
+    }
+}
+
+pub fn assure_config_dir_exists(dir: &str) -> Result<String, CLIError> {
+    let trdir = dir.trim();
+    if trdir.len() == 0 {
+        return Err(CLIError::Configuration(ConfigurationError::DirectoryUnset));
+    }
+
+    let expanded_config_dir = if trdir.as_bytes()[0] == b'~' {
+        match env::var("HOME").ok().or(env::var("UserProfile").ok()) {
+            None => return Err(CLIError::Configuration(ConfigurationError::HomeExpansionFailed(trdir.to_string()))),
+            Some(mut user) => {
+                user.push_str(&trdir[1..]);
+                user
+            }
+        }
+    } else {
+        trdir.to_string()
+    };
+
+    if let Err(err) = fs::create_dir(&expanded_config_dir) {
+        if err.kind() != io::ErrorKind::AlreadyExists {
+            return Err(CLIError::Configuration(
+                    ConfigurationError::DirectoryCreationFailed((expanded_config_dir, err))));
+        }
+    }
+
+    Ok(expanded_config_dir)
+}
+
+pub fn application_secret_from_directory(dir: &str,
+                                         secret_basename: &str,
+                                         json_console_secret: &str)
+                                         -> Result<ApplicationSecret, CLIError> {
+    let secret_path = Path::new(dir).join(secret_basename);
+    let secret_str = || secret_path.as_path().to_str().unwrap().to_string();
+    let secret_io_error = |io_err: io::Error| {
+        Err(CLIError::Configuration(ConfigurationError::Io((secret_str(), io_err))))
+    };
+
+    for _ in 0..2 {
+        match fs::File::open(&secret_path) {
+            Err(mut err) => {
+                if err.kind() == io::ErrorKind::NotFound {
+                    // Write our built-in one - user may adjust the written file at will
+
+                    err = match fs::OpenOptions::new()
+                                    .create(true)
+                                    .write(true)
+                                    .open(&secret_path) {
+                        Err(cfe) => cfe,
+                        Ok(mut f) => {
+                            // Assure we convert 'ugly' json string into pretty one
+                            let console_secret: ConsoleApplicationSecret =
+                                json::from_str(json_console_secret).unwrap();
+                            match json::to_writer_pretty(&mut f, &console_secret) {
+                                Err(serde_err) =>
+                                    panic!("Unexpected serde error: {:#?}", serde_err),
+                                Ok(_) => continue,
+                            }
+                        }
+                    };
+                    // fall through to IO error handling
+                }
+                return secret_io_error(err);
+            }
+            Ok(f) => {
+                match json::de::from_reader::<_, ConsoleApplicationSecret>(f) {
+                    Err(json_err) =>
+                        return Err(CLIError::Configuration(
+                            ConfigurationError::Secret(
+                                ApplicationSecretError::DecoderError(
+                                                (secret_str(), json_err)
+                                              )))),
+                    Ok(console_secret) => match console_secret.installed {
+                        Some(secret) => return Ok(secret),
+                        None => return Err(
+                                        CLIError::Configuration(
+                                        ConfigurationError::Secret(
+                                        ApplicationSecretError::FormatError(secret_str())
+                                        ))),
+                    },
+                }
+            }
+        }
+    }
+    unreachable!();
+}

--- a/gen/datastore1_beta3-cli/src/main.rs
+++ b/gen/datastore1_beta3-cli/src/main.rs
@@ -1,0 +1,1092 @@
+// DO NOT EDIT !
+// This file was generated automatically from 'src/mako/cli/main.rs.mako'
+// DO NOT EDIT !
+#![allow(unused_variables, unused_imports, dead_code, unused_mut)]
+
+#[macro_use]
+extern crate clap;
+extern crate yup_oauth2 as oauth2;
+extern crate yup_hyper_mock as mock;
+extern crate hyper_rustls;
+extern crate serde;
+extern crate serde_json;
+extern crate hyper;
+extern crate mime;
+extern crate strsim;
+extern crate google_datastore1_beta3 as api;
+
+use std::env;
+use std::io::{self, Write};
+use clap::{App, SubCommand, Arg};
+
+mod cmn;
+
+use cmn::{InvalidOptionsError, CLIError, JsonTokenStorage, arg_from_str, writer_from_opts, parse_kv_arg,
+          input_file_from_opts, input_mime_from_opts, FieldCursor, FieldError, CallType, UploadProtocol,
+          calltype_from_str, remove_json_null_values, ComplexType, JsonType, JsonTypeInfo};
+
+use std::default::Default;
+use std::str::FromStr;
+
+use oauth2::{Authenticator, DefaultAuthenticatorDelegate, FlowType};
+use serde_json as json;
+use clap::ArgMatches;
+
+enum DoitError {
+    IoError(String, io::Error),
+    ApiError(api::Error),
+}
+
+struct Engine<'n> {
+    opt: ArgMatches<'n>,
+    hub: api::Datastore<hyper::Client, Authenticator<DefaultAuthenticatorDelegate, JsonTokenStorage, hyper::Client>>,
+    gp: Vec<&'static str>,
+    gpm: Vec<(&'static str, &'static str)>,
+}
+
+
+impl<'n> Engine<'n> {
+    fn _projects_allocate_ids(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec![]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::AllocateIdsRequest = json::value::from_value(object).unwrap();
+        let mut call = self.hub.projects().allocate_ids(request, opt.value_of("project-id").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _projects_begin_transaction(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    "transaction-options.read-write.previous-transaction" => Some(("transactionOptions.readWrite.previousTransaction", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec!["previous-transaction", "read-write", "transaction-options"]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::BeginTransactionRequest = json::value::from_value(object).unwrap();
+        let mut call = self.hub.projects().begin_transaction(request, opt.value_of("project-id").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _projects_commit(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    "transaction" => Some(("transaction", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "mode" => Some(("mode", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec!["mode", "transaction"]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::CommitRequest = json::value::from_value(object).unwrap();
+        let mut call = self.hub.projects().commit(request, opt.value_of("project-id").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _projects_lookup(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    "read-options.transaction" => Some(("readOptions.transaction", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "read-options.read-consistency" => Some(("readOptions.readConsistency", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec!["read-consistency", "read-options", "transaction"]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::LookupRequest = json::value::from_value(object).unwrap();
+        let mut call = self.hub.projects().lookup(request, opt.value_of("project-id").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _projects_reserve_ids(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    "database-id" => Some(("databaseId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec!["database-id"]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::ReserveIdsRequest = json::value::from_value(object).unwrap();
+        let mut call = self.hub.projects().reserve_ids(request, opt.value_of("project-id").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _projects_rollback(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    "transaction" => Some(("transaction", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec!["transaction"]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::RollbackRequest = json::value::from_value(object).unwrap();
+        let mut call = self.hub.projects().rollback(request, opt.value_of("project-id").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _projects_run_query(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    "query.filter.composite-filter.op" => Some(("query.filter.compositeFilter.op", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "query.filter.property-filter.property.name" => Some(("query.filter.propertyFilter.property.name", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "query.filter.property-filter.value.entity-value.key.partition-id.project-id" => Some(("query.filter.propertyFilter.value.entityValue.key.partitionId.projectId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "query.filter.property-filter.value.entity-value.key.partition-id.namespace-id" => Some(("query.filter.propertyFilter.value.entityValue.key.partitionId.namespaceId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "query.filter.property-filter.value.timestamp-value" => Some(("query.filter.propertyFilter.value.timestampValue", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "query.filter.property-filter.value.null-value" => Some(("query.filter.propertyFilter.value.nullValue", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "query.filter.property-filter.value.double-value" => Some(("query.filter.propertyFilter.value.doubleValue", JsonTypeInfo { jtype: JsonType::Float, ctype: ComplexType::Pod })),
+                    "query.filter.property-filter.value.meaning" => Some(("query.filter.propertyFilter.value.meaning", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Pod })),
+                    "query.filter.property-filter.value.exclude-from-indexes" => Some(("query.filter.propertyFilter.value.excludeFromIndexes", JsonTypeInfo { jtype: JsonType::Boolean, ctype: ComplexType::Pod })),
+                    "query.filter.property-filter.value.key-value.partition-id.project-id" => Some(("query.filter.propertyFilter.value.keyValue.partitionId.projectId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "query.filter.property-filter.value.key-value.partition-id.namespace-id" => Some(("query.filter.propertyFilter.value.keyValue.partitionId.namespaceId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "query.filter.property-filter.value.blob-value" => Some(("query.filter.propertyFilter.value.blobValue", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "query.filter.property-filter.value.string-value" => Some(("query.filter.propertyFilter.value.stringValue", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "query.filter.property-filter.value.boolean-value" => Some(("query.filter.propertyFilter.value.booleanValue", JsonTypeInfo { jtype: JsonType::Boolean, ctype: ComplexType::Pod })),
+                    "query.filter.property-filter.value.integer-value" => Some(("query.filter.propertyFilter.value.integerValue", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "query.filter.property-filter.value.geo-point-value.latitude" => Some(("query.filter.propertyFilter.value.geoPointValue.latitude", JsonTypeInfo { jtype: JsonType::Float, ctype: ComplexType::Pod })),
+                    "query.filter.property-filter.value.geo-point-value.longitude" => Some(("query.filter.propertyFilter.value.geoPointValue.longitude", JsonTypeInfo { jtype: JsonType::Float, ctype: ComplexType::Pod })),
+                    "query.filter.property-filter.op" => Some(("query.filter.propertyFilter.op", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "query.start-cursor" => Some(("query.startCursor", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "query.end-cursor" => Some(("query.endCursor", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "query.limit" => Some(("query.limit", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Pod })),
+                    "query.offset" => Some(("query.offset", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Pod })),
+                    "partition-id.project-id" => Some(("partitionId.projectId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "partition-id.namespace-id" => Some(("partitionId.namespaceId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "gql-query.query-string" => Some(("gqlQuery.queryString", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "gql-query.allow-literals" => Some(("gqlQuery.allowLiterals", JsonTypeInfo { jtype: JsonType::Boolean, ctype: ComplexType::Pod })),
+                    "read-options.transaction" => Some(("readOptions.transaction", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "read-options.read-consistency" => Some(("readOptions.readConsistency", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec!["allow-literals", "blob-value", "boolean-value", "composite-filter", "double-value", "end-cursor", "entity-value", "exclude-from-indexes", "filter", "geo-point-value", "gql-query", "integer-value", "key", "key-value", "latitude", "limit", "longitude", "meaning", "name", "namespace-id", "null-value", "offset", "op", "partition-id", "project-id", "property", "property-filter", "query", "query-string", "read-consistency", "read-options", "start-cursor", "string-value", "timestamp-value", "transaction", "value"]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::RunQueryRequest = json::value::from_value(object).unwrap();
+        let mut call = self.hub.projects().run_query(request, opt.value_of("project-id").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _doit(&self, dry_run: bool) -> Result<Result<(), DoitError>, Option<InvalidOptionsError>> {
+        let mut err = InvalidOptionsError::new();
+        let mut call_result: Result<(), DoitError> = Ok(());
+        let mut err_opt: Option<InvalidOptionsError> = None;
+        match self.opt.subcommand() {
+            ("projects", Some(opt)) => {
+                match opt.subcommand() {
+                    ("allocate-ids", Some(opt)) => {
+                        call_result = self._projects_allocate_ids(opt, dry_run, &mut err);
+                    },
+                    ("begin-transaction", Some(opt)) => {
+                        call_result = self._projects_begin_transaction(opt, dry_run, &mut err);
+                    },
+                    ("commit", Some(opt)) => {
+                        call_result = self._projects_commit(opt, dry_run, &mut err);
+                    },
+                    ("lookup", Some(opt)) => {
+                        call_result = self._projects_lookup(opt, dry_run, &mut err);
+                    },
+                    ("reserve-ids", Some(opt)) => {
+                        call_result = self._projects_reserve_ids(opt, dry_run, &mut err);
+                    },
+                    ("rollback", Some(opt)) => {
+                        call_result = self._projects_rollback(opt, dry_run, &mut err);
+                    },
+                    ("run-query", Some(opt)) => {
+                        call_result = self._projects_run_query(opt, dry_run, &mut err);
+                    },
+                    _ => {
+                        err.issues.push(CLIError::MissingMethodError("projects".to_string()));
+                        writeln!(io::stderr(), "{}\n", opt.usage()).ok();
+                    }
+                }
+            },
+            _ => {
+                err.issues.push(CLIError::MissingCommandError);
+                writeln!(io::stderr(), "{}\n", self.opt.usage()).ok();
+            }
+        }
+
+        if dry_run {
+            if err.issues.len() > 0 {
+                err_opt = Some(err);
+            }
+            Err(err_opt)
+        } else {
+            Ok(call_result)
+        }
+    }
+
+    // Please note that this call will fail if any part of the opt can't be handled
+    fn new(opt: ArgMatches<'n>) -> Result<Engine<'n>, InvalidOptionsError> {
+        let (config_dir, secret) = {
+            let config_dir = match cmn::assure_config_dir_exists(opt.value_of("folder").unwrap_or("~/.google-service-cli")) {
+                Err(e) => return Err(InvalidOptionsError::single(e, 3)),
+                Ok(p) => p,
+            };
+
+            match cmn::application_secret_from_directory(&config_dir, "datastore1-beta3-secret.json",
+                                                         "{\"installed\":{\"auth_uri\":\"https://accounts.google.com/o/oauth2/auth\",\"client_secret\":\"hCsslbCUyfehWMmbkG8vTYxG\",\"token_uri\":\"https://accounts.google.com/o/oauth2/token\",\"client_email\":\"\",\"redirect_uris\":[\"urn:ietf:wg:oauth:2.0:oob\",\"oob\"],\"client_x509_cert_url\":\"\",\"client_id\":\"620010449518-9ngf7o4dhs0dka470npqvor6dc5lqb9b.apps.googleusercontent.com\",\"auth_provider_x509_cert_url\":\"https://www.googleapis.com/oauth2/v1/certs\"}}") {
+                Ok(secret) => (config_dir, secret),
+                Err(e) => return Err(InvalidOptionsError::single(e, 4))
+            }
+        };
+
+        let auth = Authenticator::new(  &secret, DefaultAuthenticatorDelegate,
+                                        if opt.is_present("debug-auth") {
+                                            hyper::Client::with_connector(mock::TeeConnector {
+                                                    connector: hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())
+                                                })
+                                        } else {
+                                            hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new()))
+                                        },
+                                        JsonTokenStorage {
+                                          program_name: "datastore1-beta3",
+                                          db_dir: config_dir.clone(),
+                                        }, Some(FlowType::InstalledRedirect(54324)));
+
+        let client =
+            if opt.is_present("debug") {
+                hyper::Client::with_connector(mock::TeeConnector {
+                        connector: hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())
+                    })
+            } else {
+                hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new()))
+            };
+        let engine = Engine {
+            opt: opt,
+            hub: api::Datastore::new(client, auth),
+            gp: vec!["$-xgafv", "access-token", "alt", "bearer-token", "callback", "fields", "key", "oauth-token", "pp", "pretty-print", "quota-user", "upload-type", "upload-protocol"],
+            gpm: vec![
+                    ("$-xgafv", "$.xgafv"),
+                    ("access-token", "access_token"),
+                    ("bearer-token", "bearer_token"),
+                    ("oauth-token", "oauth_token"),
+                    ("pretty-print", "prettyPrint"),
+                    ("quota-user", "quotaUser"),
+                    ("upload-type", "uploadType"),
+                    ("upload-protocol", "upload_protocol"),
+                ]
+        };
+
+        match engine._doit(true) {
+            Err(Some(err)) => Err(err),
+            Err(None)      => Ok(engine),
+            Ok(_)          => unreachable!(),
+        }
+    }
+
+    fn doit(&self) -> Result<(), DoitError> {
+        match self._doit(false) {
+            Ok(res) => res,
+            Err(_) => unreachable!(),
+        }
+    }
+}
+
+fn main() {
+    let mut exit_status = 0i32;
+    let arg_data = [
+        ("projects", "methods: 'allocate-ids', 'begin-transaction', 'commit', 'lookup', 'reserve-ids', 'rollback' and 'run-query'", vec![
+            ("allocate-ids",
+                    Some(r##"Allocates IDs for the given keys, which is useful for referencing an entity
+        before it is inserted."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_datastore1_beta3_cli/projects_allocate-ids",
+                  vec![
+                    (Some(r##"project-id"##),
+                     None,
+                     Some(r##"The ID of the project against which to make the request."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("begin-transaction",
+                    Some(r##"Begins a new transaction."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_datastore1_beta3_cli/projects_begin-transaction",
+                  vec![
+                    (Some(r##"project-id"##),
+                     None,
+                     Some(r##"The ID of the project against which to make the request."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("commit",
+                    Some(r##"Commits a transaction, optionally creating, deleting or modifying some
+        entities."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_datastore1_beta3_cli/projects_commit",
+                  vec![
+                    (Some(r##"project-id"##),
+                     None,
+                     Some(r##"The ID of the project against which to make the request."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("lookup",
+                    Some(r##"Looks up entities by key."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_datastore1_beta3_cli/projects_lookup",
+                  vec![
+                    (Some(r##"project-id"##),
+                     None,
+                     Some(r##"The ID of the project against which to make the request."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("reserve-ids",
+                    Some(r##"Prevents the supplied keys' IDs from being auto-allocated by Cloud
+        Datastore."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_datastore1_beta3_cli/projects_reserve-ids",
+                  vec![
+                    (Some(r##"project-id"##),
+                     None,
+                     Some(r##"The ID of the project against which to make the request."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("rollback",
+                    Some(r##"Rolls back a transaction."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_datastore1_beta3_cli/projects_rollback",
+                  vec![
+                    (Some(r##"project-id"##),
+                     None,
+                     Some(r##"The ID of the project against which to make the request."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("run-query",
+                    Some(r##"Queries for entities."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_datastore1_beta3_cli/projects_run-query",
+                  vec![
+                    (Some(r##"project-id"##),
+                     None,
+                     Some(r##"The ID of the project against which to make the request."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ]),
+        
+    ];
+    
+    let mut app = App::new("datastore1-beta3")
+           .author("Sebastian Thiel <byronimo@gmail.com>")
+           .version("1.0.7+20171205")
+           .about("Accesses the schemaless NoSQL database to provide fully managed, robust, scalable storage for your application.
+           ")
+           .after_help("All documentation details can be found at http://byron.github.io/google-apis-rs/google_datastore1_beta3_cli")
+           .arg(Arg::with_name("url")
+                   .long("scope")
+                   .help("Specify the authentication a method should be executed in. Each scope requires the user to grant this application permission to use it.If unset, it defaults to the shortest scope url for a particular method.")
+                   .multiple(true)
+                   .takes_value(true))
+           .arg(Arg::with_name("folder")
+                   .long("config-dir")
+                   .help("A directory into which we will store our persistent data. Defaults to a user-writable directory that we will create during the first invocation.[default: ~/.google-service-cli")
+                   .multiple(false)
+                   .takes_value(true))
+           .arg(Arg::with_name("debug")
+                   .long("debug")
+                   .help("Output all server communication to standard error. `tx` and `rx` are placed into the same stream.")
+                   .multiple(false)
+                   .takes_value(false))
+           .arg(Arg::with_name("debug-auth")
+                   .long("debug-auth")
+                   .help("Output all communication related to authentication to standard error. `tx` and `rx` are placed into the same stream.")
+                   .multiple(false)
+                   .takes_value(false));
+           
+           for &(main_command_name, about, ref subcommands) in arg_data.iter() {
+               let mut mcmd = SubCommand::with_name(main_command_name).about(about);
+           
+               for &(sub_command_name, ref desc, url_info, ref args) in subcommands {
+                   let mut scmd = SubCommand::with_name(sub_command_name);
+                   if let &Some(desc) = desc {
+                       scmd = scmd.about(desc);
+                   }
+                   scmd = scmd.after_help(url_info);
+           
+                   for &(ref arg_name, ref flag, ref desc, ref required, ref multi) in args {
+                       let arg_name_str =
+                           match (arg_name, flag) {
+                                   (&Some(an), _       ) => an,
+                                   (_        , &Some(f)) => f,
+                                    _                    => unreachable!(),
+                            };
+                       let mut arg = Arg::with_name(arg_name_str)
+                                         .empty_values(false);
+                       if let &Some(short_flag) = flag {
+                           arg = arg.short(short_flag);
+                       }
+                       if let &Some(desc) = desc {
+                           arg = arg.help(desc);
+                       }
+                       if arg_name.is_some() && flag.is_some() {
+                           arg = arg.takes_value(true);
+                       }
+                       if let &Some(required) = required {
+                           arg = arg.required(required);
+                       }
+                       if let &Some(multi) = multi {
+                           arg = arg.multiple(multi);
+                       }
+                       scmd = scmd.arg(arg);
+                   }
+                   mcmd = mcmd.subcommand(scmd);
+               }
+               app = app.subcommand(mcmd);
+           }
+           
+        let matches = app.get_matches();
+
+    let debug = matches.is_present("debug");
+    match Engine::new(matches) {
+        Err(err) => {
+            exit_status = err.exit_code;
+            writeln!(io::stderr(), "{}", err).ok();
+        },
+        Ok(engine) => {
+            if let Err(doit_err) = engine.doit() {
+                exit_status = 1;
+                match doit_err {
+                    DoitError::IoError(path, err) => {
+                        writeln!(io::stderr(), "Failed to open output file '{}': {}", path, err).ok();
+                    },
+                    DoitError::ApiError(err) => {
+                        if debug {
+                            writeln!(io::stderr(), "{:#?}", err).ok();
+                        } else {
+                            writeln!(io::stderr(), "{}", err).ok();
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    std::process::exit(exit_status);
+}

--- a/gen/datastore1_beta3/Cargo.toml
+++ b/gen/datastore1_beta3/Cargo.toml
@@ -1,0 +1,31 @@
+# DO NOT EDIT !
+# This file was generated automatically from 'src/mako/Cargo.toml.mako'
+# DO NOT EDIT !
+[package]
+
+name = "google-datastore1_beta3"
+version = "1.0.7+20171205"
+authors = ["Sebastian Thiel <byronimo@gmail.com>"]
+description = "A complete library to interact with datastore (protocol v1beta3)"
+repository = "https://github.com/Byron/google-apis-rs/tree/master/gen/datastore1_beta3"
+homepage = "https://cloud.google.com/datastore/"
+documentation = "https://docs.rs/google-datastore1_beta3/1.0.7+20171205"
+license = "MIT"
+keywords = ["datastore", "google", "protocol", "web", "api"]
+
+
+[dev-dependencies]
+hyper-rustls = "^0.6"
+
+[dependencies]
+hyper = "^ 0.10"
+mime = "^ 0.2.0"
+serde = "^ 1.0"
+serde_json = "^ 1.0"
+serde_derive = "^ 1.0"
+yup-oauth2 = "^ 1.0"
+url = "= 0.5"
+
+[features]
+
+

--- a/gen/datastore1_beta3/LICENSE.md
+++ b/gen/datastore1_beta3/LICENSE.md
@@ -1,0 +1,30 @@
+<!---
+DO NOT EDIT !
+This file was generated automatically from 'src/mako/LICENSE.md.mako'
+DO NOT EDIT !
+-->
+The MIT License (MIT)
+=====================
+
+Copyright © `2015-2016` `Sebastian Thiel`
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the “Software”), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.

--- a/gen/datastore1_beta3/README.md
+++ b/gen/datastore1_beta3/README.md
@@ -1,0 +1,180 @@
+<!---
+DO NOT EDIT !
+This file was generated automatically from 'src/mako/api/README.md.mako'
+DO NOT EDIT !
+-->
+The `google-datastore1_beta3` library allows access to all features of the *Google datastore* service.
+
+This documentation was generated from *datastore* crate version *1.0.7+20171205*, where *20171205* is the exact revision of the *datastore:v1beta3* schema built by the [mako](http://www.makotemplates.org/) code generator *v1.0.7*.
+
+Everything else about the *datastore* *v1_beta3* API can be found at the
+[official documentation site](https://cloud.google.com/datastore/).
+# Features
+
+Handle the following *Resources* with ease from the central [hub](https://docs.rs/google-datastore1_beta3/1.0.7+20171205/google_datastore1_beta3/struct.Datastore.html) ... 
+
+* projects
+ * [*allocate ids*](https://docs.rs/google-datastore1_beta3/1.0.7+20171205/google_datastore1_beta3/struct.ProjectAllocateIdCall.html), [*begin transaction*](https://docs.rs/google-datastore1_beta3/1.0.7+20171205/google_datastore1_beta3/struct.ProjectBeginTransactionCall.html), [*commit*](https://docs.rs/google-datastore1_beta3/1.0.7+20171205/google_datastore1_beta3/struct.ProjectCommitCall.html), [*lookup*](https://docs.rs/google-datastore1_beta3/1.0.7+20171205/google_datastore1_beta3/struct.ProjectLookupCall.html), [*reserve ids*](https://docs.rs/google-datastore1_beta3/1.0.7+20171205/google_datastore1_beta3/struct.ProjectReserveIdCall.html), [*rollback*](https://docs.rs/google-datastore1_beta3/1.0.7+20171205/google_datastore1_beta3/struct.ProjectRollbackCall.html) and [*run query*](https://docs.rs/google-datastore1_beta3/1.0.7+20171205/google_datastore1_beta3/struct.ProjectRunQueryCall.html)
+
+
+
+
+# Structure of this Library
+
+The API is structured into the following primary items:
+
+* **[Hub](https://docs.rs/google-datastore1_beta3/1.0.7+20171205/google_datastore1_beta3/struct.Datastore.html)**
+    * a central object to maintain state and allow accessing all *Activities*
+    * creates [*Method Builders*](https://docs.rs/google-datastore1_beta3/1.0.7+20171205/google_datastore1_beta3/trait.MethodsBuilder.html) which in turn
+      allow access to individual [*Call Builders*](https://docs.rs/google-datastore1_beta3/1.0.7+20171205/google_datastore1_beta3/trait.CallBuilder.html)
+* **[Resources](https://docs.rs/google-datastore1_beta3/1.0.7+20171205/google_datastore1_beta3/trait.Resource.html)**
+    * primary types that you can apply *Activities* to
+    * a collection of properties and *Parts*
+    * **[Parts](https://docs.rs/google-datastore1_beta3/1.0.7+20171205/google_datastore1_beta3/trait.Part.html)**
+        * a collection of properties
+        * never directly used in *Activities*
+* **[Activities](https://docs.rs/google-datastore1_beta3/1.0.7+20171205/google_datastore1_beta3/trait.CallBuilder.html)**
+    * operations to apply to *Resources*
+
+All *structures* are marked with applicable traits to further categorize them and ease browsing.
+
+Generally speaking, you can invoke *Activities* like this:
+
+```Rust,ignore
+let r = hub.resource().activity(...).doit()
+```
+
+Or specifically ...
+
+```ignore
+let r = hub.projects().run_query(...).doit()
+```
+
+The `resource()` and `activity(...)` calls create [builders][builder-pattern]. The second one dealing with `Activities` 
+supports various methods to configure the impending operation (not shown here). It is made such that all required arguments have to be 
+specified right away (i.e. `(...)`), whereas all optional ones can be [build up][builder-pattern] as desired.
+The `doit()` method performs the actual communication with the server and returns the respective result.
+
+# Usage
+
+## Setting up your Project
+
+To use this library, you would put the following lines into your `Cargo.toml` file:
+
+```toml
+[dependencies]
+google-datastore1_beta3 = "*"
+```
+
+## A complete example
+
+```Rust
+extern crate hyper;
+extern crate hyper_rustls;
+extern crate yup_oauth2 as oauth2;
+extern crate google_datastore1_beta3 as datastore1_beta3;
+use datastore1_beta3::RunQueryRequest;
+use datastore1_beta3::{Result, Error};
+use std::default::Default;
+use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+use datastore1_beta3::Datastore;
+
+// Get an ApplicationSecret instance by some means. It contains the `client_id` and 
+// `client_secret`, among other things.
+let secret: ApplicationSecret = Default::default();
+// Instantiate the authenticator. It will choose a suitable authentication flow for you, 
+// unless you replace  `None` with the desired Flow.
+// Provide your own `AuthenticatorDelegate` to adjust the way it operates and get feedback about 
+// what's going on. You probably want to bring in your own `TokenStorage` to persist tokens and
+// retrieve them from storage.
+let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+                              hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+                              <MemoryStorage as Default>::default(), None);
+let mut hub = Datastore::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+// As the method needs a request, you would usually fill it with the desired information
+// into the respective structure. Some of the parts shown here might not be applicable !
+// Values shown here are possibly random and not representative !
+let mut req = RunQueryRequest::default();
+
+// You can configure optional parameters by calling the respective setters at will, and
+// execute the final call using `doit()`.
+// Values shown here are possibly random and not representative !
+let result = hub.projects().run_query(req, "projectId")
+             .doit();
+
+match result {
+    Err(e) => match e {
+        // The Error enum provides details about what exactly happened.
+        // You can also just use its `Debug`, `Display` or `Error` traits
+         Error::HttpError(_)
+        |Error::MissingAPIKey
+        |Error::MissingToken(_)
+        |Error::Cancelled
+        |Error::UploadSizeLimitExceeded(_, _)
+        |Error::Failure(_)
+        |Error::BadRequest(_)
+        |Error::FieldClash(_)
+        |Error::JsonDecodeError(_, _) => println!("{}", e),
+    },
+    Ok(res) => println!("Success: {:?}", res),
+}
+
+```
+## Handling Errors
+
+All errors produced by the system are provided either as [Result](https://docs.rs/google-datastore1_beta3/1.0.7+20171205/google_datastore1_beta3/enum.Result.html) enumeration as return value of 
+the doit() methods, or handed as possibly intermediate results to either the 
+[Hub Delegate](https://docs.rs/google-datastore1_beta3/1.0.7+20171205/google_datastore1_beta3/trait.Delegate.html), or the [Authenticator Delegate](https://docs.rs/yup-oauth2/*/yup_oauth2/trait.AuthenticatorDelegate.html).
+
+When delegates handle errors or intermediate values, they may have a chance to instruct the system to retry. This 
+makes the system potentially resilient to all kinds of errors.
+
+## Uploads and Downloads
+If a method supports downloads, the response body, which is part of the [Result](https://docs.rs/google-datastore1_beta3/1.0.7+20171205/google_datastore1_beta3/enum.Result.html), should be
+read by you to obtain the media.
+If such a method also supports a [Response Result](https://docs.rs/google-datastore1_beta3/1.0.7+20171205/google_datastore1_beta3/trait.ResponseResult.html), it will return that by default.
+You can see it as meta-data for the actual media. To trigger a media download, you will have to set up the builder by making
+this call: `.param("alt", "media")`.
+
+Methods supporting uploads can do so using up to 2 different protocols: 
+*simple* and *resumable*. The distinctiveness of each is represented by customized 
+`doit(...)` methods, which are then named `upload(...)` and `upload_resumable(...)` respectively.
+
+## Customization and Callbacks
+
+You may alter the way an `doit()` method is called by providing a [delegate](https://docs.rs/google-datastore1_beta3/1.0.7+20171205/google_datastore1_beta3/trait.Delegate.html) to the 
+[Method Builder](https://docs.rs/google-datastore1_beta3/1.0.7+20171205/google_datastore1_beta3/trait.CallBuilder.html) before making the final `doit()` call. 
+Respective methods will be called to provide progress information, as well as determine whether the system should 
+retry on failure.
+
+The [delegate trait](https://docs.rs/google-datastore1_beta3/1.0.7+20171205/google_datastore1_beta3/trait.Delegate.html) is default-implemented, allowing you to customize it with minimal effort.
+
+## Optional Parts in Server-Requests
+
+All structures provided by this library are made to be [enocodable](https://docs.rs/google-datastore1_beta3/1.0.7+20171205/google_datastore1_beta3/trait.RequestValue.html) and 
+[decodable](https://docs.rs/google-datastore1_beta3/1.0.7+20171205/google_datastore1_beta3/trait.ResponseResult.html) via *json*. Optionals are used to indicate that partial requests are responses 
+are valid.
+Most optionals are are considered [Parts](https://docs.rs/google-datastore1_beta3/1.0.7+20171205/google_datastore1_beta3/trait.Part.html) which are identifiable by name, which will be sent to 
+the server to indicate either the set parts of the request or the desired parts in the response.
+
+## Builder Arguments
+
+Using [method builders](https://docs.rs/google-datastore1_beta3/1.0.7+20171205/google_datastore1_beta3/trait.CallBuilder.html), you are able to prepare an action call by repeatedly calling it's methods.
+These will always take a single argument, for which the following statements are true.
+
+* [PODs][wiki-pod] are handed by copy
+* strings are passed as `&str`
+* [request values](https://docs.rs/google-datastore1_beta3/1.0.7+20171205/google_datastore1_beta3/trait.RequestValue.html) are moved
+
+Arguments will always be copied or cloned into the builder, to make them independent of their original life times.
+
+[wiki-pod]: http://en.wikipedia.org/wiki/Plain_old_data_structure
+[builder-pattern]: http://en.wikipedia.org/wiki/Builder_pattern
+[google-go-api]: https://github.com/google/google-api-go-client
+
+# License
+The **datastore1_beta3** library was generated by Sebastian Thiel, and is placed 
+under the *MIT* license.
+You can read the full text at the repository's [license file][repo-license].
+
+[repo-license]: https://github.com/Byron/google-apis-rsblob/master/LICENSE.md

--- a/gen/datastore1_beta3/src/cmn.rs
+++ b/gen/datastore1_beta3/src/cmn.rs
@@ -1,0 +1,753 @@
+// COPY OF 'src/rust/api/cmn.rs'
+// DO NOT EDIT
+use std::io::{self, Read, Seek, Cursor, Write, SeekFrom};
+use std;
+use std::fmt::{self, Display};
+use std::str::FromStr;
+use std::error;
+use std::thread::sleep;
+use std::time::Duration;
+
+use mime::{Mime, TopLevel, SubLevel, Attr, Value};
+use oauth2::{TokenType, Retry, self};
+use hyper;
+use hyper::header::{ContentType, ContentLength, Headers, UserAgent, Authorization, Header,
+                    HeaderFormat, Bearer};
+use hyper::http::h1::LINE_ENDING;
+use hyper::method::Method;
+use hyper::status::StatusCode;
+
+use serde_json as json;
+
+/// Identifies the Hub. There is only one per library, this trait is supposed
+/// to make intended use more explicit.
+/// The hub allows to access all resource methods more easily.
+pub trait Hub {}
+
+/// Identifies types for building methods of a particular resource type
+pub trait MethodsBuilder {}
+
+/// Identifies types which represent builders for a particular resource method
+pub trait CallBuilder {}
+
+/// Identifies types which can be inserted and deleted.
+/// Types with this trait are most commonly used by clients of this API.
+pub trait Resource {}
+
+/// Identifies types which are used in API responses.
+pub trait ResponseResult {}
+
+/// Identifies types which are used in API requests.
+pub trait RequestValue {}
+
+/// Identifies types which are not actually used by the API
+/// This might be a bug within the google API schema.
+pub trait UnusedType {}
+
+/// Identifies types which are only used as part of other types, which
+/// usually are carrying the `Resource` trait.
+pub trait Part {}
+
+/// Identifies types which are only used by other types internally.
+/// They have no special meaning, this trait just marks them for completeness.
+pub trait NestedType {}
+
+/// A utility to specify reader types which provide seeking capabilities too
+pub trait ReadSeek: Seek + Read {}
+impl<T: Seek + Read> ReadSeek for T {}
+
+/// A trait for all types that can convert themselves into a *parts* string
+pub trait ToParts {
+    fn to_parts(&self) -> String;
+}
+
+/// A utility type which can decode a server response that indicates error
+#[derive(Deserialize)]
+pub struct JsonServerError {
+    pub error: String,
+    pub error_description: Option<String>
+}
+
+/// A utility to represent detailed errors we might see in case there are BadRequests.
+/// The latter happen if the sent parameters or request structures are unsound
+#[derive(Deserialize, Serialize, Debug)]
+pub struct ErrorResponse {
+    error: ServerError,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct ServerError {
+    errors: Vec<ServerMessage>,
+    code: u16,
+    message: String,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct ServerMessage {
+    domain: String,
+    reason: String,
+    message: String,
+    #[serde(rename="locationType")]
+    location_type: Option<String>,
+    location: Option<String>
+}
+
+#[derive(Copy, Clone)]
+pub struct DummyNetworkStream;
+
+impl Read for DummyNetworkStream {
+    fn read(&mut self, _: &mut [u8]) -> io::Result<usize> {
+        Ok(0)
+    }
+}
+
+impl Write for DummyNetworkStream {
+    fn write(&mut self, _: &[u8]) -> io::Result<usize> {
+        Ok(0)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl hyper::net::NetworkStream for DummyNetworkStream {
+    fn peer_addr(&mut self) -> io::Result<std::net::SocketAddr> {
+        Ok("127.0.0.1:1337".parse().unwrap())
+    }
+
+    fn set_read_timeout(&self, _dur: Option<Duration>) -> io::Result<()> {
+        Ok(())
+    }
+
+    fn set_write_timeout(&self, _dur: Option<Duration>) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+
+/// A trait specifying functionality to help controlling any request performed by the API.
+/// The trait has a conservative default implementation.
+///
+/// It contains methods to deal with all common issues, as well with the ones related to
+/// uploading media
+pub trait Delegate {
+
+    /// Called at the beginning of any API request. The delegate should store the method
+    /// information if he is interesting in knowing more context when further calls to it
+    /// are made.
+    /// The matching `finished()` call will always be made, no matter whether or not the API
+    /// request was successful. That way, the delegate may easily maintain a clean state
+    /// between various API calls.
+    fn begin(&mut self, MethodInfo) {}
+
+    /// Called whenever there is an [HttpError](http://hyperium.github.io/hyper/hyper/error/enum.HttpError.html), usually if there are network problems.
+    ///
+    /// If you choose to retry after a duration, the duration should be chosen using the
+    /// [exponential backoff algorithm](http://en.wikipedia.org/wiki/Exponential_backoff).
+    ///
+    /// Return retry information.
+    fn http_error(&mut self, &hyper::Error) -> Retry {
+        Retry::Abort
+    }
+
+    /// Called whenever there is the need for your applications API key after
+    /// the official authenticator implementation didn't provide one, for some reason.
+    /// If this method returns None as well, the underlying operation will fail
+    fn api_key(&mut self) -> Option<String> {
+        None
+    }
+
+    /// Called whenever the Authenticator didn't yield a token. The delegate
+    /// may attempt to provide one, or just take it as a general information about the
+    /// impending failure.
+    /// The given Error provides information about why the token couldn't be acquired in the
+    /// first place
+    fn token(&mut self, err: &error::Error) -> Option<oauth2::Token> {
+        let _ = err;
+        None
+    }
+
+    /// Called during resumable uploads to provide a URL for the impending upload.
+    /// It was saved after a previous call to `store_upload_url(...)`, and if not None,
+    /// will be used instead of asking the server for a new upload URL.
+    /// This is useful in case a previous resumable upload was aborted/canceled, but should now
+    /// be resumed.
+    /// The returned URL will be used exactly once - if it fails again and the delegate allows
+    /// to retry, we will ask the server for a new upload URL.
+    fn upload_url(&mut self) -> Option<String> {
+        None
+    }
+
+    /// Called after we have retrieved a new upload URL for a resumable upload to store it
+    /// in case we fail or cancel. That way, we can attempt to resume the upload later,
+    /// see `upload_url()`.
+    /// It will also be called with None after a successful upload, which allows the delegate
+    /// to forget the URL. That way, we will not attempt to resume an upload that has already
+    /// finished.
+    fn store_upload_url(&mut self, url: Option<&str>) {
+        let _ = url;
+    }
+
+    /// Called whenever a server response could not be decoded from json.
+    /// It's for informational purposes only, the caller will return with an error
+    /// accordingly.
+    ///
+    /// # Arguments
+    ///
+    /// * `json_encoded_value` - The json-encoded value which failed to decode.
+    /// * `json_decode_error`  - The decoder error
+    fn response_json_decode_error(&mut self, json_encoded_value: &str, json_decode_error: &json::Error) {
+        let _ = json_encoded_value;
+        let _ = json_decode_error;
+    }
+
+    /// Called whenever the http request returns with a non-success status code.
+    /// This can involve authentication issues, or anything else that very much
+    /// depends on the used API method.
+    /// The delegate should check the status, header and decoded json error to decide
+    /// whether to retry or not. In the latter case, the underlying call will fail.
+    ///
+    /// If you choose to retry after a duration, the duration should be chosen using the
+    /// [exponential backoff algorithm](http://en.wikipedia.org/wiki/Exponential_backoff).
+    fn http_failure(&mut self, _: &hyper::client::Response, Option<JsonServerError>, _: Option<ServerError>) -> Retry {
+        Retry::Abort
+    }
+
+    /// Called prior to sending the main request of the given method. It can be used to time
+    /// the call or to print progress information.
+    /// It's also useful as you can be sure that a request will definitely be made.
+    fn pre_request(&mut self) { }
+
+    /// Return the size of each chunk of a resumable upload.
+    /// Must be a power of two, with 1<<18 being the smallest allowed chunk size.
+    /// Will be called once before starting any resumable upload.
+    fn chunk_size(&mut self) -> u64 {
+        1 << 23
+    }
+
+    /// Called before the given chunk is uploaded to the server.
+    /// If true is returned, the upload will be interrupted.
+    /// However, it may be resumable if you stored the upload URL in a previous call
+    /// to `store_upload_url()`
+    fn cancel_chunk_upload(&mut self, chunk: &ContentRange) -> bool {
+        let _ = chunk;
+        false
+    }
+
+    /// Called before the API request method returns, in every case. It can be used to clean up
+    /// internal state between calls to the API.
+    /// This call always has a matching call to `begin(...)`.
+    ///
+    /// # Arguments
+    ///
+    /// * `is_success` - a true value indicates the operation was successful. If false, you should
+    ///                  discard all values stored during `store_upload_url`.
+    fn finished(&mut self, is_success: bool) {
+        let _ = is_success;
+    }
+}
+
+/// A delegate with a conservative default implementation, which is used if no other delegate is
+/// set.
+#[derive(Default)]
+pub struct DefaultDelegate;
+
+impl Delegate for DefaultDelegate {}
+
+
+#[derive(Debug)]
+pub enum Error {
+    /// The http connection failed
+    HttpError(hyper::Error),
+
+    /// An attempt was made to upload a resource with size stored in field `.0`
+    /// even though the maximum upload size is what is stored in field `.1`.
+    UploadSizeLimitExceeded(u64, u64),
+
+    /// Represents information about a request that was not understood by the server.
+    /// Details are included.
+    BadRequest(ErrorResponse),
+
+    /// We needed an API key for authentication, but didn't obtain one.
+    /// Neither through the authenticator, nor through the Delegate.
+    MissingAPIKey,
+
+    /// We required a Token, but didn't get one from the Authenticator
+    MissingToken(Box<error::Error>),
+
+    /// The delgate instructed to cancel the operation
+    Cancelled,
+
+    /// An additional, free form field clashed with one of the built-in optional ones
+    FieldClash(&'static str),
+
+    /// Shows that we failed to decode the server response.
+    /// This can happen if the protocol changes in conjunction with strict json decoding.
+    JsonDecodeError(String, json::Error),
+
+    /// Indicates an HTTP repsonse with a non-success status code
+    Failure(hyper::client::Response),
+}
+
+
+impl Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Error::HttpError(ref err) => err.fmt(f),
+            Error::UploadSizeLimitExceeded(ref resource_size, ref max_size) =>
+                writeln!(f, "The media size {} exceeds the maximum allowed upload size of {}"
+                         , resource_size, max_size),
+            Error::MissingAPIKey => {
+                (writeln!(f, "The application's API key was not found in the configuration")).ok();
+                writeln!(f, "It is used as there are no Scopes defined for this method.")
+            },
+            Error::BadRequest(ref err) => {
+                try!(writeln!(f, "Bad Request ({}): {}", err.error.code, err.error.message));
+                for err in err.error.errors.iter() {
+                    try!(writeln!(f, "    {}: {}, {}{}",
+                                            err.domain,
+                                            err.message,
+                                            err.reason,
+                                            match &err.location {
+                                                &Some(ref loc) => format!("@{}", loc),
+                                                &None => String::new(),
+                                            }));
+                }
+                Ok(())
+            },
+            Error::MissingToken(ref err) =>
+                writeln!(f, "Token retrieval failed with error: {}", err),
+            Error::Cancelled =>
+                writeln!(f, "Operation cancelled by delegate"),
+            Error::FieldClash(field) =>
+                writeln!(f, "The custom parameter '{}' is already provided natively by the CallBuilder.", field),
+            Error::JsonDecodeError(ref json_str, ref err)
+                => writeln!(f, "{}: {}", err, json_str),
+            Error::Failure(ref response) =>
+                writeln!(f, "Http status indicates failure: {:?}", response),
+        }
+    }
+}
+
+impl error::Error for Error {
+    fn description(&self) -> &str {
+        match *self {
+            Error::HttpError(ref err) => err.description(),
+            Error::JsonDecodeError(_, ref err) => err.description(),
+            _ => "NO DESCRIPTION POSSIBLE - use `Display.fmt()` instead"
+        }
+    }
+
+    fn cause(&self) -> Option<&error::Error> {
+        match *self {
+            Error::HttpError(ref err) => err.cause(),
+            Error::JsonDecodeError(_, ref err) => err.cause(),
+            _ => None
+        }
+    }
+}
+
+/// A universal result type used as return for all calls.
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Contains information about an API request.
+pub struct MethodInfo {
+    pub id: &'static str,
+    pub http_method: Method,
+}
+
+const BOUNDARY: &'static str = "MDuXWGyeE33QFXGchb2VFWc4Z7945d";
+
+/// Provides a `Read` interface that converts multiple parts into the protocol
+/// identified by [RFC2387](https://tools.ietf.org/html/rfc2387).
+/// **Note**: This implementation is just as rich as it needs to be to perform uploads
+/// to google APIs, and might not be a fully-featured implementation.
+#[derive(Default)]
+pub struct MultiPartReader<'a> {
+    raw_parts: Vec<(Headers, &'a mut Read)>,
+    current_part: Option<(Cursor<Vec<u8>>, &'a mut Read)>,
+    last_part_boundary: Option<Cursor<Vec<u8>>>,
+}
+
+impl<'a> MultiPartReader<'a> {
+
+    /// Reserve memory for exactly the given amount of parts
+    pub fn reserve_exact(&mut self, cap: usize) {
+        self.raw_parts.reserve_exact(cap);
+    }
+
+    /// Add a new part to the queue of parts to be read on the first `read` call.
+    ///
+    /// # Arguments
+    ///
+    /// `headers` - identifying the body of the part. It's similar to the header
+    ///             in an ordinary single-part call, and should thus contain the
+    ///             same information.
+    /// `reader`  - a reader providing the part's body
+    /// `size`    - the amount of bytes provided by the reader. It will be put onto the header as
+    ///             content-size.
+    /// `mime`    - It will be put onto the content type
+    pub fn add_part(&mut self, reader: &'a mut Read, size: u64, mime_type: Mime) -> &mut MultiPartReader<'a> {
+        let mut headers = Headers::new();
+        headers.set(ContentType(mime_type));
+        headers.set(ContentLength(size));
+        self.raw_parts.push((headers, reader));
+        self
+    }
+
+    /// Returns the mime-type representing our multi-part message.
+    /// Use it with the ContentType header.
+    pub fn mime_type(&self) -> Mime {
+        Mime(
+            TopLevel::Multipart,
+            SubLevel::Ext("Related".to_string()),
+            vec![(Attr::Ext("boundary".to_string()), Value::Ext(BOUNDARY.to_string()))],
+        )
+    }
+
+    /// Returns true if we are totally used
+    fn is_depleted(&self) -> bool {
+        self.raw_parts.len() == 0 && self.current_part.is_none() && self.last_part_boundary.is_none()
+    }
+
+    /// Returns true if we are handling our last part
+    fn is_last_part(&self) -> bool {
+        self.raw_parts.len() == 0 && self.current_part.is_some()
+    }
+}
+
+impl<'a> Read for MultiPartReader<'a> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        match (self.raw_parts.len(),
+               self.current_part.is_none(),
+               self.last_part_boundary.is_none()) {
+            (_, _, false) => {
+                let br = self.last_part_boundary.as_mut().unwrap().read(buf).unwrap_or(0);
+                if br < buf.len() {
+                    self.last_part_boundary = None;
+                }
+                return Ok(br)
+            },
+            (0, true, true) => return Ok(0),
+            (n, true, _) if n > 0 => {
+                let (headers, reader) = self.raw_parts.remove(0);
+                let mut c = Cursor::new(Vec::<u8>::new());
+                (write!(&mut c, "{}--{}{}{}{}", LINE_ENDING, BOUNDARY, LINE_ENDING,
+                                                headers, LINE_ENDING)).unwrap();
+                c.seek(SeekFrom::Start(0)).unwrap();
+                self.current_part = Some((c, reader));
+            }
+            _ => {},
+        }
+
+        // read headers as long as possible
+        let (hb, rr) = {
+            let &mut (ref mut c, ref mut reader) = self.current_part.as_mut().unwrap();
+            let b = c.read(buf).unwrap_or(0);
+            (b, reader.read(&mut buf[b..]))
+        };
+
+        match rr {
+            Ok(bytes_read) => {
+                if hb < buf.len() && bytes_read == 0 {
+                    if self.is_last_part() {
+                        // before clearing the last part, we will add the boundary that
+                        // will be written last
+                        self.last_part_boundary = Some(Cursor::new(
+                                                        format!("{}--{}--", LINE_ENDING, BOUNDARY).into_bytes()))
+                    }
+                    // We are depleted - this can trigger the next part to come in
+                    self.current_part = None;
+                }
+                let mut total_bytes_read = hb + bytes_read;
+                while total_bytes_read < buf.len() && !self.is_depleted() {
+                    match self.read(&mut buf[total_bytes_read ..]) {
+                        Ok(br) => total_bytes_read += br,
+                        Err(err) => return Err(err),
+                    }
+                }
+                Ok(total_bytes_read)
+            }
+            Err(err) => {
+                // fail permanently
+                self.current_part = None;
+                self.last_part_boundary = None;
+                self.raw_parts.clear();
+                Err(err)
+            }
+        }
+    }
+}
+
+/// The `X-Upload-Content-Type` header.
+///
+/// Generated via rustc --pretty expanded -Z unstable-options, and manually
+/// processed to be more readable.
+#[derive(PartialEq, Debug, Clone)]
+pub struct XUploadContentType(pub Mime);
+
+impl ::std::ops::Deref for XUploadContentType {
+    type Target = Mime;
+    fn deref<'a>(&'a self) -> &'a Mime { &self.0 }
+}
+impl ::std::ops::DerefMut for XUploadContentType {
+    fn deref_mut<'a>(&'a mut self) -> &'a mut Mime { &mut self.0 }
+}
+impl Header for XUploadContentType {
+    fn header_name() -> &'static str { "X-Upload-Content-Type" }
+    fn parse_header(raw: &[Vec<u8>]) -> hyper::error::Result<Self> {
+        hyper::header::parsing::from_one_raw_str(raw).map(XUploadContentType)
+    }
+}
+impl HeaderFormat for XUploadContentType {
+    fn fmt_header(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        Display::fmt(&**self, f)
+    }
+}
+impl Display for XUploadContentType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(&**self, f)
+    }
+}
+
+#[derive(Clone, PartialEq, Debug)]
+pub struct Chunk {
+    pub first: u64,
+    pub last: u64
+}
+
+impl fmt::Display for Chunk {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        (write!(fmt, "{}-{}", self.first, self.last)).ok();
+        Ok(())
+    }
+}
+
+impl FromStr for Chunk {
+    type Err = &'static str;
+
+    /// NOTE: only implements `%i-%i`, not `*`
+    fn from_str(s: &str) -> std::result::Result<Chunk, &'static str> {
+        let parts: Vec<&str> = s.split('-').collect();
+        if parts.len() != 2 {
+            return Err("Expected two parts: %i-%i")
+        }
+        Ok(
+            Chunk {
+                first: match FromStr::from_str(parts[0]) {
+                    Ok(d) => d,
+                    _ => return Err("Couldn't parse 'first' as digit")
+                },
+                last: match FromStr::from_str(parts[1]) {
+                    Ok(d) => d,
+                    _ => return Err("Couldn't parse 'last' as digit")
+                }
+            }
+        )
+    }
+}
+
+/// Implements the Content-Range header, for serialization only
+#[derive(Clone, PartialEq, Debug)]
+pub struct ContentRange {
+    pub range: Option<Chunk>,
+    pub total_length: u64,
+}
+
+impl Header for ContentRange {
+    fn header_name() -> &'static str {
+        "Content-Range"
+    }
+
+    /// We are not parsable, as parsing is done by the `Range` header
+    fn parse_header(_: &[Vec<u8>]) -> hyper::error::Result<Self> {
+        Err(hyper::error::Error::Method)
+    }
+}
+
+
+impl HeaderFormat for ContentRange {
+    fn fmt_header(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        try!(fmt.write_str("bytes "));
+        match self.range {
+            Some(ref c) => try!(c.fmt(fmt)),
+            None => try!(fmt.write_str("*"))
+        }
+        (write!(fmt, "/{}", self.total_length)).ok();
+        Ok(())
+    }
+}
+
+#[derive(Clone, PartialEq, Debug)]
+pub struct RangeResponseHeader(pub Chunk);
+
+impl Header for RangeResponseHeader {
+    fn header_name() -> &'static str {
+        "Range"
+    }
+
+    fn parse_header(raw: &[Vec<u8>]) -> hyper::error::Result<Self> {
+        if raw.len() > 0 {
+            let v = &raw[0];
+            if let Ok(s) = std::str::from_utf8(v) {
+                const PREFIX: &'static str = "bytes ";
+                if s.starts_with(PREFIX) {
+                    if let Ok(c) = <Chunk as FromStr>::from_str(&s[PREFIX.len()..]) {
+                        return  Ok(RangeResponseHeader(c))
+                    }
+                }
+            }
+        }
+        Err(hyper::error::Error::Method)
+    }
+}
+
+impl HeaderFormat for RangeResponseHeader {
+    /// No implmentation necessary, we just need to parse
+    fn fmt_header(&self, _: &mut fmt::Formatter) -> fmt::Result {
+        Err(fmt::Error)
+    }
+}
+
+/// A utility type to perform a resumable upload from start to end.
+pub struct ResumableUploadHelper<'a, A: 'a> {
+    pub client: &'a mut hyper::client::Client,
+    pub delegate: &'a mut Delegate,
+    pub start_at: Option<u64>,
+    pub auth: &'a mut A,
+    pub user_agent: &'a str,
+    pub auth_header: Authorization<Bearer>,
+    pub url: &'a str,
+    pub reader: &'a mut ReadSeek,
+    pub media_type: Mime,
+    pub content_length: u64
+}
+
+impl<'a, A> ResumableUploadHelper<'a, A>
+    where A: oauth2::GetToken {
+
+    fn query_transfer_status(&mut self) -> std::result::Result<u64, hyper::Result<hyper::client::Response>> {
+        loop {
+            match self.client.post(self.url)
+                .header(UserAgent(self.user_agent.to_string()))
+                .header(ContentRange { range: None, total_length: self.content_length })
+                .header(self.auth_header.clone())
+                .send() {
+                Ok(r) => {
+                    // 308 = resume-incomplete == PermanentRedirect
+                    let headers = r.headers.clone();
+                    let h: &RangeResponseHeader = match headers.get() {
+                        Some(hh) if r.status == StatusCode::PermanentRedirect => hh,
+                        None|Some(_) => {
+                            if let Retry::After(d) = self.delegate.http_failure(&r, None, None) {
+                                sleep(d);
+                                continue;
+                            }
+                            return Err(Ok(r))
+                        }
+                    };
+                    return Ok(h.0.last)
+                }
+                Err(err) => {
+                    if let Retry::After(d) = self.delegate.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    return Err(Err(err))
+                }
+            }
+        }
+    }
+
+    /// returns None if operation was cancelled by delegate, or the HttpResult.
+    /// It can be that we return the result just because we didn't understand the status code -
+    /// caller should check for status himself before assuming it's OK to use
+    pub fn upload(&mut self) -> Option<hyper::Result<hyper::client::Response>> {
+        let mut start = match self.start_at {
+            Some(s) => s,
+            None => match self.query_transfer_status() {
+                Ok(s) => s,
+                Err(result) => return Some(result)
+            }
+        };
+
+        const MIN_CHUNK_SIZE: u64 = 1 << 18;
+        let chunk_size = match self.delegate.chunk_size() {
+            cs if cs > MIN_CHUNK_SIZE => cs,
+            _ => MIN_CHUNK_SIZE
+        };
+
+        self.reader.seek(SeekFrom::Start(start)).unwrap();
+        loop {
+            let request_size = match self.content_length - start {
+                rs if rs > chunk_size => chunk_size,
+                rs => rs
+            };
+
+            let mut section_reader = self.reader.take(request_size);
+            let range_header = ContentRange {
+                range: Some(Chunk {first: start, last: start + request_size - 1}),
+                total_length: self.content_length
+            };
+            start += request_size;
+            if self.delegate.cancel_chunk_upload(&range_header) {
+                return None
+            }
+            let res = self.client.post(self.url)
+                                 .header(range_header)
+                                 .header(ContentType(self.media_type.clone()))
+                                 .header(UserAgent(self.user_agent.to_string()))
+                                 .body(&mut section_reader)
+                                 .send();
+            match res {
+                Ok(mut res) => {
+                    if res.status == StatusCode::PermanentRedirect  {
+                        continue
+                    }
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let Retry::After(d) = self.delegate.http_failure(&res,
+                                                        json::from_str(&json_err).ok(),
+                                                        json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                    }
+                    return Some(Ok(res))
+                },
+                Err(err) => {
+                    if let Retry::After(d) = self.delegate.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    return Some(Err(err))
+                }
+            }
+        }
+    }
+}
+
+// Copy of src/rust/cli/cmn.rs
+// TODO(ST): Allow sharing common code between program types
+pub fn remove_json_null_values(value: &mut json::value::Value) {
+    match *value {
+        json::value::Value::Object(ref mut map) => {
+            let mut for_removal = Vec::new();
+
+            for (key, mut value) in map.iter_mut() {
+                if value.is_null() {
+                    for_removal.push(key.clone());
+                } else {
+                    remove_json_null_values(&mut value);
+                }
+            }
+
+            for key in &for_removal {
+                map.remove(key);
+            }
+        }
+        _ => {}
+    }
+}

--- a/gen/datastore1_beta3/src/lib.rs
+++ b/gen/datastore1_beta3/src/lib.rs
@@ -1,0 +1,3434 @@
+// DO NOT EDIT !
+// This file was generated automatically from 'src/mako/api/lib.rs.mako'
+// DO NOT EDIT !
+
+//! This documentation was generated from *datastore* crate version *1.0.7+20171205*, where *20171205* is the exact revision of the *datastore:v1beta3* schema built by the [mako](http://www.makotemplates.org/) code generator *v1.0.7*.
+//! 
+//! Everything else about the *datastore* *v1_beta3* API can be found at the
+//! [official documentation site](https://cloud.google.com/datastore/).
+//! The original source code is [on github](https://github.com/Byron/google-apis-rs/tree/master/gen/datastore1_beta3).
+//! # Features
+//! 
+//! Handle the following *Resources* with ease from the central [hub](struct.Datastore.html) ... 
+//! 
+//! * projects
+//!  * [*allocate ids*](struct.ProjectAllocateIdCall.html), [*begin transaction*](struct.ProjectBeginTransactionCall.html), [*commit*](struct.ProjectCommitCall.html), [*lookup*](struct.ProjectLookupCall.html), [*reserve ids*](struct.ProjectReserveIdCall.html), [*rollback*](struct.ProjectRollbackCall.html) and [*run query*](struct.ProjectRunQueryCall.html)
+//! 
+//! 
+//! 
+//! 
+//! Not what you are looking for ? Find all other Google APIs in their Rust [documentation index](http://byron.github.io/google-apis-rs).
+//! 
+//! # Structure of this Library
+//! 
+//! The API is structured into the following primary items:
+//! 
+//! * **[Hub](struct.Datastore.html)**
+//!     * a central object to maintain state and allow accessing all *Activities*
+//!     * creates [*Method Builders*](trait.MethodsBuilder.html) which in turn
+//!       allow access to individual [*Call Builders*](trait.CallBuilder.html)
+//! * **[Resources](trait.Resource.html)**
+//!     * primary types that you can apply *Activities* to
+//!     * a collection of properties and *Parts*
+//!     * **[Parts](trait.Part.html)**
+//!         * a collection of properties
+//!         * never directly used in *Activities*
+//! * **[Activities](trait.CallBuilder.html)**
+//!     * operations to apply to *Resources*
+//! 
+//! All *structures* are marked with applicable traits to further categorize them and ease browsing.
+//! 
+//! Generally speaking, you can invoke *Activities* like this:
+//! 
+//! ```Rust,ignore
+//! let r = hub.resource().activity(...).doit()
+//! ```
+//! 
+//! Or specifically ...
+//! 
+//! ```ignore
+//! let r = hub.projects().run_query(...).doit()
+//! ```
+//! 
+//! The `resource()` and `activity(...)` calls create [builders][builder-pattern]. The second one dealing with `Activities` 
+//! supports various methods to configure the impending operation (not shown here). It is made such that all required arguments have to be 
+//! specified right away (i.e. `(...)`), whereas all optional ones can be [build up][builder-pattern] as desired.
+//! The `doit()` method performs the actual communication with the server and returns the respective result.
+//! 
+//! # Usage
+//! 
+//! ## Setting up your Project
+//! 
+//! To use this library, you would put the following lines into your `Cargo.toml` file:
+//! 
+//! ```toml
+//! [dependencies]
+//! google-datastore1_beta3 = "*"
+//! ```
+//! 
+//! ## A complete example
+//! 
+//! ```test_harness,no_run
+//! extern crate hyper;
+//! extern crate hyper_rustls;
+//! extern crate yup_oauth2 as oauth2;
+//! extern crate google_datastore1_beta3 as datastore1_beta3;
+//! use datastore1_beta3::RunQueryRequest;
+//! use datastore1_beta3::{Result, Error};
+//! # #[test] fn egal() {
+//! use std::default::Default;
+//! use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+//! use datastore1_beta3::Datastore;
+//! 
+//! // Get an ApplicationSecret instance by some means. It contains the `client_id` and 
+//! // `client_secret`, among other things.
+//! let secret: ApplicationSecret = Default::default();
+//! // Instantiate the authenticator. It will choose a suitable authentication flow for you, 
+//! // unless you replace  `None` with the desired Flow.
+//! // Provide your own `AuthenticatorDelegate` to adjust the way it operates and get feedback about 
+//! // what's going on. You probably want to bring in your own `TokenStorage` to persist tokens and
+//! // retrieve them from storage.
+//! let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+//!                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+//!                               <MemoryStorage as Default>::default(), None);
+//! let mut hub = Datastore::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+//! // As the method needs a request, you would usually fill it with the desired information
+//! // into the respective structure. Some of the parts shown here might not be applicable !
+//! // Values shown here are possibly random and not representative !
+//! let mut req = RunQueryRequest::default();
+//! 
+//! // You can configure optional parameters by calling the respective setters at will, and
+//! // execute the final call using `doit()`.
+//! // Values shown here are possibly random and not representative !
+//! let result = hub.projects().run_query(req, "projectId")
+//!              .doit();
+//! 
+//! match result {
+//!     Err(e) => match e {
+//!         // The Error enum provides details about what exactly happened.
+//!         // You can also just use its `Debug`, `Display` or `Error` traits
+//!          Error::HttpError(_)
+//!         |Error::MissingAPIKey
+//!         |Error::MissingToken(_)
+//!         |Error::Cancelled
+//!         |Error::UploadSizeLimitExceeded(_, _)
+//!         |Error::Failure(_)
+//!         |Error::BadRequest(_)
+//!         |Error::FieldClash(_)
+//!         |Error::JsonDecodeError(_, _) => println!("{}", e),
+//!     },
+//!     Ok(res) => println!("Success: {:?}", res),
+//! }
+//! # }
+//! ```
+//! ## Handling Errors
+//! 
+//! All errors produced by the system are provided either as [Result](enum.Result.html) enumeration as return value of 
+//! the doit() methods, or handed as possibly intermediate results to either the 
+//! [Hub Delegate](trait.Delegate.html), or the [Authenticator Delegate](https://docs.rs/yup-oauth2/*/yup_oauth2/trait.AuthenticatorDelegate.html).
+//! 
+//! When delegates handle errors or intermediate values, they may have a chance to instruct the system to retry. This 
+//! makes the system potentially resilient to all kinds of errors.
+//! 
+//! ## Uploads and Downloads
+//! If a method supports downloads, the response body, which is part of the [Result](enum.Result.html), should be
+//! read by you to obtain the media.
+//! If such a method also supports a [Response Result](trait.ResponseResult.html), it will return that by default.
+//! You can see it as meta-data for the actual media. To trigger a media download, you will have to set up the builder by making
+//! this call: `.param("alt", "media")`.
+//! 
+//! Methods supporting uploads can do so using up to 2 different protocols: 
+//! *simple* and *resumable*. The distinctiveness of each is represented by customized 
+//! `doit(...)` methods, which are then named `upload(...)` and `upload_resumable(...)` respectively.
+//! 
+//! ## Customization and Callbacks
+//! 
+//! You may alter the way an `doit()` method is called by providing a [delegate](trait.Delegate.html) to the 
+//! [Method Builder](trait.CallBuilder.html) before making the final `doit()` call. 
+//! Respective methods will be called to provide progress information, as well as determine whether the system should 
+//! retry on failure.
+//! 
+//! The [delegate trait](trait.Delegate.html) is default-implemented, allowing you to customize it with minimal effort.
+//! 
+//! ## Optional Parts in Server-Requests
+//! 
+//! All structures provided by this library are made to be [enocodable](trait.RequestValue.html) and 
+//! [decodable](trait.ResponseResult.html) via *json*. Optionals are used to indicate that partial requests are responses 
+//! are valid.
+//! Most optionals are are considered [Parts](trait.Part.html) which are identifiable by name, which will be sent to 
+//! the server to indicate either the set parts of the request or the desired parts in the response.
+//! 
+//! ## Builder Arguments
+//! 
+//! Using [method builders](trait.CallBuilder.html), you are able to prepare an action call by repeatedly calling it's methods.
+//! These will always take a single argument, for which the following statements are true.
+//! 
+//! * [PODs][wiki-pod] are handed by copy
+//! * strings are passed as `&str`
+//! * [request values](trait.RequestValue.html) are moved
+//! 
+//! Arguments will always be copied or cloned into the builder, to make them independent of their original life times.
+//! 
+//! [wiki-pod]: http://en.wikipedia.org/wiki/Plain_old_data_structure
+//! [builder-pattern]: http://en.wikipedia.org/wiki/Builder_pattern
+//! [google-go-api]: https://github.com/google/google-api-go-client
+//! 
+//! 
+
+// Unused attributes happen thanks to defined, but unused structures
+// We don't warn about this, as depending on the API, some data structures or facilities are never used.
+// Instead of pre-determining this, we just disable the lint. It's manually tuned to not have any
+// unused imports in fully featured APIs. Same with unused_mut ... .
+#![allow(unused_imports, unused_mut, dead_code)]
+
+// DO NOT EDIT !
+// This file was generated automatically from 'src/mako/api/lib.rs.mako'
+// DO NOT EDIT !
+
+#[macro_use]
+extern crate serde_derive;
+
+extern crate hyper;
+extern crate serde;
+extern crate serde_json;
+extern crate yup_oauth2 as oauth2;
+extern crate mime;
+extern crate url;
+
+mod cmn;
+
+use std::collections::HashMap;
+use std::cell::RefCell;
+use std::borrow::BorrowMut;
+use std::default::Default;
+use std::collections::BTreeMap;
+use serde_json as json;
+use std::io;
+use std::fs;
+use std::mem;
+use std::thread::sleep;
+use std::time::Duration;
+
+pub use cmn::{MultiPartReader, ToParts, MethodInfo, Result, Error, CallBuilder, Hub, ReadSeek, Part,
+              ResponseResult, RequestValue, NestedType, Delegate, DefaultDelegate, MethodsBuilder,
+              Resource, ErrorResponse, remove_json_null_values};
+
+
+// ##############
+// UTILITIES ###
+// ############
+
+/// Identifies the an OAuth2 authorization scope.
+/// A scope is needed when requesting an
+/// [authorization token](https://developers.google.com/youtube/v3/guides/authentication).
+#[derive(PartialEq, Eq, Hash)]
+pub enum Scope {
+    /// View and manage your Google Cloud Datastore data
+    Full,
+
+    /// View and manage your data across Google Cloud Platform services
+    CloudPlatform,
+}
+
+impl AsRef<str> for Scope {
+    fn as_ref(&self) -> &str {
+        match *self {
+            Scope::Full => "https://www.googleapis.com/auth/datastore",
+            Scope::CloudPlatform => "https://www.googleapis.com/auth/cloud-platform",
+        }
+    }
+}
+
+impl Default for Scope {
+    fn default() -> Scope {
+        Scope::Full
+    }
+}
+
+
+
+// ########
+// HUB ###
+// ######
+
+/// Central instance to access all Datastore related resource activities
+///
+/// # Examples
+///
+/// Instantiate a new hub
+///
+/// ```test_harness,no_run
+/// extern crate hyper;
+/// extern crate hyper_rustls;
+/// extern crate yup_oauth2 as oauth2;
+/// extern crate google_datastore1_beta3 as datastore1_beta3;
+/// use datastore1_beta3::RunQueryRequest;
+/// use datastore1_beta3::{Result, Error};
+/// # #[test] fn egal() {
+/// use std::default::Default;
+/// use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// use datastore1_beta3::Datastore;
+/// 
+/// // Get an ApplicationSecret instance by some means. It contains the `client_id` and 
+/// // `client_secret`, among other things.
+/// let secret: ApplicationSecret = Default::default();
+/// // Instantiate the authenticator. It will choose a suitable authentication flow for you, 
+/// // unless you replace  `None` with the desired Flow.
+/// // Provide your own `AuthenticatorDelegate` to adjust the way it operates and get feedback about 
+/// // what's going on. You probably want to bring in your own `TokenStorage` to persist tokens and
+/// // retrieve them from storage.
+/// let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+///                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+///                               <MemoryStorage as Default>::default(), None);
+/// let mut hub = Datastore::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = RunQueryRequest::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.projects().run_query(req, "projectId")
+///              .doit();
+/// 
+/// match result {
+///     Err(e) => match e {
+///         // The Error enum provides details about what exactly happened.
+///         // You can also just use its `Debug`, `Display` or `Error` traits
+///          Error::HttpError(_)
+///         |Error::MissingAPIKey
+///         |Error::MissingToken(_)
+///         |Error::Cancelled
+///         |Error::UploadSizeLimitExceeded(_, _)
+///         |Error::Failure(_)
+///         |Error::BadRequest(_)
+///         |Error::FieldClash(_)
+///         |Error::JsonDecodeError(_, _) => println!("{}", e),
+///     },
+///     Ok(res) => println!("Success: {:?}", res),
+/// }
+/// # }
+/// ```
+pub struct Datastore<C, A> {
+    client: RefCell<C>,
+    auth: RefCell<A>,
+    _user_agent: String,
+    _base_url: String,
+    _root_url: String,
+}
+
+impl<'a, C, A> Hub for Datastore<C, A> {}
+
+impl<'a, C, A> Datastore<C, A>
+    where  C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+    pub fn new(client: C, authenticator: A) -> Datastore<C, A> {
+        Datastore {
+            client: RefCell::new(client),
+            auth: RefCell::new(authenticator),
+            _user_agent: "google-api-rust-client/1.0.7".to_string(),
+            _base_url: "https://datastore.googleapis.com/".to_string(),
+            _root_url: "https://datastore.googleapis.com/".to_string(),
+        }
+    }
+
+    pub fn projects(&'a self) -> ProjectMethods<'a, C, A> {
+        ProjectMethods { hub: &self }
+    }
+
+    /// Set the user-agent header field to use in all requests to the server.
+    /// It defaults to `google-api-rust-client/1.0.7`.
+    ///
+    /// Returns the previously set user-agent.
+    pub fn user_agent(&mut self, agent_name: String) -> String {
+        mem::replace(&mut self._user_agent, agent_name)
+    }
+
+    /// Set the base url to use in all requests to the server.
+    /// It defaults to `https://datastore.googleapis.com/`.
+    ///
+    /// Returns the previously set base url.
+    pub fn base_url(&mut self, new_base_url: String) -> String {
+        mem::replace(&mut self._base_url, new_base_url)
+    }
+
+    /// Set the root url to use in all requests to the server.
+    /// It defaults to `https://datastore.googleapis.com/`.
+    ///
+    /// Returns the previously set root url.
+    pub fn root_url(&mut self, new_root_url: String) -> String {
+        mem::replace(&mut self._root_url, new_root_url)
+    }
+}
+
+
+// ############
+// SCHEMAS ###
+// ##########
+/// A partition ID identifies a grouping of entities. The grouping is always
+/// by project and namespace, however the namespace ID may be empty.
+/// 
+/// A partition ID contains several dimensions:
+/// project ID and namespace ID.
+/// 
+/// Partition dimensions:
+/// 
+/// - May be `""`.
+/// - Must be valid UTF-8 bytes.
+/// - Must have values that match regex `[A-Za-z\d\.\-_]{1,100}`
+/// If the value of any dimension matches regex `__.*__`, the partition is
+/// reserved/read-only.
+/// A reserved/read-only partition ID is forbidden in certain documented
+/// contexts.
+/// 
+/// Foreign partition IDs (in which the project ID does
+/// not match the context project ID ) are discouraged.
+/// Reads and writes of foreign partition IDs may fail if the project is not in an active state.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct PartitionId {
+    /// The ID of the project to which the entities belong.
+    #[serde(rename="projectId")]
+    pub project_id: Option<String>,
+    /// If not empty, the ID of the namespace to which the entities belong.
+    #[serde(rename="namespaceId")]
+    pub namespace_id: Option<String>,
+}
+
+impl Part for PartitionId {}
+
+
+/// The request for Datastore.Lookup.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [lookup projects](struct.ProjectLookupCall.html) (request)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct LookupRequest {
+    /// Keys of entities to look up.
+    pub keys: Option<Vec<Key>>,
+    /// The options for this lookup request.
+    #[serde(rename="readOptions")]
+    pub read_options: Option<ReadOptions>,
+}
+
+impl RequestValue for LookupRequest {}
+
+
+/// The response for Datastore.BeginTransaction.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [begin transaction projects](struct.ProjectBeginTransactionCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct BeginTransactionResponse {
+    /// The transaction identifier (always present).
+    pub transaction: Option<String>,
+}
+
+impl ResponseResult for BeginTransactionResponse {}
+
+
+/// The request for Datastore.AllocateIds.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [allocate ids projects](struct.ProjectAllocateIdCall.html) (request)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct AllocateIdsRequest {
+    /// A list of keys with incomplete key paths for which to allocate IDs.
+    /// No key may be reserved/read-only.
+    pub keys: Option<Vec<Key>>,
+}
+
+impl RequestValue for AllocateIdsRequest {}
+
+
+/// The response for Datastore.RunQuery.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [run query projects](struct.ProjectRunQueryCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct RunQueryResponse {
+    /// The parsed form of the `GqlQuery` from the request, if it was set.
+    pub query: Option<Query>,
+    /// A batch of query results (always present).
+    pub batch: Option<QueryResultBatch>,
+}
+
+impl ResponseResult for RunQueryResponse {}
+
+
+/// A mutation to apply to an entity.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Mutation {
+    /// The entity to insert. The entity must not already exist.
+    /// The entity key's final path element may be incomplete.
+    pub insert: Option<Entity>,
+    /// The key of the entity to delete. The entity may or may not already exist.
+    /// Must have a complete key path and must not be reserved/read-only.
+    pub delete: Option<Key>,
+    /// The entity to update. The entity must already exist.
+    /// Must have a complete key path.
+    pub update: Option<Entity>,
+    /// The version of the entity that this mutation is being applied to. If this
+    /// does not match the current version on the server, the mutation conflicts.
+    #[serde(rename="baseVersion")]
+    pub base_version: Option<String>,
+    /// The entity to upsert. The entity may or may not already exist.
+    /// The entity key's final path element may be incomplete.
+    pub upsert: Option<Entity>,
+}
+
+impl Part for Mutation {}
+
+
+/// An array value.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct ArrayValue {
+    /// Values in the array.
+    /// The order of this array may not be preserved if it contains a mix of
+    /// indexed and unindexed values.
+    pub values: Option<Vec<Value>>,
+}
+
+impl Part for ArrayValue {}
+
+
+/// Options for beginning a new transaction.
+/// 
+/// Transactions can be created explicitly with calls to
+/// Datastore.BeginTransaction or implicitly by setting
+/// ReadOptions.new_transaction in read requests.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct TransactionOptions {
+    /// The transaction should allow both reads and writes.
+    #[serde(rename="readWrite")]
+    pub read_write: Option<ReadWrite>,
+    /// The transaction should only allow reads.
+    #[serde(rename="readOnly")]
+    pub read_only: Option<ReadOnly>,
+}
+
+impl Part for TransactionOptions {}
+
+
+/// A batch of results produced by a query.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct QueryResultBatch {
+    /// The state of the query after the current batch.
+    #[serde(rename="moreResults")]
+    pub more_results: Option<String>,
+    /// The result type for every entity in `entity_results`.
+    #[serde(rename="entityResultType")]
+    pub entity_result_type: Option<String>,
+    /// The version number of the snapshot this batch was returned from.
+    /// This applies to the range of results from the query's `start_cursor` (or
+    /// the beginning of the query if no cursor was given) to this batch's
+    /// `end_cursor` (not the query's `end_cursor`).
+    /// 
+    /// In a single transaction, subsequent query result batches for the same query
+    /// can have a greater snapshot version number. Each batch's snapshot version
+    /// is valid for all preceding batches.
+    /// The value will be zero for eventually consistent queries.
+    #[serde(rename="snapshotVersion")]
+    pub snapshot_version: Option<String>,
+    /// The number of results skipped, typically because of an offset.
+    #[serde(rename="skippedResults")]
+    pub skipped_results: Option<i32>,
+    /// A cursor that points to the position after the last result in the batch.
+    #[serde(rename="endCursor")]
+    pub end_cursor: Option<String>,
+    /// A cursor that points to the position after the last skipped result.
+    /// Will be set when `skipped_results` != 0.
+    #[serde(rename="skippedCursor")]
+    pub skipped_cursor: Option<String>,
+    /// The results for this batch.
+    #[serde(rename="entityResults")]
+    pub entity_results: Option<Vec<EntityResult>>,
+}
+
+impl Part for QueryResultBatch {}
+
+
+/// The response for Datastore.Commit.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [commit projects](struct.ProjectCommitCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct CommitResponse {
+    /// The result of performing the mutations.
+    /// The i-th mutation result corresponds to the i-th mutation in the request.
+    #[serde(rename="mutationResults")]
+    pub mutation_results: Option<Vec<MutationResult>>,
+    /// The number of index entries updated during the commit, or zero if none were
+    /// updated.
+    #[serde(rename="indexUpdates")]
+    pub index_updates: Option<i32>,
+}
+
+impl ResponseResult for CommitResponse {}
+
+
+/// The result of fetching an entity from Datastore.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct EntityResult {
+    /// A cursor that points to the position after the result entity.
+    /// Set only when the `EntityResult` is part of a `QueryResultBatch` message.
+    pub cursor: Option<String>,
+    /// The version of the entity, a strictly positive number that monotonically
+    /// increases with changes to the entity.
+    /// 
+    /// This field is set for `FULL` entity
+    /// results.
+    /// 
+    /// For missing entities in `LookupResponse`, this
+    /// is the version of the snapshot that was used to look up the entity, and it
+    /// is always set except for eventually consistent reads.
+    pub version: Option<String>,
+    /// The resulting entity.
+    pub entity: Option<Entity>,
+}
+
+impl Part for EntityResult {}
+
+
+/// The response for Datastore.Rollback.
+/// (an empty message).
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [rollback projects](struct.ProjectRollbackCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct RollbackResponse { _never_set: Option<bool> }
+
+impl ResponseResult for RollbackResponse {}
+
+
+/// The result of applying a mutation.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct MutationResult {
+    /// The version of the entity on the server after processing the mutation. If
+    /// the mutation doesn't change anything on the server, then the version will
+    /// be the version of the current entity or, if no entity is present, a version
+    /// that is strictly greater than the version of any previous entity and less
+    /// than the version of any possible future entity.
+    pub version: Option<String>,
+    /// Whether a conflict was detected for this mutation. Always false when a
+    /// conflict detection strategy field is not set in the mutation.
+    #[serde(rename="conflictDetected")]
+    pub conflict_detected: Option<bool>,
+    /// The automatically allocated key.
+    /// Set only when the mutation allocated a key.
+    pub key: Option<Key>,
+}
+
+impl Part for MutationResult {}
+
+
+/// A unique identifier for an entity.
+/// If a key's partition ID or any of its path kinds or names are
+/// reserved/read-only, the key is reserved/read-only.
+/// A reserved/read-only key is forbidden in certain documented contexts.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Key {
+    /// The entity path.
+    /// An entity path consists of one or more elements composed of a kind and a
+    /// string or numerical identifier, which identify entities. The first
+    /// element identifies a _root entity_, the second element identifies
+    /// a _child_ of the root entity, the third element identifies a child of the
+    /// second entity, and so forth. The entities identified by all prefixes of
+    /// the path are called the element's _ancestors_.
+    /// 
+    /// An entity path is always fully complete: *all* of the entity's ancestors
+    /// are required to be in the path along with the entity identifier itself.
+    /// The only exception is that in some documented cases, the identifier in the
+    /// last path element (for the entity) itself may be omitted. For example,
+    /// the last path element of the key of `Mutation.insert` may have no
+    /// identifier.
+    /// 
+    /// A path can never be empty, and a path can have at most 100 elements.
+    pub path: Option<Vec<PathElement>>,
+    /// Entities are partitioned into subsets, currently identified by a project
+    /// ID and namespace ID.
+    /// Queries are scoped to a single partition.
+    #[serde(rename="partitionId")]
+    pub partition_id: Option<PartitionId>,
+}
+
+impl Part for Key {}
+
+
+/// A [GQL query](https://cloud.google.com/datastore/docs/apis/gql/gql_reference).
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct GqlQuery {
+    /// A string of the format described
+    /// [here](https://cloud.google.com/datastore/docs/apis/gql/gql_reference).
+    #[serde(rename="queryString")]
+    pub query_string: Option<String>,
+    /// Numbered binding site @1 references the first numbered parameter,
+    /// effectively using 1-based indexing, rather than the usual 0.
+    /// 
+    /// For each binding site numbered i in `query_string`, there must be an i-th
+    /// numbered parameter. The inverse must also be true.
+    #[serde(rename="positionalBindings")]
+    pub positional_bindings: Option<Vec<GqlQueryParameter>>,
+    /// For each non-reserved named binding site in the query string, there must be
+    /// a named parameter with that name, but not necessarily the inverse.
+    /// 
+    /// Key must match regex `A-Za-z_$*`, must not match regex
+    /// `__.*__`, and must not be `""`.
+    #[serde(rename="namedBindings")]
+    pub named_bindings: Option<HashMap<String, GqlQueryParameter>>,
+    /// When false, the query string must not contain any literals and instead must
+    /// bind all values. For example,
+    /// `SELECT * FROM Kind WHERE a = 'string literal'` is not allowed, while
+    /// `SELECT * FROM Kind WHERE a = @value` is.
+    #[serde(rename="allowLiterals")]
+    pub allow_literals: Option<bool>,
+}
+
+impl Part for GqlQuery {}
+
+
+/// The request for Datastore.ReserveIds.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [reserve ids projects](struct.ProjectReserveIdCall.html) (request)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct ReserveIdsRequest {
+    /// A list of keys with complete key paths whose numeric IDs should not be
+    /// auto-allocated.
+    pub keys: Option<Vec<Key>>,
+    /// If not empty, the ID of the database against which to make the request.
+    #[serde(rename="databaseId")]
+    pub database_id: Option<String>,
+}
+
+impl RequestValue for ReserveIdsRequest {}
+
+
+/// The options shared by read requests.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct ReadOptions {
+    /// The identifier of the transaction in which to read. A
+    /// transaction identifier is returned by a call to
+    /// Datastore.BeginTransaction.
+    pub transaction: Option<String>,
+    /// The non-transactional read consistency to use.
+    /// Cannot be set to `STRONG` for global queries.
+    #[serde(rename="readConsistency")]
+    pub read_consistency: Option<String>,
+}
+
+impl Part for ReadOptions {}
+
+
+/// A filter on a specific property.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct PropertyFilter {
+    /// The property to filter by.
+    pub property: Option<PropertyReference>,
+    /// The value to compare the property to.
+    pub value: Option<Value>,
+    /// The operator to filter by.
+    pub op: Option<String>,
+}
+
+impl Part for PropertyFilter {}
+
+
+/// A binding parameter for a GQL query.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct GqlQueryParameter {
+    /// A query cursor. Query cursors are returned in query
+    /// result batches.
+    pub cursor: Option<String>,
+    /// A value parameter.
+    pub value: Option<Value>,
+}
+
+impl Part for GqlQueryParameter {}
+
+
+/// A message that can hold any of the supported value types and associated
+/// metadata.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Value {
+    /// An entity value.
+    /// 
+    /// - May have no key.
+    /// - May have a key with an incomplete key path.
+    /// - May have a reserved/read-only key.
+    #[serde(rename="entityValue")]
+    pub entity_value: Option<Entity>,
+    /// A timestamp value.
+    /// When stored in the Datastore, precise only to microseconds;
+    /// any additional precision is rounded down.
+    #[serde(rename="timestampValue")]
+    pub timestamp_value: Option<String>,
+    /// A UTF-8 encoded string value.
+    /// When `exclude_from_indexes` is false (it is indexed) , may have at most 1500 bytes.
+    /// Otherwise, may be set to at least 1,000,000 bytes.
+    #[serde(rename="stringValue")]
+    pub string_value: Option<String>,
+    /// A double value.
+    #[serde(rename="doubleValue")]
+    pub double_value: Option<f64>,
+    /// The `meaning` field should only be populated for backwards compatibility.
+    pub meaning: Option<i32>,
+    /// If the value should be excluded from all indexes including those defined
+    /// explicitly.
+    #[serde(rename="excludeFromIndexes")]
+    pub exclude_from_indexes: Option<bool>,
+    /// A blob value.
+    /// May have at most 1,000,000 bytes.
+    /// When `exclude_from_indexes` is false, may have at most 1500 bytes.
+    /// In JSON requests, must be base64-encoded.
+    #[serde(rename="blobValue")]
+    pub blob_value: Option<String>,
+    /// A key value.
+    #[serde(rename="keyValue")]
+    pub key_value: Option<Key>,
+    /// A boolean value.
+    #[serde(rename="booleanValue")]
+    pub boolean_value: Option<bool>,
+    /// An array value.
+    /// Cannot contain another array value.
+    /// A `Value` instance that sets field `array_value` must not set fields
+    /// `meaning` or `exclude_from_indexes`.
+    #[serde(rename="arrayValue")]
+    pub array_value: Option<ArrayValue>,
+    /// An integer value.
+    #[serde(rename="integerValue")]
+    pub integer_value: Option<String>,
+    /// A geo point value representing a point on the surface of Earth.
+    #[serde(rename="geoPointValue")]
+    pub geo_point_value: Option<LatLng>,
+    /// A null value.
+    #[serde(rename="nullValue")]
+    pub null_value: Option<String>,
+}
+
+impl Part for Value {}
+
+
+/// A filter that merges multiple other filters using the given operator.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct CompositeFilter {
+    /// The list of filters to combine.
+    /// Must contain at least one filter.
+    pub filters: Option<Vec<Filter>>,
+    /// The operator for combining multiple filters.
+    pub op: Option<String>,
+}
+
+impl Part for CompositeFilter {}
+
+
+/// A reference to a property relative to the kind expressions.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct PropertyReference {
+    /// The name of the property.
+    /// If name includes "."s, it may be interpreted as a property name path.
+    pub name: Option<String>,
+}
+
+impl Part for PropertyReference {}
+
+
+/// A representation of a kind.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct KindExpression {
+    /// The name of the kind.
+    pub name: Option<String>,
+}
+
+impl Part for KindExpression {}
+
+
+/// A query for entities.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Query {
+    /// A starting point for the query results. Query cursors are
+    /// returned in query result batches and
+    /// [can only be used to continue the same query](https://cloud.google.com/datastore/docs/concepts/queries#cursors_limits_and_offsets).
+    #[serde(rename="startCursor")]
+    pub start_cursor: Option<String>,
+    /// The kinds to query (if empty, returns entities of all kinds).
+    /// Currently at most 1 kind may be specified.
+    pub kind: Option<Vec<KindExpression>>,
+    /// The projection to return. Defaults to returning all properties.
+    pub projection: Option<Vec<Projection>>,
+    /// The properties to make distinct. The query results will contain the first
+    /// result for each distinct combination of values for the given properties
+    /// (if empty, all results are returned).
+    #[serde(rename="distinctOn")]
+    pub distinct_on: Option<Vec<PropertyReference>>,
+    /// The filter to apply.
+    pub filter: Option<Filter>,
+    /// The maximum number of results to return. Applies after all other
+    /// constraints. Optional.
+    /// Unspecified is interpreted as no limit.
+    /// Must be >= 0 if specified.
+    pub limit: Option<i32>,
+    /// The number of results to skip. Applies before limit, but after all other
+    /// constraints. Optional. Must be >= 0 if specified.
+    pub offset: Option<i32>,
+    /// An ending point for the query results. Query cursors are
+    /// returned in query result batches and
+    /// [can only be used to limit the same query](https://cloud.google.com/datastore/docs/concepts/queries#cursors_limits_and_offsets).
+    #[serde(rename="endCursor")]
+    pub end_cursor: Option<String>,
+    /// The order to apply to the query results (if empty, order is unspecified).
+    pub order: Option<Vec<PropertyOrder>>,
+}
+
+impl Part for Query {}
+
+
+/// The request for Datastore.RunQuery.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [run query projects](struct.ProjectRunQueryCall.html) (request)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct RunQueryRequest {
+    /// The query to run.
+    pub query: Option<Query>,
+    /// Entities are partitioned into subsets, identified by a partition ID.
+    /// Queries are scoped to a single partition.
+    /// This partition ID is normalized with the standard default context
+    /// partition ID.
+    #[serde(rename="partitionId")]
+    pub partition_id: Option<PartitionId>,
+    /// The GQL query to run.
+    #[serde(rename="gqlQuery")]
+    pub gql_query: Option<GqlQuery>,
+    /// The options for this query.
+    #[serde(rename="readOptions")]
+    pub read_options: Option<ReadOptions>,
+}
+
+impl RequestValue for RunQueryRequest {}
+
+
+/// The response for Datastore.Lookup.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [lookup projects](struct.ProjectLookupCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct LookupResponse {
+    /// Entities found as `ResultType.FULL` entities. The order of results in this
+    /// field is undefined and has no relation to the order of the keys in the
+    /// input.
+    pub found: Option<Vec<EntityResult>>,
+    /// A list of keys that were not looked up due to resource constraints. The
+    /// order of results in this field is undefined and has no relation to the
+    /// order of the keys in the input.
+    pub deferred: Option<Vec<Key>>,
+    /// Entities not found as `ResultType.KEY_ONLY` entities. The order of results
+    /// in this field is undefined and has no relation to the order of the keys
+    /// in the input.
+    pub missing: Option<Vec<EntityResult>>,
+}
+
+impl ResponseResult for LookupResponse {}
+
+
+/// The response for Datastore.ReserveIds.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [reserve ids projects](struct.ProjectReserveIdCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct ReserveIdsResponse { _never_set: Option<bool> }
+
+impl ResponseResult for ReserveIdsResponse {}
+
+
+/// A holder for any type of filter.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Filter {
+    /// A composite filter.
+    #[serde(rename="compositeFilter")]
+    pub composite_filter: Option<CompositeFilter>,
+    /// A filter on a property.
+    #[serde(rename="propertyFilter")]
+    pub property_filter: Option<PropertyFilter>,
+}
+
+impl Part for Filter {}
+
+
+/// The request for Datastore.Commit.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [commit projects](struct.ProjectCommitCall.html) (request)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct CommitRequest {
+    /// The identifier of the transaction associated with the commit. A
+    /// transaction identifier is returned by a call to
+    /// Datastore.BeginTransaction.
+    pub transaction: Option<String>,
+    /// The mutations to perform.
+    /// 
+    /// When mode is `TRANSACTIONAL`, mutations affecting a single entity are
+    /// applied in order. The following sequences of mutations affecting a single
+    /// entity are not permitted in a single `Commit` request:
+    /// 
+    /// - `insert` followed by `insert`
+    /// - `update` followed by `insert`
+    /// - `upsert` followed by `insert`
+    /// - `delete` followed by `update`
+    /// 
+    /// When mode is `NON_TRANSACTIONAL`, no two mutations may affect a single
+    /// entity.
+    pub mutations: Option<Vec<Mutation>>,
+    /// The type of commit to perform. Defaults to `TRANSACTIONAL`.
+    pub mode: Option<String>,
+}
+
+impl RequestValue for CommitRequest {}
+
+
+/// A representation of a property in a projection.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Projection {
+    /// The property to project.
+    pub property: Option<PropertyReference>,
+}
+
+impl Part for Projection {}
+
+
+/// Options specific to read / write transactions.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct ReadWrite {
+    /// The transaction identifier of the transaction being retried.
+    #[serde(rename="previousTransaction")]
+    pub previous_transaction: Option<String>,
+}
+
+impl Part for ReadWrite {}
+
+
+/// An object representing a latitude/longitude pair. This is expressed as a pair
+/// of doubles representing degrees latitude and degrees longitude. Unless
+/// specified otherwise, this must conform to the
+/// <a href="http://www.unoosa.org/pdf/icg/2012/template/WGS_84.pdf">WGS84
+/// standard</a>. Values must be within normalized ranges.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct LatLng {
+    /// The latitude in degrees. It must be in the range [-90.0, +90.0].
+    pub latitude: Option<f64>,
+    /// The longitude in degrees. It must be in the range [-180.0, +180.0].
+    pub longitude: Option<f64>,
+}
+
+impl Part for LatLng {}
+
+
+/// The response for Datastore.AllocateIds.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [allocate ids projects](struct.ProjectAllocateIdCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct AllocateIdsResponse {
+    /// The keys specified in the request (in the same order), each with
+    /// its key path completed with a newly allocated ID.
+    pub keys: Option<Vec<Key>>,
+}
+
+impl ResponseResult for AllocateIdsResponse {}
+
+
+/// A Datastore data object.
+/// 
+/// An entity is limited to 1 megabyte when stored. That _roughly_
+/// corresponds to a limit of 1 megabyte for the serialized form of this
+/// message.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Entity {
+    /// The entity's properties.
+    /// The map's keys are property names.
+    /// A property name matching regex `__.*__` is reserved.
+    /// A reserved property name is forbidden in certain documented contexts.
+    /// The name must not contain more than 500 characters.
+    /// The name cannot be `""`.
+    pub properties: Option<HashMap<String, Value>>,
+    /// The entity's key.
+    /// 
+    /// An entity must have a key, unless otherwise documented (for example,
+    /// an entity in `Value.entity_value` may have no key).
+    /// An entity's kind is its key path's last element's kind,
+    /// or null if it has no key.
+    pub key: Option<Key>,
+}
+
+impl Part for Entity {}
+
+
+/// The request for Datastore.Rollback.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [rollback projects](struct.ProjectRollbackCall.html) (request)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct RollbackRequest {
+    /// The transaction identifier, returned by a call to
+    /// Datastore.BeginTransaction.
+    pub transaction: Option<String>,
+}
+
+impl RequestValue for RollbackRequest {}
+
+
+/// Options specific to read-only transactions.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct ReadOnly { _never_set: Option<bool> }
+
+impl Part for ReadOnly {}
+
+
+/// The request for Datastore.BeginTransaction.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [begin transaction projects](struct.ProjectBeginTransactionCall.html) (request)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct BeginTransactionRequest {
+    /// Options for a new transaction.
+    #[serde(rename="transactionOptions")]
+    pub transaction_options: Option<TransactionOptions>,
+}
+
+impl RequestValue for BeginTransactionRequest {}
+
+
+/// The desired order for a specific property.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct PropertyOrder {
+    /// The direction to order by. Defaults to `ASCENDING`.
+    pub direction: Option<String>,
+    /// The property to order by.
+    pub property: Option<PropertyReference>,
+}
+
+impl Part for PropertyOrder {}
+
+
+/// A (kind, ID/name) pair used to construct a key path.
+/// 
+/// If either name or ID is set, the element is complete.
+/// If neither is set, the element is incomplete.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct PathElement {
+    /// The kind of the entity.
+    /// A kind matching regex `__.*__` is reserved/read-only.
+    /// A kind must not contain more than 1500 bytes when UTF-8 encoded.
+    /// Cannot be `""`.
+    pub kind: Option<String>,
+    /// The name of the entity.
+    /// A name matching regex `__.*__` is reserved/read-only.
+    /// A name must not be more than 1500 bytes when UTF-8 encoded.
+    /// Cannot be `""`.
+    pub name: Option<String>,
+    /// The auto-allocated ID of the entity.
+    /// Never equal to zero. Values less than zero are discouraged and may not
+    /// be supported in the future.
+    pub id: Option<String>,
+}
+
+impl Part for PathElement {}
+
+
+
+// ###################
+// MethodBuilders ###
+// #################
+
+/// A builder providing access to all methods supported on *project* resources.
+/// It is not used directly, but through the `Datastore` hub.
+///
+/// # Example
+///
+/// Instantiate a resource builder
+///
+/// ```test_harness,no_run
+/// extern crate hyper;
+/// extern crate hyper_rustls;
+/// extern crate yup_oauth2 as oauth2;
+/// extern crate google_datastore1_beta3 as datastore1_beta3;
+/// 
+/// # #[test] fn egal() {
+/// use std::default::Default;
+/// use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// use datastore1_beta3::Datastore;
+/// 
+/// let secret: ApplicationSecret = Default::default();
+/// let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+///                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+///                               <MemoryStorage as Default>::default(), None);
+/// let mut hub = Datastore::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // Usually you wouldn't bind this to a variable, but keep calling *CallBuilders*
+/// // like `allocate_ids(...)`, `begin_transaction(...)`, `commit(...)`, `lookup(...)`, `reserve_ids(...)`, `rollback(...)` and `run_query(...)`
+/// // to build up your call.
+/// let rb = hub.projects();
+/// # }
+/// ```
+pub struct ProjectMethods<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a Datastore<C, A>,
+}
+
+impl<'a, C, A> MethodsBuilder for ProjectMethods<'a, C, A> {}
+
+impl<'a, C, A> ProjectMethods<'a, C, A> {
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Queries for entities.
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    /// * `projectId` - The ID of the project against which to make the request.
+    pub fn run_query(&self, request: RunQueryRequest, project_id: &str) -> ProjectRunQueryCall<'a, C, A> {
+        ProjectRunQueryCall {
+            hub: self.hub,
+            _request: request,
+            _project_id: project_id.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Prevents the supplied keys' IDs from being auto-allocated by Cloud
+    /// Datastore.
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    /// * `projectId` - The ID of the project against which to make the request.
+    pub fn reserve_ids(&self, request: ReserveIdsRequest, project_id: &str) -> ProjectReserveIdCall<'a, C, A> {
+        ProjectReserveIdCall {
+            hub: self.hub,
+            _request: request,
+            _project_id: project_id.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Looks up entities by key.
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    /// * `projectId` - The ID of the project against which to make the request.
+    pub fn lookup(&self, request: LookupRequest, project_id: &str) -> ProjectLookupCall<'a, C, A> {
+        ProjectLookupCall {
+            hub: self.hub,
+            _request: request,
+            _project_id: project_id.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Commits a transaction, optionally creating, deleting or modifying some
+    /// entities.
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    /// * `projectId` - The ID of the project against which to make the request.
+    pub fn commit(&self, request: CommitRequest, project_id: &str) -> ProjectCommitCall<'a, C, A> {
+        ProjectCommitCall {
+            hub: self.hub,
+            _request: request,
+            _project_id: project_id.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Allocates IDs for the given keys, which is useful for referencing an entity
+    /// before it is inserted.
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    /// * `projectId` - The ID of the project against which to make the request.
+    pub fn allocate_ids(&self, request: AllocateIdsRequest, project_id: &str) -> ProjectAllocateIdCall<'a, C, A> {
+        ProjectAllocateIdCall {
+            hub: self.hub,
+            _request: request,
+            _project_id: project_id.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Rolls back a transaction.
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    /// * `projectId` - The ID of the project against which to make the request.
+    pub fn rollback(&self, request: RollbackRequest, project_id: &str) -> ProjectRollbackCall<'a, C, A> {
+        ProjectRollbackCall {
+            hub: self.hub,
+            _request: request,
+            _project_id: project_id.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Begins a new transaction.
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    /// * `projectId` - The ID of the project against which to make the request.
+    pub fn begin_transaction(&self, request: BeginTransactionRequest, project_id: &str) -> ProjectBeginTransactionCall<'a, C, A> {
+        ProjectBeginTransactionCall {
+            hub: self.hub,
+            _request: request,
+            _project_id: project_id.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+}
+
+
+
+
+
+// ###################
+// CallBuilders   ###
+// #################
+
+/// Queries for entities.
+///
+/// A builder for the *runQuery* method supported by a *project* resource.
+/// It is not used directly, but through a `ProjectMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_datastore1_beta3 as datastore1_beta3;
+/// use datastore1_beta3::RunQueryRequest;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use datastore1_beta3::Datastore;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = Datastore::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = RunQueryRequest::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.projects().run_query(req, "projectId")
+///              .doit();
+/// # }
+/// ```
+pub struct ProjectRunQueryCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a Datastore<C, A>,
+    _request: RunQueryRequest,
+    _project_id: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for ProjectRunQueryCall<'a, C, A> {}
+
+impl<'a, C, A> ProjectRunQueryCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, RunQueryResponse)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "datastore.projects.runQuery",
+                               http_method: hyper::method::Method::Post });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((4 + self._additional_params.len()));
+        params.push(("projectId", self._project_id.to_string()));
+        for &field in ["alt", "projectId"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1beta3/projects/{projectId}:runQuery";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{projectId}", "projectId")].iter() {
+            let mut replace_with: Option<&str> = None;
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = Some(value);
+                    break;
+                }
+            }
+            url = url.replace(find_this, replace_with.expect("to find substitution value in params"));
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["projectId"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Post, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: RunQueryRequest) -> ProjectRunQueryCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// The ID of the project against which to make the request.
+    ///
+    /// Sets the *project id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn project_id(mut self, new_value: &str) -> ProjectRunQueryCall<'a, C, A> {
+        self._project_id = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> ProjectRunQueryCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> ProjectRunQueryCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> ProjectRunQueryCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Prevents the supplied keys' IDs from being auto-allocated by Cloud
+/// Datastore.
+///
+/// A builder for the *reserveIds* method supported by a *project* resource.
+/// It is not used directly, but through a `ProjectMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_datastore1_beta3 as datastore1_beta3;
+/// use datastore1_beta3::ReserveIdsRequest;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use datastore1_beta3::Datastore;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = Datastore::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = ReserveIdsRequest::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.projects().reserve_ids(req, "projectId")
+///              .doit();
+/// # }
+/// ```
+pub struct ProjectReserveIdCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a Datastore<C, A>,
+    _request: ReserveIdsRequest,
+    _project_id: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for ProjectReserveIdCall<'a, C, A> {}
+
+impl<'a, C, A> ProjectReserveIdCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, ReserveIdsResponse)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "datastore.projects.reserveIds",
+                               http_method: hyper::method::Method::Post });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((4 + self._additional_params.len()));
+        params.push(("projectId", self._project_id.to_string()));
+        for &field in ["alt", "projectId"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1beta3/projects/{projectId}:reserveIds";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{projectId}", "projectId")].iter() {
+            let mut replace_with: Option<&str> = None;
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = Some(value);
+                    break;
+                }
+            }
+            url = url.replace(find_this, replace_with.expect("to find substitution value in params"));
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["projectId"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Post, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: ReserveIdsRequest) -> ProjectReserveIdCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// The ID of the project against which to make the request.
+    ///
+    /// Sets the *project id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn project_id(mut self, new_value: &str) -> ProjectReserveIdCall<'a, C, A> {
+        self._project_id = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> ProjectReserveIdCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> ProjectReserveIdCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> ProjectReserveIdCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Looks up entities by key.
+///
+/// A builder for the *lookup* method supported by a *project* resource.
+/// It is not used directly, but through a `ProjectMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_datastore1_beta3 as datastore1_beta3;
+/// use datastore1_beta3::LookupRequest;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use datastore1_beta3::Datastore;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = Datastore::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = LookupRequest::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.projects().lookup(req, "projectId")
+///              .doit();
+/// # }
+/// ```
+pub struct ProjectLookupCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a Datastore<C, A>,
+    _request: LookupRequest,
+    _project_id: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for ProjectLookupCall<'a, C, A> {}
+
+impl<'a, C, A> ProjectLookupCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, LookupResponse)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "datastore.projects.lookup",
+                               http_method: hyper::method::Method::Post });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((4 + self._additional_params.len()));
+        params.push(("projectId", self._project_id.to_string()));
+        for &field in ["alt", "projectId"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1beta3/projects/{projectId}:lookup";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{projectId}", "projectId")].iter() {
+            let mut replace_with: Option<&str> = None;
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = Some(value);
+                    break;
+                }
+            }
+            url = url.replace(find_this, replace_with.expect("to find substitution value in params"));
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["projectId"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Post, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: LookupRequest) -> ProjectLookupCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// The ID of the project against which to make the request.
+    ///
+    /// Sets the *project id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn project_id(mut self, new_value: &str) -> ProjectLookupCall<'a, C, A> {
+        self._project_id = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> ProjectLookupCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> ProjectLookupCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> ProjectLookupCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Commits a transaction, optionally creating, deleting or modifying some
+/// entities.
+///
+/// A builder for the *commit* method supported by a *project* resource.
+/// It is not used directly, but through a `ProjectMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_datastore1_beta3 as datastore1_beta3;
+/// use datastore1_beta3::CommitRequest;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use datastore1_beta3::Datastore;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = Datastore::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = CommitRequest::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.projects().commit(req, "projectId")
+///              .doit();
+/// # }
+/// ```
+pub struct ProjectCommitCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a Datastore<C, A>,
+    _request: CommitRequest,
+    _project_id: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for ProjectCommitCall<'a, C, A> {}
+
+impl<'a, C, A> ProjectCommitCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, CommitResponse)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "datastore.projects.commit",
+                               http_method: hyper::method::Method::Post });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((4 + self._additional_params.len()));
+        params.push(("projectId", self._project_id.to_string()));
+        for &field in ["alt", "projectId"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1beta3/projects/{projectId}:commit";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{projectId}", "projectId")].iter() {
+            let mut replace_with: Option<&str> = None;
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = Some(value);
+                    break;
+                }
+            }
+            url = url.replace(find_this, replace_with.expect("to find substitution value in params"));
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["projectId"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Post, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: CommitRequest) -> ProjectCommitCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// The ID of the project against which to make the request.
+    ///
+    /// Sets the *project id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn project_id(mut self, new_value: &str) -> ProjectCommitCall<'a, C, A> {
+        self._project_id = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> ProjectCommitCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> ProjectCommitCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> ProjectCommitCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Allocates IDs for the given keys, which is useful for referencing an entity
+/// before it is inserted.
+///
+/// A builder for the *allocateIds* method supported by a *project* resource.
+/// It is not used directly, but through a `ProjectMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_datastore1_beta3 as datastore1_beta3;
+/// use datastore1_beta3::AllocateIdsRequest;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use datastore1_beta3::Datastore;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = Datastore::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = AllocateIdsRequest::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.projects().allocate_ids(req, "projectId")
+///              .doit();
+/// # }
+/// ```
+pub struct ProjectAllocateIdCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a Datastore<C, A>,
+    _request: AllocateIdsRequest,
+    _project_id: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for ProjectAllocateIdCall<'a, C, A> {}
+
+impl<'a, C, A> ProjectAllocateIdCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, AllocateIdsResponse)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "datastore.projects.allocateIds",
+                               http_method: hyper::method::Method::Post });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((4 + self._additional_params.len()));
+        params.push(("projectId", self._project_id.to_string()));
+        for &field in ["alt", "projectId"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1beta3/projects/{projectId}:allocateIds";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{projectId}", "projectId")].iter() {
+            let mut replace_with: Option<&str> = None;
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = Some(value);
+                    break;
+                }
+            }
+            url = url.replace(find_this, replace_with.expect("to find substitution value in params"));
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["projectId"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Post, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: AllocateIdsRequest) -> ProjectAllocateIdCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// The ID of the project against which to make the request.
+    ///
+    /// Sets the *project id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn project_id(mut self, new_value: &str) -> ProjectAllocateIdCall<'a, C, A> {
+        self._project_id = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> ProjectAllocateIdCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> ProjectAllocateIdCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> ProjectAllocateIdCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Rolls back a transaction.
+///
+/// A builder for the *rollback* method supported by a *project* resource.
+/// It is not used directly, but through a `ProjectMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_datastore1_beta3 as datastore1_beta3;
+/// use datastore1_beta3::RollbackRequest;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use datastore1_beta3::Datastore;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = Datastore::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = RollbackRequest::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.projects().rollback(req, "projectId")
+///              .doit();
+/// # }
+/// ```
+pub struct ProjectRollbackCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a Datastore<C, A>,
+    _request: RollbackRequest,
+    _project_id: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for ProjectRollbackCall<'a, C, A> {}
+
+impl<'a, C, A> ProjectRollbackCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, RollbackResponse)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "datastore.projects.rollback",
+                               http_method: hyper::method::Method::Post });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((4 + self._additional_params.len()));
+        params.push(("projectId", self._project_id.to_string()));
+        for &field in ["alt", "projectId"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1beta3/projects/{projectId}:rollback";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{projectId}", "projectId")].iter() {
+            let mut replace_with: Option<&str> = None;
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = Some(value);
+                    break;
+                }
+            }
+            url = url.replace(find_this, replace_with.expect("to find substitution value in params"));
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["projectId"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Post, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: RollbackRequest) -> ProjectRollbackCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// The ID of the project against which to make the request.
+    ///
+    /// Sets the *project id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn project_id(mut self, new_value: &str) -> ProjectRollbackCall<'a, C, A> {
+        self._project_id = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> ProjectRollbackCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> ProjectRollbackCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> ProjectRollbackCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Begins a new transaction.
+///
+/// A builder for the *beginTransaction* method supported by a *project* resource.
+/// It is not used directly, but through a `ProjectMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_datastore1_beta3 as datastore1_beta3;
+/// use datastore1_beta3::BeginTransactionRequest;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use datastore1_beta3::Datastore;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = Datastore::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = BeginTransactionRequest::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.projects().begin_transaction(req, "projectId")
+///              .doit();
+/// # }
+/// ```
+pub struct ProjectBeginTransactionCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a Datastore<C, A>,
+    _request: BeginTransactionRequest,
+    _project_id: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for ProjectBeginTransactionCall<'a, C, A> {}
+
+impl<'a, C, A> ProjectBeginTransactionCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, BeginTransactionResponse)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "datastore.projects.beginTransaction",
+                               http_method: hyper::method::Method::Post });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((4 + self._additional_params.len()));
+        params.push(("projectId", self._project_id.to_string()));
+        for &field in ["alt", "projectId"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1beta3/projects/{projectId}:beginTransaction";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{projectId}", "projectId")].iter() {
+            let mut replace_with: Option<&str> = None;
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = Some(value);
+                    break;
+                }
+            }
+            url = url.replace(find_this, replace_with.expect("to find substitution value in params"));
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["projectId"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Post, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: BeginTransactionRequest) -> ProjectBeginTransactionCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// The ID of the project against which to make the request.
+    ///
+    /// Sets the *project id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn project_id(mut self, new_value: &str) -> ProjectBeginTransactionCall<'a, C, A> {
+        self._project_id = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> ProjectBeginTransactionCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> ProjectBeginTransactionCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> ProjectBeginTransactionCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+

--- a/gen/language1-cli/Cargo.toml
+++ b/gen/language1-cli/Cargo.toml
@@ -1,0 +1,40 @@
+# DO NOT EDIT !
+# This file was generated automatically from 'src/mako/Cargo.toml.mako'
+# DO NOT EDIT !
+[package]
+
+name = "google-language1-cli"
+version = "1.0.7+20171204"
+authors = ["Sebastian Thiel <byronimo@gmail.com>"]
+description = "A complete library to interact with Cloud Natural Language (protocol v1)"
+repository = "https://github.com/Byron/google-apis-rs/tree/master/gen/language1-cli"
+homepage = "https://cloud.google.com/natural-language/"
+documentation = "http://byron.github.io/google-apis-rs/google_language1_cli"
+license = "MIT"
+keywords = ["language", "google", "cli"]
+
+[[bin]]
+name = "language1"
+
+[dev-dependencies]
+hyper-rustls = "^0.6"
+
+[dependencies]
+hyper = "^ 0.10"
+mime = "^ 0.2.0"
+serde = "^ 1.0"
+serde_json = "^ 1.0"
+serde_derive = "^ 1.0"
+yup-oauth2 = "^ 1.0"
+strsim = "^0.5"
+hyper-rustls = "^0.6"
+yup-hyper-mock = "^2.0"
+clap = "^2.0"
+
+[features]
+
+
+
+[dependencies.google-language1]
+path = "../language1"
+version = "1.0.7+20171204"

--- a/gen/language1-cli/LICENSE.md
+++ b/gen/language1-cli/LICENSE.md
@@ -1,0 +1,30 @@
+<!---
+DO NOT EDIT !
+This file was generated automatically from 'src/mako/LICENSE.md.mako'
+DO NOT EDIT !
+-->
+The MIT License (MIT)
+=====================
+
+Copyright © `2015-2016` `Sebastian Thiel`
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the “Software”), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.

--- a/gen/language1-cli/README.md
+++ b/gen/language1-cli/README.md
@@ -1,0 +1,119 @@
+<!---
+DO NOT EDIT !
+This file was generated automatically from 'src/mako/cli/README.md.mako'
+DO NOT EDIT !
+-->
+The `language1` command-line interface *(CLI)* allows to use most features of the *Google Cloud Natural Language* service from the comfort of your terminal.
+
+By default all output is printed to standard out, but flags can be set to direct it into a file independent of your shell's
+capabilities. Errors will be printed to standard error, and cause the program's exit code to be non-zero.
+
+If data-structures are requested, these will be returned as pretty-printed JSON, to be useful as input to other tools.
+
+Everything else about the *Cloud Natural Language* API can be found at the
+[official documentation site](https://cloud.google.com/natural-language/).
+
+# Installation and Source Code
+
+Install the command-line interface with cargo using:
+
+```bash
+cargo install google-language1-cli
+```
+
+Find the source code [on github](https://github.com/Byron/google-apis-rs/tree/master/gen/language1-cli).
+
+# Usage
+
+This documentation was generated from the *Cloud Natural Language* API at revision *20171204*. The CLI is at version *1.0.7*.
+
+```bash
+language1 [options]
+        documents
+                analyze-entities (-r <kv>)... [-p <v>]... [-o <out>]
+                analyze-entity-sentiment (-r <kv>)... [-p <v>]... [-o <out>]
+                analyze-sentiment (-r <kv>)... [-p <v>]... [-o <out>]
+                analyze-syntax (-r <kv>)... [-p <v>]... [-o <out>]
+                annotate-text (-r <kv>)... [-p <v>]... [-o <out>]
+                classify-text (-r <kv>)... [-p <v>]... [-o <out>]
+  language1 --help
+
+Configuration:
+  [--scope <url>]...
+            Specify the authentication a method should be executed in. Each scope
+            requires the user to grant this application permission to use it.
+            If unset, it defaults to the shortest scope url for a particular method.
+  --config-dir <folder>
+            A directory into which we will store our persistent data. Defaults to
+            a user-writable directory that we will create during the first invocation.
+            [default: ~/.google-service-cli]
+  --debug
+            Output all server communication to standard error. `tx` and `rx` are placed
+            into the same stream.
+  --debug-auth
+            Output all communication related to authentication to standard error. `tx`
+            and `rx` are placed into the same stream.
+
+```
+
+# Configuration
+
+The program will store all persistent data in the `~/.google-service-cli` directory in *JSON* files prefixed with `language1-`.  You can change the directory used to store configuration with the `--config-dir` flag on a per-invocation basis.
+
+More information about the various kinds of persistent data are given in the following paragraphs.
+
+# Authentication
+
+Most APIs require a user to authenticate any request. If this is the case, the [scope][scopes] determines the 
+set of permissions granted. The granularity of these is usually no more than *read-only* or *full-access*.
+
+If not set, the system will automatically select the smallest feasible scope, e.g. when invoking a
+method that is read-only, it will ask only for a read-only scope. 
+You may use the `--scope` flag to specify a scope directly. 
+All applicable scopes are documented in the respective method's CLI documentation.
+
+The first time a scope is used, the user is asked for permission. Follow the instructions given 
+by the CLI to grant permissions, or to decline.
+
+If a scope was authenticated by the user, the respective information will be stored as *JSON* in the configuration
+directory, e.g. `~/.google-service-cli/language1-token-<scope-hash>.json`. No manual management of these tokens
+is necessary.
+
+To revoke granted authentication, please refer to the [official documentation][revoke-access].
+
+# Application Secrets
+
+In order to allow any application to use Google services, it will need to be registered using the 
+[Google Developer Console][google-dev-console]. APIs the application may use are then enabled for it
+one by one. Most APIs can be used for free and have a daily quota.
+
+To allow more comfortable usage of the CLI without forcing anyone to register an own application, the CLI
+comes with a default application secret that is configured accordingly. This also means that heavy usage
+all around the world may deplete the daily quota.
+
+You can workaround this limitation by putting your own secrets file at this location: 
+`~/.google-service-cli/language1-secret.json`, assuming that the required *language* API 
+was enabled for it. Such a secret file can be downloaded in the *Google Developer Console* at 
+*APIs & auth -> Credentials -> Download JSON* and used as is.
+
+Learn more about how to setup Google projects and enable APIs using the [official documentation][google-project-new].
+
+
+# Debugging
+
+Even though the CLI does its best to provide usable error messages, sometimes it might be desirable to know
+what exactly led to a particular issue. This is done by allowing all client-server communication to be 
+output to standard error *as-is*.
+
+The `--debug` flag will print all client-server communication to standard error, whereas the `--debug-auth` flag
+will cause all communication related to authentication to standard error.
+If the `--debug` flag is set, error-results will be debug-printed, possibly yielding more information about the 
+issue at hand.
+
+You may consider redirecting standard error into a file for ease of use, e.g. `language1 --debug <resource> <method> [options] 2>debug.txt`.
+
+
+[scopes]: https://developers.google.com/+/api/oauth#scopes
+[revoke-access]: http://webapps.stackexchange.com/a/30849
+[google-dev-console]: https://console.developers.google.com/
+[google-project-new]: https://developers.google.com/console/help/new/

--- a/gen/language1-cli/mkdocs.yml
+++ b/gen/language1-cli/mkdocs.yml
@@ -1,0 +1,22 @@
+site_name: Cloud Natural Language v1.0.7+20171204
+site_url: http://byron.github.io/google-apis-rs/google-language1-cli
+site_description: A complete library to interact with Cloud Natural Language (protocol v1)
+
+repo_url: https://github.com/Byron/google-apis-rs/tree/master/gen/language1-cli
+
+docs_dir: docs
+site_dir: build_html
+
+pages:
+- ['index.md', 'Home']
+- ['documents_analyze-entities.md', 'Documents', 'Analyze Entities']
+- ['documents_analyze-entity-sentiment.md', 'Documents', 'Analyze Entity Sentiment']
+- ['documents_analyze-sentiment.md', 'Documents', 'Analyze Sentiment']
+- ['documents_analyze-syntax.md', 'Documents', 'Analyze Syntax']
+- ['documents_annotate-text.md', 'Documents', 'Annotate Text']
+- ['documents_classify-text.md', 'Documents', 'Classify Text']
+
+theme: readthedocs
+
+copyright: Copyright &copy; 2015-2016, `Sebastian Thiel`
+

--- a/gen/language1-cli/src/cmn.rs
+++ b/gen/language1-cli/src/cmn.rs
@@ -1,0 +1,799 @@
+// COPY OF 'src/rust/cli/cmn.rs'
+// DO NOT EDIT
+use oauth2::{ApplicationSecret, ConsoleApplicationSecret, TokenStorage, Token};
+use serde_json as json;
+use serde_json::value::Value;
+use mime::Mime;
+use clap::{App, SubCommand};
+use strsim;
+
+use std::fs;
+use std::env;
+use std::io;
+use std::error::Error as StdError;
+use std::fmt;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+use std::string::ToString;
+use std::io::{Write, Read, stdout};
+
+use std::default::Default;
+
+const FIELD_SEP: char = '.';
+
+
+pub enum ComplexType {
+    Pod,
+    Vec,
+    Map,
+}
+
+// Null,
+// Bool(bool),
+// I64(i64),
+// U64(u64),
+// F64(f64),
+// String(String),
+
+pub enum JsonType {
+    Boolean,
+    Int,
+    Uint,
+    Float,
+    String,
+}
+
+pub struct JsonTypeInfo {
+    pub jtype: JsonType,
+    pub ctype: ComplexType,
+}
+
+// Based on @erickt user comment. Thanks for the idea !
+// Remove all keys whose values are null from given value (changed in place)
+pub fn remove_json_null_values(value: &mut Value) {
+    match *value {
+        Value::Object(ref mut map) => {
+            let mut for_removal = Vec::new();
+
+            for (key, mut value) in map.iter_mut() {
+                if value.is_null() {
+                    for_removal.push(key.clone());
+                } else {
+                    remove_json_null_values(&mut value);
+                }
+            }
+
+            for key in &for_removal {
+                map.remove(key);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn did_you_mean<'a>(v: &str, possible_values: &[&'a str]) -> Option<&'a str> {
+
+    let mut candidate: Option<(f64, &str)> = None;
+    for pv in possible_values {
+        let confidence = strsim::jaro_winkler(v, pv);
+        if confidence > 0.8 &&
+           (candidate.is_none() || (candidate.as_ref().unwrap().0 < confidence)) {
+            candidate = Some((confidence, pv));
+        }
+    }
+    match candidate {
+        None => None,
+        Some((_, candidate)) => Some(candidate),
+    }
+}
+
+pub enum CallType {
+    Upload(UploadProtocol),
+    Standard,
+}
+
+arg_enum!{
+    pub enum UploadProtocol {
+        Simple,
+        Resumable
+    }
+}
+
+impl AsRef<str> for UploadProtocol {
+    fn as_ref(&self) -> &str {
+        match *self {
+            UploadProtocol::Simple => "simple",
+            UploadProtocol::Resumable => "resumable",
+        }
+    }
+}
+
+impl AsRef<str> for CallType {
+    fn as_ref(&self) -> &str {
+        match *self {
+            CallType::Upload(ref proto) => proto.as_ref(),
+            CallType::Standard => "standard-request",
+        }
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct FieldCursor(Vec<String>);
+
+impl ToString for  FieldCursor {
+    fn to_string(&self) -> String {
+        self.0.join(".")
+    }
+}
+
+impl From<&'static str> for FieldCursor {
+    fn from(value: &'static str) -> FieldCursor {
+        let mut res = FieldCursor::default();
+        res.set(value).unwrap();
+        res
+    }
+}
+
+fn assure_entry<'a, 'b>(m: &'a mut json::Map<String, Value>, k: &'b String) -> &'a mut Value {
+    if m.contains_key(k) {
+        return m.get_mut(k).expect("value to exist");
+    }
+    m.insert(k.to_owned(), Value::Object(Default::default()));
+    m.get_mut(k).expect("value to exist")
+}
+
+impl FieldCursor {
+    pub fn set(&mut self, value: &str) -> Result<(), CLIError> {
+        if value.len() == 0 {
+            return Err(CLIError::Field(FieldError::Empty));
+        }
+
+        let mut first_is_field_sep = false;
+        let mut char_count: usize = 0;
+        let mut last_c = FIELD_SEP;
+        let mut num_conscutive_field_seps = 0;
+
+        let mut field = String::new();
+        let mut fields = self.0.clone();
+
+        let push_field = |fs: &mut Vec<String>, f: &mut String| {
+            if f.len() > 0 {
+                fs.push(f.clone());
+                f.truncate(0);
+            }
+        };
+
+        for (cid, c) in value.chars().enumerate() {
+            char_count += 1;
+
+            if c == FIELD_SEP {
+                if cid == 0 {
+                    first_is_field_sep = true;
+                }
+                num_conscutive_field_seps += 1;
+                if cid > 0 && last_c == FIELD_SEP {
+                    if fields.pop().is_none() {
+                        return Err(CLIError::Field(FieldError::PopOnEmpty(value.to_string())));
+                    }
+                } else {
+                    push_field(&mut fields, &mut field);
+                }
+            } else {
+                num_conscutive_field_seps = 0;
+                if cid == 1 {
+                    if first_is_field_sep {
+                        fields.truncate(0);
+                    }
+                }
+                field.push(c);
+            }
+
+            last_c = c;
+        }
+
+        push_field(&mut fields, &mut field);
+
+        if char_count == 1 && first_is_field_sep {
+            fields.truncate(0);
+        }
+        if char_count > 1 && num_conscutive_field_seps == 1 {
+            return Err(CLIError::Field(FieldError::TrailingFieldSep(value.to_string())));
+        }
+
+        self.0 = fields;
+        Ok(())
+    }
+
+    pub fn did_you_mean(value: &str, possible_values: &[&str]) -> Option<String> {
+        if value.len() == 0 {
+            return None;
+        }
+
+        let mut last_c = FIELD_SEP;
+
+        let mut field = String::new();
+        let mut output = String::new();
+
+        let push_field = |fs: &mut String, f: &mut String| {
+            if f.len() > 0 {
+                fs.push_str(match did_you_mean(&f, possible_values) {
+                    Some(candidate) => candidate,
+                    None => &f,
+                });
+                f.truncate(0);
+            }
+        };
+
+        for (cid, c) in value.chars().enumerate() {
+            if c == FIELD_SEP {
+                if last_c != FIELD_SEP {
+                    push_field(&mut output, &mut field);
+                }
+                output.push(c);
+            } else {
+                field.push(c);
+            }
+
+            last_c = c;
+        }
+
+        push_field(&mut output, &mut field);
+
+        if &output == value {
+            None
+        } else {
+            Some(output)
+        }
+    }
+
+    pub fn set_json_value(&self,
+                          mut object: &mut Value,
+                          value: &str,
+                          type_info: JsonTypeInfo,
+                          err: &mut InvalidOptionsError,
+                          orig_cursor: &FieldCursor) {
+        assert!(self.0.len() > 0);
+
+        for field in &self.0[..self.0.len() - 1] {
+            let tmp = object;
+            object = match *tmp {
+                Value::Object(ref mut mapping) => {
+                    assure_entry(mapping, &field)
+                }
+                _ => panic!("We don't expect non-object Values here ..."),
+            };
+        }
+
+        match *object {
+            Value::Object(ref mut mapping) => {
+                let field = &self.0[self.0.len() - 1];
+                let to_jval = |value: &str,
+                               jtype: JsonType,
+                               err: &mut InvalidOptionsError|
+                               -> Value {
+                    match jtype {
+                        JsonType::Boolean =>
+                            Value::Bool(arg_from_str(value, err, &field, "boolean")),
+                        JsonType::Int =>
+                            Value::Number(json::Number::from_f64(arg_from_str(value,
+                                                                              err,
+                                                                              &field,
+                                                                              "int"))
+                                              .expect("valid f64")),
+                        JsonType::Uint =>
+                            Value::Number(json::Number::from_f64(arg_from_str(value,
+                                                                              err,
+                                                                              &field,
+                                                                              "uint"))
+                                              .expect("valid f64")),
+                        JsonType::Float =>
+                            Value::Number(json::Number::from_f64(arg_from_str(value,
+                                                                              err,
+                                                                              &field,
+                                                                              "float"))
+                                              .expect("valid f64")),
+                        JsonType::String => Value::String(value.to_owned()),
+                    }
+                };
+
+                match type_info.ctype {
+                    ComplexType::Pod => {
+                        if mapping.insert(field.to_owned(), to_jval(value, type_info.jtype, err))
+                                  .is_some() {
+                            err.issues.push(CLIError::Field(FieldError::Duplicate(orig_cursor.to_string())));
+                        }
+                    }
+                    ComplexType::Vec => {
+                        match *assure_entry(mapping, field) {
+                            Value::Array(ref mut values) =>
+                                values.push(to_jval(value, type_info.jtype, err)),
+                            _ => unreachable!(),
+                        }
+                    }
+                    ComplexType::Map => {
+                        let (key, value) = parse_kv_arg(value, err, true);
+                        let jval = to_jval(value.unwrap_or(""), type_info.jtype, err);
+
+                        match *assure_entry(mapping, &field) {
+
+                            Value::Object(ref mut value_map) => {
+                                if value_map.insert(key.to_owned(), jval).is_some() {
+                                    err.issues.push(CLIError::Field(FieldError::Duplicate(orig_cursor.to_string())));
+                                }
+                            }
+                            _ => unreachable!(),
+                        }
+                    }
+                }
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    pub fn num_fields(&self) -> usize {
+        self.0.len()
+    }
+}
+
+pub fn parse_kv_arg<'a>(kv: &'a str,
+                        err: &mut InvalidOptionsError,
+                        for_hashmap: bool)
+                        -> (&'a str, Option<&'a str>) {
+    let mut add_err = || {
+        err.issues.push(CLIError::InvalidKeyValueSyntax(kv.to_string(), for_hashmap))
+    };
+    match kv.find('=') {
+        None => {
+            add_err();
+            return (kv, None);
+        }
+        Some(pos) => {
+            let key = &kv[..pos];
+            if kv.len() <= pos + 1 {
+                add_err();
+                return (key, Some(""));
+            }
+            (key, Some(&kv[pos + 1..]))
+        }
+    }
+}
+
+pub fn calltype_from_str(name: &str,
+                         valid_protocols: Vec<String>,
+                         err: &mut InvalidOptionsError)
+                         -> CallType {
+    CallType::Upload(match UploadProtocol::from_str(name) {
+        Ok(up) => up,
+        Err(msg) => {
+            err.issues.push(CLIError::InvalidUploadProtocol(name.to_string(), valid_protocols));
+            UploadProtocol::Simple
+        }
+    })
+}
+
+pub fn input_file_from_opts(file_path: &str, err: &mut InvalidOptionsError) -> Option<fs::File> {
+    match fs::File::open(file_path) {
+        Ok(f) => Some(f),
+        Err(io_err) => {
+            err.issues.push(CLIError::Input(InputError::Io((file_path.to_string(), io_err))));
+            None
+        }
+    }
+}
+
+pub fn input_mime_from_opts(mime: &str, err: &mut InvalidOptionsError) -> Option<Mime> {
+    match mime.parse() {
+        Ok(m) => Some(m),
+        Err(_) => {
+            err.issues.push(CLIError::Input(InputError::Mime(mime.to_string())));
+            None
+        }
+    }
+}
+
+pub fn writer_from_opts(arg: Option<&str>) -> Result<Box<Write>, io::Error> {
+    let f = arg.unwrap_or("-");
+    match f {
+        "-" => Ok(Box::new(stdout())),
+        _ => match fs::OpenOptions::new().create(true).write(true).open(f) {
+            Ok(f) => Ok(Box::new(f)),
+            Err(io_err) => Err(io_err),
+        },
+    }
+}
+
+
+pub fn arg_from_str<'a, T>(arg: &str,
+                           err: &mut InvalidOptionsError,
+                           arg_name: &'a str,
+                           arg_type: &'a str)
+                           -> T
+    where T: FromStr + Default,
+          <T as FromStr>::Err: fmt::Display
+{
+    match FromStr::from_str(arg) {
+        Err(perr) => {
+            err.issues.push(CLIError::ParseError(arg_name.to_owned(),
+                                                 arg_type.to_owned(),
+                                                 arg.to_string(),
+                                                 format!("{}", perr)));
+            Default::default()
+        }
+        Ok(v) => v,
+    }
+}
+
+pub struct JsonTokenStorage {
+    pub program_name: &'static str,
+    pub db_dir: String,
+}
+
+impl JsonTokenStorage {
+    fn path(&self, scope_hash: u64) -> PathBuf {
+        Path::new(&self.db_dir).join(&format!("{}-token-{}.json", self.program_name, scope_hash))
+    }
+}
+
+
+#[derive(Debug)]
+pub enum TokenStorageError {
+    Json(json::Error),
+    Io(io::Error),
+}
+
+impl fmt::Display for TokenStorageError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            TokenStorageError::Json(ref err) => writeln!(f, "Could not serialize secrets: {}", err),
+            TokenStorageError::Io(ref err) => writeln!(f, "Failed to write secret token: {}", err),
+        }
+    }
+}
+
+impl StdError for TokenStorageError {
+    fn description(&self) -> &str {
+        "Failure when getting or setting the token storage"
+    }
+}
+
+
+impl TokenStorage for JsonTokenStorage {
+    type Error = TokenStorageError;
+
+    // NOTE: logging might be interesting, currently we swallow all errors
+    fn set(&mut self,
+           scope_hash: u64,
+           _: &Vec<&str>,
+           token: Option<Token>)
+           -> Result<(), TokenStorageError> {
+        match token {
+            None => {
+                match fs::remove_file(self.path(scope_hash)) {
+                    Err(err) => match err.kind() {
+                        io::ErrorKind::NotFound => Ok(()),
+                        _ => Err(TokenStorageError::Io(err)),
+                    },
+                    Ok(_) => Ok(()),
+                }
+            }
+            Some(token) => {
+                match fs::OpenOptions::new().create(true).write(true).open(&self.path(scope_hash)) {
+                    Ok(mut f) => {
+                        match json::to_writer_pretty(&mut f, &token) {
+                            Ok(_) => Ok(()),
+                            Err(serde_err) => Err(TokenStorageError::Json(serde_err)),
+                        }
+                    }
+                    Err(io_err) => Err(TokenStorageError::Io(io_err)),
+                }
+            }
+        }
+    }
+
+    fn get(&self, scope_hash: u64, _: &Vec<&str>) -> Result<Option<Token>, TokenStorageError> {
+        match fs::File::open(&self.path(scope_hash)) {
+            Ok(f) => {
+                match json::de::from_reader(f) {
+                    Ok(token) => Ok(Some(token)),
+                    Err(err) => Err(TokenStorageError::Json(err)),
+                }
+            }
+            Err(io_err) => {
+                match io_err.kind() {
+                    io::ErrorKind::NotFound => Ok(None),
+                    _ => Err(TokenStorageError::Io(io_err)),
+                }
+            }
+        }
+    }
+}
+
+
+#[derive(Debug)]
+pub enum ApplicationSecretError {
+    DecoderError((String, json::Error)),
+    FormatError(String),
+}
+
+impl fmt::Display for ApplicationSecretError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            ApplicationSecretError::DecoderError((ref path, ref err)) =>
+                writeln!(f,
+                         "Could not decode file at '{}' with error: {}.",
+                         path,
+                         err),
+            ApplicationSecretError::FormatError(ref path) =>
+                writeln!(f,
+                         "'installed' field is unset in secret file at '{}'.",
+                         path),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum ConfigurationError {
+    DirectoryCreationFailed((String, io::Error)),
+    DirectoryUnset,
+    HomeExpansionFailed(String),
+    Secret(ApplicationSecretError),
+    Io((String, io::Error)),
+}
+
+impl fmt::Display for ConfigurationError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            ConfigurationError::DirectoryCreationFailed((ref dir, ref err)) =>
+                writeln!(f,
+                         "Directory '{}' could not be created with error: {}.",
+                         dir,
+                         err),
+            ConfigurationError::DirectoryUnset => writeln!(f, "--config-dir was unset or empty."),
+            ConfigurationError::HomeExpansionFailed(ref dir) =>
+                writeln!(f,
+                         "Couldn't find HOME directory of current user, failed to expand '{}'.",
+                         dir),
+            ConfigurationError::Secret(ref err) => writeln!(f, "Secret -> {}", err),
+            ConfigurationError::Io((ref path, ref err)) =>
+                writeln!(f,
+                         "IO operation failed on path '{}' with error: {}.",
+                         path,
+                         err),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum InputError {
+    Io((String, io::Error)),
+    Mime(String),
+}
+
+impl fmt::Display for InputError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            InputError::Io((ref file_path, ref io_err)) =>
+                writeln!(f,
+                         "Failed to open '{}' for reading with error: {}.",
+                         file_path,
+                         io_err),
+            InputError::Mime(ref mime) => writeln!(f, "'{}' is not a known mime-type.", mime),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum FieldError {
+    PopOnEmpty(String),
+    TrailingFieldSep(String),
+    Unknown(String, Option<String>, Option<String>),
+    Duplicate(String),
+    Empty,
+}
+
+
+impl fmt::Display for FieldError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            FieldError::PopOnEmpty(ref field) =>
+                writeln!(f, "'{}': Cannot move up on empty field cursor.", field),
+            FieldError::TrailingFieldSep(ref field) =>
+                writeln!(f,
+                         "'{}': Single field separator may not be last character.",
+                         field),
+            FieldError::Unknown(ref field, ref suggestion, ref value) => {
+                let suffix = match *suggestion {
+                    Some(ref s) => {
+                        let kv = match *value {
+                            Some(ref v) => format!("{}={}", s, v),
+                            None => s.clone(),
+                        };
+                        format!(" Did you mean '{}' ?", kv)
+                    }
+                    None => String::new(),
+                };
+                writeln!(f, "Field '{}' does not exist.{}", field, suffix)
+            }
+            FieldError::Duplicate(ref cursor) =>
+                writeln!(f, "Value at '{}' was already set", cursor),
+            FieldError::Empty => writeln!(f, "Field names must not be empty."),
+        }
+    }
+}
+
+
+#[derive(Debug)]
+pub enum CLIError {
+    Configuration(ConfigurationError),
+    ParseError(String, String, String, String),
+    UnknownParameter(String, Vec<&'static str>),
+    InvalidUploadProtocol(String, Vec<String>),
+    InvalidKeyValueSyntax(String, bool),
+    Input(InputError),
+    Field(FieldError),
+    MissingCommandError,
+    MissingMethodError(String),
+}
+
+impl fmt::Display for CLIError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            CLIError::Configuration(ref err) => write!(f, "Configuration -> {}", err),
+            CLIError::Input(ref err) => write!(f, "Input -> {}", err),
+            CLIError::Field(ref err) => write!(f, "Field -> {}", err),
+            CLIError::InvalidUploadProtocol(ref proto_name, ref valid_names) =>
+                writeln!(f,
+                         "'{}' is not a valid upload protocol. Choose from one of {}.",
+                         proto_name,
+                         valid_names.join(", ")),
+            CLIError::ParseError(ref arg_name, ref type_name, ref value, ref err_desc) =>
+                writeln!(f,
+                         "Failed to parse argument '{}' with value '{}' as {} with error: {}.",
+                         arg_name,
+                         value,
+                         type_name,
+                         err_desc),
+            CLIError::UnknownParameter(ref param_name, ref possible_values) => {
+                let suffix = match did_you_mean(param_name, &possible_values) {
+                    Some(v) => format!(" Did you mean '{}' ?", v),
+                    None => String::new(),
+                };
+                write!(f, "Parameter '{}' is unknown.{}\n", param_name, suffix)
+            }
+            CLIError::InvalidKeyValueSyntax(ref kv, is_hashmap) => {
+                let hashmap_info = if is_hashmap {
+                    "hashmap "
+                } else {
+                    ""
+                };
+                writeln!(f,
+                         "'{}' does not match {}pattern <key>=<value>.",
+                         kv,
+                         hashmap_info)
+            }
+            CLIError::MissingCommandError => writeln!(f, "Please specify the main sub-command."),
+            CLIError::MissingMethodError(ref cmd) =>
+                writeln!(f,
+                         "Please specify the method to call on the '{}' command.",
+                         cmd),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct InvalidOptionsError {
+    pub issues: Vec<CLIError>,
+    pub exit_code: i32,
+}
+
+impl fmt::Display for InvalidOptionsError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        for issue in &self.issues {
+            try!(issue.fmt(f));
+        }
+        Ok(())
+    }
+}
+
+impl InvalidOptionsError {
+    pub fn single(err: CLIError, exit_code: i32) -> InvalidOptionsError {
+        InvalidOptionsError {
+            issues: vec![err],
+            exit_code: exit_code,
+        }
+    }
+
+    pub fn new() -> InvalidOptionsError {
+        InvalidOptionsError {
+            issues: Vec::new(),
+            exit_code: 1,
+        }
+    }
+}
+
+pub fn assure_config_dir_exists(dir: &str) -> Result<String, CLIError> {
+    let trdir = dir.trim();
+    if trdir.len() == 0 {
+        return Err(CLIError::Configuration(ConfigurationError::DirectoryUnset));
+    }
+
+    let expanded_config_dir = if trdir.as_bytes()[0] == b'~' {
+        match env::var("HOME").ok().or(env::var("UserProfile").ok()) {
+            None => return Err(CLIError::Configuration(ConfigurationError::HomeExpansionFailed(trdir.to_string()))),
+            Some(mut user) => {
+                user.push_str(&trdir[1..]);
+                user
+            }
+        }
+    } else {
+        trdir.to_string()
+    };
+
+    if let Err(err) = fs::create_dir(&expanded_config_dir) {
+        if err.kind() != io::ErrorKind::AlreadyExists {
+            return Err(CLIError::Configuration(
+                    ConfigurationError::DirectoryCreationFailed((expanded_config_dir, err))));
+        }
+    }
+
+    Ok(expanded_config_dir)
+}
+
+pub fn application_secret_from_directory(dir: &str,
+                                         secret_basename: &str,
+                                         json_console_secret: &str)
+                                         -> Result<ApplicationSecret, CLIError> {
+    let secret_path = Path::new(dir).join(secret_basename);
+    let secret_str = || secret_path.as_path().to_str().unwrap().to_string();
+    let secret_io_error = |io_err: io::Error| {
+        Err(CLIError::Configuration(ConfigurationError::Io((secret_str(), io_err))))
+    };
+
+    for _ in 0..2 {
+        match fs::File::open(&secret_path) {
+            Err(mut err) => {
+                if err.kind() == io::ErrorKind::NotFound {
+                    // Write our built-in one - user may adjust the written file at will
+
+                    err = match fs::OpenOptions::new()
+                                    .create(true)
+                                    .write(true)
+                                    .open(&secret_path) {
+                        Err(cfe) => cfe,
+                        Ok(mut f) => {
+                            // Assure we convert 'ugly' json string into pretty one
+                            let console_secret: ConsoleApplicationSecret =
+                                json::from_str(json_console_secret).unwrap();
+                            match json::to_writer_pretty(&mut f, &console_secret) {
+                                Err(serde_err) =>
+                                    panic!("Unexpected serde error: {:#?}", serde_err),
+                                Ok(_) => continue,
+                            }
+                        }
+                    };
+                    // fall through to IO error handling
+                }
+                return secret_io_error(err);
+            }
+            Ok(f) => {
+                match json::de::from_reader::<_, ConsoleApplicationSecret>(f) {
+                    Err(json_err) =>
+                        return Err(CLIError::Configuration(
+                            ConfigurationError::Secret(
+                                ApplicationSecretError::DecoderError(
+                                                (secret_str(), json_err)
+                                              )))),
+                    Ok(console_secret) => match console_secret.installed {
+                        Some(secret) => return Ok(secret),
+                        None => return Err(
+                                        CLIError::Configuration(
+                                        ConfigurationError::Secret(
+                                        ApplicationSecretError::FormatError(secret_str())
+                                        ))),
+                    },
+                }
+            }
+        }
+    }
+    unreachable!();
+}

--- a/gen/language1-cli/src/main.rs
+++ b/gen/language1-cli/src/main.rs
@@ -1,0 +1,942 @@
+// DO NOT EDIT !
+// This file was generated automatically from 'src/mako/cli/main.rs.mako'
+// DO NOT EDIT !
+#![allow(unused_variables, unused_imports, dead_code, unused_mut)]
+
+#[macro_use]
+extern crate clap;
+extern crate yup_oauth2 as oauth2;
+extern crate yup_hyper_mock as mock;
+extern crate hyper_rustls;
+extern crate serde;
+extern crate serde_json;
+extern crate hyper;
+extern crate mime;
+extern crate strsim;
+extern crate google_language1 as api;
+
+use std::env;
+use std::io::{self, Write};
+use clap::{App, SubCommand, Arg};
+
+mod cmn;
+
+use cmn::{InvalidOptionsError, CLIError, JsonTokenStorage, arg_from_str, writer_from_opts, parse_kv_arg,
+          input_file_from_opts, input_mime_from_opts, FieldCursor, FieldError, CallType, UploadProtocol,
+          calltype_from_str, remove_json_null_values, ComplexType, JsonType, JsonTypeInfo};
+
+use std::default::Default;
+use std::str::FromStr;
+
+use oauth2::{Authenticator, DefaultAuthenticatorDelegate, FlowType};
+use serde_json as json;
+use clap::ArgMatches;
+
+enum DoitError {
+    IoError(String, io::Error),
+    ApiError(api::Error),
+}
+
+struct Engine<'n> {
+    opt: ArgMatches<'n>,
+    hub: api::CloudNaturalLanguage<hyper::Client, Authenticator<DefaultAuthenticatorDelegate, JsonTokenStorage, hyper::Client>>,
+    gp: Vec<&'static str>,
+    gpm: Vec<(&'static str, &'static str)>,
+}
+
+
+impl<'n> Engine<'n> {
+    fn _documents_analyze_entities(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    "encoding-type" => Some(("encodingType", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "document.content" => Some(("document.content", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "document.type" => Some(("document.type", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "document.language" => Some(("document.language", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "document.gcs-content-uri" => Some(("document.gcsContentUri", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec!["content", "document", "encoding-type", "gcs-content-uri", "language", "type"]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::AnalyzeEntitiesRequest = json::value::from_value(object).unwrap();
+        let mut call = self.hub.documents().analyze_entities(request);
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _documents_analyze_entity_sentiment(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    "encoding-type" => Some(("encodingType", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "document.content" => Some(("document.content", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "document.type" => Some(("document.type", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "document.language" => Some(("document.language", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "document.gcs-content-uri" => Some(("document.gcsContentUri", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec!["content", "document", "encoding-type", "gcs-content-uri", "language", "type"]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::AnalyzeEntitySentimentRequest = json::value::from_value(object).unwrap();
+        let mut call = self.hub.documents().analyze_entity_sentiment(request);
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _documents_analyze_sentiment(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    "encoding-type" => Some(("encodingType", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "document.content" => Some(("document.content", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "document.type" => Some(("document.type", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "document.language" => Some(("document.language", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "document.gcs-content-uri" => Some(("document.gcsContentUri", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec!["content", "document", "encoding-type", "gcs-content-uri", "language", "type"]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::AnalyzeSentimentRequest = json::value::from_value(object).unwrap();
+        let mut call = self.hub.documents().analyze_sentiment(request);
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _documents_analyze_syntax(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    "encoding-type" => Some(("encodingType", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "document.content" => Some(("document.content", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "document.type" => Some(("document.type", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "document.language" => Some(("document.language", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "document.gcs-content-uri" => Some(("document.gcsContentUri", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec!["content", "document", "encoding-type", "gcs-content-uri", "language", "type"]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::AnalyzeSyntaxRequest = json::value::from_value(object).unwrap();
+        let mut call = self.hub.documents().analyze_syntax(request);
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _documents_annotate_text(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    "encoding-type" => Some(("encodingType", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "document.content" => Some(("document.content", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "document.type" => Some(("document.type", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "document.language" => Some(("document.language", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "document.gcs-content-uri" => Some(("document.gcsContentUri", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "features.extract-document-sentiment" => Some(("features.extractDocumentSentiment", JsonTypeInfo { jtype: JsonType::Boolean, ctype: ComplexType::Pod })),
+                    "features.extract-entity-sentiment" => Some(("features.extractEntitySentiment", JsonTypeInfo { jtype: JsonType::Boolean, ctype: ComplexType::Pod })),
+                    "features.extract-entities" => Some(("features.extractEntities", JsonTypeInfo { jtype: JsonType::Boolean, ctype: ComplexType::Pod })),
+                    "features.extract-syntax" => Some(("features.extractSyntax", JsonTypeInfo { jtype: JsonType::Boolean, ctype: ComplexType::Pod })),
+                    "features.classify-text" => Some(("features.classifyText", JsonTypeInfo { jtype: JsonType::Boolean, ctype: ComplexType::Pod })),
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec!["classify-text", "content", "document", "encoding-type", "extract-document-sentiment", "extract-entities", "extract-entity-sentiment", "extract-syntax", "features", "gcs-content-uri", "language", "type"]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::AnnotateTextRequest = json::value::from_value(object).unwrap();
+        let mut call = self.hub.documents().annotate_text(request);
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _documents_classify_text(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    "document.content" => Some(("document.content", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "document.type" => Some(("document.type", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "document.language" => Some(("document.language", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "document.gcs-content-uri" => Some(("document.gcsContentUri", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec!["content", "document", "gcs-content-uri", "language", "type"]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::ClassifyTextRequest = json::value::from_value(object).unwrap();
+        let mut call = self.hub.documents().classify_text(request);
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _doit(&self, dry_run: bool) -> Result<Result<(), DoitError>, Option<InvalidOptionsError>> {
+        let mut err = InvalidOptionsError::new();
+        let mut call_result: Result<(), DoitError> = Ok(());
+        let mut err_opt: Option<InvalidOptionsError> = None;
+        match self.opt.subcommand() {
+            ("documents", Some(opt)) => {
+                match opt.subcommand() {
+                    ("analyze-entities", Some(opt)) => {
+                        call_result = self._documents_analyze_entities(opt, dry_run, &mut err);
+                    },
+                    ("analyze-entity-sentiment", Some(opt)) => {
+                        call_result = self._documents_analyze_entity_sentiment(opt, dry_run, &mut err);
+                    },
+                    ("analyze-sentiment", Some(opt)) => {
+                        call_result = self._documents_analyze_sentiment(opt, dry_run, &mut err);
+                    },
+                    ("analyze-syntax", Some(opt)) => {
+                        call_result = self._documents_analyze_syntax(opt, dry_run, &mut err);
+                    },
+                    ("annotate-text", Some(opt)) => {
+                        call_result = self._documents_annotate_text(opt, dry_run, &mut err);
+                    },
+                    ("classify-text", Some(opt)) => {
+                        call_result = self._documents_classify_text(opt, dry_run, &mut err);
+                    },
+                    _ => {
+                        err.issues.push(CLIError::MissingMethodError("documents".to_string()));
+                        writeln!(io::stderr(), "{}\n", opt.usage()).ok();
+                    }
+                }
+            },
+            _ => {
+                err.issues.push(CLIError::MissingCommandError);
+                writeln!(io::stderr(), "{}\n", self.opt.usage()).ok();
+            }
+        }
+
+        if dry_run {
+            if err.issues.len() > 0 {
+                err_opt = Some(err);
+            }
+            Err(err_opt)
+        } else {
+            Ok(call_result)
+        }
+    }
+
+    // Please note that this call will fail if any part of the opt can't be handled
+    fn new(opt: ArgMatches<'n>) -> Result<Engine<'n>, InvalidOptionsError> {
+        let (config_dir, secret) = {
+            let config_dir = match cmn::assure_config_dir_exists(opt.value_of("folder").unwrap_or("~/.google-service-cli")) {
+                Err(e) => return Err(InvalidOptionsError::single(e, 3)),
+                Ok(p) => p,
+            };
+
+            match cmn::application_secret_from_directory(&config_dir, "language1-secret.json",
+                                                         "{\"installed\":{\"auth_uri\":\"https://accounts.google.com/o/oauth2/auth\",\"client_secret\":\"hCsslbCUyfehWMmbkG8vTYxG\",\"token_uri\":\"https://accounts.google.com/o/oauth2/token\",\"client_email\":\"\",\"redirect_uris\":[\"urn:ietf:wg:oauth:2.0:oob\",\"oob\"],\"client_x509_cert_url\":\"\",\"client_id\":\"620010449518-9ngf7o4dhs0dka470npqvor6dc5lqb9b.apps.googleusercontent.com\",\"auth_provider_x509_cert_url\":\"https://www.googleapis.com/oauth2/v1/certs\"}}") {
+                Ok(secret) => (config_dir, secret),
+                Err(e) => return Err(InvalidOptionsError::single(e, 4))
+            }
+        };
+
+        let auth = Authenticator::new(  &secret, DefaultAuthenticatorDelegate,
+                                        if opt.is_present("debug-auth") {
+                                            hyper::Client::with_connector(mock::TeeConnector {
+                                                    connector: hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())
+                                                })
+                                        } else {
+                                            hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new()))
+                                        },
+                                        JsonTokenStorage {
+                                          program_name: "language1",
+                                          db_dir: config_dir.clone(),
+                                        }, Some(FlowType::InstalledRedirect(54324)));
+
+        let client =
+            if opt.is_present("debug") {
+                hyper::Client::with_connector(mock::TeeConnector {
+                        connector: hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())
+                    })
+            } else {
+                hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new()))
+            };
+        let engine = Engine {
+            opt: opt,
+            hub: api::CloudNaturalLanguage::new(client, auth),
+            gp: vec!["$-xgafv", "access-token", "alt", "bearer-token", "callback", "fields", "key", "oauth-token", "pp", "pretty-print", "quota-user", "upload-type", "upload-protocol"],
+            gpm: vec![
+                    ("$-xgafv", "$.xgafv"),
+                    ("access-token", "access_token"),
+                    ("bearer-token", "bearer_token"),
+                    ("oauth-token", "oauth_token"),
+                    ("pretty-print", "prettyPrint"),
+                    ("quota-user", "quotaUser"),
+                    ("upload-type", "uploadType"),
+                    ("upload-protocol", "upload_protocol"),
+                ]
+        };
+
+        match engine._doit(true) {
+            Err(Some(err)) => Err(err),
+            Err(None)      => Ok(engine),
+            Ok(_)          => unreachable!(),
+        }
+    }
+
+    fn doit(&self) -> Result<(), DoitError> {
+        match self._doit(false) {
+            Ok(res) => res,
+            Err(_) => unreachable!(),
+        }
+    }
+}
+
+fn main() {
+    let mut exit_status = 0i32;
+    let arg_data = [
+        ("documents", "methods: 'analyze-entities', 'analyze-entity-sentiment', 'analyze-sentiment', 'analyze-syntax', 'annotate-text' and 'classify-text'", vec![
+            ("analyze-entities",
+                    Some(r##"Finds named entities (currently proper names and common nouns) in the text
+        along with entity types, salience, mentions for each entity, and
+        other properties."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_language1_cli/documents_analyze-entities",
+                  vec![
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("analyze-entity-sentiment",
+                    Some(r##"Finds entities, similar to AnalyzeEntities in the text and analyzes
+        sentiment associated with each entity and its mentions."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_language1_cli/documents_analyze-entity-sentiment",
+                  vec![
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("analyze-sentiment",
+                    Some(r##"Analyzes the sentiment of the provided text."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_language1_cli/documents_analyze-sentiment",
+                  vec![
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("analyze-syntax",
+                    Some(r##"Analyzes the syntax of the text and provides sentence boundaries and
+        tokenization along with part of speech tags, dependency trees, and other
+        properties."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_language1_cli/documents_analyze-syntax",
+                  vec![
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("annotate-text",
+                    Some(r##"A convenience method that provides all the features that analyzeSentiment,
+        analyzeEntities, and analyzeSyntax provide in one call."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_language1_cli/documents_annotate-text",
+                  vec![
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("classify-text",
+                    Some(r##"Classifies a document into categories."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_language1_cli/documents_classify-text",
+                  vec![
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ]),
+        
+    ];
+    
+    let mut app = App::new("language1")
+           .author("Sebastian Thiel <byronimo@gmail.com>")
+           .version("1.0.7+20171204")
+           .about("Provides natural language understanding technologies to developers. Examples include sentiment analysis, entity recognition, entity sentiment analysis, and text annotations.")
+           .after_help("All documentation details can be found at http://byron.github.io/google-apis-rs/google_language1_cli")
+           .arg(Arg::with_name("url")
+                   .long("scope")
+                   .help("Specify the authentication a method should be executed in. Each scope requires the user to grant this application permission to use it.If unset, it defaults to the shortest scope url for a particular method.")
+                   .multiple(true)
+                   .takes_value(true))
+           .arg(Arg::with_name("folder")
+                   .long("config-dir")
+                   .help("A directory into which we will store our persistent data. Defaults to a user-writable directory that we will create during the first invocation.[default: ~/.google-service-cli")
+                   .multiple(false)
+                   .takes_value(true))
+           .arg(Arg::with_name("debug")
+                   .long("debug")
+                   .help("Output all server communication to standard error. `tx` and `rx` are placed into the same stream.")
+                   .multiple(false)
+                   .takes_value(false))
+           .arg(Arg::with_name("debug-auth")
+                   .long("debug-auth")
+                   .help("Output all communication related to authentication to standard error. `tx` and `rx` are placed into the same stream.")
+                   .multiple(false)
+                   .takes_value(false));
+           
+           for &(main_command_name, about, ref subcommands) in arg_data.iter() {
+               let mut mcmd = SubCommand::with_name(main_command_name).about(about);
+           
+               for &(sub_command_name, ref desc, url_info, ref args) in subcommands {
+                   let mut scmd = SubCommand::with_name(sub_command_name);
+                   if let &Some(desc) = desc {
+                       scmd = scmd.about(desc);
+                   }
+                   scmd = scmd.after_help(url_info);
+           
+                   for &(ref arg_name, ref flag, ref desc, ref required, ref multi) in args {
+                       let arg_name_str =
+                           match (arg_name, flag) {
+                                   (&Some(an), _       ) => an,
+                                   (_        , &Some(f)) => f,
+                                    _                    => unreachable!(),
+                            };
+                       let mut arg = Arg::with_name(arg_name_str)
+                                         .empty_values(false);
+                       if let &Some(short_flag) = flag {
+                           arg = arg.short(short_flag);
+                       }
+                       if let &Some(desc) = desc {
+                           arg = arg.help(desc);
+                       }
+                       if arg_name.is_some() && flag.is_some() {
+                           arg = arg.takes_value(true);
+                       }
+                       if let &Some(required) = required {
+                           arg = arg.required(required);
+                       }
+                       if let &Some(multi) = multi {
+                           arg = arg.multiple(multi);
+                       }
+                       scmd = scmd.arg(arg);
+                   }
+                   mcmd = mcmd.subcommand(scmd);
+               }
+               app = app.subcommand(mcmd);
+           }
+           
+        let matches = app.get_matches();
+
+    let debug = matches.is_present("debug");
+    match Engine::new(matches) {
+        Err(err) => {
+            exit_status = err.exit_code;
+            writeln!(io::stderr(), "{}", err).ok();
+        },
+        Ok(engine) => {
+            if let Err(doit_err) = engine.doit() {
+                exit_status = 1;
+                match doit_err {
+                    DoitError::IoError(path, err) => {
+                        writeln!(io::stderr(), "Failed to open output file '{}': {}", path, err).ok();
+                    },
+                    DoitError::ApiError(err) => {
+                        if debug {
+                            writeln!(io::stderr(), "{:#?}", err).ok();
+                        } else {
+                            writeln!(io::stderr(), "{}", err).ok();
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    std::process::exit(exit_status);
+}

--- a/gen/language1/Cargo.toml
+++ b/gen/language1/Cargo.toml
@@ -1,0 +1,31 @@
+# DO NOT EDIT !
+# This file was generated automatically from 'src/mako/Cargo.toml.mako'
+# DO NOT EDIT !
+[package]
+
+name = "google-language1"
+version = "1.0.7+20171204"
+authors = ["Sebastian Thiel <byronimo@gmail.com>"]
+description = "A complete library to interact with Cloud Natural Language (protocol v1)"
+repository = "https://github.com/Byron/google-apis-rs/tree/master/gen/language1"
+homepage = "https://cloud.google.com/natural-language/"
+documentation = "https://docs.rs/google-language1/1.0.7+20171204"
+license = "MIT"
+keywords = ["language", "google", "protocol", "web", "api"]
+
+
+[dev-dependencies]
+hyper-rustls = "^0.6"
+
+[dependencies]
+hyper = "^ 0.10"
+mime = "^ 0.2.0"
+serde = "^ 1.0"
+serde_json = "^ 1.0"
+serde_derive = "^ 1.0"
+yup-oauth2 = "^ 1.0"
+url = "= 0.5"
+
+[features]
+
+

--- a/gen/language1/LICENSE.md
+++ b/gen/language1/LICENSE.md
@@ -1,0 +1,30 @@
+<!---
+DO NOT EDIT !
+This file was generated automatically from 'src/mako/LICENSE.md.mako'
+DO NOT EDIT !
+-->
+The MIT License (MIT)
+=====================
+
+Copyright © `2015-2016` `Sebastian Thiel`
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the “Software”), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.

--- a/gen/language1/README.md
+++ b/gen/language1/README.md
@@ -1,0 +1,185 @@
+<!---
+DO NOT EDIT !
+This file was generated automatically from 'src/mako/api/README.md.mako'
+DO NOT EDIT !
+-->
+The `google-language1` library allows access to all features of the *Google Cloud Natural Language* service.
+
+This documentation was generated from *Cloud Natural Language* crate version *1.0.7+20171204*, where *20171204* is the exact revision of the *language:v1* schema built by the [mako](http://www.makotemplates.org/) code generator *v1.0.7*.
+
+Everything else about the *Cloud Natural Language* *v1* API can be found at the
+[official documentation site](https://cloud.google.com/natural-language/).
+# Features
+
+Handle the following *Resources* with ease from the central [hub](https://docs.rs/google-language1/1.0.7+20171204/google_language1/struct.CloudNaturalLanguage.html) ... 
+
+* [documents](https://docs.rs/google-language1/1.0.7+20171204/google_language1/struct.Document.html)
+ * [*analyze entities*](https://docs.rs/google-language1/1.0.7+20171204/google_language1/struct.DocumentAnalyzeEntityCall.html), [*analyze entity sentiment*](https://docs.rs/google-language1/1.0.7+20171204/google_language1/struct.DocumentAnalyzeEntitySentimentCall.html), [*analyze sentiment*](https://docs.rs/google-language1/1.0.7+20171204/google_language1/struct.DocumentAnalyzeSentimentCall.html), [*analyze syntax*](https://docs.rs/google-language1/1.0.7+20171204/google_language1/struct.DocumentAnalyzeSyntaxCall.html), [*annotate text*](https://docs.rs/google-language1/1.0.7+20171204/google_language1/struct.DocumentAnnotateTextCall.html) and [*classify text*](https://docs.rs/google-language1/1.0.7+20171204/google_language1/struct.DocumentClassifyTextCall.html)
+
+
+
+
+# Structure of this Library
+
+The API is structured into the following primary items:
+
+* **[Hub](https://docs.rs/google-language1/1.0.7+20171204/google_language1/struct.CloudNaturalLanguage.html)**
+    * a central object to maintain state and allow accessing all *Activities*
+    * creates [*Method Builders*](https://docs.rs/google-language1/1.0.7+20171204/google_language1/trait.MethodsBuilder.html) which in turn
+      allow access to individual [*Call Builders*](https://docs.rs/google-language1/1.0.7+20171204/google_language1/trait.CallBuilder.html)
+* **[Resources](https://docs.rs/google-language1/1.0.7+20171204/google_language1/trait.Resource.html)**
+    * primary types that you can apply *Activities* to
+    * a collection of properties and *Parts*
+    * **[Parts](https://docs.rs/google-language1/1.0.7+20171204/google_language1/trait.Part.html)**
+        * a collection of properties
+        * never directly used in *Activities*
+* **[Activities](https://docs.rs/google-language1/1.0.7+20171204/google_language1/trait.CallBuilder.html)**
+    * operations to apply to *Resources*
+
+All *structures* are marked with applicable traits to further categorize them and ease browsing.
+
+Generally speaking, you can invoke *Activities* like this:
+
+```Rust,ignore
+let r = hub.resource().activity(...).doit()
+```
+
+Or specifically ...
+
+```ignore
+let r = hub.documents().analyze_syntax(...).doit()
+let r = hub.documents().analyze_sentiment(...).doit()
+let r = hub.documents().classify_text(...).doit()
+let r = hub.documents().analyze_entity_sentiment(...).doit()
+let r = hub.documents().analyze_entities(...).doit()
+let r = hub.documents().annotate_text(...).doit()
+```
+
+The `resource()` and `activity(...)` calls create [builders][builder-pattern]. The second one dealing with `Activities` 
+supports various methods to configure the impending operation (not shown here). It is made such that all required arguments have to be 
+specified right away (i.e. `(...)`), whereas all optional ones can be [build up][builder-pattern] as desired.
+The `doit()` method performs the actual communication with the server and returns the respective result.
+
+# Usage
+
+## Setting up your Project
+
+To use this library, you would put the following lines into your `Cargo.toml` file:
+
+```toml
+[dependencies]
+google-language1 = "*"
+```
+
+## A complete example
+
+```Rust
+extern crate hyper;
+extern crate hyper_rustls;
+extern crate yup_oauth2 as oauth2;
+extern crate google_language1 as language1;
+use language1::AnalyzeSyntaxRequest;
+use language1::{Result, Error};
+use std::default::Default;
+use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+use language1::CloudNaturalLanguage;
+
+// Get an ApplicationSecret instance by some means. It contains the `client_id` and 
+// `client_secret`, among other things.
+let secret: ApplicationSecret = Default::default();
+// Instantiate the authenticator. It will choose a suitable authentication flow for you, 
+// unless you replace  `None` with the desired Flow.
+// Provide your own `AuthenticatorDelegate` to adjust the way it operates and get feedback about 
+// what's going on. You probably want to bring in your own `TokenStorage` to persist tokens and
+// retrieve them from storage.
+let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+                              hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+                              <MemoryStorage as Default>::default(), None);
+let mut hub = CloudNaturalLanguage::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+// As the method needs a request, you would usually fill it with the desired information
+// into the respective structure. Some of the parts shown here might not be applicable !
+// Values shown here are possibly random and not representative !
+let mut req = AnalyzeSyntaxRequest::default();
+
+// You can configure optional parameters by calling the respective setters at will, and
+// execute the final call using `doit()`.
+// Values shown here are possibly random and not representative !
+let result = hub.documents().analyze_syntax(req)
+             .doit();
+
+match result {
+    Err(e) => match e {
+        // The Error enum provides details about what exactly happened.
+        // You can also just use its `Debug`, `Display` or `Error` traits
+         Error::HttpError(_)
+        |Error::MissingAPIKey
+        |Error::MissingToken(_)
+        |Error::Cancelled
+        |Error::UploadSizeLimitExceeded(_, _)
+        |Error::Failure(_)
+        |Error::BadRequest(_)
+        |Error::FieldClash(_)
+        |Error::JsonDecodeError(_, _) => println!("{}", e),
+    },
+    Ok(res) => println!("Success: {:?}", res),
+}
+
+```
+## Handling Errors
+
+All errors produced by the system are provided either as [Result](https://docs.rs/google-language1/1.0.7+20171204/google_language1/enum.Result.html) enumeration as return value of 
+the doit() methods, or handed as possibly intermediate results to either the 
+[Hub Delegate](https://docs.rs/google-language1/1.0.7+20171204/google_language1/trait.Delegate.html), or the [Authenticator Delegate](https://docs.rs/yup-oauth2/*/yup_oauth2/trait.AuthenticatorDelegate.html).
+
+When delegates handle errors or intermediate values, they may have a chance to instruct the system to retry. This 
+makes the system potentially resilient to all kinds of errors.
+
+## Uploads and Downloads
+If a method supports downloads, the response body, which is part of the [Result](https://docs.rs/google-language1/1.0.7+20171204/google_language1/enum.Result.html), should be
+read by you to obtain the media.
+If such a method also supports a [Response Result](https://docs.rs/google-language1/1.0.7+20171204/google_language1/trait.ResponseResult.html), it will return that by default.
+You can see it as meta-data for the actual media. To trigger a media download, you will have to set up the builder by making
+this call: `.param("alt", "media")`.
+
+Methods supporting uploads can do so using up to 2 different protocols: 
+*simple* and *resumable*. The distinctiveness of each is represented by customized 
+`doit(...)` methods, which are then named `upload(...)` and `upload_resumable(...)` respectively.
+
+## Customization and Callbacks
+
+You may alter the way an `doit()` method is called by providing a [delegate](https://docs.rs/google-language1/1.0.7+20171204/google_language1/trait.Delegate.html) to the 
+[Method Builder](https://docs.rs/google-language1/1.0.7+20171204/google_language1/trait.CallBuilder.html) before making the final `doit()` call. 
+Respective methods will be called to provide progress information, as well as determine whether the system should 
+retry on failure.
+
+The [delegate trait](https://docs.rs/google-language1/1.0.7+20171204/google_language1/trait.Delegate.html) is default-implemented, allowing you to customize it with minimal effort.
+
+## Optional Parts in Server-Requests
+
+All structures provided by this library are made to be [enocodable](https://docs.rs/google-language1/1.0.7+20171204/google_language1/trait.RequestValue.html) and 
+[decodable](https://docs.rs/google-language1/1.0.7+20171204/google_language1/trait.ResponseResult.html) via *json*. Optionals are used to indicate that partial requests are responses 
+are valid.
+Most optionals are are considered [Parts](https://docs.rs/google-language1/1.0.7+20171204/google_language1/trait.Part.html) which are identifiable by name, which will be sent to 
+the server to indicate either the set parts of the request or the desired parts in the response.
+
+## Builder Arguments
+
+Using [method builders](https://docs.rs/google-language1/1.0.7+20171204/google_language1/trait.CallBuilder.html), you are able to prepare an action call by repeatedly calling it's methods.
+These will always take a single argument, for which the following statements are true.
+
+* [PODs][wiki-pod] are handed by copy
+* strings are passed as `&str`
+* [request values](https://docs.rs/google-language1/1.0.7+20171204/google_language1/trait.RequestValue.html) are moved
+
+Arguments will always be copied or cloned into the builder, to make them independent of their original life times.
+
+[wiki-pod]: http://en.wikipedia.org/wiki/Plain_old_data_structure
+[builder-pattern]: http://en.wikipedia.org/wiki/Builder_pattern
+[google-go-api]: https://github.com/google/google-api-go-client
+
+# License
+The **language1** library was generated by Sebastian Thiel, and is placed 
+under the *MIT* license.
+You can read the full text at the repository's [license file][repo-license].
+
+[repo-license]: https://github.com/Byron/google-apis-rsblob/master/LICENSE.md

--- a/gen/language1/src/cmn.rs
+++ b/gen/language1/src/cmn.rs
@@ -1,0 +1,753 @@
+// COPY OF 'src/rust/api/cmn.rs'
+// DO NOT EDIT
+use std::io::{self, Read, Seek, Cursor, Write, SeekFrom};
+use std;
+use std::fmt::{self, Display};
+use std::str::FromStr;
+use std::error;
+use std::thread::sleep;
+use std::time::Duration;
+
+use mime::{Mime, TopLevel, SubLevel, Attr, Value};
+use oauth2::{TokenType, Retry, self};
+use hyper;
+use hyper::header::{ContentType, ContentLength, Headers, UserAgent, Authorization, Header,
+                    HeaderFormat, Bearer};
+use hyper::http::h1::LINE_ENDING;
+use hyper::method::Method;
+use hyper::status::StatusCode;
+
+use serde_json as json;
+
+/// Identifies the Hub. There is only one per library, this trait is supposed
+/// to make intended use more explicit.
+/// The hub allows to access all resource methods more easily.
+pub trait Hub {}
+
+/// Identifies types for building methods of a particular resource type
+pub trait MethodsBuilder {}
+
+/// Identifies types which represent builders for a particular resource method
+pub trait CallBuilder {}
+
+/// Identifies types which can be inserted and deleted.
+/// Types with this trait are most commonly used by clients of this API.
+pub trait Resource {}
+
+/// Identifies types which are used in API responses.
+pub trait ResponseResult {}
+
+/// Identifies types which are used in API requests.
+pub trait RequestValue {}
+
+/// Identifies types which are not actually used by the API
+/// This might be a bug within the google API schema.
+pub trait UnusedType {}
+
+/// Identifies types which are only used as part of other types, which
+/// usually are carrying the `Resource` trait.
+pub trait Part {}
+
+/// Identifies types which are only used by other types internally.
+/// They have no special meaning, this trait just marks them for completeness.
+pub trait NestedType {}
+
+/// A utility to specify reader types which provide seeking capabilities too
+pub trait ReadSeek: Seek + Read {}
+impl<T: Seek + Read> ReadSeek for T {}
+
+/// A trait for all types that can convert themselves into a *parts* string
+pub trait ToParts {
+    fn to_parts(&self) -> String;
+}
+
+/// A utility type which can decode a server response that indicates error
+#[derive(Deserialize)]
+pub struct JsonServerError {
+    pub error: String,
+    pub error_description: Option<String>
+}
+
+/// A utility to represent detailed errors we might see in case there are BadRequests.
+/// The latter happen if the sent parameters or request structures are unsound
+#[derive(Deserialize, Serialize, Debug)]
+pub struct ErrorResponse {
+    error: ServerError,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct ServerError {
+    errors: Vec<ServerMessage>,
+    code: u16,
+    message: String,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct ServerMessage {
+    domain: String,
+    reason: String,
+    message: String,
+    #[serde(rename="locationType")]
+    location_type: Option<String>,
+    location: Option<String>
+}
+
+#[derive(Copy, Clone)]
+pub struct DummyNetworkStream;
+
+impl Read for DummyNetworkStream {
+    fn read(&mut self, _: &mut [u8]) -> io::Result<usize> {
+        Ok(0)
+    }
+}
+
+impl Write for DummyNetworkStream {
+    fn write(&mut self, _: &[u8]) -> io::Result<usize> {
+        Ok(0)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl hyper::net::NetworkStream for DummyNetworkStream {
+    fn peer_addr(&mut self) -> io::Result<std::net::SocketAddr> {
+        Ok("127.0.0.1:1337".parse().unwrap())
+    }
+
+    fn set_read_timeout(&self, _dur: Option<Duration>) -> io::Result<()> {
+        Ok(())
+    }
+
+    fn set_write_timeout(&self, _dur: Option<Duration>) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+
+/// A trait specifying functionality to help controlling any request performed by the API.
+/// The trait has a conservative default implementation.
+///
+/// It contains methods to deal with all common issues, as well with the ones related to
+/// uploading media
+pub trait Delegate {
+
+    /// Called at the beginning of any API request. The delegate should store the method
+    /// information if he is interesting in knowing more context when further calls to it
+    /// are made.
+    /// The matching `finished()` call will always be made, no matter whether or not the API
+    /// request was successful. That way, the delegate may easily maintain a clean state
+    /// between various API calls.
+    fn begin(&mut self, MethodInfo) {}
+
+    /// Called whenever there is an [HttpError](http://hyperium.github.io/hyper/hyper/error/enum.HttpError.html), usually if there are network problems.
+    ///
+    /// If you choose to retry after a duration, the duration should be chosen using the
+    /// [exponential backoff algorithm](http://en.wikipedia.org/wiki/Exponential_backoff).
+    ///
+    /// Return retry information.
+    fn http_error(&mut self, &hyper::Error) -> Retry {
+        Retry::Abort
+    }
+
+    /// Called whenever there is the need for your applications API key after
+    /// the official authenticator implementation didn't provide one, for some reason.
+    /// If this method returns None as well, the underlying operation will fail
+    fn api_key(&mut self) -> Option<String> {
+        None
+    }
+
+    /// Called whenever the Authenticator didn't yield a token. The delegate
+    /// may attempt to provide one, or just take it as a general information about the
+    /// impending failure.
+    /// The given Error provides information about why the token couldn't be acquired in the
+    /// first place
+    fn token(&mut self, err: &error::Error) -> Option<oauth2::Token> {
+        let _ = err;
+        None
+    }
+
+    /// Called during resumable uploads to provide a URL for the impending upload.
+    /// It was saved after a previous call to `store_upload_url(...)`, and if not None,
+    /// will be used instead of asking the server for a new upload URL.
+    /// This is useful in case a previous resumable upload was aborted/canceled, but should now
+    /// be resumed.
+    /// The returned URL will be used exactly once - if it fails again and the delegate allows
+    /// to retry, we will ask the server for a new upload URL.
+    fn upload_url(&mut self) -> Option<String> {
+        None
+    }
+
+    /// Called after we have retrieved a new upload URL for a resumable upload to store it
+    /// in case we fail or cancel. That way, we can attempt to resume the upload later,
+    /// see `upload_url()`.
+    /// It will also be called with None after a successful upload, which allows the delegate
+    /// to forget the URL. That way, we will not attempt to resume an upload that has already
+    /// finished.
+    fn store_upload_url(&mut self, url: Option<&str>) {
+        let _ = url;
+    }
+
+    /// Called whenever a server response could not be decoded from json.
+    /// It's for informational purposes only, the caller will return with an error
+    /// accordingly.
+    ///
+    /// # Arguments
+    ///
+    /// * `json_encoded_value` - The json-encoded value which failed to decode.
+    /// * `json_decode_error`  - The decoder error
+    fn response_json_decode_error(&mut self, json_encoded_value: &str, json_decode_error: &json::Error) {
+        let _ = json_encoded_value;
+        let _ = json_decode_error;
+    }
+
+    /// Called whenever the http request returns with a non-success status code.
+    /// This can involve authentication issues, or anything else that very much
+    /// depends on the used API method.
+    /// The delegate should check the status, header and decoded json error to decide
+    /// whether to retry or not. In the latter case, the underlying call will fail.
+    ///
+    /// If you choose to retry after a duration, the duration should be chosen using the
+    /// [exponential backoff algorithm](http://en.wikipedia.org/wiki/Exponential_backoff).
+    fn http_failure(&mut self, _: &hyper::client::Response, Option<JsonServerError>, _: Option<ServerError>) -> Retry {
+        Retry::Abort
+    }
+
+    /// Called prior to sending the main request of the given method. It can be used to time
+    /// the call or to print progress information.
+    /// It's also useful as you can be sure that a request will definitely be made.
+    fn pre_request(&mut self) { }
+
+    /// Return the size of each chunk of a resumable upload.
+    /// Must be a power of two, with 1<<18 being the smallest allowed chunk size.
+    /// Will be called once before starting any resumable upload.
+    fn chunk_size(&mut self) -> u64 {
+        1 << 23
+    }
+
+    /// Called before the given chunk is uploaded to the server.
+    /// If true is returned, the upload will be interrupted.
+    /// However, it may be resumable if you stored the upload URL in a previous call
+    /// to `store_upload_url()`
+    fn cancel_chunk_upload(&mut self, chunk: &ContentRange) -> bool {
+        let _ = chunk;
+        false
+    }
+
+    /// Called before the API request method returns, in every case. It can be used to clean up
+    /// internal state between calls to the API.
+    /// This call always has a matching call to `begin(...)`.
+    ///
+    /// # Arguments
+    ///
+    /// * `is_success` - a true value indicates the operation was successful. If false, you should
+    ///                  discard all values stored during `store_upload_url`.
+    fn finished(&mut self, is_success: bool) {
+        let _ = is_success;
+    }
+}
+
+/// A delegate with a conservative default implementation, which is used if no other delegate is
+/// set.
+#[derive(Default)]
+pub struct DefaultDelegate;
+
+impl Delegate for DefaultDelegate {}
+
+
+#[derive(Debug)]
+pub enum Error {
+    /// The http connection failed
+    HttpError(hyper::Error),
+
+    /// An attempt was made to upload a resource with size stored in field `.0`
+    /// even though the maximum upload size is what is stored in field `.1`.
+    UploadSizeLimitExceeded(u64, u64),
+
+    /// Represents information about a request that was not understood by the server.
+    /// Details are included.
+    BadRequest(ErrorResponse),
+
+    /// We needed an API key for authentication, but didn't obtain one.
+    /// Neither through the authenticator, nor through the Delegate.
+    MissingAPIKey,
+
+    /// We required a Token, but didn't get one from the Authenticator
+    MissingToken(Box<error::Error>),
+
+    /// The delgate instructed to cancel the operation
+    Cancelled,
+
+    /// An additional, free form field clashed with one of the built-in optional ones
+    FieldClash(&'static str),
+
+    /// Shows that we failed to decode the server response.
+    /// This can happen if the protocol changes in conjunction with strict json decoding.
+    JsonDecodeError(String, json::Error),
+
+    /// Indicates an HTTP repsonse with a non-success status code
+    Failure(hyper::client::Response),
+}
+
+
+impl Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Error::HttpError(ref err) => err.fmt(f),
+            Error::UploadSizeLimitExceeded(ref resource_size, ref max_size) =>
+                writeln!(f, "The media size {} exceeds the maximum allowed upload size of {}"
+                         , resource_size, max_size),
+            Error::MissingAPIKey => {
+                (writeln!(f, "The application's API key was not found in the configuration")).ok();
+                writeln!(f, "It is used as there are no Scopes defined for this method.")
+            },
+            Error::BadRequest(ref err) => {
+                try!(writeln!(f, "Bad Request ({}): {}", err.error.code, err.error.message));
+                for err in err.error.errors.iter() {
+                    try!(writeln!(f, "    {}: {}, {}{}",
+                                            err.domain,
+                                            err.message,
+                                            err.reason,
+                                            match &err.location {
+                                                &Some(ref loc) => format!("@{}", loc),
+                                                &None => String::new(),
+                                            }));
+                }
+                Ok(())
+            },
+            Error::MissingToken(ref err) =>
+                writeln!(f, "Token retrieval failed with error: {}", err),
+            Error::Cancelled =>
+                writeln!(f, "Operation cancelled by delegate"),
+            Error::FieldClash(field) =>
+                writeln!(f, "The custom parameter '{}' is already provided natively by the CallBuilder.", field),
+            Error::JsonDecodeError(ref json_str, ref err)
+                => writeln!(f, "{}: {}", err, json_str),
+            Error::Failure(ref response) =>
+                writeln!(f, "Http status indicates failure: {:?}", response),
+        }
+    }
+}
+
+impl error::Error for Error {
+    fn description(&self) -> &str {
+        match *self {
+            Error::HttpError(ref err) => err.description(),
+            Error::JsonDecodeError(_, ref err) => err.description(),
+            _ => "NO DESCRIPTION POSSIBLE - use `Display.fmt()` instead"
+        }
+    }
+
+    fn cause(&self) -> Option<&error::Error> {
+        match *self {
+            Error::HttpError(ref err) => err.cause(),
+            Error::JsonDecodeError(_, ref err) => err.cause(),
+            _ => None
+        }
+    }
+}
+
+/// A universal result type used as return for all calls.
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Contains information about an API request.
+pub struct MethodInfo {
+    pub id: &'static str,
+    pub http_method: Method,
+}
+
+const BOUNDARY: &'static str = "MDuXWGyeE33QFXGchb2VFWc4Z7945d";
+
+/// Provides a `Read` interface that converts multiple parts into the protocol
+/// identified by [RFC2387](https://tools.ietf.org/html/rfc2387).
+/// **Note**: This implementation is just as rich as it needs to be to perform uploads
+/// to google APIs, and might not be a fully-featured implementation.
+#[derive(Default)]
+pub struct MultiPartReader<'a> {
+    raw_parts: Vec<(Headers, &'a mut Read)>,
+    current_part: Option<(Cursor<Vec<u8>>, &'a mut Read)>,
+    last_part_boundary: Option<Cursor<Vec<u8>>>,
+}
+
+impl<'a> MultiPartReader<'a> {
+
+    /// Reserve memory for exactly the given amount of parts
+    pub fn reserve_exact(&mut self, cap: usize) {
+        self.raw_parts.reserve_exact(cap);
+    }
+
+    /// Add a new part to the queue of parts to be read on the first `read` call.
+    ///
+    /// # Arguments
+    ///
+    /// `headers` - identifying the body of the part. It's similar to the header
+    ///             in an ordinary single-part call, and should thus contain the
+    ///             same information.
+    /// `reader`  - a reader providing the part's body
+    /// `size`    - the amount of bytes provided by the reader. It will be put onto the header as
+    ///             content-size.
+    /// `mime`    - It will be put onto the content type
+    pub fn add_part(&mut self, reader: &'a mut Read, size: u64, mime_type: Mime) -> &mut MultiPartReader<'a> {
+        let mut headers = Headers::new();
+        headers.set(ContentType(mime_type));
+        headers.set(ContentLength(size));
+        self.raw_parts.push((headers, reader));
+        self
+    }
+
+    /// Returns the mime-type representing our multi-part message.
+    /// Use it with the ContentType header.
+    pub fn mime_type(&self) -> Mime {
+        Mime(
+            TopLevel::Multipart,
+            SubLevel::Ext("Related".to_string()),
+            vec![(Attr::Ext("boundary".to_string()), Value::Ext(BOUNDARY.to_string()))],
+        )
+    }
+
+    /// Returns true if we are totally used
+    fn is_depleted(&self) -> bool {
+        self.raw_parts.len() == 0 && self.current_part.is_none() && self.last_part_boundary.is_none()
+    }
+
+    /// Returns true if we are handling our last part
+    fn is_last_part(&self) -> bool {
+        self.raw_parts.len() == 0 && self.current_part.is_some()
+    }
+}
+
+impl<'a> Read for MultiPartReader<'a> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        match (self.raw_parts.len(),
+               self.current_part.is_none(),
+               self.last_part_boundary.is_none()) {
+            (_, _, false) => {
+                let br = self.last_part_boundary.as_mut().unwrap().read(buf).unwrap_or(0);
+                if br < buf.len() {
+                    self.last_part_boundary = None;
+                }
+                return Ok(br)
+            },
+            (0, true, true) => return Ok(0),
+            (n, true, _) if n > 0 => {
+                let (headers, reader) = self.raw_parts.remove(0);
+                let mut c = Cursor::new(Vec::<u8>::new());
+                (write!(&mut c, "{}--{}{}{}{}", LINE_ENDING, BOUNDARY, LINE_ENDING,
+                                                headers, LINE_ENDING)).unwrap();
+                c.seek(SeekFrom::Start(0)).unwrap();
+                self.current_part = Some((c, reader));
+            }
+            _ => {},
+        }
+
+        // read headers as long as possible
+        let (hb, rr) = {
+            let &mut (ref mut c, ref mut reader) = self.current_part.as_mut().unwrap();
+            let b = c.read(buf).unwrap_or(0);
+            (b, reader.read(&mut buf[b..]))
+        };
+
+        match rr {
+            Ok(bytes_read) => {
+                if hb < buf.len() && bytes_read == 0 {
+                    if self.is_last_part() {
+                        // before clearing the last part, we will add the boundary that
+                        // will be written last
+                        self.last_part_boundary = Some(Cursor::new(
+                                                        format!("{}--{}--", LINE_ENDING, BOUNDARY).into_bytes()))
+                    }
+                    // We are depleted - this can trigger the next part to come in
+                    self.current_part = None;
+                }
+                let mut total_bytes_read = hb + bytes_read;
+                while total_bytes_read < buf.len() && !self.is_depleted() {
+                    match self.read(&mut buf[total_bytes_read ..]) {
+                        Ok(br) => total_bytes_read += br,
+                        Err(err) => return Err(err),
+                    }
+                }
+                Ok(total_bytes_read)
+            }
+            Err(err) => {
+                // fail permanently
+                self.current_part = None;
+                self.last_part_boundary = None;
+                self.raw_parts.clear();
+                Err(err)
+            }
+        }
+    }
+}
+
+/// The `X-Upload-Content-Type` header.
+///
+/// Generated via rustc --pretty expanded -Z unstable-options, and manually
+/// processed to be more readable.
+#[derive(PartialEq, Debug, Clone)]
+pub struct XUploadContentType(pub Mime);
+
+impl ::std::ops::Deref for XUploadContentType {
+    type Target = Mime;
+    fn deref<'a>(&'a self) -> &'a Mime { &self.0 }
+}
+impl ::std::ops::DerefMut for XUploadContentType {
+    fn deref_mut<'a>(&'a mut self) -> &'a mut Mime { &mut self.0 }
+}
+impl Header for XUploadContentType {
+    fn header_name() -> &'static str { "X-Upload-Content-Type" }
+    fn parse_header(raw: &[Vec<u8>]) -> hyper::error::Result<Self> {
+        hyper::header::parsing::from_one_raw_str(raw).map(XUploadContentType)
+    }
+}
+impl HeaderFormat for XUploadContentType {
+    fn fmt_header(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        Display::fmt(&**self, f)
+    }
+}
+impl Display for XUploadContentType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(&**self, f)
+    }
+}
+
+#[derive(Clone, PartialEq, Debug)]
+pub struct Chunk {
+    pub first: u64,
+    pub last: u64
+}
+
+impl fmt::Display for Chunk {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        (write!(fmt, "{}-{}", self.first, self.last)).ok();
+        Ok(())
+    }
+}
+
+impl FromStr for Chunk {
+    type Err = &'static str;
+
+    /// NOTE: only implements `%i-%i`, not `*`
+    fn from_str(s: &str) -> std::result::Result<Chunk, &'static str> {
+        let parts: Vec<&str> = s.split('-').collect();
+        if parts.len() != 2 {
+            return Err("Expected two parts: %i-%i")
+        }
+        Ok(
+            Chunk {
+                first: match FromStr::from_str(parts[0]) {
+                    Ok(d) => d,
+                    _ => return Err("Couldn't parse 'first' as digit")
+                },
+                last: match FromStr::from_str(parts[1]) {
+                    Ok(d) => d,
+                    _ => return Err("Couldn't parse 'last' as digit")
+                }
+            }
+        )
+    }
+}
+
+/// Implements the Content-Range header, for serialization only
+#[derive(Clone, PartialEq, Debug)]
+pub struct ContentRange {
+    pub range: Option<Chunk>,
+    pub total_length: u64,
+}
+
+impl Header for ContentRange {
+    fn header_name() -> &'static str {
+        "Content-Range"
+    }
+
+    /// We are not parsable, as parsing is done by the `Range` header
+    fn parse_header(_: &[Vec<u8>]) -> hyper::error::Result<Self> {
+        Err(hyper::error::Error::Method)
+    }
+}
+
+
+impl HeaderFormat for ContentRange {
+    fn fmt_header(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        try!(fmt.write_str("bytes "));
+        match self.range {
+            Some(ref c) => try!(c.fmt(fmt)),
+            None => try!(fmt.write_str("*"))
+        }
+        (write!(fmt, "/{}", self.total_length)).ok();
+        Ok(())
+    }
+}
+
+#[derive(Clone, PartialEq, Debug)]
+pub struct RangeResponseHeader(pub Chunk);
+
+impl Header for RangeResponseHeader {
+    fn header_name() -> &'static str {
+        "Range"
+    }
+
+    fn parse_header(raw: &[Vec<u8>]) -> hyper::error::Result<Self> {
+        if raw.len() > 0 {
+            let v = &raw[0];
+            if let Ok(s) = std::str::from_utf8(v) {
+                const PREFIX: &'static str = "bytes ";
+                if s.starts_with(PREFIX) {
+                    if let Ok(c) = <Chunk as FromStr>::from_str(&s[PREFIX.len()..]) {
+                        return  Ok(RangeResponseHeader(c))
+                    }
+                }
+            }
+        }
+        Err(hyper::error::Error::Method)
+    }
+}
+
+impl HeaderFormat for RangeResponseHeader {
+    /// No implmentation necessary, we just need to parse
+    fn fmt_header(&self, _: &mut fmt::Formatter) -> fmt::Result {
+        Err(fmt::Error)
+    }
+}
+
+/// A utility type to perform a resumable upload from start to end.
+pub struct ResumableUploadHelper<'a, A: 'a> {
+    pub client: &'a mut hyper::client::Client,
+    pub delegate: &'a mut Delegate,
+    pub start_at: Option<u64>,
+    pub auth: &'a mut A,
+    pub user_agent: &'a str,
+    pub auth_header: Authorization<Bearer>,
+    pub url: &'a str,
+    pub reader: &'a mut ReadSeek,
+    pub media_type: Mime,
+    pub content_length: u64
+}
+
+impl<'a, A> ResumableUploadHelper<'a, A>
+    where A: oauth2::GetToken {
+
+    fn query_transfer_status(&mut self) -> std::result::Result<u64, hyper::Result<hyper::client::Response>> {
+        loop {
+            match self.client.post(self.url)
+                .header(UserAgent(self.user_agent.to_string()))
+                .header(ContentRange { range: None, total_length: self.content_length })
+                .header(self.auth_header.clone())
+                .send() {
+                Ok(r) => {
+                    // 308 = resume-incomplete == PermanentRedirect
+                    let headers = r.headers.clone();
+                    let h: &RangeResponseHeader = match headers.get() {
+                        Some(hh) if r.status == StatusCode::PermanentRedirect => hh,
+                        None|Some(_) => {
+                            if let Retry::After(d) = self.delegate.http_failure(&r, None, None) {
+                                sleep(d);
+                                continue;
+                            }
+                            return Err(Ok(r))
+                        }
+                    };
+                    return Ok(h.0.last)
+                }
+                Err(err) => {
+                    if let Retry::After(d) = self.delegate.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    return Err(Err(err))
+                }
+            }
+        }
+    }
+
+    /// returns None if operation was cancelled by delegate, or the HttpResult.
+    /// It can be that we return the result just because we didn't understand the status code -
+    /// caller should check for status himself before assuming it's OK to use
+    pub fn upload(&mut self) -> Option<hyper::Result<hyper::client::Response>> {
+        let mut start = match self.start_at {
+            Some(s) => s,
+            None => match self.query_transfer_status() {
+                Ok(s) => s,
+                Err(result) => return Some(result)
+            }
+        };
+
+        const MIN_CHUNK_SIZE: u64 = 1 << 18;
+        let chunk_size = match self.delegate.chunk_size() {
+            cs if cs > MIN_CHUNK_SIZE => cs,
+            _ => MIN_CHUNK_SIZE
+        };
+
+        self.reader.seek(SeekFrom::Start(start)).unwrap();
+        loop {
+            let request_size = match self.content_length - start {
+                rs if rs > chunk_size => chunk_size,
+                rs => rs
+            };
+
+            let mut section_reader = self.reader.take(request_size);
+            let range_header = ContentRange {
+                range: Some(Chunk {first: start, last: start + request_size - 1}),
+                total_length: self.content_length
+            };
+            start += request_size;
+            if self.delegate.cancel_chunk_upload(&range_header) {
+                return None
+            }
+            let res = self.client.post(self.url)
+                                 .header(range_header)
+                                 .header(ContentType(self.media_type.clone()))
+                                 .header(UserAgent(self.user_agent.to_string()))
+                                 .body(&mut section_reader)
+                                 .send();
+            match res {
+                Ok(mut res) => {
+                    if res.status == StatusCode::PermanentRedirect  {
+                        continue
+                    }
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let Retry::After(d) = self.delegate.http_failure(&res,
+                                                        json::from_str(&json_err).ok(),
+                                                        json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                    }
+                    return Some(Ok(res))
+                },
+                Err(err) => {
+                    if let Retry::After(d) = self.delegate.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    return Some(Err(err))
+                }
+            }
+        }
+    }
+}
+
+// Copy of src/rust/cli/cmn.rs
+// TODO(ST): Allow sharing common code between program types
+pub fn remove_json_null_values(value: &mut json::value::Value) {
+    match *value {
+        json::value::Value::Object(ref mut map) => {
+            let mut for_removal = Vec::new();
+
+            for (key, mut value) in map.iter_mut() {
+                if value.is_null() {
+                    for_removal.push(key.clone());
+                } else {
+                    remove_json_null_values(&mut value);
+                }
+            }
+
+            for key in &for_removal {
+                map.remove(key);
+            }
+        }
+        _ => {}
+    }
+}

--- a/gen/language1/src/lib.rs
+++ b/gen/language1/src/lib.rs
@@ -1,0 +1,2576 @@
+// DO NOT EDIT !
+// This file was generated automatically from 'src/mako/api/lib.rs.mako'
+// DO NOT EDIT !
+
+//! This documentation was generated from *Cloud Natural Language* crate version *1.0.7+20171204*, where *20171204* is the exact revision of the *language:v1* schema built by the [mako](http://www.makotemplates.org/) code generator *v1.0.7*.
+//! 
+//! Everything else about the *Cloud Natural Language* *v1* API can be found at the
+//! [official documentation site](https://cloud.google.com/natural-language/).
+//! The original source code is [on github](https://github.com/Byron/google-apis-rs/tree/master/gen/language1).
+//! # Features
+//! 
+//! Handle the following *Resources* with ease from the central [hub](struct.CloudNaturalLanguage.html) ... 
+//! 
+//! * [documents](struct.Document.html)
+//!  * [*analyze entities*](struct.DocumentAnalyzeEntityCall.html), [*analyze entity sentiment*](struct.DocumentAnalyzeEntitySentimentCall.html), [*analyze sentiment*](struct.DocumentAnalyzeSentimentCall.html), [*analyze syntax*](struct.DocumentAnalyzeSyntaxCall.html), [*annotate text*](struct.DocumentAnnotateTextCall.html) and [*classify text*](struct.DocumentClassifyTextCall.html)
+//! 
+//! 
+//! 
+//! 
+//! Not what you are looking for ? Find all other Google APIs in their Rust [documentation index](http://byron.github.io/google-apis-rs).
+//! 
+//! # Structure of this Library
+//! 
+//! The API is structured into the following primary items:
+//! 
+//! * **[Hub](struct.CloudNaturalLanguage.html)**
+//!     * a central object to maintain state and allow accessing all *Activities*
+//!     * creates [*Method Builders*](trait.MethodsBuilder.html) which in turn
+//!       allow access to individual [*Call Builders*](trait.CallBuilder.html)
+//! * **[Resources](trait.Resource.html)**
+//!     * primary types that you can apply *Activities* to
+//!     * a collection of properties and *Parts*
+//!     * **[Parts](trait.Part.html)**
+//!         * a collection of properties
+//!         * never directly used in *Activities*
+//! * **[Activities](trait.CallBuilder.html)**
+//!     * operations to apply to *Resources*
+//! 
+//! All *structures* are marked with applicable traits to further categorize them and ease browsing.
+//! 
+//! Generally speaking, you can invoke *Activities* like this:
+//! 
+//! ```Rust,ignore
+//! let r = hub.resource().activity(...).doit()
+//! ```
+//! 
+//! Or specifically ...
+//! 
+//! ```ignore
+//! let r = hub.documents().analyze_syntax(...).doit()
+//! let r = hub.documents().analyze_sentiment(...).doit()
+//! let r = hub.documents().classify_text(...).doit()
+//! let r = hub.documents().analyze_entity_sentiment(...).doit()
+//! let r = hub.documents().analyze_entities(...).doit()
+//! let r = hub.documents().annotate_text(...).doit()
+//! ```
+//! 
+//! The `resource()` and `activity(...)` calls create [builders][builder-pattern]. The second one dealing with `Activities` 
+//! supports various methods to configure the impending operation (not shown here). It is made such that all required arguments have to be 
+//! specified right away (i.e. `(...)`), whereas all optional ones can be [build up][builder-pattern] as desired.
+//! The `doit()` method performs the actual communication with the server and returns the respective result.
+//! 
+//! # Usage
+//! 
+//! ## Setting up your Project
+//! 
+//! To use this library, you would put the following lines into your `Cargo.toml` file:
+//! 
+//! ```toml
+//! [dependencies]
+//! google-language1 = "*"
+//! ```
+//! 
+//! ## A complete example
+//! 
+//! ```test_harness,no_run
+//! extern crate hyper;
+//! extern crate hyper_rustls;
+//! extern crate yup_oauth2 as oauth2;
+//! extern crate google_language1 as language1;
+//! use language1::AnalyzeSyntaxRequest;
+//! use language1::{Result, Error};
+//! # #[test] fn egal() {
+//! use std::default::Default;
+//! use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+//! use language1::CloudNaturalLanguage;
+//! 
+//! // Get an ApplicationSecret instance by some means. It contains the `client_id` and 
+//! // `client_secret`, among other things.
+//! let secret: ApplicationSecret = Default::default();
+//! // Instantiate the authenticator. It will choose a suitable authentication flow for you, 
+//! // unless you replace  `None` with the desired Flow.
+//! // Provide your own `AuthenticatorDelegate` to adjust the way it operates and get feedback about 
+//! // what's going on. You probably want to bring in your own `TokenStorage` to persist tokens and
+//! // retrieve them from storage.
+//! let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+//!                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+//!                               <MemoryStorage as Default>::default(), None);
+//! let mut hub = CloudNaturalLanguage::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+//! // As the method needs a request, you would usually fill it with the desired information
+//! // into the respective structure. Some of the parts shown here might not be applicable !
+//! // Values shown here are possibly random and not representative !
+//! let mut req = AnalyzeSyntaxRequest::default();
+//! 
+//! // You can configure optional parameters by calling the respective setters at will, and
+//! // execute the final call using `doit()`.
+//! // Values shown here are possibly random and not representative !
+//! let result = hub.documents().analyze_syntax(req)
+//!              .doit();
+//! 
+//! match result {
+//!     Err(e) => match e {
+//!         // The Error enum provides details about what exactly happened.
+//!         // You can also just use its `Debug`, `Display` or `Error` traits
+//!          Error::HttpError(_)
+//!         |Error::MissingAPIKey
+//!         |Error::MissingToken(_)
+//!         |Error::Cancelled
+//!         |Error::UploadSizeLimitExceeded(_, _)
+//!         |Error::Failure(_)
+//!         |Error::BadRequest(_)
+//!         |Error::FieldClash(_)
+//!         |Error::JsonDecodeError(_, _) => println!("{}", e),
+//!     },
+//!     Ok(res) => println!("Success: {:?}", res),
+//! }
+//! # }
+//! ```
+//! ## Handling Errors
+//! 
+//! All errors produced by the system are provided either as [Result](enum.Result.html) enumeration as return value of 
+//! the doit() methods, or handed as possibly intermediate results to either the 
+//! [Hub Delegate](trait.Delegate.html), or the [Authenticator Delegate](https://docs.rs/yup-oauth2/*/yup_oauth2/trait.AuthenticatorDelegate.html).
+//! 
+//! When delegates handle errors or intermediate values, they may have a chance to instruct the system to retry. This 
+//! makes the system potentially resilient to all kinds of errors.
+//! 
+//! ## Uploads and Downloads
+//! If a method supports downloads, the response body, which is part of the [Result](enum.Result.html), should be
+//! read by you to obtain the media.
+//! If such a method also supports a [Response Result](trait.ResponseResult.html), it will return that by default.
+//! You can see it as meta-data for the actual media. To trigger a media download, you will have to set up the builder by making
+//! this call: `.param("alt", "media")`.
+//! 
+//! Methods supporting uploads can do so using up to 2 different protocols: 
+//! *simple* and *resumable*. The distinctiveness of each is represented by customized 
+//! `doit(...)` methods, which are then named `upload(...)` and `upload_resumable(...)` respectively.
+//! 
+//! ## Customization and Callbacks
+//! 
+//! You may alter the way an `doit()` method is called by providing a [delegate](trait.Delegate.html) to the 
+//! [Method Builder](trait.CallBuilder.html) before making the final `doit()` call. 
+//! Respective methods will be called to provide progress information, as well as determine whether the system should 
+//! retry on failure.
+//! 
+//! The [delegate trait](trait.Delegate.html) is default-implemented, allowing you to customize it with minimal effort.
+//! 
+//! ## Optional Parts in Server-Requests
+//! 
+//! All structures provided by this library are made to be [enocodable](trait.RequestValue.html) and 
+//! [decodable](trait.ResponseResult.html) via *json*. Optionals are used to indicate that partial requests are responses 
+//! are valid.
+//! Most optionals are are considered [Parts](trait.Part.html) which are identifiable by name, which will be sent to 
+//! the server to indicate either the set parts of the request or the desired parts in the response.
+//! 
+//! ## Builder Arguments
+//! 
+//! Using [method builders](trait.CallBuilder.html), you are able to prepare an action call by repeatedly calling it's methods.
+//! These will always take a single argument, for which the following statements are true.
+//! 
+//! * [PODs][wiki-pod] are handed by copy
+//! * strings are passed as `&str`
+//! * [request values](trait.RequestValue.html) are moved
+//! 
+//! Arguments will always be copied or cloned into the builder, to make them independent of their original life times.
+//! 
+//! [wiki-pod]: http://en.wikipedia.org/wiki/Plain_old_data_structure
+//! [builder-pattern]: http://en.wikipedia.org/wiki/Builder_pattern
+//! [google-go-api]: https://github.com/google/google-api-go-client
+//! 
+//! 
+
+// Unused attributes happen thanks to defined, but unused structures
+// We don't warn about this, as depending on the API, some data structures or facilities are never used.
+// Instead of pre-determining this, we just disable the lint. It's manually tuned to not have any
+// unused imports in fully featured APIs. Same with unused_mut ... .
+#![allow(unused_imports, unused_mut, dead_code)]
+
+// DO NOT EDIT !
+// This file was generated automatically from 'src/mako/api/lib.rs.mako'
+// DO NOT EDIT !
+
+#[macro_use]
+extern crate serde_derive;
+
+extern crate hyper;
+extern crate serde;
+extern crate serde_json;
+extern crate yup_oauth2 as oauth2;
+extern crate mime;
+extern crate url;
+
+mod cmn;
+
+use std::collections::HashMap;
+use std::cell::RefCell;
+use std::borrow::BorrowMut;
+use std::default::Default;
+use std::collections::BTreeMap;
+use serde_json as json;
+use std::io;
+use std::fs;
+use std::mem;
+use std::thread::sleep;
+use std::time::Duration;
+
+pub use cmn::{MultiPartReader, ToParts, MethodInfo, Result, Error, CallBuilder, Hub, ReadSeek, Part,
+              ResponseResult, RequestValue, NestedType, Delegate, DefaultDelegate, MethodsBuilder,
+              Resource, ErrorResponse, remove_json_null_values};
+
+
+// ##############
+// UTILITIES ###
+// ############
+
+/// Identifies the an OAuth2 authorization scope.
+/// A scope is needed when requesting an
+/// [authorization token](https://developers.google.com/youtube/v3/guides/authentication).
+#[derive(PartialEq, Eq, Hash)]
+pub enum Scope {
+    /// Apply machine learning models to reveal the structure and meaning of text
+    CloudLanguage,
+
+    /// View and manage your data across Google Cloud Platform services
+    CloudPlatform,
+}
+
+impl AsRef<str> for Scope {
+    fn as_ref(&self) -> &str {
+        match *self {
+            Scope::CloudLanguage => "https://www.googleapis.com/auth/cloud-language",
+            Scope::CloudPlatform => "https://www.googleapis.com/auth/cloud-platform",
+        }
+    }
+}
+
+impl Default for Scope {
+    fn default() -> Scope {
+        Scope::CloudLanguage
+    }
+}
+
+
+
+// ########
+// HUB ###
+// ######
+
+/// Central instance to access all CloudNaturalLanguage related resource activities
+///
+/// # Examples
+///
+/// Instantiate a new hub
+///
+/// ```test_harness,no_run
+/// extern crate hyper;
+/// extern crate hyper_rustls;
+/// extern crate yup_oauth2 as oauth2;
+/// extern crate google_language1 as language1;
+/// use language1::AnalyzeSyntaxRequest;
+/// use language1::{Result, Error};
+/// # #[test] fn egal() {
+/// use std::default::Default;
+/// use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// use language1::CloudNaturalLanguage;
+/// 
+/// // Get an ApplicationSecret instance by some means. It contains the `client_id` and 
+/// // `client_secret`, among other things.
+/// let secret: ApplicationSecret = Default::default();
+/// // Instantiate the authenticator. It will choose a suitable authentication flow for you, 
+/// // unless you replace  `None` with the desired Flow.
+/// // Provide your own `AuthenticatorDelegate` to adjust the way it operates and get feedback about 
+/// // what's going on. You probably want to bring in your own `TokenStorage` to persist tokens and
+/// // retrieve them from storage.
+/// let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+///                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+///                               <MemoryStorage as Default>::default(), None);
+/// let mut hub = CloudNaturalLanguage::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = AnalyzeSyntaxRequest::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.documents().analyze_syntax(req)
+///              .doit();
+/// 
+/// match result {
+///     Err(e) => match e {
+///         // The Error enum provides details about what exactly happened.
+///         // You can also just use its `Debug`, `Display` or `Error` traits
+///          Error::HttpError(_)
+///         |Error::MissingAPIKey
+///         |Error::MissingToken(_)
+///         |Error::Cancelled
+///         |Error::UploadSizeLimitExceeded(_, _)
+///         |Error::Failure(_)
+///         |Error::BadRequest(_)
+///         |Error::FieldClash(_)
+///         |Error::JsonDecodeError(_, _) => println!("{}", e),
+///     },
+///     Ok(res) => println!("Success: {:?}", res),
+/// }
+/// # }
+/// ```
+pub struct CloudNaturalLanguage<C, A> {
+    client: RefCell<C>,
+    auth: RefCell<A>,
+    _user_agent: String,
+    _base_url: String,
+    _root_url: String,
+}
+
+impl<'a, C, A> Hub for CloudNaturalLanguage<C, A> {}
+
+impl<'a, C, A> CloudNaturalLanguage<C, A>
+    where  C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+    pub fn new(client: C, authenticator: A) -> CloudNaturalLanguage<C, A> {
+        CloudNaturalLanguage {
+            client: RefCell::new(client),
+            auth: RefCell::new(authenticator),
+            _user_agent: "google-api-rust-client/1.0.7".to_string(),
+            _base_url: "https://language.googleapis.com/".to_string(),
+            _root_url: "https://language.googleapis.com/".to_string(),
+        }
+    }
+
+    pub fn documents(&'a self) -> DocumentMethods<'a, C, A> {
+        DocumentMethods { hub: &self }
+    }
+
+    /// Set the user-agent header field to use in all requests to the server.
+    /// It defaults to `google-api-rust-client/1.0.7`.
+    ///
+    /// Returns the previously set user-agent.
+    pub fn user_agent(&mut self, agent_name: String) -> String {
+        mem::replace(&mut self._user_agent, agent_name)
+    }
+
+    /// Set the base url to use in all requests to the server.
+    /// It defaults to `https://language.googleapis.com/`.
+    ///
+    /// Returns the previously set base url.
+    pub fn base_url(&mut self, new_base_url: String) -> String {
+        mem::replace(&mut self._base_url, new_base_url)
+    }
+
+    /// Set the root url to use in all requests to the server.
+    /// It defaults to `https://language.googleapis.com/`.
+    ///
+    /// Returns the previously set root url.
+    pub fn root_url(&mut self, new_root_url: String) -> String {
+        mem::replace(&mut self._root_url, new_root_url)
+    }
+}
+
+
+// ############
+// SCHEMAS ###
+// ##########
+/// Represents part of speech information for a token. Parts of speech
+/// are as defined in
+/// http://www.lrec-conf.org/proceedings/lrec2012/pdf/274_Paper.pdf
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct PartOfSpeech {
+    /// The grammatical case.
+    pub case: Option<String>,
+    /// The grammatical reciprocity.
+    pub reciprocity: Option<String>,
+    /// The grammatical form.
+    pub form: Option<String>,
+    /// The grammatical gender.
+    pub gender: Option<String>,
+    /// The grammatical number.
+    pub number: Option<String>,
+    /// The grammatical person.
+    pub person: Option<String>,
+    /// The part of speech tag.
+    pub tag: Option<String>,
+    /// The grammatical tense.
+    pub tense: Option<String>,
+    /// The grammatical aspect.
+    pub aspect: Option<String>,
+    /// The grammatical properness.
+    pub proper: Option<String>,
+    /// The grammatical voice.
+    pub voice: Option<String>,
+    /// The grammatical mood.
+    pub mood: Option<String>,
+}
+
+impl Part for PartOfSpeech {}
+
+
+/// Represents the feeling associated with the entire text or entities in
+/// the text.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Sentiment {
+    /// Sentiment score between -1.0 (negative sentiment) and 1.0
+    /// (positive sentiment).
+    pub score: Option<f32>,
+    /// A non-negative number in the [0, +inf) range, which represents
+    /// the absolute magnitude of sentiment regardless of score (positive or
+    /// negative).
+    pub magnitude: Option<f32>,
+}
+
+impl Part for Sentiment {}
+
+
+/// The document classification request message.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [classify text documents](struct.DocumentClassifyTextCall.html) (request)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct ClassifyTextRequest {
+    /// Input document.
+    pub document: Option<Document>,
+}
+
+impl RequestValue for ClassifyTextRequest {}
+
+
+/// The entity-level sentiment analysis request message.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [analyze entity sentiment documents](struct.DocumentAnalyzeEntitySentimentCall.html) (request)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct AnalyzeEntitySentimentRequest {
+    /// The encoding type used by the API to calculate offsets.
+    #[serde(rename="encodingType")]
+    pub encoding_type: Option<String>,
+    /// Input document.
+    pub document: Option<Document>,
+}
+
+impl RequestValue for AnalyzeEntitySentimentRequest {}
+
+
+/// The text annotations response message.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [annotate text documents](struct.DocumentAnnotateTextCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct AnnotateTextResponse {
+    /// Tokens, along with their syntactic information, in the input document.
+    /// Populated if the user enables
+    /// AnnotateTextRequest.Features.extract_syntax.
+    pub tokens: Option<Vec<Token>>,
+    /// Entities, along with their semantic information, in the input document.
+    /// Populated if the user enables
+    /// AnnotateTextRequest.Features.extract_entities.
+    pub entities: Option<Vec<Entity>>,
+    /// The overall sentiment for the document. Populated if the user enables
+    /// AnnotateTextRequest.Features.extract_document_sentiment.
+    #[serde(rename="documentSentiment")]
+    pub document_sentiment: Option<Sentiment>,
+    /// The language of the text, which will be the same as the language specified
+    /// in the request or, if not specified, the automatically-detected language.
+    /// See Document.language field for more details.
+    pub language: Option<String>,
+    /// Sentences in the input document. Populated if the user enables
+    /// AnnotateTextRequest.Features.extract_syntax.
+    pub sentences: Option<Vec<Sentence>>,
+    /// Categories identified in the input document.
+    pub categories: Option<Vec<ClassificationCategory>>,
+}
+
+impl ResponseResult for AnnotateTextResponse {}
+
+
+/// Represents dependency parse tree information for a token. (For more
+/// information on dependency labels, see
+/// http://www.aclweb.org/anthology/P13-2017
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct DependencyEdge {
+    /// Represents the head of this token in the dependency tree.
+    /// This is the index of the token which has an arc going to this token.
+    /// The index is the position of the token in the array of tokens returned
+    /// by the API method. If this token is a root token, then the
+    /// `head_token_index` is its own index.
+    #[serde(rename="headTokenIndex")]
+    pub head_token_index: Option<i32>,
+    /// The parse label for the token.
+    pub label: Option<String>,
+}
+
+impl Part for DependencyEdge {}
+
+
+/// Represents the smallest syntactic building block of the text.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Token {
+    /// The token text.
+    pub text: Option<TextSpan>,
+    /// Dependency tree parse for this token.
+    #[serde(rename="dependencyEdge")]
+    pub dependency_edge: Option<DependencyEdge>,
+    /// Parts of speech tag for this token.
+    #[serde(rename="partOfSpeech")]
+    pub part_of_speech: Option<PartOfSpeech>,
+    /// [Lemma](https://en.wikipedia.org/wiki/Lemma_%28morphology%29) of the token.
+    pub lemma: Option<String>,
+}
+
+impl Part for Token {}
+
+
+/// ################################################################ #
+/// 
+/// Represents the input to API methods.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [analyze syntax documents](struct.DocumentAnalyzeSyntaxCall.html) (none)
+/// * [analyze sentiment documents](struct.DocumentAnalyzeSentimentCall.html) (none)
+/// * [classify text documents](struct.DocumentClassifyTextCall.html) (none)
+/// * [analyze entity sentiment documents](struct.DocumentAnalyzeEntitySentimentCall.html) (none)
+/// * [analyze entities documents](struct.DocumentAnalyzeEntityCall.html) (none)
+/// * [annotate text documents](struct.DocumentAnnotateTextCall.html) (none)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Document {
+    /// The content of the input in string format.
+    pub content: Option<String>,
+    /// Required. If the type is not set or is `TYPE_UNSPECIFIED`,
+    /// returns an `INVALID_ARGUMENT` error.
+    #[serde(rename="type")]
+    pub type_: Option<String>,
+    /// The language of the document (if not specified, the language is
+    /// automatically detected). Both ISO and BCP-47 language codes are
+    /// accepted.<br>
+    /// [Language Support](/natural-language/docs/languages)
+    /// lists currently supported languages for each API method.
+    /// If the language (either specified by the caller or automatically detected)
+    /// is not supported by the called API method, an `INVALID_ARGUMENT` error
+    /// is returned.
+    pub language: Option<String>,
+    /// The Google Cloud Storage URI where the file content is located.
+    /// This URI must be of the form: gs://bucket_name/object_name. For more
+    /// details, see https://cloud.google.com/storage/docs/reference-uris.
+    /// NOTE: Cloud Storage object versioning is not supported.
+    #[serde(rename="gcsContentUri")]
+    pub gcs_content_uri: Option<String>,
+}
+
+impl Resource for Document {}
+
+
+/// The syntax analysis response message.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [analyze syntax documents](struct.DocumentAnalyzeSyntaxCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct AnalyzeSyntaxResponse {
+    /// Tokens, along with their syntactic information, in the input document.
+    pub tokens: Option<Vec<Token>>,
+    /// The language of the text, which will be the same as the language specified
+    /// in the request or, if not specified, the automatically-detected language.
+    /// See Document.language field for more details.
+    pub language: Option<String>,
+    /// Sentences in the input document.
+    pub sentences: Option<Vec<Sentence>>,
+}
+
+impl ResponseResult for AnalyzeSyntaxResponse {}
+
+
+/// The document classification response message.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [classify text documents](struct.DocumentClassifyTextCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct ClassifyTextResponse {
+    /// Categories representing the input document.
+    pub categories: Option<Vec<ClassificationCategory>>,
+}
+
+impl ResponseResult for ClassifyTextResponse {}
+
+
+/// The request message for the text annotation API, which can perform multiple
+/// analysis types (sentiment, entities, and syntax) in one call.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [annotate text documents](struct.DocumentAnnotateTextCall.html) (request)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct AnnotateTextRequest {
+    /// The encoding type used by the API to calculate offsets.
+    #[serde(rename="encodingType")]
+    pub encoding_type: Option<String>,
+    /// Input document.
+    pub document: Option<Document>,
+    /// The enabled features.
+    pub features: Option<Features>,
+}
+
+impl RequestValue for AnnotateTextRequest {}
+
+
+/// All available features for sentiment, syntax, and semantic analysis.
+/// Setting each one to true will enable that specific analysis for the input.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Features {
+    /// Classify the full document into categories.
+    #[serde(rename="classifyText")]
+    pub classify_text: Option<bool>,
+    /// Extract entities and their associated sentiment.
+    #[serde(rename="extractEntitySentiment")]
+    pub extract_entity_sentiment: Option<bool>,
+    /// Extract syntax information.
+    #[serde(rename="extractSyntax")]
+    pub extract_syntax: Option<bool>,
+    /// Extract entities.
+    #[serde(rename="extractEntities")]
+    pub extract_entities: Option<bool>,
+    /// Extract document-level sentiment.
+    #[serde(rename="extractDocumentSentiment")]
+    pub extract_document_sentiment: Option<bool>,
+}
+
+impl Part for Features {}
+
+
+/// Represents a category returned from the text classifier.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct ClassificationCategory {
+    /// The classifier's confidence of the category. Number represents how certain
+    /// the classifier is that this category represents the given text.
+    pub confidence: Option<f32>,
+    /// The name of the category representing the document.
+    pub name: Option<String>,
+}
+
+impl Part for ClassificationCategory {}
+
+
+/// Represents a sentence in the input document.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Sentence {
+    /// The sentence text.
+    pub text: Option<TextSpan>,
+    /// For calls to AnalyzeSentiment or if
+    /// AnnotateTextRequest.Features.extract_document_sentiment is set to
+    /// true, this field will contain the sentiment for the sentence.
+    pub sentiment: Option<Sentiment>,
+}
+
+impl Part for Sentence {}
+
+
+/// Represents an output piece of text.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct TextSpan {
+    /// The content of the output text.
+    pub content: Option<String>,
+    /// The API calculates the beginning offset of the content in the original
+    /// document according to the EncodingType specified in the API request.
+    #[serde(rename="beginOffset")]
+    pub begin_offset: Option<i32>,
+}
+
+impl Part for TextSpan {}
+
+
+/// Represents a phrase in the text that is a known entity, such as
+/// a person, an organization, or location. The API associates information, such
+/// as salience and mentions, with entities.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Entity {
+    /// The salience score associated with the entity in the [0, 1.0] range.
+    /// 
+    /// The salience score for an entity provides information about the
+    /// importance or centrality of that entity to the entire document text.
+    /// Scores closer to 0 are less salient, while scores closer to 1.0 are highly
+    /// salient.
+    pub salience: Option<f32>,
+    /// The representative name for the entity.
+    pub name: Option<String>,
+    /// For calls to AnalyzeEntitySentiment or if
+    /// AnnotateTextRequest.Features.extract_entity_sentiment is set to
+    /// true, this field will contain the aggregate sentiment expressed for this
+    /// entity in the provided document.
+    pub sentiment: Option<Sentiment>,
+    /// The mentions of this entity in the input document. The API currently
+    /// supports proper noun mentions.
+    pub mentions: Option<Vec<EntityMention>>,
+    /// The entity type.
+    #[serde(rename="type")]
+    pub type_: Option<String>,
+    /// Metadata associated with the entity.
+    /// 
+    /// Currently, Wikipedia URLs and Knowledge Graph MIDs are provided, if
+    /// available. The associated keys are "wikipedia_url" and "mid", respectively.
+    pub metadata: Option<HashMap<String, String>>,
+}
+
+impl Part for Entity {}
+
+
+/// Represents a mention for an entity in the text. Currently, proper noun
+/// mentions are supported.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct EntityMention {
+    /// The mention text.
+    pub text: Option<TextSpan>,
+    /// The type of the entity mention.
+    #[serde(rename="type")]
+    pub type_: Option<String>,
+    /// For calls to AnalyzeEntitySentiment or if
+    /// AnnotateTextRequest.Features.extract_entity_sentiment is set to
+    /// true, this field will contain the sentiment expressed for this mention of
+    /// the entity in the provided document.
+    pub sentiment: Option<Sentiment>,
+}
+
+impl Part for EntityMention {}
+
+
+/// The sentiment analysis request message.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [analyze sentiment documents](struct.DocumentAnalyzeSentimentCall.html) (request)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct AnalyzeSentimentRequest {
+    /// The encoding type used by the API to calculate sentence offsets.
+    #[serde(rename="encodingType")]
+    pub encoding_type: Option<String>,
+    /// Input document.
+    pub document: Option<Document>,
+}
+
+impl RequestValue for AnalyzeSentimentRequest {}
+
+
+/// The sentiment analysis response message.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [analyze sentiment documents](struct.DocumentAnalyzeSentimentCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct AnalyzeSentimentResponse {
+    /// The overall sentiment of the input document.
+    #[serde(rename="documentSentiment")]
+    pub document_sentiment: Option<Sentiment>,
+    /// The language of the text, which will be the same as the language specified
+    /// in the request or, if not specified, the automatically-detected language.
+    /// See Document.language field for more details.
+    pub language: Option<String>,
+    /// The sentiment for all the sentences in the document.
+    pub sentences: Option<Vec<Sentence>>,
+}
+
+impl ResponseResult for AnalyzeSentimentResponse {}
+
+
+/// The syntax analysis request message.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [analyze syntax documents](struct.DocumentAnalyzeSyntaxCall.html) (request)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct AnalyzeSyntaxRequest {
+    /// The encoding type used by the API to calculate offsets.
+    #[serde(rename="encodingType")]
+    pub encoding_type: Option<String>,
+    /// Input document.
+    pub document: Option<Document>,
+}
+
+impl RequestValue for AnalyzeSyntaxRequest {}
+
+
+/// The entity analysis response message.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [analyze entities documents](struct.DocumentAnalyzeEntityCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct AnalyzeEntitiesResponse {
+    /// The recognized entities in the input document.
+    pub entities: Option<Vec<Entity>>,
+    /// The language of the text, which will be the same as the language specified
+    /// in the request or, if not specified, the automatically-detected language.
+    /// See Document.language field for more details.
+    pub language: Option<String>,
+}
+
+impl ResponseResult for AnalyzeEntitiesResponse {}
+
+
+/// The entity analysis request message.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [analyze entities documents](struct.DocumentAnalyzeEntityCall.html) (request)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct AnalyzeEntitiesRequest {
+    /// The encoding type used by the API to calculate offsets.
+    #[serde(rename="encodingType")]
+    pub encoding_type: Option<String>,
+    /// Input document.
+    pub document: Option<Document>,
+}
+
+impl RequestValue for AnalyzeEntitiesRequest {}
+
+
+/// The entity-level sentiment analysis response message.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [analyze entity sentiment documents](struct.DocumentAnalyzeEntitySentimentCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct AnalyzeEntitySentimentResponse {
+    /// The recognized entities in the input document with associated sentiments.
+    pub entities: Option<Vec<Entity>>,
+    /// The language of the text, which will be the same as the language specified
+    /// in the request or, if not specified, the automatically-detected language.
+    /// See Document.language field for more details.
+    pub language: Option<String>,
+}
+
+impl ResponseResult for AnalyzeEntitySentimentResponse {}
+
+
+
+// ###################
+// MethodBuilders ###
+// #################
+
+/// A builder providing access to all methods supported on *document* resources.
+/// It is not used directly, but through the `CloudNaturalLanguage` hub.
+///
+/// # Example
+///
+/// Instantiate a resource builder
+///
+/// ```test_harness,no_run
+/// extern crate hyper;
+/// extern crate hyper_rustls;
+/// extern crate yup_oauth2 as oauth2;
+/// extern crate google_language1 as language1;
+/// 
+/// # #[test] fn egal() {
+/// use std::default::Default;
+/// use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// use language1::CloudNaturalLanguage;
+/// 
+/// let secret: ApplicationSecret = Default::default();
+/// let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+///                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+///                               <MemoryStorage as Default>::default(), None);
+/// let mut hub = CloudNaturalLanguage::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // Usually you wouldn't bind this to a variable, but keep calling *CallBuilders*
+/// // like `analyze_entities(...)`, `analyze_entity_sentiment(...)`, `analyze_sentiment(...)`, `analyze_syntax(...)`, `annotate_text(...)` and `classify_text(...)`
+/// // to build up your call.
+/// let rb = hub.documents();
+/// # }
+/// ```
+pub struct DocumentMethods<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a CloudNaturalLanguage<C, A>,
+}
+
+impl<'a, C, A> MethodsBuilder for DocumentMethods<'a, C, A> {}
+
+impl<'a, C, A> DocumentMethods<'a, C, A> {
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Analyzes the syntax of the text and provides sentence boundaries and
+    /// tokenization along with part of speech tags, dependency trees, and other
+    /// properties.
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    pub fn analyze_syntax(&self, request: AnalyzeSyntaxRequest) -> DocumentAnalyzeSyntaxCall<'a, C, A> {
+        DocumentAnalyzeSyntaxCall {
+            hub: self.hub,
+            _request: request,
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Analyzes the sentiment of the provided text.
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    pub fn analyze_sentiment(&self, request: AnalyzeSentimentRequest) -> DocumentAnalyzeSentimentCall<'a, C, A> {
+        DocumentAnalyzeSentimentCall {
+            hub: self.hub,
+            _request: request,
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Classifies a document into categories.
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    pub fn classify_text(&self, request: ClassifyTextRequest) -> DocumentClassifyTextCall<'a, C, A> {
+        DocumentClassifyTextCall {
+            hub: self.hub,
+            _request: request,
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Finds entities, similar to AnalyzeEntities in the text and analyzes
+    /// sentiment associated with each entity and its mentions.
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    pub fn analyze_entity_sentiment(&self, request: AnalyzeEntitySentimentRequest) -> DocumentAnalyzeEntitySentimentCall<'a, C, A> {
+        DocumentAnalyzeEntitySentimentCall {
+            hub: self.hub,
+            _request: request,
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Finds named entities (currently proper names and common nouns) in the text
+    /// along with entity types, salience, mentions for each entity, and
+    /// other properties.
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    pub fn analyze_entities(&self, request: AnalyzeEntitiesRequest) -> DocumentAnalyzeEntityCall<'a, C, A> {
+        DocumentAnalyzeEntityCall {
+            hub: self.hub,
+            _request: request,
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// A convenience method that provides all the features that analyzeSentiment,
+    /// analyzeEntities, and analyzeSyntax provide in one call.
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    pub fn annotate_text(&self, request: AnnotateTextRequest) -> DocumentAnnotateTextCall<'a, C, A> {
+        DocumentAnnotateTextCall {
+            hub: self.hub,
+            _request: request,
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+}
+
+
+
+
+
+// ###################
+// CallBuilders   ###
+// #################
+
+/// Analyzes the syntax of the text and provides sentence boundaries and
+/// tokenization along with part of speech tags, dependency trees, and other
+/// properties.
+///
+/// A builder for the *analyzeSyntax* method supported by a *document* resource.
+/// It is not used directly, but through a `DocumentMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_language1 as language1;
+/// use language1::AnalyzeSyntaxRequest;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use language1::CloudNaturalLanguage;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = CloudNaturalLanguage::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = AnalyzeSyntaxRequest::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.documents().analyze_syntax(req)
+///              .doit();
+/// # }
+/// ```
+pub struct DocumentAnalyzeSyntaxCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a CloudNaturalLanguage<C, A>,
+    _request: AnalyzeSyntaxRequest,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for DocumentAnalyzeSyntaxCall<'a, C, A> {}
+
+impl<'a, C, A> DocumentAnalyzeSyntaxCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, AnalyzeSyntaxResponse)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "language.documents.analyzeSyntax",
+                               http_method: hyper::method::Method::Post });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((3 + self._additional_params.len()));
+        for &field in ["alt"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1/documents:analyzeSyntax";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudLanguage.as_ref().to_string(), ());
+        }
+
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Post, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: AnalyzeSyntaxRequest) -> DocumentAnalyzeSyntaxCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> DocumentAnalyzeSyntaxCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> DocumentAnalyzeSyntaxCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudLanguage`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> DocumentAnalyzeSyntaxCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Analyzes the sentiment of the provided text.
+///
+/// A builder for the *analyzeSentiment* method supported by a *document* resource.
+/// It is not used directly, but through a `DocumentMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_language1 as language1;
+/// use language1::AnalyzeSentimentRequest;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use language1::CloudNaturalLanguage;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = CloudNaturalLanguage::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = AnalyzeSentimentRequest::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.documents().analyze_sentiment(req)
+///              .doit();
+/// # }
+/// ```
+pub struct DocumentAnalyzeSentimentCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a CloudNaturalLanguage<C, A>,
+    _request: AnalyzeSentimentRequest,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for DocumentAnalyzeSentimentCall<'a, C, A> {}
+
+impl<'a, C, A> DocumentAnalyzeSentimentCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, AnalyzeSentimentResponse)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "language.documents.analyzeSentiment",
+                               http_method: hyper::method::Method::Post });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((3 + self._additional_params.len()));
+        for &field in ["alt"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1/documents:analyzeSentiment";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudLanguage.as_ref().to_string(), ());
+        }
+
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Post, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: AnalyzeSentimentRequest) -> DocumentAnalyzeSentimentCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> DocumentAnalyzeSentimentCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> DocumentAnalyzeSentimentCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudLanguage`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> DocumentAnalyzeSentimentCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Classifies a document into categories.
+///
+/// A builder for the *classifyText* method supported by a *document* resource.
+/// It is not used directly, but through a `DocumentMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_language1 as language1;
+/// use language1::ClassifyTextRequest;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use language1::CloudNaturalLanguage;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = CloudNaturalLanguage::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = ClassifyTextRequest::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.documents().classify_text(req)
+///              .doit();
+/// # }
+/// ```
+pub struct DocumentClassifyTextCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a CloudNaturalLanguage<C, A>,
+    _request: ClassifyTextRequest,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for DocumentClassifyTextCall<'a, C, A> {}
+
+impl<'a, C, A> DocumentClassifyTextCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, ClassifyTextResponse)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "language.documents.classifyText",
+                               http_method: hyper::method::Method::Post });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((3 + self._additional_params.len()));
+        for &field in ["alt"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1/documents:classifyText";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudLanguage.as_ref().to_string(), ());
+        }
+
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Post, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: ClassifyTextRequest) -> DocumentClassifyTextCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> DocumentClassifyTextCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> DocumentClassifyTextCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudLanguage`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> DocumentClassifyTextCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Finds entities, similar to AnalyzeEntities in the text and analyzes
+/// sentiment associated with each entity and its mentions.
+///
+/// A builder for the *analyzeEntitySentiment* method supported by a *document* resource.
+/// It is not used directly, but through a `DocumentMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_language1 as language1;
+/// use language1::AnalyzeEntitySentimentRequest;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use language1::CloudNaturalLanguage;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = CloudNaturalLanguage::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = AnalyzeEntitySentimentRequest::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.documents().analyze_entity_sentiment(req)
+///              .doit();
+/// # }
+/// ```
+pub struct DocumentAnalyzeEntitySentimentCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a CloudNaturalLanguage<C, A>,
+    _request: AnalyzeEntitySentimentRequest,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for DocumentAnalyzeEntitySentimentCall<'a, C, A> {}
+
+impl<'a, C, A> DocumentAnalyzeEntitySentimentCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, AnalyzeEntitySentimentResponse)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "language.documents.analyzeEntitySentiment",
+                               http_method: hyper::method::Method::Post });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((3 + self._additional_params.len()));
+        for &field in ["alt"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1/documents:analyzeEntitySentiment";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudLanguage.as_ref().to_string(), ());
+        }
+
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Post, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: AnalyzeEntitySentimentRequest) -> DocumentAnalyzeEntitySentimentCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> DocumentAnalyzeEntitySentimentCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> DocumentAnalyzeEntitySentimentCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudLanguage`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> DocumentAnalyzeEntitySentimentCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Finds named entities (currently proper names and common nouns) in the text
+/// along with entity types, salience, mentions for each entity, and
+/// other properties.
+///
+/// A builder for the *analyzeEntities* method supported by a *document* resource.
+/// It is not used directly, but through a `DocumentMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_language1 as language1;
+/// use language1::AnalyzeEntitiesRequest;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use language1::CloudNaturalLanguage;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = CloudNaturalLanguage::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = AnalyzeEntitiesRequest::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.documents().analyze_entities(req)
+///              .doit();
+/// # }
+/// ```
+pub struct DocumentAnalyzeEntityCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a CloudNaturalLanguage<C, A>,
+    _request: AnalyzeEntitiesRequest,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for DocumentAnalyzeEntityCall<'a, C, A> {}
+
+impl<'a, C, A> DocumentAnalyzeEntityCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, AnalyzeEntitiesResponse)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "language.documents.analyzeEntities",
+                               http_method: hyper::method::Method::Post });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((3 + self._additional_params.len()));
+        for &field in ["alt"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1/documents:analyzeEntities";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudLanguage.as_ref().to_string(), ());
+        }
+
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Post, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: AnalyzeEntitiesRequest) -> DocumentAnalyzeEntityCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> DocumentAnalyzeEntityCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> DocumentAnalyzeEntityCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudLanguage`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> DocumentAnalyzeEntityCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// A convenience method that provides all the features that analyzeSentiment,
+/// analyzeEntities, and analyzeSyntax provide in one call.
+///
+/// A builder for the *annotateText* method supported by a *document* resource.
+/// It is not used directly, but through a `DocumentMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_language1 as language1;
+/// use language1::AnnotateTextRequest;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use language1::CloudNaturalLanguage;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = CloudNaturalLanguage::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = AnnotateTextRequest::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.documents().annotate_text(req)
+///              .doit();
+/// # }
+/// ```
+pub struct DocumentAnnotateTextCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a CloudNaturalLanguage<C, A>,
+    _request: AnnotateTextRequest,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for DocumentAnnotateTextCall<'a, C, A> {}
+
+impl<'a, C, A> DocumentAnnotateTextCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, AnnotateTextResponse)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "language.documents.annotateText",
+                               http_method: hyper::method::Method::Post });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((3 + self._additional_params.len()));
+        for &field in ["alt"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1/documents:annotateText";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudLanguage.as_ref().to_string(), ());
+        }
+
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Post, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: AnnotateTextRequest) -> DocumentAnnotateTextCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> DocumentAnnotateTextCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> DocumentAnnotateTextCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudLanguage`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> DocumentAnnotateTextCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+

--- a/gen/language1_beta1-cli/Cargo.toml
+++ b/gen/language1_beta1-cli/Cargo.toml
@@ -1,0 +1,40 @@
+# DO NOT EDIT !
+# This file was generated automatically from 'src/mako/Cargo.toml.mako'
+# DO NOT EDIT !
+[package]
+
+name = "google-language1_beta1-cli"
+version = "1.0.7+20171204"
+authors = ["Sebastian Thiel <byronimo@gmail.com>"]
+description = "A complete library to interact with Cloud Natural Language (protocol v1beta1)"
+repository = "https://github.com/Byron/google-apis-rs/tree/master/gen/language1_beta1-cli"
+homepage = "https://cloud.google.com/natural-language/"
+documentation = "http://byron.github.io/google-apis-rs/google_language1_beta1_cli"
+license = "MIT"
+keywords = ["language", "google", "cli"]
+
+[[bin]]
+name = "language1-beta1"
+
+[dev-dependencies]
+hyper-rustls = "^0.6"
+
+[dependencies]
+hyper = "^ 0.10"
+mime = "^ 0.2.0"
+serde = "^ 1.0"
+serde_json = "^ 1.0"
+serde_derive = "^ 1.0"
+yup-oauth2 = "^ 1.0"
+strsim = "^0.5"
+hyper-rustls = "^0.6"
+yup-hyper-mock = "^2.0"
+clap = "^2.0"
+
+[features]
+
+
+
+[dependencies.google-language1_beta1]
+path = "../language1_beta1"
+version = "1.0.7+20171204"

--- a/gen/language1_beta1-cli/LICENSE.md
+++ b/gen/language1_beta1-cli/LICENSE.md
@@ -1,0 +1,30 @@
+<!---
+DO NOT EDIT !
+This file was generated automatically from 'src/mako/LICENSE.md.mako'
+DO NOT EDIT !
+-->
+The MIT License (MIT)
+=====================
+
+Copyright © `2015-2016` `Sebastian Thiel`
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the “Software”), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.

--- a/gen/language1_beta1-cli/README.md
+++ b/gen/language1_beta1-cli/README.md
@@ -1,0 +1,117 @@
+<!---
+DO NOT EDIT !
+This file was generated automatically from 'src/mako/cli/README.md.mako'
+DO NOT EDIT !
+-->
+The `language1-beta1` command-line interface *(CLI)* allows to use most features of the *Google Cloud Natural Language* service from the comfort of your terminal.
+
+By default all output is printed to standard out, but flags can be set to direct it into a file independent of your shell's
+capabilities. Errors will be printed to standard error, and cause the program's exit code to be non-zero.
+
+If data-structures are requested, these will be returned as pretty-printed JSON, to be useful as input to other tools.
+
+Everything else about the *Cloud Natural Language* API can be found at the
+[official documentation site](https://cloud.google.com/natural-language/).
+
+# Installation and Source Code
+
+Install the command-line interface with cargo using:
+
+```bash
+cargo install google-language1_beta1-cli
+```
+
+Find the source code [on github](https://github.com/Byron/google-apis-rs/tree/master/gen/language1_beta1-cli).
+
+# Usage
+
+This documentation was generated from the *Cloud Natural Language* API at revision *20171204*. The CLI is at version *1.0.7*.
+
+```bash
+language1-beta1 [options]
+        documents
+                analyze-entities (-r <kv>)... [-p <v>]... [-o <out>]
+                analyze-sentiment (-r <kv>)... [-p <v>]... [-o <out>]
+                analyze-syntax (-r <kv>)... [-p <v>]... [-o <out>]
+                annotate-text (-r <kv>)... [-p <v>]... [-o <out>]
+  language1-beta1 --help
+
+Configuration:
+  [--scope <url>]...
+            Specify the authentication a method should be executed in. Each scope
+            requires the user to grant this application permission to use it.
+            If unset, it defaults to the shortest scope url for a particular method.
+  --config-dir <folder>
+            A directory into which we will store our persistent data. Defaults to
+            a user-writable directory that we will create during the first invocation.
+            [default: ~/.google-service-cli]
+  --debug
+            Output all server communication to standard error. `tx` and `rx` are placed
+            into the same stream.
+  --debug-auth
+            Output all communication related to authentication to standard error. `tx`
+            and `rx` are placed into the same stream.
+
+```
+
+# Configuration
+
+The program will store all persistent data in the `~/.google-service-cli` directory in *JSON* files prefixed with `language1-beta1-`.  You can change the directory used to store configuration with the `--config-dir` flag on a per-invocation basis.
+
+More information about the various kinds of persistent data are given in the following paragraphs.
+
+# Authentication
+
+Most APIs require a user to authenticate any request. If this is the case, the [scope][scopes] determines the 
+set of permissions granted. The granularity of these is usually no more than *read-only* or *full-access*.
+
+If not set, the system will automatically select the smallest feasible scope, e.g. when invoking a
+method that is read-only, it will ask only for a read-only scope. 
+You may use the `--scope` flag to specify a scope directly. 
+All applicable scopes are documented in the respective method's CLI documentation.
+
+The first time a scope is used, the user is asked for permission. Follow the instructions given 
+by the CLI to grant permissions, or to decline.
+
+If a scope was authenticated by the user, the respective information will be stored as *JSON* in the configuration
+directory, e.g. `~/.google-service-cli/language1-beta1-token-<scope-hash>.json`. No manual management of these tokens
+is necessary.
+
+To revoke granted authentication, please refer to the [official documentation][revoke-access].
+
+# Application Secrets
+
+In order to allow any application to use Google services, it will need to be registered using the 
+[Google Developer Console][google-dev-console]. APIs the application may use are then enabled for it
+one by one. Most APIs can be used for free and have a daily quota.
+
+To allow more comfortable usage of the CLI without forcing anyone to register an own application, the CLI
+comes with a default application secret that is configured accordingly. This also means that heavy usage
+all around the world may deplete the daily quota.
+
+You can workaround this limitation by putting your own secrets file at this location: 
+`~/.google-service-cli/language1-beta1-secret.json`, assuming that the required *language* API 
+was enabled for it. Such a secret file can be downloaded in the *Google Developer Console* at 
+*APIs & auth -> Credentials -> Download JSON* and used as is.
+
+Learn more about how to setup Google projects and enable APIs using the [official documentation][google-project-new].
+
+
+# Debugging
+
+Even though the CLI does its best to provide usable error messages, sometimes it might be desirable to know
+what exactly led to a particular issue. This is done by allowing all client-server communication to be 
+output to standard error *as-is*.
+
+The `--debug` flag will print all client-server communication to standard error, whereas the `--debug-auth` flag
+will cause all communication related to authentication to standard error.
+If the `--debug` flag is set, error-results will be debug-printed, possibly yielding more information about the 
+issue at hand.
+
+You may consider redirecting standard error into a file for ease of use, e.g. `language1-beta1 --debug <resource> <method> [options] 2>debug.txt`.
+
+
+[scopes]: https://developers.google.com/+/api/oauth#scopes
+[revoke-access]: http://webapps.stackexchange.com/a/30849
+[google-dev-console]: https://console.developers.google.com/
+[google-project-new]: https://developers.google.com/console/help/new/

--- a/gen/language1_beta1-cli/mkdocs.yml
+++ b/gen/language1_beta1-cli/mkdocs.yml
@@ -1,0 +1,20 @@
+site_name: Cloud Natural Language v1.0.7+20171204
+site_url: http://byron.github.io/google-apis-rs/google-language1_beta1-cli
+site_description: A complete library to interact with Cloud Natural Language (protocol v1beta1)
+
+repo_url: https://github.com/Byron/google-apis-rs/tree/master/gen/language1_beta1-cli
+
+docs_dir: docs
+site_dir: build_html
+
+pages:
+- ['index.md', 'Home']
+- ['documents_analyze-entities.md', 'Documents', 'Analyze Entities']
+- ['documents_analyze-sentiment.md', 'Documents', 'Analyze Sentiment']
+- ['documents_analyze-syntax.md', 'Documents', 'Analyze Syntax']
+- ['documents_annotate-text.md', 'Documents', 'Annotate Text']
+
+theme: readthedocs
+
+copyright: Copyright &copy; 2015-2016, `Sebastian Thiel`
+

--- a/gen/language1_beta1-cli/src/cmn.rs
+++ b/gen/language1_beta1-cli/src/cmn.rs
@@ -1,0 +1,799 @@
+// COPY OF 'src/rust/cli/cmn.rs'
+// DO NOT EDIT
+use oauth2::{ApplicationSecret, ConsoleApplicationSecret, TokenStorage, Token};
+use serde_json as json;
+use serde_json::value::Value;
+use mime::Mime;
+use clap::{App, SubCommand};
+use strsim;
+
+use std::fs;
+use std::env;
+use std::io;
+use std::error::Error as StdError;
+use std::fmt;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+use std::string::ToString;
+use std::io::{Write, Read, stdout};
+
+use std::default::Default;
+
+const FIELD_SEP: char = '.';
+
+
+pub enum ComplexType {
+    Pod,
+    Vec,
+    Map,
+}
+
+// Null,
+// Bool(bool),
+// I64(i64),
+// U64(u64),
+// F64(f64),
+// String(String),
+
+pub enum JsonType {
+    Boolean,
+    Int,
+    Uint,
+    Float,
+    String,
+}
+
+pub struct JsonTypeInfo {
+    pub jtype: JsonType,
+    pub ctype: ComplexType,
+}
+
+// Based on @erickt user comment. Thanks for the idea !
+// Remove all keys whose values are null from given value (changed in place)
+pub fn remove_json_null_values(value: &mut Value) {
+    match *value {
+        Value::Object(ref mut map) => {
+            let mut for_removal = Vec::new();
+
+            for (key, mut value) in map.iter_mut() {
+                if value.is_null() {
+                    for_removal.push(key.clone());
+                } else {
+                    remove_json_null_values(&mut value);
+                }
+            }
+
+            for key in &for_removal {
+                map.remove(key);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn did_you_mean<'a>(v: &str, possible_values: &[&'a str]) -> Option<&'a str> {
+
+    let mut candidate: Option<(f64, &str)> = None;
+    for pv in possible_values {
+        let confidence = strsim::jaro_winkler(v, pv);
+        if confidence > 0.8 &&
+           (candidate.is_none() || (candidate.as_ref().unwrap().0 < confidence)) {
+            candidate = Some((confidence, pv));
+        }
+    }
+    match candidate {
+        None => None,
+        Some((_, candidate)) => Some(candidate),
+    }
+}
+
+pub enum CallType {
+    Upload(UploadProtocol),
+    Standard,
+}
+
+arg_enum!{
+    pub enum UploadProtocol {
+        Simple,
+        Resumable
+    }
+}
+
+impl AsRef<str> for UploadProtocol {
+    fn as_ref(&self) -> &str {
+        match *self {
+            UploadProtocol::Simple => "simple",
+            UploadProtocol::Resumable => "resumable",
+        }
+    }
+}
+
+impl AsRef<str> for CallType {
+    fn as_ref(&self) -> &str {
+        match *self {
+            CallType::Upload(ref proto) => proto.as_ref(),
+            CallType::Standard => "standard-request",
+        }
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct FieldCursor(Vec<String>);
+
+impl ToString for  FieldCursor {
+    fn to_string(&self) -> String {
+        self.0.join(".")
+    }
+}
+
+impl From<&'static str> for FieldCursor {
+    fn from(value: &'static str) -> FieldCursor {
+        let mut res = FieldCursor::default();
+        res.set(value).unwrap();
+        res
+    }
+}
+
+fn assure_entry<'a, 'b>(m: &'a mut json::Map<String, Value>, k: &'b String) -> &'a mut Value {
+    if m.contains_key(k) {
+        return m.get_mut(k).expect("value to exist");
+    }
+    m.insert(k.to_owned(), Value::Object(Default::default()));
+    m.get_mut(k).expect("value to exist")
+}
+
+impl FieldCursor {
+    pub fn set(&mut self, value: &str) -> Result<(), CLIError> {
+        if value.len() == 0 {
+            return Err(CLIError::Field(FieldError::Empty));
+        }
+
+        let mut first_is_field_sep = false;
+        let mut char_count: usize = 0;
+        let mut last_c = FIELD_SEP;
+        let mut num_conscutive_field_seps = 0;
+
+        let mut field = String::new();
+        let mut fields = self.0.clone();
+
+        let push_field = |fs: &mut Vec<String>, f: &mut String| {
+            if f.len() > 0 {
+                fs.push(f.clone());
+                f.truncate(0);
+            }
+        };
+
+        for (cid, c) in value.chars().enumerate() {
+            char_count += 1;
+
+            if c == FIELD_SEP {
+                if cid == 0 {
+                    first_is_field_sep = true;
+                }
+                num_conscutive_field_seps += 1;
+                if cid > 0 && last_c == FIELD_SEP {
+                    if fields.pop().is_none() {
+                        return Err(CLIError::Field(FieldError::PopOnEmpty(value.to_string())));
+                    }
+                } else {
+                    push_field(&mut fields, &mut field);
+                }
+            } else {
+                num_conscutive_field_seps = 0;
+                if cid == 1 {
+                    if first_is_field_sep {
+                        fields.truncate(0);
+                    }
+                }
+                field.push(c);
+            }
+
+            last_c = c;
+        }
+
+        push_field(&mut fields, &mut field);
+
+        if char_count == 1 && first_is_field_sep {
+            fields.truncate(0);
+        }
+        if char_count > 1 && num_conscutive_field_seps == 1 {
+            return Err(CLIError::Field(FieldError::TrailingFieldSep(value.to_string())));
+        }
+
+        self.0 = fields;
+        Ok(())
+    }
+
+    pub fn did_you_mean(value: &str, possible_values: &[&str]) -> Option<String> {
+        if value.len() == 0 {
+            return None;
+        }
+
+        let mut last_c = FIELD_SEP;
+
+        let mut field = String::new();
+        let mut output = String::new();
+
+        let push_field = |fs: &mut String, f: &mut String| {
+            if f.len() > 0 {
+                fs.push_str(match did_you_mean(&f, possible_values) {
+                    Some(candidate) => candidate,
+                    None => &f,
+                });
+                f.truncate(0);
+            }
+        };
+
+        for (cid, c) in value.chars().enumerate() {
+            if c == FIELD_SEP {
+                if last_c != FIELD_SEP {
+                    push_field(&mut output, &mut field);
+                }
+                output.push(c);
+            } else {
+                field.push(c);
+            }
+
+            last_c = c;
+        }
+
+        push_field(&mut output, &mut field);
+
+        if &output == value {
+            None
+        } else {
+            Some(output)
+        }
+    }
+
+    pub fn set_json_value(&self,
+                          mut object: &mut Value,
+                          value: &str,
+                          type_info: JsonTypeInfo,
+                          err: &mut InvalidOptionsError,
+                          orig_cursor: &FieldCursor) {
+        assert!(self.0.len() > 0);
+
+        for field in &self.0[..self.0.len() - 1] {
+            let tmp = object;
+            object = match *tmp {
+                Value::Object(ref mut mapping) => {
+                    assure_entry(mapping, &field)
+                }
+                _ => panic!("We don't expect non-object Values here ..."),
+            };
+        }
+
+        match *object {
+            Value::Object(ref mut mapping) => {
+                let field = &self.0[self.0.len() - 1];
+                let to_jval = |value: &str,
+                               jtype: JsonType,
+                               err: &mut InvalidOptionsError|
+                               -> Value {
+                    match jtype {
+                        JsonType::Boolean =>
+                            Value::Bool(arg_from_str(value, err, &field, "boolean")),
+                        JsonType::Int =>
+                            Value::Number(json::Number::from_f64(arg_from_str(value,
+                                                                              err,
+                                                                              &field,
+                                                                              "int"))
+                                              .expect("valid f64")),
+                        JsonType::Uint =>
+                            Value::Number(json::Number::from_f64(arg_from_str(value,
+                                                                              err,
+                                                                              &field,
+                                                                              "uint"))
+                                              .expect("valid f64")),
+                        JsonType::Float =>
+                            Value::Number(json::Number::from_f64(arg_from_str(value,
+                                                                              err,
+                                                                              &field,
+                                                                              "float"))
+                                              .expect("valid f64")),
+                        JsonType::String => Value::String(value.to_owned()),
+                    }
+                };
+
+                match type_info.ctype {
+                    ComplexType::Pod => {
+                        if mapping.insert(field.to_owned(), to_jval(value, type_info.jtype, err))
+                                  .is_some() {
+                            err.issues.push(CLIError::Field(FieldError::Duplicate(orig_cursor.to_string())));
+                        }
+                    }
+                    ComplexType::Vec => {
+                        match *assure_entry(mapping, field) {
+                            Value::Array(ref mut values) =>
+                                values.push(to_jval(value, type_info.jtype, err)),
+                            _ => unreachable!(),
+                        }
+                    }
+                    ComplexType::Map => {
+                        let (key, value) = parse_kv_arg(value, err, true);
+                        let jval = to_jval(value.unwrap_or(""), type_info.jtype, err);
+
+                        match *assure_entry(mapping, &field) {
+
+                            Value::Object(ref mut value_map) => {
+                                if value_map.insert(key.to_owned(), jval).is_some() {
+                                    err.issues.push(CLIError::Field(FieldError::Duplicate(orig_cursor.to_string())));
+                                }
+                            }
+                            _ => unreachable!(),
+                        }
+                    }
+                }
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    pub fn num_fields(&self) -> usize {
+        self.0.len()
+    }
+}
+
+pub fn parse_kv_arg<'a>(kv: &'a str,
+                        err: &mut InvalidOptionsError,
+                        for_hashmap: bool)
+                        -> (&'a str, Option<&'a str>) {
+    let mut add_err = || {
+        err.issues.push(CLIError::InvalidKeyValueSyntax(kv.to_string(), for_hashmap))
+    };
+    match kv.find('=') {
+        None => {
+            add_err();
+            return (kv, None);
+        }
+        Some(pos) => {
+            let key = &kv[..pos];
+            if kv.len() <= pos + 1 {
+                add_err();
+                return (key, Some(""));
+            }
+            (key, Some(&kv[pos + 1..]))
+        }
+    }
+}
+
+pub fn calltype_from_str(name: &str,
+                         valid_protocols: Vec<String>,
+                         err: &mut InvalidOptionsError)
+                         -> CallType {
+    CallType::Upload(match UploadProtocol::from_str(name) {
+        Ok(up) => up,
+        Err(msg) => {
+            err.issues.push(CLIError::InvalidUploadProtocol(name.to_string(), valid_protocols));
+            UploadProtocol::Simple
+        }
+    })
+}
+
+pub fn input_file_from_opts(file_path: &str, err: &mut InvalidOptionsError) -> Option<fs::File> {
+    match fs::File::open(file_path) {
+        Ok(f) => Some(f),
+        Err(io_err) => {
+            err.issues.push(CLIError::Input(InputError::Io((file_path.to_string(), io_err))));
+            None
+        }
+    }
+}
+
+pub fn input_mime_from_opts(mime: &str, err: &mut InvalidOptionsError) -> Option<Mime> {
+    match mime.parse() {
+        Ok(m) => Some(m),
+        Err(_) => {
+            err.issues.push(CLIError::Input(InputError::Mime(mime.to_string())));
+            None
+        }
+    }
+}
+
+pub fn writer_from_opts(arg: Option<&str>) -> Result<Box<Write>, io::Error> {
+    let f = arg.unwrap_or("-");
+    match f {
+        "-" => Ok(Box::new(stdout())),
+        _ => match fs::OpenOptions::new().create(true).write(true).open(f) {
+            Ok(f) => Ok(Box::new(f)),
+            Err(io_err) => Err(io_err),
+        },
+    }
+}
+
+
+pub fn arg_from_str<'a, T>(arg: &str,
+                           err: &mut InvalidOptionsError,
+                           arg_name: &'a str,
+                           arg_type: &'a str)
+                           -> T
+    where T: FromStr + Default,
+          <T as FromStr>::Err: fmt::Display
+{
+    match FromStr::from_str(arg) {
+        Err(perr) => {
+            err.issues.push(CLIError::ParseError(arg_name.to_owned(),
+                                                 arg_type.to_owned(),
+                                                 arg.to_string(),
+                                                 format!("{}", perr)));
+            Default::default()
+        }
+        Ok(v) => v,
+    }
+}
+
+pub struct JsonTokenStorage {
+    pub program_name: &'static str,
+    pub db_dir: String,
+}
+
+impl JsonTokenStorage {
+    fn path(&self, scope_hash: u64) -> PathBuf {
+        Path::new(&self.db_dir).join(&format!("{}-token-{}.json", self.program_name, scope_hash))
+    }
+}
+
+
+#[derive(Debug)]
+pub enum TokenStorageError {
+    Json(json::Error),
+    Io(io::Error),
+}
+
+impl fmt::Display for TokenStorageError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            TokenStorageError::Json(ref err) => writeln!(f, "Could not serialize secrets: {}", err),
+            TokenStorageError::Io(ref err) => writeln!(f, "Failed to write secret token: {}", err),
+        }
+    }
+}
+
+impl StdError for TokenStorageError {
+    fn description(&self) -> &str {
+        "Failure when getting or setting the token storage"
+    }
+}
+
+
+impl TokenStorage for JsonTokenStorage {
+    type Error = TokenStorageError;
+
+    // NOTE: logging might be interesting, currently we swallow all errors
+    fn set(&mut self,
+           scope_hash: u64,
+           _: &Vec<&str>,
+           token: Option<Token>)
+           -> Result<(), TokenStorageError> {
+        match token {
+            None => {
+                match fs::remove_file(self.path(scope_hash)) {
+                    Err(err) => match err.kind() {
+                        io::ErrorKind::NotFound => Ok(()),
+                        _ => Err(TokenStorageError::Io(err)),
+                    },
+                    Ok(_) => Ok(()),
+                }
+            }
+            Some(token) => {
+                match fs::OpenOptions::new().create(true).write(true).open(&self.path(scope_hash)) {
+                    Ok(mut f) => {
+                        match json::to_writer_pretty(&mut f, &token) {
+                            Ok(_) => Ok(()),
+                            Err(serde_err) => Err(TokenStorageError::Json(serde_err)),
+                        }
+                    }
+                    Err(io_err) => Err(TokenStorageError::Io(io_err)),
+                }
+            }
+        }
+    }
+
+    fn get(&self, scope_hash: u64, _: &Vec<&str>) -> Result<Option<Token>, TokenStorageError> {
+        match fs::File::open(&self.path(scope_hash)) {
+            Ok(f) => {
+                match json::de::from_reader(f) {
+                    Ok(token) => Ok(Some(token)),
+                    Err(err) => Err(TokenStorageError::Json(err)),
+                }
+            }
+            Err(io_err) => {
+                match io_err.kind() {
+                    io::ErrorKind::NotFound => Ok(None),
+                    _ => Err(TokenStorageError::Io(io_err)),
+                }
+            }
+        }
+    }
+}
+
+
+#[derive(Debug)]
+pub enum ApplicationSecretError {
+    DecoderError((String, json::Error)),
+    FormatError(String),
+}
+
+impl fmt::Display for ApplicationSecretError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            ApplicationSecretError::DecoderError((ref path, ref err)) =>
+                writeln!(f,
+                         "Could not decode file at '{}' with error: {}.",
+                         path,
+                         err),
+            ApplicationSecretError::FormatError(ref path) =>
+                writeln!(f,
+                         "'installed' field is unset in secret file at '{}'.",
+                         path),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum ConfigurationError {
+    DirectoryCreationFailed((String, io::Error)),
+    DirectoryUnset,
+    HomeExpansionFailed(String),
+    Secret(ApplicationSecretError),
+    Io((String, io::Error)),
+}
+
+impl fmt::Display for ConfigurationError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            ConfigurationError::DirectoryCreationFailed((ref dir, ref err)) =>
+                writeln!(f,
+                         "Directory '{}' could not be created with error: {}.",
+                         dir,
+                         err),
+            ConfigurationError::DirectoryUnset => writeln!(f, "--config-dir was unset or empty."),
+            ConfigurationError::HomeExpansionFailed(ref dir) =>
+                writeln!(f,
+                         "Couldn't find HOME directory of current user, failed to expand '{}'.",
+                         dir),
+            ConfigurationError::Secret(ref err) => writeln!(f, "Secret -> {}", err),
+            ConfigurationError::Io((ref path, ref err)) =>
+                writeln!(f,
+                         "IO operation failed on path '{}' with error: {}.",
+                         path,
+                         err),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum InputError {
+    Io((String, io::Error)),
+    Mime(String),
+}
+
+impl fmt::Display for InputError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            InputError::Io((ref file_path, ref io_err)) =>
+                writeln!(f,
+                         "Failed to open '{}' for reading with error: {}.",
+                         file_path,
+                         io_err),
+            InputError::Mime(ref mime) => writeln!(f, "'{}' is not a known mime-type.", mime),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum FieldError {
+    PopOnEmpty(String),
+    TrailingFieldSep(String),
+    Unknown(String, Option<String>, Option<String>),
+    Duplicate(String),
+    Empty,
+}
+
+
+impl fmt::Display for FieldError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            FieldError::PopOnEmpty(ref field) =>
+                writeln!(f, "'{}': Cannot move up on empty field cursor.", field),
+            FieldError::TrailingFieldSep(ref field) =>
+                writeln!(f,
+                         "'{}': Single field separator may not be last character.",
+                         field),
+            FieldError::Unknown(ref field, ref suggestion, ref value) => {
+                let suffix = match *suggestion {
+                    Some(ref s) => {
+                        let kv = match *value {
+                            Some(ref v) => format!("{}={}", s, v),
+                            None => s.clone(),
+                        };
+                        format!(" Did you mean '{}' ?", kv)
+                    }
+                    None => String::new(),
+                };
+                writeln!(f, "Field '{}' does not exist.{}", field, suffix)
+            }
+            FieldError::Duplicate(ref cursor) =>
+                writeln!(f, "Value at '{}' was already set", cursor),
+            FieldError::Empty => writeln!(f, "Field names must not be empty."),
+        }
+    }
+}
+
+
+#[derive(Debug)]
+pub enum CLIError {
+    Configuration(ConfigurationError),
+    ParseError(String, String, String, String),
+    UnknownParameter(String, Vec<&'static str>),
+    InvalidUploadProtocol(String, Vec<String>),
+    InvalidKeyValueSyntax(String, bool),
+    Input(InputError),
+    Field(FieldError),
+    MissingCommandError,
+    MissingMethodError(String),
+}
+
+impl fmt::Display for CLIError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            CLIError::Configuration(ref err) => write!(f, "Configuration -> {}", err),
+            CLIError::Input(ref err) => write!(f, "Input -> {}", err),
+            CLIError::Field(ref err) => write!(f, "Field -> {}", err),
+            CLIError::InvalidUploadProtocol(ref proto_name, ref valid_names) =>
+                writeln!(f,
+                         "'{}' is not a valid upload protocol. Choose from one of {}.",
+                         proto_name,
+                         valid_names.join(", ")),
+            CLIError::ParseError(ref arg_name, ref type_name, ref value, ref err_desc) =>
+                writeln!(f,
+                         "Failed to parse argument '{}' with value '{}' as {} with error: {}.",
+                         arg_name,
+                         value,
+                         type_name,
+                         err_desc),
+            CLIError::UnknownParameter(ref param_name, ref possible_values) => {
+                let suffix = match did_you_mean(param_name, &possible_values) {
+                    Some(v) => format!(" Did you mean '{}' ?", v),
+                    None => String::new(),
+                };
+                write!(f, "Parameter '{}' is unknown.{}\n", param_name, suffix)
+            }
+            CLIError::InvalidKeyValueSyntax(ref kv, is_hashmap) => {
+                let hashmap_info = if is_hashmap {
+                    "hashmap "
+                } else {
+                    ""
+                };
+                writeln!(f,
+                         "'{}' does not match {}pattern <key>=<value>.",
+                         kv,
+                         hashmap_info)
+            }
+            CLIError::MissingCommandError => writeln!(f, "Please specify the main sub-command."),
+            CLIError::MissingMethodError(ref cmd) =>
+                writeln!(f,
+                         "Please specify the method to call on the '{}' command.",
+                         cmd),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct InvalidOptionsError {
+    pub issues: Vec<CLIError>,
+    pub exit_code: i32,
+}
+
+impl fmt::Display for InvalidOptionsError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        for issue in &self.issues {
+            try!(issue.fmt(f));
+        }
+        Ok(())
+    }
+}
+
+impl InvalidOptionsError {
+    pub fn single(err: CLIError, exit_code: i32) -> InvalidOptionsError {
+        InvalidOptionsError {
+            issues: vec![err],
+            exit_code: exit_code,
+        }
+    }
+
+    pub fn new() -> InvalidOptionsError {
+        InvalidOptionsError {
+            issues: Vec::new(),
+            exit_code: 1,
+        }
+    }
+}
+
+pub fn assure_config_dir_exists(dir: &str) -> Result<String, CLIError> {
+    let trdir = dir.trim();
+    if trdir.len() == 0 {
+        return Err(CLIError::Configuration(ConfigurationError::DirectoryUnset));
+    }
+
+    let expanded_config_dir = if trdir.as_bytes()[0] == b'~' {
+        match env::var("HOME").ok().or(env::var("UserProfile").ok()) {
+            None => return Err(CLIError::Configuration(ConfigurationError::HomeExpansionFailed(trdir.to_string()))),
+            Some(mut user) => {
+                user.push_str(&trdir[1..]);
+                user
+            }
+        }
+    } else {
+        trdir.to_string()
+    };
+
+    if let Err(err) = fs::create_dir(&expanded_config_dir) {
+        if err.kind() != io::ErrorKind::AlreadyExists {
+            return Err(CLIError::Configuration(
+                    ConfigurationError::DirectoryCreationFailed((expanded_config_dir, err))));
+        }
+    }
+
+    Ok(expanded_config_dir)
+}
+
+pub fn application_secret_from_directory(dir: &str,
+                                         secret_basename: &str,
+                                         json_console_secret: &str)
+                                         -> Result<ApplicationSecret, CLIError> {
+    let secret_path = Path::new(dir).join(secret_basename);
+    let secret_str = || secret_path.as_path().to_str().unwrap().to_string();
+    let secret_io_error = |io_err: io::Error| {
+        Err(CLIError::Configuration(ConfigurationError::Io((secret_str(), io_err))))
+    };
+
+    for _ in 0..2 {
+        match fs::File::open(&secret_path) {
+            Err(mut err) => {
+                if err.kind() == io::ErrorKind::NotFound {
+                    // Write our built-in one - user may adjust the written file at will
+
+                    err = match fs::OpenOptions::new()
+                                    .create(true)
+                                    .write(true)
+                                    .open(&secret_path) {
+                        Err(cfe) => cfe,
+                        Ok(mut f) => {
+                            // Assure we convert 'ugly' json string into pretty one
+                            let console_secret: ConsoleApplicationSecret =
+                                json::from_str(json_console_secret).unwrap();
+                            match json::to_writer_pretty(&mut f, &console_secret) {
+                                Err(serde_err) =>
+                                    panic!("Unexpected serde error: {:#?}", serde_err),
+                                Ok(_) => continue,
+                            }
+                        }
+                    };
+                    // fall through to IO error handling
+                }
+                return secret_io_error(err);
+            }
+            Ok(f) => {
+                match json::de::from_reader::<_, ConsoleApplicationSecret>(f) {
+                    Err(json_err) =>
+                        return Err(CLIError::Configuration(
+                            ConfigurationError::Secret(
+                                ApplicationSecretError::DecoderError(
+                                                (secret_str(), json_err)
+                                              )))),
+                    Ok(console_secret) => match console_secret.installed {
+                        Some(secret) => return Ok(secret),
+                        None => return Err(
+                                        CLIError::Configuration(
+                                        ConfigurationError::Secret(
+                                        ApplicationSecretError::FormatError(secret_str())
+                                        ))),
+                    },
+                }
+            }
+        }
+    }
+    unreachable!();
+}

--- a/gen/language1_beta1-cli/src/main.rs
+++ b/gen/language1_beta1-cli/src/main.rs
@@ -1,0 +1,712 @@
+// DO NOT EDIT !
+// This file was generated automatically from 'src/mako/cli/main.rs.mako'
+// DO NOT EDIT !
+#![allow(unused_variables, unused_imports, dead_code, unused_mut)]
+
+#[macro_use]
+extern crate clap;
+extern crate yup_oauth2 as oauth2;
+extern crate yup_hyper_mock as mock;
+extern crate hyper_rustls;
+extern crate serde;
+extern crate serde_json;
+extern crate hyper;
+extern crate mime;
+extern crate strsim;
+extern crate google_language1_beta1 as api;
+
+use std::env;
+use std::io::{self, Write};
+use clap::{App, SubCommand, Arg};
+
+mod cmn;
+
+use cmn::{InvalidOptionsError, CLIError, JsonTokenStorage, arg_from_str, writer_from_opts, parse_kv_arg,
+          input_file_from_opts, input_mime_from_opts, FieldCursor, FieldError, CallType, UploadProtocol,
+          calltype_from_str, remove_json_null_values, ComplexType, JsonType, JsonTypeInfo};
+
+use std::default::Default;
+use std::str::FromStr;
+
+use oauth2::{Authenticator, DefaultAuthenticatorDelegate, FlowType};
+use serde_json as json;
+use clap::ArgMatches;
+
+enum DoitError {
+    IoError(String, io::Error),
+    ApiError(api::Error),
+}
+
+struct Engine<'n> {
+    opt: ArgMatches<'n>,
+    hub: api::CloudNaturalLanguage<hyper::Client, Authenticator<DefaultAuthenticatorDelegate, JsonTokenStorage, hyper::Client>>,
+    gp: Vec<&'static str>,
+    gpm: Vec<(&'static str, &'static str)>,
+}
+
+
+impl<'n> Engine<'n> {
+    fn _documents_analyze_entities(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    "encoding-type" => Some(("encodingType", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "document.content" => Some(("document.content", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "document.type" => Some(("document.type", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "document.language" => Some(("document.language", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "document.gcs-content-uri" => Some(("document.gcsContentUri", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec!["content", "document", "encoding-type", "gcs-content-uri", "language", "type"]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::AnalyzeEntitiesRequest = json::value::from_value(object).unwrap();
+        let mut call = self.hub.documents().analyze_entities(request);
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _documents_analyze_sentiment(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    "encoding-type" => Some(("encodingType", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "document.content" => Some(("document.content", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "document.type" => Some(("document.type", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "document.language" => Some(("document.language", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "document.gcs-content-uri" => Some(("document.gcsContentUri", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec!["content", "document", "encoding-type", "gcs-content-uri", "language", "type"]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::AnalyzeSentimentRequest = json::value::from_value(object).unwrap();
+        let mut call = self.hub.documents().analyze_sentiment(request);
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _documents_analyze_syntax(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    "encoding-type" => Some(("encodingType", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "document.content" => Some(("document.content", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "document.type" => Some(("document.type", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "document.language" => Some(("document.language", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "document.gcs-content-uri" => Some(("document.gcsContentUri", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec!["content", "document", "encoding-type", "gcs-content-uri", "language", "type"]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::AnalyzeSyntaxRequest = json::value::from_value(object).unwrap();
+        let mut call = self.hub.documents().analyze_syntax(request);
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _documents_annotate_text(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    "encoding-type" => Some(("encodingType", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "features.extract-document-sentiment" => Some(("features.extractDocumentSentiment", JsonTypeInfo { jtype: JsonType::Boolean, ctype: ComplexType::Pod })),
+                    "features.extract-entities" => Some(("features.extractEntities", JsonTypeInfo { jtype: JsonType::Boolean, ctype: ComplexType::Pod })),
+                    "features.extract-syntax" => Some(("features.extractSyntax", JsonTypeInfo { jtype: JsonType::Boolean, ctype: ComplexType::Pod })),
+                    "document.content" => Some(("document.content", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "document.type" => Some(("document.type", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "document.language" => Some(("document.language", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "document.gcs-content-uri" => Some(("document.gcsContentUri", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec!["content", "document", "encoding-type", "extract-document-sentiment", "extract-entities", "extract-syntax", "features", "gcs-content-uri", "language", "type"]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::AnnotateTextRequest = json::value::from_value(object).unwrap();
+        let mut call = self.hub.documents().annotate_text(request);
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _doit(&self, dry_run: bool) -> Result<Result<(), DoitError>, Option<InvalidOptionsError>> {
+        let mut err = InvalidOptionsError::new();
+        let mut call_result: Result<(), DoitError> = Ok(());
+        let mut err_opt: Option<InvalidOptionsError> = None;
+        match self.opt.subcommand() {
+            ("documents", Some(opt)) => {
+                match opt.subcommand() {
+                    ("analyze-entities", Some(opt)) => {
+                        call_result = self._documents_analyze_entities(opt, dry_run, &mut err);
+                    },
+                    ("analyze-sentiment", Some(opt)) => {
+                        call_result = self._documents_analyze_sentiment(opt, dry_run, &mut err);
+                    },
+                    ("analyze-syntax", Some(opt)) => {
+                        call_result = self._documents_analyze_syntax(opt, dry_run, &mut err);
+                    },
+                    ("annotate-text", Some(opt)) => {
+                        call_result = self._documents_annotate_text(opt, dry_run, &mut err);
+                    },
+                    _ => {
+                        err.issues.push(CLIError::MissingMethodError("documents".to_string()));
+                        writeln!(io::stderr(), "{}\n", opt.usage()).ok();
+                    }
+                }
+            },
+            _ => {
+                err.issues.push(CLIError::MissingCommandError);
+                writeln!(io::stderr(), "{}\n", self.opt.usage()).ok();
+            }
+        }
+
+        if dry_run {
+            if err.issues.len() > 0 {
+                err_opt = Some(err);
+            }
+            Err(err_opt)
+        } else {
+            Ok(call_result)
+        }
+    }
+
+    // Please note that this call will fail if any part of the opt can't be handled
+    fn new(opt: ArgMatches<'n>) -> Result<Engine<'n>, InvalidOptionsError> {
+        let (config_dir, secret) = {
+            let config_dir = match cmn::assure_config_dir_exists(opt.value_of("folder").unwrap_or("~/.google-service-cli")) {
+                Err(e) => return Err(InvalidOptionsError::single(e, 3)),
+                Ok(p) => p,
+            };
+
+            match cmn::application_secret_from_directory(&config_dir, "language1-beta1-secret.json",
+                                                         "{\"installed\":{\"auth_uri\":\"https://accounts.google.com/o/oauth2/auth\",\"client_secret\":\"hCsslbCUyfehWMmbkG8vTYxG\",\"token_uri\":\"https://accounts.google.com/o/oauth2/token\",\"client_email\":\"\",\"redirect_uris\":[\"urn:ietf:wg:oauth:2.0:oob\",\"oob\"],\"client_x509_cert_url\":\"\",\"client_id\":\"620010449518-9ngf7o4dhs0dka470npqvor6dc5lqb9b.apps.googleusercontent.com\",\"auth_provider_x509_cert_url\":\"https://www.googleapis.com/oauth2/v1/certs\"}}") {
+                Ok(secret) => (config_dir, secret),
+                Err(e) => return Err(InvalidOptionsError::single(e, 4))
+            }
+        };
+
+        let auth = Authenticator::new(  &secret, DefaultAuthenticatorDelegate,
+                                        if opt.is_present("debug-auth") {
+                                            hyper::Client::with_connector(mock::TeeConnector {
+                                                    connector: hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())
+                                                })
+                                        } else {
+                                            hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new()))
+                                        },
+                                        JsonTokenStorage {
+                                          program_name: "language1-beta1",
+                                          db_dir: config_dir.clone(),
+                                        }, Some(FlowType::InstalledRedirect(54324)));
+
+        let client =
+            if opt.is_present("debug") {
+                hyper::Client::with_connector(mock::TeeConnector {
+                        connector: hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())
+                    })
+            } else {
+                hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new()))
+            };
+        let engine = Engine {
+            opt: opt,
+            hub: api::CloudNaturalLanguage::new(client, auth),
+            gp: vec!["$-xgafv", "access-token", "alt", "bearer-token", "callback", "fields", "key", "oauth-token", "pp", "pretty-print", "quota-user", "upload-type", "upload-protocol"],
+            gpm: vec![
+                    ("$-xgafv", "$.xgafv"),
+                    ("access-token", "access_token"),
+                    ("bearer-token", "bearer_token"),
+                    ("oauth-token", "oauth_token"),
+                    ("pretty-print", "prettyPrint"),
+                    ("quota-user", "quotaUser"),
+                    ("upload-type", "uploadType"),
+                    ("upload-protocol", "upload_protocol"),
+                ]
+        };
+
+        match engine._doit(true) {
+            Err(Some(err)) => Err(err),
+            Err(None)      => Ok(engine),
+            Ok(_)          => unreachable!(),
+        }
+    }
+
+    fn doit(&self) -> Result<(), DoitError> {
+        match self._doit(false) {
+            Ok(res) => res,
+            Err(_) => unreachable!(),
+        }
+    }
+}
+
+fn main() {
+    let mut exit_status = 0i32;
+    let arg_data = [
+        ("documents", "methods: 'analyze-entities', 'analyze-sentiment', 'analyze-syntax' and 'annotate-text'", vec![
+            ("analyze-entities",
+                    Some(r##"Finds named entities (currently proper names and common nouns) in the text
+        along with entity types, salience, mentions for each entity, and
+        other properties."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_language1_beta1_cli/documents_analyze-entities",
+                  vec![
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("analyze-sentiment",
+                    Some(r##"Analyzes the sentiment of the provided text."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_language1_beta1_cli/documents_analyze-sentiment",
+                  vec![
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("analyze-syntax",
+                    Some(r##"Analyzes the syntax of the text and provides sentence boundaries and
+        tokenization along with part of speech tags, dependency trees, and other
+        properties."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_language1_beta1_cli/documents_analyze-syntax",
+                  vec![
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("annotate-text",
+                    Some(r##"A convenience method that provides all the features that analyzeSentiment,
+        analyzeEntities, and analyzeSyntax provide in one call."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_language1_beta1_cli/documents_annotate-text",
+                  vec![
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ]),
+        
+    ];
+    
+    let mut app = App::new("language1-beta1")
+           .author("Sebastian Thiel <byronimo@gmail.com>")
+           .version("1.0.7+20171204")
+           .about("Provides natural language understanding technologies to developers. Examples include sentiment analysis, entity recognition, entity sentiment analysis, and text annotations.")
+           .after_help("All documentation details can be found at http://byron.github.io/google-apis-rs/google_language1_beta1_cli")
+           .arg(Arg::with_name("url")
+                   .long("scope")
+                   .help("Specify the authentication a method should be executed in. Each scope requires the user to grant this application permission to use it.If unset, it defaults to the shortest scope url for a particular method.")
+                   .multiple(true)
+                   .takes_value(true))
+           .arg(Arg::with_name("folder")
+                   .long("config-dir")
+                   .help("A directory into which we will store our persistent data. Defaults to a user-writable directory that we will create during the first invocation.[default: ~/.google-service-cli")
+                   .multiple(false)
+                   .takes_value(true))
+           .arg(Arg::with_name("debug")
+                   .long("debug")
+                   .help("Output all server communication to standard error. `tx` and `rx` are placed into the same stream.")
+                   .multiple(false)
+                   .takes_value(false))
+           .arg(Arg::with_name("debug-auth")
+                   .long("debug-auth")
+                   .help("Output all communication related to authentication to standard error. `tx` and `rx` are placed into the same stream.")
+                   .multiple(false)
+                   .takes_value(false));
+           
+           for &(main_command_name, about, ref subcommands) in arg_data.iter() {
+               let mut mcmd = SubCommand::with_name(main_command_name).about(about);
+           
+               for &(sub_command_name, ref desc, url_info, ref args) in subcommands {
+                   let mut scmd = SubCommand::with_name(sub_command_name);
+                   if let &Some(desc) = desc {
+                       scmd = scmd.about(desc);
+                   }
+                   scmd = scmd.after_help(url_info);
+           
+                   for &(ref arg_name, ref flag, ref desc, ref required, ref multi) in args {
+                       let arg_name_str =
+                           match (arg_name, flag) {
+                                   (&Some(an), _       ) => an,
+                                   (_        , &Some(f)) => f,
+                                    _                    => unreachable!(),
+                            };
+                       let mut arg = Arg::with_name(arg_name_str)
+                                         .empty_values(false);
+                       if let &Some(short_flag) = flag {
+                           arg = arg.short(short_flag);
+                       }
+                       if let &Some(desc) = desc {
+                           arg = arg.help(desc);
+                       }
+                       if arg_name.is_some() && flag.is_some() {
+                           arg = arg.takes_value(true);
+                       }
+                       if let &Some(required) = required {
+                           arg = arg.required(required);
+                       }
+                       if let &Some(multi) = multi {
+                           arg = arg.multiple(multi);
+                       }
+                       scmd = scmd.arg(arg);
+                   }
+                   mcmd = mcmd.subcommand(scmd);
+               }
+               app = app.subcommand(mcmd);
+           }
+           
+        let matches = app.get_matches();
+
+    let debug = matches.is_present("debug");
+    match Engine::new(matches) {
+        Err(err) => {
+            exit_status = err.exit_code;
+            writeln!(io::stderr(), "{}", err).ok();
+        },
+        Ok(engine) => {
+            if let Err(doit_err) = engine.doit() {
+                exit_status = 1;
+                match doit_err {
+                    DoitError::IoError(path, err) => {
+                        writeln!(io::stderr(), "Failed to open output file '{}': {}", path, err).ok();
+                    },
+                    DoitError::ApiError(err) => {
+                        if debug {
+                            writeln!(io::stderr(), "{:#?}", err).ok();
+                        } else {
+                            writeln!(io::stderr(), "{}", err).ok();
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    std::process::exit(exit_status);
+}

--- a/gen/language1_beta1/Cargo.toml
+++ b/gen/language1_beta1/Cargo.toml
@@ -1,0 +1,31 @@
+# DO NOT EDIT !
+# This file was generated automatically from 'src/mako/Cargo.toml.mako'
+# DO NOT EDIT !
+[package]
+
+name = "google-language1_beta1"
+version = "1.0.7+20171204"
+authors = ["Sebastian Thiel <byronimo@gmail.com>"]
+description = "A complete library to interact with Cloud Natural Language (protocol v1beta1)"
+repository = "https://github.com/Byron/google-apis-rs/tree/master/gen/language1_beta1"
+homepage = "https://cloud.google.com/natural-language/"
+documentation = "https://docs.rs/google-language1_beta1/1.0.7+20171204"
+license = "MIT"
+keywords = ["language", "google", "protocol", "web", "api"]
+
+
+[dev-dependencies]
+hyper-rustls = "^0.6"
+
+[dependencies]
+hyper = "^ 0.10"
+mime = "^ 0.2.0"
+serde = "^ 1.0"
+serde_json = "^ 1.0"
+serde_derive = "^ 1.0"
+yup-oauth2 = "^ 1.0"
+url = "= 0.5"
+
+[features]
+
+

--- a/gen/language1_beta1/LICENSE.md
+++ b/gen/language1_beta1/LICENSE.md
@@ -1,0 +1,30 @@
+<!---
+DO NOT EDIT !
+This file was generated automatically from 'src/mako/LICENSE.md.mako'
+DO NOT EDIT !
+-->
+The MIT License (MIT)
+=====================
+
+Copyright © `2015-2016` `Sebastian Thiel`
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the “Software”), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.

--- a/gen/language1_beta1/README.md
+++ b/gen/language1_beta1/README.md
@@ -1,0 +1,183 @@
+<!---
+DO NOT EDIT !
+This file was generated automatically from 'src/mako/api/README.md.mako'
+DO NOT EDIT !
+-->
+The `google-language1_beta1` library allows access to all features of the *Google Cloud Natural Language* service.
+
+This documentation was generated from *Cloud Natural Language* crate version *1.0.7+20171204*, where *20171204* is the exact revision of the *language:v1beta1* schema built by the [mako](http://www.makotemplates.org/) code generator *v1.0.7*.
+
+Everything else about the *Cloud Natural Language* *v1_beta1* API can be found at the
+[official documentation site](https://cloud.google.com/natural-language/).
+# Features
+
+Handle the following *Resources* with ease from the central [hub](https://docs.rs/google-language1_beta1/1.0.7+20171204/google_language1_beta1/struct.CloudNaturalLanguage.html) ... 
+
+* [documents](https://docs.rs/google-language1_beta1/1.0.7+20171204/google_language1_beta1/struct.Document.html)
+ * [*analyze entities*](https://docs.rs/google-language1_beta1/1.0.7+20171204/google_language1_beta1/struct.DocumentAnalyzeEntityCall.html), [*analyze sentiment*](https://docs.rs/google-language1_beta1/1.0.7+20171204/google_language1_beta1/struct.DocumentAnalyzeSentimentCall.html), [*analyze syntax*](https://docs.rs/google-language1_beta1/1.0.7+20171204/google_language1_beta1/struct.DocumentAnalyzeSyntaxCall.html) and [*annotate text*](https://docs.rs/google-language1_beta1/1.0.7+20171204/google_language1_beta1/struct.DocumentAnnotateTextCall.html)
+
+
+
+
+# Structure of this Library
+
+The API is structured into the following primary items:
+
+* **[Hub](https://docs.rs/google-language1_beta1/1.0.7+20171204/google_language1_beta1/struct.CloudNaturalLanguage.html)**
+    * a central object to maintain state and allow accessing all *Activities*
+    * creates [*Method Builders*](https://docs.rs/google-language1_beta1/1.0.7+20171204/google_language1_beta1/trait.MethodsBuilder.html) which in turn
+      allow access to individual [*Call Builders*](https://docs.rs/google-language1_beta1/1.0.7+20171204/google_language1_beta1/trait.CallBuilder.html)
+* **[Resources](https://docs.rs/google-language1_beta1/1.0.7+20171204/google_language1_beta1/trait.Resource.html)**
+    * primary types that you can apply *Activities* to
+    * a collection of properties and *Parts*
+    * **[Parts](https://docs.rs/google-language1_beta1/1.0.7+20171204/google_language1_beta1/trait.Part.html)**
+        * a collection of properties
+        * never directly used in *Activities*
+* **[Activities](https://docs.rs/google-language1_beta1/1.0.7+20171204/google_language1_beta1/trait.CallBuilder.html)**
+    * operations to apply to *Resources*
+
+All *structures* are marked with applicable traits to further categorize them and ease browsing.
+
+Generally speaking, you can invoke *Activities* like this:
+
+```Rust,ignore
+let r = hub.resource().activity(...).doit()
+```
+
+Or specifically ...
+
+```ignore
+let r = hub.documents().analyze_syntax(...).doit()
+let r = hub.documents().analyze_entities(...).doit()
+let r = hub.documents().analyze_sentiment(...).doit()
+let r = hub.documents().annotate_text(...).doit()
+```
+
+The `resource()` and `activity(...)` calls create [builders][builder-pattern]. The second one dealing with `Activities` 
+supports various methods to configure the impending operation (not shown here). It is made such that all required arguments have to be 
+specified right away (i.e. `(...)`), whereas all optional ones can be [build up][builder-pattern] as desired.
+The `doit()` method performs the actual communication with the server and returns the respective result.
+
+# Usage
+
+## Setting up your Project
+
+To use this library, you would put the following lines into your `Cargo.toml` file:
+
+```toml
+[dependencies]
+google-language1_beta1 = "*"
+```
+
+## A complete example
+
+```Rust
+extern crate hyper;
+extern crate hyper_rustls;
+extern crate yup_oauth2 as oauth2;
+extern crate google_language1_beta1 as language1_beta1;
+use language1_beta1::AnalyzeSyntaxRequest;
+use language1_beta1::{Result, Error};
+use std::default::Default;
+use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+use language1_beta1::CloudNaturalLanguage;
+
+// Get an ApplicationSecret instance by some means. It contains the `client_id` and 
+// `client_secret`, among other things.
+let secret: ApplicationSecret = Default::default();
+// Instantiate the authenticator. It will choose a suitable authentication flow for you, 
+// unless you replace  `None` with the desired Flow.
+// Provide your own `AuthenticatorDelegate` to adjust the way it operates and get feedback about 
+// what's going on. You probably want to bring in your own `TokenStorage` to persist tokens and
+// retrieve them from storage.
+let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+                              hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+                              <MemoryStorage as Default>::default(), None);
+let mut hub = CloudNaturalLanguage::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+// As the method needs a request, you would usually fill it with the desired information
+// into the respective structure. Some of the parts shown here might not be applicable !
+// Values shown here are possibly random and not representative !
+let mut req = AnalyzeSyntaxRequest::default();
+
+// You can configure optional parameters by calling the respective setters at will, and
+// execute the final call using `doit()`.
+// Values shown here are possibly random and not representative !
+let result = hub.documents().analyze_syntax(req)
+             .doit();
+
+match result {
+    Err(e) => match e {
+        // The Error enum provides details about what exactly happened.
+        // You can also just use its `Debug`, `Display` or `Error` traits
+         Error::HttpError(_)
+        |Error::MissingAPIKey
+        |Error::MissingToken(_)
+        |Error::Cancelled
+        |Error::UploadSizeLimitExceeded(_, _)
+        |Error::Failure(_)
+        |Error::BadRequest(_)
+        |Error::FieldClash(_)
+        |Error::JsonDecodeError(_, _) => println!("{}", e),
+    },
+    Ok(res) => println!("Success: {:?}", res),
+}
+
+```
+## Handling Errors
+
+All errors produced by the system are provided either as [Result](https://docs.rs/google-language1_beta1/1.0.7+20171204/google_language1_beta1/enum.Result.html) enumeration as return value of 
+the doit() methods, or handed as possibly intermediate results to either the 
+[Hub Delegate](https://docs.rs/google-language1_beta1/1.0.7+20171204/google_language1_beta1/trait.Delegate.html), or the [Authenticator Delegate](https://docs.rs/yup-oauth2/*/yup_oauth2/trait.AuthenticatorDelegate.html).
+
+When delegates handle errors or intermediate values, they may have a chance to instruct the system to retry. This 
+makes the system potentially resilient to all kinds of errors.
+
+## Uploads and Downloads
+If a method supports downloads, the response body, which is part of the [Result](https://docs.rs/google-language1_beta1/1.0.7+20171204/google_language1_beta1/enum.Result.html), should be
+read by you to obtain the media.
+If such a method also supports a [Response Result](https://docs.rs/google-language1_beta1/1.0.7+20171204/google_language1_beta1/trait.ResponseResult.html), it will return that by default.
+You can see it as meta-data for the actual media. To trigger a media download, you will have to set up the builder by making
+this call: `.param("alt", "media")`.
+
+Methods supporting uploads can do so using up to 2 different protocols: 
+*simple* and *resumable*. The distinctiveness of each is represented by customized 
+`doit(...)` methods, which are then named `upload(...)` and `upload_resumable(...)` respectively.
+
+## Customization and Callbacks
+
+You may alter the way an `doit()` method is called by providing a [delegate](https://docs.rs/google-language1_beta1/1.0.7+20171204/google_language1_beta1/trait.Delegate.html) to the 
+[Method Builder](https://docs.rs/google-language1_beta1/1.0.7+20171204/google_language1_beta1/trait.CallBuilder.html) before making the final `doit()` call. 
+Respective methods will be called to provide progress information, as well as determine whether the system should 
+retry on failure.
+
+The [delegate trait](https://docs.rs/google-language1_beta1/1.0.7+20171204/google_language1_beta1/trait.Delegate.html) is default-implemented, allowing you to customize it with minimal effort.
+
+## Optional Parts in Server-Requests
+
+All structures provided by this library are made to be [enocodable](https://docs.rs/google-language1_beta1/1.0.7+20171204/google_language1_beta1/trait.RequestValue.html) and 
+[decodable](https://docs.rs/google-language1_beta1/1.0.7+20171204/google_language1_beta1/trait.ResponseResult.html) via *json*. Optionals are used to indicate that partial requests are responses 
+are valid.
+Most optionals are are considered [Parts](https://docs.rs/google-language1_beta1/1.0.7+20171204/google_language1_beta1/trait.Part.html) which are identifiable by name, which will be sent to 
+the server to indicate either the set parts of the request or the desired parts in the response.
+
+## Builder Arguments
+
+Using [method builders](https://docs.rs/google-language1_beta1/1.0.7+20171204/google_language1_beta1/trait.CallBuilder.html), you are able to prepare an action call by repeatedly calling it's methods.
+These will always take a single argument, for which the following statements are true.
+
+* [PODs][wiki-pod] are handed by copy
+* strings are passed as `&str`
+* [request values](https://docs.rs/google-language1_beta1/1.0.7+20171204/google_language1_beta1/trait.RequestValue.html) are moved
+
+Arguments will always be copied or cloned into the builder, to make them independent of their original life times.
+
+[wiki-pod]: http://en.wikipedia.org/wiki/Plain_old_data_structure
+[builder-pattern]: http://en.wikipedia.org/wiki/Builder_pattern
+[google-go-api]: https://github.com/google/google-api-go-client
+
+# License
+The **language1_beta1** library was generated by Sebastian Thiel, and is placed 
+under the *MIT* license.
+You can read the full text at the repository's [license file][repo-license].
+
+[repo-license]: https://github.com/Byron/google-apis-rsblob/master/LICENSE.md

--- a/gen/language1_beta1/src/cmn.rs
+++ b/gen/language1_beta1/src/cmn.rs
@@ -1,0 +1,753 @@
+// COPY OF 'src/rust/api/cmn.rs'
+// DO NOT EDIT
+use std::io::{self, Read, Seek, Cursor, Write, SeekFrom};
+use std;
+use std::fmt::{self, Display};
+use std::str::FromStr;
+use std::error;
+use std::thread::sleep;
+use std::time::Duration;
+
+use mime::{Mime, TopLevel, SubLevel, Attr, Value};
+use oauth2::{TokenType, Retry, self};
+use hyper;
+use hyper::header::{ContentType, ContentLength, Headers, UserAgent, Authorization, Header,
+                    HeaderFormat, Bearer};
+use hyper::http::h1::LINE_ENDING;
+use hyper::method::Method;
+use hyper::status::StatusCode;
+
+use serde_json as json;
+
+/// Identifies the Hub. There is only one per library, this trait is supposed
+/// to make intended use more explicit.
+/// The hub allows to access all resource methods more easily.
+pub trait Hub {}
+
+/// Identifies types for building methods of a particular resource type
+pub trait MethodsBuilder {}
+
+/// Identifies types which represent builders for a particular resource method
+pub trait CallBuilder {}
+
+/// Identifies types which can be inserted and deleted.
+/// Types with this trait are most commonly used by clients of this API.
+pub trait Resource {}
+
+/// Identifies types which are used in API responses.
+pub trait ResponseResult {}
+
+/// Identifies types which are used in API requests.
+pub trait RequestValue {}
+
+/// Identifies types which are not actually used by the API
+/// This might be a bug within the google API schema.
+pub trait UnusedType {}
+
+/// Identifies types which are only used as part of other types, which
+/// usually are carrying the `Resource` trait.
+pub trait Part {}
+
+/// Identifies types which are only used by other types internally.
+/// They have no special meaning, this trait just marks them for completeness.
+pub trait NestedType {}
+
+/// A utility to specify reader types which provide seeking capabilities too
+pub trait ReadSeek: Seek + Read {}
+impl<T: Seek + Read> ReadSeek for T {}
+
+/// A trait for all types that can convert themselves into a *parts* string
+pub trait ToParts {
+    fn to_parts(&self) -> String;
+}
+
+/// A utility type which can decode a server response that indicates error
+#[derive(Deserialize)]
+pub struct JsonServerError {
+    pub error: String,
+    pub error_description: Option<String>
+}
+
+/// A utility to represent detailed errors we might see in case there are BadRequests.
+/// The latter happen if the sent parameters or request structures are unsound
+#[derive(Deserialize, Serialize, Debug)]
+pub struct ErrorResponse {
+    error: ServerError,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct ServerError {
+    errors: Vec<ServerMessage>,
+    code: u16,
+    message: String,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct ServerMessage {
+    domain: String,
+    reason: String,
+    message: String,
+    #[serde(rename="locationType")]
+    location_type: Option<String>,
+    location: Option<String>
+}
+
+#[derive(Copy, Clone)]
+pub struct DummyNetworkStream;
+
+impl Read for DummyNetworkStream {
+    fn read(&mut self, _: &mut [u8]) -> io::Result<usize> {
+        Ok(0)
+    }
+}
+
+impl Write for DummyNetworkStream {
+    fn write(&mut self, _: &[u8]) -> io::Result<usize> {
+        Ok(0)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl hyper::net::NetworkStream for DummyNetworkStream {
+    fn peer_addr(&mut self) -> io::Result<std::net::SocketAddr> {
+        Ok("127.0.0.1:1337".parse().unwrap())
+    }
+
+    fn set_read_timeout(&self, _dur: Option<Duration>) -> io::Result<()> {
+        Ok(())
+    }
+
+    fn set_write_timeout(&self, _dur: Option<Duration>) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+
+/// A trait specifying functionality to help controlling any request performed by the API.
+/// The trait has a conservative default implementation.
+///
+/// It contains methods to deal with all common issues, as well with the ones related to
+/// uploading media
+pub trait Delegate {
+
+    /// Called at the beginning of any API request. The delegate should store the method
+    /// information if he is interesting in knowing more context when further calls to it
+    /// are made.
+    /// The matching `finished()` call will always be made, no matter whether or not the API
+    /// request was successful. That way, the delegate may easily maintain a clean state
+    /// between various API calls.
+    fn begin(&mut self, MethodInfo) {}
+
+    /// Called whenever there is an [HttpError](http://hyperium.github.io/hyper/hyper/error/enum.HttpError.html), usually if there are network problems.
+    ///
+    /// If you choose to retry after a duration, the duration should be chosen using the
+    /// [exponential backoff algorithm](http://en.wikipedia.org/wiki/Exponential_backoff).
+    ///
+    /// Return retry information.
+    fn http_error(&mut self, &hyper::Error) -> Retry {
+        Retry::Abort
+    }
+
+    /// Called whenever there is the need for your applications API key after
+    /// the official authenticator implementation didn't provide one, for some reason.
+    /// If this method returns None as well, the underlying operation will fail
+    fn api_key(&mut self) -> Option<String> {
+        None
+    }
+
+    /// Called whenever the Authenticator didn't yield a token. The delegate
+    /// may attempt to provide one, or just take it as a general information about the
+    /// impending failure.
+    /// The given Error provides information about why the token couldn't be acquired in the
+    /// first place
+    fn token(&mut self, err: &error::Error) -> Option<oauth2::Token> {
+        let _ = err;
+        None
+    }
+
+    /// Called during resumable uploads to provide a URL for the impending upload.
+    /// It was saved after a previous call to `store_upload_url(...)`, and if not None,
+    /// will be used instead of asking the server for a new upload URL.
+    /// This is useful in case a previous resumable upload was aborted/canceled, but should now
+    /// be resumed.
+    /// The returned URL will be used exactly once - if it fails again and the delegate allows
+    /// to retry, we will ask the server for a new upload URL.
+    fn upload_url(&mut self) -> Option<String> {
+        None
+    }
+
+    /// Called after we have retrieved a new upload URL for a resumable upload to store it
+    /// in case we fail or cancel. That way, we can attempt to resume the upload later,
+    /// see `upload_url()`.
+    /// It will also be called with None after a successful upload, which allows the delegate
+    /// to forget the URL. That way, we will not attempt to resume an upload that has already
+    /// finished.
+    fn store_upload_url(&mut self, url: Option<&str>) {
+        let _ = url;
+    }
+
+    /// Called whenever a server response could not be decoded from json.
+    /// It's for informational purposes only, the caller will return with an error
+    /// accordingly.
+    ///
+    /// # Arguments
+    ///
+    /// * `json_encoded_value` - The json-encoded value which failed to decode.
+    /// * `json_decode_error`  - The decoder error
+    fn response_json_decode_error(&mut self, json_encoded_value: &str, json_decode_error: &json::Error) {
+        let _ = json_encoded_value;
+        let _ = json_decode_error;
+    }
+
+    /// Called whenever the http request returns with a non-success status code.
+    /// This can involve authentication issues, or anything else that very much
+    /// depends on the used API method.
+    /// The delegate should check the status, header and decoded json error to decide
+    /// whether to retry or not. In the latter case, the underlying call will fail.
+    ///
+    /// If you choose to retry after a duration, the duration should be chosen using the
+    /// [exponential backoff algorithm](http://en.wikipedia.org/wiki/Exponential_backoff).
+    fn http_failure(&mut self, _: &hyper::client::Response, Option<JsonServerError>, _: Option<ServerError>) -> Retry {
+        Retry::Abort
+    }
+
+    /// Called prior to sending the main request of the given method. It can be used to time
+    /// the call or to print progress information.
+    /// It's also useful as you can be sure that a request will definitely be made.
+    fn pre_request(&mut self) { }
+
+    /// Return the size of each chunk of a resumable upload.
+    /// Must be a power of two, with 1<<18 being the smallest allowed chunk size.
+    /// Will be called once before starting any resumable upload.
+    fn chunk_size(&mut self) -> u64 {
+        1 << 23
+    }
+
+    /// Called before the given chunk is uploaded to the server.
+    /// If true is returned, the upload will be interrupted.
+    /// However, it may be resumable if you stored the upload URL in a previous call
+    /// to `store_upload_url()`
+    fn cancel_chunk_upload(&mut self, chunk: &ContentRange) -> bool {
+        let _ = chunk;
+        false
+    }
+
+    /// Called before the API request method returns, in every case. It can be used to clean up
+    /// internal state between calls to the API.
+    /// This call always has a matching call to `begin(...)`.
+    ///
+    /// # Arguments
+    ///
+    /// * `is_success` - a true value indicates the operation was successful. If false, you should
+    ///                  discard all values stored during `store_upload_url`.
+    fn finished(&mut self, is_success: bool) {
+        let _ = is_success;
+    }
+}
+
+/// A delegate with a conservative default implementation, which is used if no other delegate is
+/// set.
+#[derive(Default)]
+pub struct DefaultDelegate;
+
+impl Delegate for DefaultDelegate {}
+
+
+#[derive(Debug)]
+pub enum Error {
+    /// The http connection failed
+    HttpError(hyper::Error),
+
+    /// An attempt was made to upload a resource with size stored in field `.0`
+    /// even though the maximum upload size is what is stored in field `.1`.
+    UploadSizeLimitExceeded(u64, u64),
+
+    /// Represents information about a request that was not understood by the server.
+    /// Details are included.
+    BadRequest(ErrorResponse),
+
+    /// We needed an API key for authentication, but didn't obtain one.
+    /// Neither through the authenticator, nor through the Delegate.
+    MissingAPIKey,
+
+    /// We required a Token, but didn't get one from the Authenticator
+    MissingToken(Box<error::Error>),
+
+    /// The delgate instructed to cancel the operation
+    Cancelled,
+
+    /// An additional, free form field clashed with one of the built-in optional ones
+    FieldClash(&'static str),
+
+    /// Shows that we failed to decode the server response.
+    /// This can happen if the protocol changes in conjunction with strict json decoding.
+    JsonDecodeError(String, json::Error),
+
+    /// Indicates an HTTP repsonse with a non-success status code
+    Failure(hyper::client::Response),
+}
+
+
+impl Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Error::HttpError(ref err) => err.fmt(f),
+            Error::UploadSizeLimitExceeded(ref resource_size, ref max_size) =>
+                writeln!(f, "The media size {} exceeds the maximum allowed upload size of {}"
+                         , resource_size, max_size),
+            Error::MissingAPIKey => {
+                (writeln!(f, "The application's API key was not found in the configuration")).ok();
+                writeln!(f, "It is used as there are no Scopes defined for this method.")
+            },
+            Error::BadRequest(ref err) => {
+                try!(writeln!(f, "Bad Request ({}): {}", err.error.code, err.error.message));
+                for err in err.error.errors.iter() {
+                    try!(writeln!(f, "    {}: {}, {}{}",
+                                            err.domain,
+                                            err.message,
+                                            err.reason,
+                                            match &err.location {
+                                                &Some(ref loc) => format!("@{}", loc),
+                                                &None => String::new(),
+                                            }));
+                }
+                Ok(())
+            },
+            Error::MissingToken(ref err) =>
+                writeln!(f, "Token retrieval failed with error: {}", err),
+            Error::Cancelled =>
+                writeln!(f, "Operation cancelled by delegate"),
+            Error::FieldClash(field) =>
+                writeln!(f, "The custom parameter '{}' is already provided natively by the CallBuilder.", field),
+            Error::JsonDecodeError(ref json_str, ref err)
+                => writeln!(f, "{}: {}", err, json_str),
+            Error::Failure(ref response) =>
+                writeln!(f, "Http status indicates failure: {:?}", response),
+        }
+    }
+}
+
+impl error::Error for Error {
+    fn description(&self) -> &str {
+        match *self {
+            Error::HttpError(ref err) => err.description(),
+            Error::JsonDecodeError(_, ref err) => err.description(),
+            _ => "NO DESCRIPTION POSSIBLE - use `Display.fmt()` instead"
+        }
+    }
+
+    fn cause(&self) -> Option<&error::Error> {
+        match *self {
+            Error::HttpError(ref err) => err.cause(),
+            Error::JsonDecodeError(_, ref err) => err.cause(),
+            _ => None
+        }
+    }
+}
+
+/// A universal result type used as return for all calls.
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Contains information about an API request.
+pub struct MethodInfo {
+    pub id: &'static str,
+    pub http_method: Method,
+}
+
+const BOUNDARY: &'static str = "MDuXWGyeE33QFXGchb2VFWc4Z7945d";
+
+/// Provides a `Read` interface that converts multiple parts into the protocol
+/// identified by [RFC2387](https://tools.ietf.org/html/rfc2387).
+/// **Note**: This implementation is just as rich as it needs to be to perform uploads
+/// to google APIs, and might not be a fully-featured implementation.
+#[derive(Default)]
+pub struct MultiPartReader<'a> {
+    raw_parts: Vec<(Headers, &'a mut Read)>,
+    current_part: Option<(Cursor<Vec<u8>>, &'a mut Read)>,
+    last_part_boundary: Option<Cursor<Vec<u8>>>,
+}
+
+impl<'a> MultiPartReader<'a> {
+
+    /// Reserve memory for exactly the given amount of parts
+    pub fn reserve_exact(&mut self, cap: usize) {
+        self.raw_parts.reserve_exact(cap);
+    }
+
+    /// Add a new part to the queue of parts to be read on the first `read` call.
+    ///
+    /// # Arguments
+    ///
+    /// `headers` - identifying the body of the part. It's similar to the header
+    ///             in an ordinary single-part call, and should thus contain the
+    ///             same information.
+    /// `reader`  - a reader providing the part's body
+    /// `size`    - the amount of bytes provided by the reader. It will be put onto the header as
+    ///             content-size.
+    /// `mime`    - It will be put onto the content type
+    pub fn add_part(&mut self, reader: &'a mut Read, size: u64, mime_type: Mime) -> &mut MultiPartReader<'a> {
+        let mut headers = Headers::new();
+        headers.set(ContentType(mime_type));
+        headers.set(ContentLength(size));
+        self.raw_parts.push((headers, reader));
+        self
+    }
+
+    /// Returns the mime-type representing our multi-part message.
+    /// Use it with the ContentType header.
+    pub fn mime_type(&self) -> Mime {
+        Mime(
+            TopLevel::Multipart,
+            SubLevel::Ext("Related".to_string()),
+            vec![(Attr::Ext("boundary".to_string()), Value::Ext(BOUNDARY.to_string()))],
+        )
+    }
+
+    /// Returns true if we are totally used
+    fn is_depleted(&self) -> bool {
+        self.raw_parts.len() == 0 && self.current_part.is_none() && self.last_part_boundary.is_none()
+    }
+
+    /// Returns true if we are handling our last part
+    fn is_last_part(&self) -> bool {
+        self.raw_parts.len() == 0 && self.current_part.is_some()
+    }
+}
+
+impl<'a> Read for MultiPartReader<'a> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        match (self.raw_parts.len(),
+               self.current_part.is_none(),
+               self.last_part_boundary.is_none()) {
+            (_, _, false) => {
+                let br = self.last_part_boundary.as_mut().unwrap().read(buf).unwrap_or(0);
+                if br < buf.len() {
+                    self.last_part_boundary = None;
+                }
+                return Ok(br)
+            },
+            (0, true, true) => return Ok(0),
+            (n, true, _) if n > 0 => {
+                let (headers, reader) = self.raw_parts.remove(0);
+                let mut c = Cursor::new(Vec::<u8>::new());
+                (write!(&mut c, "{}--{}{}{}{}", LINE_ENDING, BOUNDARY, LINE_ENDING,
+                                                headers, LINE_ENDING)).unwrap();
+                c.seek(SeekFrom::Start(0)).unwrap();
+                self.current_part = Some((c, reader));
+            }
+            _ => {},
+        }
+
+        // read headers as long as possible
+        let (hb, rr) = {
+            let &mut (ref mut c, ref mut reader) = self.current_part.as_mut().unwrap();
+            let b = c.read(buf).unwrap_or(0);
+            (b, reader.read(&mut buf[b..]))
+        };
+
+        match rr {
+            Ok(bytes_read) => {
+                if hb < buf.len() && bytes_read == 0 {
+                    if self.is_last_part() {
+                        // before clearing the last part, we will add the boundary that
+                        // will be written last
+                        self.last_part_boundary = Some(Cursor::new(
+                                                        format!("{}--{}--", LINE_ENDING, BOUNDARY).into_bytes()))
+                    }
+                    // We are depleted - this can trigger the next part to come in
+                    self.current_part = None;
+                }
+                let mut total_bytes_read = hb + bytes_read;
+                while total_bytes_read < buf.len() && !self.is_depleted() {
+                    match self.read(&mut buf[total_bytes_read ..]) {
+                        Ok(br) => total_bytes_read += br,
+                        Err(err) => return Err(err),
+                    }
+                }
+                Ok(total_bytes_read)
+            }
+            Err(err) => {
+                // fail permanently
+                self.current_part = None;
+                self.last_part_boundary = None;
+                self.raw_parts.clear();
+                Err(err)
+            }
+        }
+    }
+}
+
+/// The `X-Upload-Content-Type` header.
+///
+/// Generated via rustc --pretty expanded -Z unstable-options, and manually
+/// processed to be more readable.
+#[derive(PartialEq, Debug, Clone)]
+pub struct XUploadContentType(pub Mime);
+
+impl ::std::ops::Deref for XUploadContentType {
+    type Target = Mime;
+    fn deref<'a>(&'a self) -> &'a Mime { &self.0 }
+}
+impl ::std::ops::DerefMut for XUploadContentType {
+    fn deref_mut<'a>(&'a mut self) -> &'a mut Mime { &mut self.0 }
+}
+impl Header for XUploadContentType {
+    fn header_name() -> &'static str { "X-Upload-Content-Type" }
+    fn parse_header(raw: &[Vec<u8>]) -> hyper::error::Result<Self> {
+        hyper::header::parsing::from_one_raw_str(raw).map(XUploadContentType)
+    }
+}
+impl HeaderFormat for XUploadContentType {
+    fn fmt_header(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        Display::fmt(&**self, f)
+    }
+}
+impl Display for XUploadContentType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(&**self, f)
+    }
+}
+
+#[derive(Clone, PartialEq, Debug)]
+pub struct Chunk {
+    pub first: u64,
+    pub last: u64
+}
+
+impl fmt::Display for Chunk {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        (write!(fmt, "{}-{}", self.first, self.last)).ok();
+        Ok(())
+    }
+}
+
+impl FromStr for Chunk {
+    type Err = &'static str;
+
+    /// NOTE: only implements `%i-%i`, not `*`
+    fn from_str(s: &str) -> std::result::Result<Chunk, &'static str> {
+        let parts: Vec<&str> = s.split('-').collect();
+        if parts.len() != 2 {
+            return Err("Expected two parts: %i-%i")
+        }
+        Ok(
+            Chunk {
+                first: match FromStr::from_str(parts[0]) {
+                    Ok(d) => d,
+                    _ => return Err("Couldn't parse 'first' as digit")
+                },
+                last: match FromStr::from_str(parts[1]) {
+                    Ok(d) => d,
+                    _ => return Err("Couldn't parse 'last' as digit")
+                }
+            }
+        )
+    }
+}
+
+/// Implements the Content-Range header, for serialization only
+#[derive(Clone, PartialEq, Debug)]
+pub struct ContentRange {
+    pub range: Option<Chunk>,
+    pub total_length: u64,
+}
+
+impl Header for ContentRange {
+    fn header_name() -> &'static str {
+        "Content-Range"
+    }
+
+    /// We are not parsable, as parsing is done by the `Range` header
+    fn parse_header(_: &[Vec<u8>]) -> hyper::error::Result<Self> {
+        Err(hyper::error::Error::Method)
+    }
+}
+
+
+impl HeaderFormat for ContentRange {
+    fn fmt_header(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        try!(fmt.write_str("bytes "));
+        match self.range {
+            Some(ref c) => try!(c.fmt(fmt)),
+            None => try!(fmt.write_str("*"))
+        }
+        (write!(fmt, "/{}", self.total_length)).ok();
+        Ok(())
+    }
+}
+
+#[derive(Clone, PartialEq, Debug)]
+pub struct RangeResponseHeader(pub Chunk);
+
+impl Header for RangeResponseHeader {
+    fn header_name() -> &'static str {
+        "Range"
+    }
+
+    fn parse_header(raw: &[Vec<u8>]) -> hyper::error::Result<Self> {
+        if raw.len() > 0 {
+            let v = &raw[0];
+            if let Ok(s) = std::str::from_utf8(v) {
+                const PREFIX: &'static str = "bytes ";
+                if s.starts_with(PREFIX) {
+                    if let Ok(c) = <Chunk as FromStr>::from_str(&s[PREFIX.len()..]) {
+                        return  Ok(RangeResponseHeader(c))
+                    }
+                }
+            }
+        }
+        Err(hyper::error::Error::Method)
+    }
+}
+
+impl HeaderFormat for RangeResponseHeader {
+    /// No implmentation necessary, we just need to parse
+    fn fmt_header(&self, _: &mut fmt::Formatter) -> fmt::Result {
+        Err(fmt::Error)
+    }
+}
+
+/// A utility type to perform a resumable upload from start to end.
+pub struct ResumableUploadHelper<'a, A: 'a> {
+    pub client: &'a mut hyper::client::Client,
+    pub delegate: &'a mut Delegate,
+    pub start_at: Option<u64>,
+    pub auth: &'a mut A,
+    pub user_agent: &'a str,
+    pub auth_header: Authorization<Bearer>,
+    pub url: &'a str,
+    pub reader: &'a mut ReadSeek,
+    pub media_type: Mime,
+    pub content_length: u64
+}
+
+impl<'a, A> ResumableUploadHelper<'a, A>
+    where A: oauth2::GetToken {
+
+    fn query_transfer_status(&mut self) -> std::result::Result<u64, hyper::Result<hyper::client::Response>> {
+        loop {
+            match self.client.post(self.url)
+                .header(UserAgent(self.user_agent.to_string()))
+                .header(ContentRange { range: None, total_length: self.content_length })
+                .header(self.auth_header.clone())
+                .send() {
+                Ok(r) => {
+                    // 308 = resume-incomplete == PermanentRedirect
+                    let headers = r.headers.clone();
+                    let h: &RangeResponseHeader = match headers.get() {
+                        Some(hh) if r.status == StatusCode::PermanentRedirect => hh,
+                        None|Some(_) => {
+                            if let Retry::After(d) = self.delegate.http_failure(&r, None, None) {
+                                sleep(d);
+                                continue;
+                            }
+                            return Err(Ok(r))
+                        }
+                    };
+                    return Ok(h.0.last)
+                }
+                Err(err) => {
+                    if let Retry::After(d) = self.delegate.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    return Err(Err(err))
+                }
+            }
+        }
+    }
+
+    /// returns None if operation was cancelled by delegate, or the HttpResult.
+    /// It can be that we return the result just because we didn't understand the status code -
+    /// caller should check for status himself before assuming it's OK to use
+    pub fn upload(&mut self) -> Option<hyper::Result<hyper::client::Response>> {
+        let mut start = match self.start_at {
+            Some(s) => s,
+            None => match self.query_transfer_status() {
+                Ok(s) => s,
+                Err(result) => return Some(result)
+            }
+        };
+
+        const MIN_CHUNK_SIZE: u64 = 1 << 18;
+        let chunk_size = match self.delegate.chunk_size() {
+            cs if cs > MIN_CHUNK_SIZE => cs,
+            _ => MIN_CHUNK_SIZE
+        };
+
+        self.reader.seek(SeekFrom::Start(start)).unwrap();
+        loop {
+            let request_size = match self.content_length - start {
+                rs if rs > chunk_size => chunk_size,
+                rs => rs
+            };
+
+            let mut section_reader = self.reader.take(request_size);
+            let range_header = ContentRange {
+                range: Some(Chunk {first: start, last: start + request_size - 1}),
+                total_length: self.content_length
+            };
+            start += request_size;
+            if self.delegate.cancel_chunk_upload(&range_header) {
+                return None
+            }
+            let res = self.client.post(self.url)
+                                 .header(range_header)
+                                 .header(ContentType(self.media_type.clone()))
+                                 .header(UserAgent(self.user_agent.to_string()))
+                                 .body(&mut section_reader)
+                                 .send();
+            match res {
+                Ok(mut res) => {
+                    if res.status == StatusCode::PermanentRedirect  {
+                        continue
+                    }
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let Retry::After(d) = self.delegate.http_failure(&res,
+                                                        json::from_str(&json_err).ok(),
+                                                        json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                    }
+                    return Some(Ok(res))
+                },
+                Err(err) => {
+                    if let Retry::After(d) = self.delegate.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    return Some(Err(err))
+                }
+            }
+        }
+    }
+}
+
+// Copy of src/rust/cli/cmn.rs
+// TODO(ST): Allow sharing common code between program types
+pub fn remove_json_null_values(value: &mut json::value::Value) {
+    match *value {
+        json::value::Value::Object(ref mut map) => {
+            let mut for_removal = Vec::new();
+
+            for (key, mut value) in map.iter_mut() {
+                if value.is_null() {
+                    for_removal.push(key.clone());
+                } else {
+                    remove_json_null_values(&mut value);
+                }
+            }
+
+            for key in &for_removal {
+                map.remove(key);
+            }
+        }
+        _ => {}
+    }
+}

--- a/gen/language1_beta1/src/lib.rs
+++ b/gen/language1_beta1/src/lib.rs
@@ -1,0 +1,1930 @@
+// DO NOT EDIT !
+// This file was generated automatically from 'src/mako/api/lib.rs.mako'
+// DO NOT EDIT !
+
+//! This documentation was generated from *Cloud Natural Language* crate version *1.0.7+20171204*, where *20171204* is the exact revision of the *language:v1beta1* schema built by the [mako](http://www.makotemplates.org/) code generator *v1.0.7*.
+//! 
+//! Everything else about the *Cloud Natural Language* *v1_beta1* API can be found at the
+//! [official documentation site](https://cloud.google.com/natural-language/).
+//! The original source code is [on github](https://github.com/Byron/google-apis-rs/tree/master/gen/language1_beta1).
+//! # Features
+//! 
+//! Handle the following *Resources* with ease from the central [hub](struct.CloudNaturalLanguage.html) ... 
+//! 
+//! * [documents](struct.Document.html)
+//!  * [*analyze entities*](struct.DocumentAnalyzeEntityCall.html), [*analyze sentiment*](struct.DocumentAnalyzeSentimentCall.html), [*analyze syntax*](struct.DocumentAnalyzeSyntaxCall.html) and [*annotate text*](struct.DocumentAnnotateTextCall.html)
+//! 
+//! 
+//! 
+//! 
+//! Not what you are looking for ? Find all other Google APIs in their Rust [documentation index](http://byron.github.io/google-apis-rs).
+//! 
+//! # Structure of this Library
+//! 
+//! The API is structured into the following primary items:
+//! 
+//! * **[Hub](struct.CloudNaturalLanguage.html)**
+//!     * a central object to maintain state and allow accessing all *Activities*
+//!     * creates [*Method Builders*](trait.MethodsBuilder.html) which in turn
+//!       allow access to individual [*Call Builders*](trait.CallBuilder.html)
+//! * **[Resources](trait.Resource.html)**
+//!     * primary types that you can apply *Activities* to
+//!     * a collection of properties and *Parts*
+//!     * **[Parts](trait.Part.html)**
+//!         * a collection of properties
+//!         * never directly used in *Activities*
+//! * **[Activities](trait.CallBuilder.html)**
+//!     * operations to apply to *Resources*
+//! 
+//! All *structures* are marked with applicable traits to further categorize them and ease browsing.
+//! 
+//! Generally speaking, you can invoke *Activities* like this:
+//! 
+//! ```Rust,ignore
+//! let r = hub.resource().activity(...).doit()
+//! ```
+//! 
+//! Or specifically ...
+//! 
+//! ```ignore
+//! let r = hub.documents().analyze_syntax(...).doit()
+//! let r = hub.documents().analyze_entities(...).doit()
+//! let r = hub.documents().analyze_sentiment(...).doit()
+//! let r = hub.documents().annotate_text(...).doit()
+//! ```
+//! 
+//! The `resource()` and `activity(...)` calls create [builders][builder-pattern]. The second one dealing with `Activities` 
+//! supports various methods to configure the impending operation (not shown here). It is made such that all required arguments have to be 
+//! specified right away (i.e. `(...)`), whereas all optional ones can be [build up][builder-pattern] as desired.
+//! The `doit()` method performs the actual communication with the server and returns the respective result.
+//! 
+//! # Usage
+//! 
+//! ## Setting up your Project
+//! 
+//! To use this library, you would put the following lines into your `Cargo.toml` file:
+//! 
+//! ```toml
+//! [dependencies]
+//! google-language1_beta1 = "*"
+//! ```
+//! 
+//! ## A complete example
+//! 
+//! ```test_harness,no_run
+//! extern crate hyper;
+//! extern crate hyper_rustls;
+//! extern crate yup_oauth2 as oauth2;
+//! extern crate google_language1_beta1 as language1_beta1;
+//! use language1_beta1::AnalyzeSyntaxRequest;
+//! use language1_beta1::{Result, Error};
+//! # #[test] fn egal() {
+//! use std::default::Default;
+//! use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+//! use language1_beta1::CloudNaturalLanguage;
+//! 
+//! // Get an ApplicationSecret instance by some means. It contains the `client_id` and 
+//! // `client_secret`, among other things.
+//! let secret: ApplicationSecret = Default::default();
+//! // Instantiate the authenticator. It will choose a suitable authentication flow for you, 
+//! // unless you replace  `None` with the desired Flow.
+//! // Provide your own `AuthenticatorDelegate` to adjust the way it operates and get feedback about 
+//! // what's going on. You probably want to bring in your own `TokenStorage` to persist tokens and
+//! // retrieve them from storage.
+//! let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+//!                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+//!                               <MemoryStorage as Default>::default(), None);
+//! let mut hub = CloudNaturalLanguage::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+//! // As the method needs a request, you would usually fill it with the desired information
+//! // into the respective structure. Some of the parts shown here might not be applicable !
+//! // Values shown here are possibly random and not representative !
+//! let mut req = AnalyzeSyntaxRequest::default();
+//! 
+//! // You can configure optional parameters by calling the respective setters at will, and
+//! // execute the final call using `doit()`.
+//! // Values shown here are possibly random and not representative !
+//! let result = hub.documents().analyze_syntax(req)
+//!              .doit();
+//! 
+//! match result {
+//!     Err(e) => match e {
+//!         // The Error enum provides details about what exactly happened.
+//!         // You can also just use its `Debug`, `Display` or `Error` traits
+//!          Error::HttpError(_)
+//!         |Error::MissingAPIKey
+//!         |Error::MissingToken(_)
+//!         |Error::Cancelled
+//!         |Error::UploadSizeLimitExceeded(_, _)
+//!         |Error::Failure(_)
+//!         |Error::BadRequest(_)
+//!         |Error::FieldClash(_)
+//!         |Error::JsonDecodeError(_, _) => println!("{}", e),
+//!     },
+//!     Ok(res) => println!("Success: {:?}", res),
+//! }
+//! # }
+//! ```
+//! ## Handling Errors
+//! 
+//! All errors produced by the system are provided either as [Result](enum.Result.html) enumeration as return value of 
+//! the doit() methods, or handed as possibly intermediate results to either the 
+//! [Hub Delegate](trait.Delegate.html), or the [Authenticator Delegate](https://docs.rs/yup-oauth2/*/yup_oauth2/trait.AuthenticatorDelegate.html).
+//! 
+//! When delegates handle errors or intermediate values, they may have a chance to instruct the system to retry. This 
+//! makes the system potentially resilient to all kinds of errors.
+//! 
+//! ## Uploads and Downloads
+//! If a method supports downloads, the response body, which is part of the [Result](enum.Result.html), should be
+//! read by you to obtain the media.
+//! If such a method also supports a [Response Result](trait.ResponseResult.html), it will return that by default.
+//! You can see it as meta-data for the actual media. To trigger a media download, you will have to set up the builder by making
+//! this call: `.param("alt", "media")`.
+//! 
+//! Methods supporting uploads can do so using up to 2 different protocols: 
+//! *simple* and *resumable*. The distinctiveness of each is represented by customized 
+//! `doit(...)` methods, which are then named `upload(...)` and `upload_resumable(...)` respectively.
+//! 
+//! ## Customization and Callbacks
+//! 
+//! You may alter the way an `doit()` method is called by providing a [delegate](trait.Delegate.html) to the 
+//! [Method Builder](trait.CallBuilder.html) before making the final `doit()` call. 
+//! Respective methods will be called to provide progress information, as well as determine whether the system should 
+//! retry on failure.
+//! 
+//! The [delegate trait](trait.Delegate.html) is default-implemented, allowing you to customize it with minimal effort.
+//! 
+//! ## Optional Parts in Server-Requests
+//! 
+//! All structures provided by this library are made to be [enocodable](trait.RequestValue.html) and 
+//! [decodable](trait.ResponseResult.html) via *json*. Optionals are used to indicate that partial requests are responses 
+//! are valid.
+//! Most optionals are are considered [Parts](trait.Part.html) which are identifiable by name, which will be sent to 
+//! the server to indicate either the set parts of the request or the desired parts in the response.
+//! 
+//! ## Builder Arguments
+//! 
+//! Using [method builders](trait.CallBuilder.html), you are able to prepare an action call by repeatedly calling it's methods.
+//! These will always take a single argument, for which the following statements are true.
+//! 
+//! * [PODs][wiki-pod] are handed by copy
+//! * strings are passed as `&str`
+//! * [request values](trait.RequestValue.html) are moved
+//! 
+//! Arguments will always be copied or cloned into the builder, to make them independent of their original life times.
+//! 
+//! [wiki-pod]: http://en.wikipedia.org/wiki/Plain_old_data_structure
+//! [builder-pattern]: http://en.wikipedia.org/wiki/Builder_pattern
+//! [google-go-api]: https://github.com/google/google-api-go-client
+//! 
+//! 
+
+// Unused attributes happen thanks to defined, but unused structures
+// We don't warn about this, as depending on the API, some data structures or facilities are never used.
+// Instead of pre-determining this, we just disable the lint. It's manually tuned to not have any
+// unused imports in fully featured APIs. Same with unused_mut ... .
+#![allow(unused_imports, unused_mut, dead_code)]
+
+// DO NOT EDIT !
+// This file was generated automatically from 'src/mako/api/lib.rs.mako'
+// DO NOT EDIT !
+
+#[macro_use]
+extern crate serde_derive;
+
+extern crate hyper;
+extern crate serde;
+extern crate serde_json;
+extern crate yup_oauth2 as oauth2;
+extern crate mime;
+extern crate url;
+
+mod cmn;
+
+use std::collections::HashMap;
+use std::cell::RefCell;
+use std::borrow::BorrowMut;
+use std::default::Default;
+use std::collections::BTreeMap;
+use serde_json as json;
+use std::io;
+use std::fs;
+use std::mem;
+use std::thread::sleep;
+use std::time::Duration;
+
+pub use cmn::{MultiPartReader, ToParts, MethodInfo, Result, Error, CallBuilder, Hub, ReadSeek, Part,
+              ResponseResult, RequestValue, NestedType, Delegate, DefaultDelegate, MethodsBuilder,
+              Resource, ErrorResponse, remove_json_null_values};
+
+
+// ##############
+// UTILITIES ###
+// ############
+
+/// Identifies the an OAuth2 authorization scope.
+/// A scope is needed when requesting an
+/// [authorization token](https://developers.google.com/youtube/v3/guides/authentication).
+#[derive(PartialEq, Eq, Hash)]
+pub enum Scope {
+    /// Apply machine learning models to reveal the structure and meaning of text
+    CloudLanguage,
+
+    /// View and manage your data across Google Cloud Platform services
+    CloudPlatform,
+}
+
+impl AsRef<str> for Scope {
+    fn as_ref(&self) -> &str {
+        match *self {
+            Scope::CloudLanguage => "https://www.googleapis.com/auth/cloud-language",
+            Scope::CloudPlatform => "https://www.googleapis.com/auth/cloud-platform",
+        }
+    }
+}
+
+impl Default for Scope {
+    fn default() -> Scope {
+        Scope::CloudLanguage
+    }
+}
+
+
+
+// ########
+// HUB ###
+// ######
+
+/// Central instance to access all CloudNaturalLanguage related resource activities
+///
+/// # Examples
+///
+/// Instantiate a new hub
+///
+/// ```test_harness,no_run
+/// extern crate hyper;
+/// extern crate hyper_rustls;
+/// extern crate yup_oauth2 as oauth2;
+/// extern crate google_language1_beta1 as language1_beta1;
+/// use language1_beta1::AnalyzeSyntaxRequest;
+/// use language1_beta1::{Result, Error};
+/// # #[test] fn egal() {
+/// use std::default::Default;
+/// use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// use language1_beta1::CloudNaturalLanguage;
+/// 
+/// // Get an ApplicationSecret instance by some means. It contains the `client_id` and 
+/// // `client_secret`, among other things.
+/// let secret: ApplicationSecret = Default::default();
+/// // Instantiate the authenticator. It will choose a suitable authentication flow for you, 
+/// // unless you replace  `None` with the desired Flow.
+/// // Provide your own `AuthenticatorDelegate` to adjust the way it operates and get feedback about 
+/// // what's going on. You probably want to bring in your own `TokenStorage` to persist tokens and
+/// // retrieve them from storage.
+/// let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+///                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+///                               <MemoryStorage as Default>::default(), None);
+/// let mut hub = CloudNaturalLanguage::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = AnalyzeSyntaxRequest::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.documents().analyze_syntax(req)
+///              .doit();
+/// 
+/// match result {
+///     Err(e) => match e {
+///         // The Error enum provides details about what exactly happened.
+///         // You can also just use its `Debug`, `Display` or `Error` traits
+///          Error::HttpError(_)
+///         |Error::MissingAPIKey
+///         |Error::MissingToken(_)
+///         |Error::Cancelled
+///         |Error::UploadSizeLimitExceeded(_, _)
+///         |Error::Failure(_)
+///         |Error::BadRequest(_)
+///         |Error::FieldClash(_)
+///         |Error::JsonDecodeError(_, _) => println!("{}", e),
+///     },
+///     Ok(res) => println!("Success: {:?}", res),
+/// }
+/// # }
+/// ```
+pub struct CloudNaturalLanguage<C, A> {
+    client: RefCell<C>,
+    auth: RefCell<A>,
+    _user_agent: String,
+    _base_url: String,
+    _root_url: String,
+}
+
+impl<'a, C, A> Hub for CloudNaturalLanguage<C, A> {}
+
+impl<'a, C, A> CloudNaturalLanguage<C, A>
+    where  C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+    pub fn new(client: C, authenticator: A) -> CloudNaturalLanguage<C, A> {
+        CloudNaturalLanguage {
+            client: RefCell::new(client),
+            auth: RefCell::new(authenticator),
+            _user_agent: "google-api-rust-client/1.0.7".to_string(),
+            _base_url: "https://language.googleapis.com/".to_string(),
+            _root_url: "https://language.googleapis.com/".to_string(),
+        }
+    }
+
+    pub fn documents(&'a self) -> DocumentMethods<'a, C, A> {
+        DocumentMethods { hub: &self }
+    }
+
+    /// Set the user-agent header field to use in all requests to the server.
+    /// It defaults to `google-api-rust-client/1.0.7`.
+    ///
+    /// Returns the previously set user-agent.
+    pub fn user_agent(&mut self, agent_name: String) -> String {
+        mem::replace(&mut self._user_agent, agent_name)
+    }
+
+    /// Set the base url to use in all requests to the server.
+    /// It defaults to `https://language.googleapis.com/`.
+    ///
+    /// Returns the previously set base url.
+    pub fn base_url(&mut self, new_base_url: String) -> String {
+        mem::replace(&mut self._base_url, new_base_url)
+    }
+
+    /// Set the root url to use in all requests to the server.
+    /// It defaults to `https://language.googleapis.com/`.
+    ///
+    /// Returns the previously set root url.
+    pub fn root_url(&mut self, new_root_url: String) -> String {
+        mem::replace(&mut self._root_url, new_root_url)
+    }
+}
+
+
+// ############
+// SCHEMAS ###
+// ##########
+/// Represents part of speech information for a token.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct PartOfSpeech {
+    /// The grammatical case.
+    pub case: Option<String>,
+    /// The grammatical mood.
+    pub mood: Option<String>,
+    /// The grammatical form.
+    pub form: Option<String>,
+    /// The grammatical gender.
+    pub gender: Option<String>,
+    /// The grammatical aspect.
+    pub aspect: Option<String>,
+    /// The grammatical number.
+    pub number: Option<String>,
+    /// The grammatical person.
+    pub person: Option<String>,
+    /// The part of speech tag.
+    pub tag: Option<String>,
+    /// The grammatical tense.
+    pub tense: Option<String>,
+    /// The grammatical reciprocity.
+    pub reciprocity: Option<String>,
+    /// The grammatical properness.
+    pub proper: Option<String>,
+    /// The grammatical voice.
+    pub voice: Option<String>,
+}
+
+impl Part for PartOfSpeech {}
+
+
+/// Represents the feeling associated with the entire text or entities in
+/// the text.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Sentiment {
+    /// DEPRECATED FIELD - This field is being deprecated in
+    /// favor of score. Please refer to our documentation at
+    /// https://cloud.google.com/natural-language/docs for more information.
+    pub polarity: Option<f32>,
+    /// Sentiment score between -1.0 (negative sentiment) and 1.0
+    /// (positive sentiment).
+    pub score: Option<f32>,
+    /// A non-negative number in the [0, +inf) range, which represents
+    /// the absolute magnitude of sentiment regardless of score (positive or
+    /// negative).
+    pub magnitude: Option<f32>,
+}
+
+impl Part for Sentiment {}
+
+
+/// The text annotations response message.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [annotate text documents](struct.DocumentAnnotateTextCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct AnnotateTextResponse {
+    /// Tokens, along with their syntactic information, in the input document.
+    /// Populated if the user enables
+    /// AnnotateTextRequest.Features.extract_syntax.
+    pub tokens: Option<Vec<Token>>,
+    /// Entities, along with their semantic information, in the input document.
+    /// Populated if the user enables
+    /// AnnotateTextRequest.Features.extract_entities.
+    pub entities: Option<Vec<Entity>>,
+    /// The overall sentiment for the document. Populated if the user enables
+    /// AnnotateTextRequest.Features.extract_document_sentiment.
+    #[serde(rename="documentSentiment")]
+    pub document_sentiment: Option<Sentiment>,
+    /// The language of the text, which will be the same as the language specified
+    /// in the request or, if not specified, the automatically-detected language.
+    /// See Document.language field for more details.
+    pub language: Option<String>,
+    /// Sentences in the input document. Populated if the user enables
+    /// AnnotateTextRequest.Features.extract_syntax.
+    pub sentences: Option<Vec<Sentence>>,
+}
+
+impl ResponseResult for AnnotateTextResponse {}
+
+
+/// Represents the smallest syntactic building block of the text.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Token {
+    /// The token text.
+    pub text: Option<TextSpan>,
+    /// Parts of speech tag for this token.
+    #[serde(rename="partOfSpeech")]
+    pub part_of_speech: Option<PartOfSpeech>,
+    /// Dependency tree parse for this token.
+    #[serde(rename="dependencyEdge")]
+    pub dependency_edge: Option<DependencyEdge>,
+    /// [Lemma](https://en.wikipedia.org/wiki/Lemma_%28morphology%29) of the token.
+    pub lemma: Option<String>,
+}
+
+impl Part for Token {}
+
+
+/// ################################################################ #
+/// 
+/// Represents the input to API methods.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [analyze syntax documents](struct.DocumentAnalyzeSyntaxCall.html) (none)
+/// * [analyze entities documents](struct.DocumentAnalyzeEntityCall.html) (none)
+/// * [analyze sentiment documents](struct.DocumentAnalyzeSentimentCall.html) (none)
+/// * [annotate text documents](struct.DocumentAnnotateTextCall.html) (none)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Document {
+    /// The content of the input in string format.
+    pub content: Option<String>,
+    /// Required. If the type is not set or is `TYPE_UNSPECIFIED`,
+    /// returns an `INVALID_ARGUMENT` error.
+    #[serde(rename="type")]
+    pub type_: Option<String>,
+    /// The language of the document (if not specified, the language is
+    /// automatically detected). Both ISO and BCP-47 language codes are
+    /// accepted.<br>
+    /// [Language Support](/natural-language/docs/languages)
+    /// lists currently supported languages for each API method.
+    /// If the language (either specified by the caller or automatically detected)
+    /// is not supported by the called API method, an `INVALID_ARGUMENT` error
+    /// is returned.
+    pub language: Option<String>,
+    /// The Google Cloud Storage URI where the file content is located.
+    /// This URI must be of the form: gs://bucket_name/object_name. For more
+    /// details, see https://cloud.google.com/storage/docs/reference-uris.
+    /// NOTE: Cloud Storage object versioning is not supported.
+    #[serde(rename="gcsContentUri")]
+    pub gcs_content_uri: Option<String>,
+}
+
+impl Resource for Document {}
+
+
+/// The syntax analysis response message.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [analyze syntax documents](struct.DocumentAnalyzeSyntaxCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct AnalyzeSyntaxResponse {
+    /// Tokens, along with their syntactic information, in the input document.
+    pub tokens: Option<Vec<Token>>,
+    /// The language of the text, which will be the same as the language specified
+    /// in the request or, if not specified, the automatically-detected language.
+    /// See Document.language field for more details.
+    pub language: Option<String>,
+    /// Sentences in the input document.
+    pub sentences: Option<Vec<Sentence>>,
+}
+
+impl ResponseResult for AnalyzeSyntaxResponse {}
+
+
+/// The request message for the text annotation API, which can perform multiple
+/// analysis types (sentiment, entities, and syntax) in one call.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [annotate text documents](struct.DocumentAnnotateTextCall.html) (request)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct AnnotateTextRequest {
+    /// The encoding type used by the API to calculate offsets.
+    #[serde(rename="encodingType")]
+    pub encoding_type: Option<String>,
+    /// The enabled features.
+    pub features: Option<Features>,
+    /// Input document.
+    pub document: Option<Document>,
+}
+
+impl RequestValue for AnnotateTextRequest {}
+
+
+/// All available features for sentiment, syntax, and semantic analysis.
+/// Setting each one to true will enable that specific analysis for the input.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Features {
+    /// Extract syntax information.
+    #[serde(rename="extractSyntax")]
+    pub extract_syntax: Option<bool>,
+    /// Extract entities.
+    #[serde(rename="extractEntities")]
+    pub extract_entities: Option<bool>,
+    /// Extract document-level sentiment.
+    #[serde(rename="extractDocumentSentiment")]
+    pub extract_document_sentiment: Option<bool>,
+}
+
+impl Part for Features {}
+
+
+/// Represents dependency parse tree information for a token.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct DependencyEdge {
+    /// Represents the head of this token in the dependency tree.
+    /// This is the index of the token which has an arc going to this token.
+    /// The index is the position of the token in the array of tokens returned
+    /// by the API method. If this token is a root token, then the
+    /// `head_token_index` is its own index.
+    #[serde(rename="headTokenIndex")]
+    pub head_token_index: Option<i32>,
+    /// The parse label for the token.
+    pub label: Option<String>,
+}
+
+impl Part for DependencyEdge {}
+
+
+/// Represents a sentence in the input document.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Sentence {
+    /// The sentence text.
+    pub text: Option<TextSpan>,
+    /// For calls to AnalyzeSentiment or if
+    /// AnnotateTextRequest.Features.extract_document_sentiment is set to
+    /// true, this field will contain the sentiment for the sentence.
+    pub sentiment: Option<Sentiment>,
+}
+
+impl Part for Sentence {}
+
+
+/// Represents an output piece of text.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct TextSpan {
+    /// The content of the output text.
+    pub content: Option<String>,
+    /// The API calculates the beginning offset of the content in the original
+    /// document according to the EncodingType specified in the API request.
+    #[serde(rename="beginOffset")]
+    pub begin_offset: Option<i32>,
+}
+
+impl Part for TextSpan {}
+
+
+/// Represents a phrase in the text that is a known entity, such as
+/// a person, an organization, or location. The API associates information, such
+/// as salience and mentions, with entities.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Entity {
+    /// The mentions of this entity in the input document. The API currently
+    /// supports proper noun mentions.
+    pub mentions: Option<Vec<EntityMention>>,
+    /// Metadata associated with the entity.
+    /// 
+    /// Currently, Wikipedia URLs and Knowledge Graph MIDs are provided, if
+    /// available. The associated keys are "wikipedia_url" and "mid", respectively.
+    pub metadata: Option<HashMap<String, String>>,
+    /// The entity type.
+    #[serde(rename="type")]
+    pub type_: Option<String>,
+    /// The representative name for the entity.
+    pub name: Option<String>,
+    /// The salience score associated with the entity in the [0, 1.0] range.
+    /// 
+    /// The salience score for an entity provides information about the
+    /// importance or centrality of that entity to the entire document text.
+    /// Scores closer to 0 are less salient, while scores closer to 1.0 are highly
+    /// salient.
+    pub salience: Option<f32>,
+}
+
+impl Part for Entity {}
+
+
+/// The syntax analysis request message.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [analyze syntax documents](struct.DocumentAnalyzeSyntaxCall.html) (request)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct AnalyzeSyntaxRequest {
+    /// The encoding type used by the API to calculate offsets.
+    #[serde(rename="encodingType")]
+    pub encoding_type: Option<String>,
+    /// Input document.
+    pub document: Option<Document>,
+}
+
+impl RequestValue for AnalyzeSyntaxRequest {}
+
+
+/// The sentiment analysis request message.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [analyze sentiment documents](struct.DocumentAnalyzeSentimentCall.html) (request)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct AnalyzeSentimentRequest {
+    /// The encoding type used by the API to calculate sentence offsets for the
+    /// sentence sentiment.
+    #[serde(rename="encodingType")]
+    pub encoding_type: Option<String>,
+    /// Input document.
+    pub document: Option<Document>,
+}
+
+impl RequestValue for AnalyzeSentimentRequest {}
+
+
+/// The sentiment analysis response message.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [analyze sentiment documents](struct.DocumentAnalyzeSentimentCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct AnalyzeSentimentResponse {
+    /// The overall sentiment of the input document.
+    #[serde(rename="documentSentiment")]
+    pub document_sentiment: Option<Sentiment>,
+    /// The language of the text, which will be the same as the language specified
+    /// in the request or, if not specified, the automatically-detected language.
+    /// See Document.language field for more details.
+    pub language: Option<String>,
+    /// The sentiment for all the sentences in the document.
+    pub sentences: Option<Vec<Sentence>>,
+}
+
+impl ResponseResult for AnalyzeSentimentResponse {}
+
+
+/// Represents a mention for an entity in the text. Currently, proper noun
+/// mentions are supported.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct EntityMention {
+    /// The mention text.
+    pub text: Option<TextSpan>,
+    /// The type of the entity mention.
+    #[serde(rename="type")]
+    pub type_: Option<String>,
+}
+
+impl Part for EntityMention {}
+
+
+/// The entity analysis response message.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [analyze entities documents](struct.DocumentAnalyzeEntityCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct AnalyzeEntitiesResponse {
+    /// The recognized entities in the input document.
+    pub entities: Option<Vec<Entity>>,
+    /// The language of the text, which will be the same as the language specified
+    /// in the request or, if not specified, the automatically-detected language.
+    /// See Document.language field for more details.
+    pub language: Option<String>,
+}
+
+impl ResponseResult for AnalyzeEntitiesResponse {}
+
+
+/// The entity analysis request message.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [analyze entities documents](struct.DocumentAnalyzeEntityCall.html) (request)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct AnalyzeEntitiesRequest {
+    /// The encoding type used by the API to calculate offsets.
+    #[serde(rename="encodingType")]
+    pub encoding_type: Option<String>,
+    /// Input document.
+    pub document: Option<Document>,
+}
+
+impl RequestValue for AnalyzeEntitiesRequest {}
+
+
+
+// ###################
+// MethodBuilders ###
+// #################
+
+/// A builder providing access to all methods supported on *document* resources.
+/// It is not used directly, but through the `CloudNaturalLanguage` hub.
+///
+/// # Example
+///
+/// Instantiate a resource builder
+///
+/// ```test_harness,no_run
+/// extern crate hyper;
+/// extern crate hyper_rustls;
+/// extern crate yup_oauth2 as oauth2;
+/// extern crate google_language1_beta1 as language1_beta1;
+/// 
+/// # #[test] fn egal() {
+/// use std::default::Default;
+/// use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// use language1_beta1::CloudNaturalLanguage;
+/// 
+/// let secret: ApplicationSecret = Default::default();
+/// let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+///                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+///                               <MemoryStorage as Default>::default(), None);
+/// let mut hub = CloudNaturalLanguage::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // Usually you wouldn't bind this to a variable, but keep calling *CallBuilders*
+/// // like `analyze_entities(...)`, `analyze_sentiment(...)`, `analyze_syntax(...)` and `annotate_text(...)`
+/// // to build up your call.
+/// let rb = hub.documents();
+/// # }
+/// ```
+pub struct DocumentMethods<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a CloudNaturalLanguage<C, A>,
+}
+
+impl<'a, C, A> MethodsBuilder for DocumentMethods<'a, C, A> {}
+
+impl<'a, C, A> DocumentMethods<'a, C, A> {
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Analyzes the syntax of the text and provides sentence boundaries and
+    /// tokenization along with part of speech tags, dependency trees, and other
+    /// properties.
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    pub fn analyze_syntax(&self, request: AnalyzeSyntaxRequest) -> DocumentAnalyzeSyntaxCall<'a, C, A> {
+        DocumentAnalyzeSyntaxCall {
+            hub: self.hub,
+            _request: request,
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Finds named entities (currently proper names and common nouns) in the text
+    /// along with entity types, salience, mentions for each entity, and
+    /// other properties.
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    pub fn analyze_entities(&self, request: AnalyzeEntitiesRequest) -> DocumentAnalyzeEntityCall<'a, C, A> {
+        DocumentAnalyzeEntityCall {
+            hub: self.hub,
+            _request: request,
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Analyzes the sentiment of the provided text.
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    pub fn analyze_sentiment(&self, request: AnalyzeSentimentRequest) -> DocumentAnalyzeSentimentCall<'a, C, A> {
+        DocumentAnalyzeSentimentCall {
+            hub: self.hub,
+            _request: request,
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// A convenience method that provides all the features that analyzeSentiment,
+    /// analyzeEntities, and analyzeSyntax provide in one call.
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    pub fn annotate_text(&self, request: AnnotateTextRequest) -> DocumentAnnotateTextCall<'a, C, A> {
+        DocumentAnnotateTextCall {
+            hub: self.hub,
+            _request: request,
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+}
+
+
+
+
+
+// ###################
+// CallBuilders   ###
+// #################
+
+/// Analyzes the syntax of the text and provides sentence boundaries and
+/// tokenization along with part of speech tags, dependency trees, and other
+/// properties.
+///
+/// A builder for the *analyzeSyntax* method supported by a *document* resource.
+/// It is not used directly, but through a `DocumentMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_language1_beta1 as language1_beta1;
+/// use language1_beta1::AnalyzeSyntaxRequest;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use language1_beta1::CloudNaturalLanguage;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = CloudNaturalLanguage::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = AnalyzeSyntaxRequest::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.documents().analyze_syntax(req)
+///              .doit();
+/// # }
+/// ```
+pub struct DocumentAnalyzeSyntaxCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a CloudNaturalLanguage<C, A>,
+    _request: AnalyzeSyntaxRequest,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for DocumentAnalyzeSyntaxCall<'a, C, A> {}
+
+impl<'a, C, A> DocumentAnalyzeSyntaxCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, AnalyzeSyntaxResponse)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "language.documents.analyzeSyntax",
+                               http_method: hyper::method::Method::Post });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((3 + self._additional_params.len()));
+        for &field in ["alt"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1beta1/documents:analyzeSyntax";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudLanguage.as_ref().to_string(), ());
+        }
+
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Post, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: AnalyzeSyntaxRequest) -> DocumentAnalyzeSyntaxCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> DocumentAnalyzeSyntaxCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> DocumentAnalyzeSyntaxCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudLanguage`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> DocumentAnalyzeSyntaxCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Finds named entities (currently proper names and common nouns) in the text
+/// along with entity types, salience, mentions for each entity, and
+/// other properties.
+///
+/// A builder for the *analyzeEntities* method supported by a *document* resource.
+/// It is not used directly, but through a `DocumentMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_language1_beta1 as language1_beta1;
+/// use language1_beta1::AnalyzeEntitiesRequest;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use language1_beta1::CloudNaturalLanguage;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = CloudNaturalLanguage::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = AnalyzeEntitiesRequest::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.documents().analyze_entities(req)
+///              .doit();
+/// # }
+/// ```
+pub struct DocumentAnalyzeEntityCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a CloudNaturalLanguage<C, A>,
+    _request: AnalyzeEntitiesRequest,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for DocumentAnalyzeEntityCall<'a, C, A> {}
+
+impl<'a, C, A> DocumentAnalyzeEntityCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, AnalyzeEntitiesResponse)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "language.documents.analyzeEntities",
+                               http_method: hyper::method::Method::Post });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((3 + self._additional_params.len()));
+        for &field in ["alt"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1beta1/documents:analyzeEntities";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudLanguage.as_ref().to_string(), ());
+        }
+
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Post, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: AnalyzeEntitiesRequest) -> DocumentAnalyzeEntityCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> DocumentAnalyzeEntityCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> DocumentAnalyzeEntityCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudLanguage`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> DocumentAnalyzeEntityCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Analyzes the sentiment of the provided text.
+///
+/// A builder for the *analyzeSentiment* method supported by a *document* resource.
+/// It is not used directly, but through a `DocumentMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_language1_beta1 as language1_beta1;
+/// use language1_beta1::AnalyzeSentimentRequest;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use language1_beta1::CloudNaturalLanguage;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = CloudNaturalLanguage::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = AnalyzeSentimentRequest::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.documents().analyze_sentiment(req)
+///              .doit();
+/// # }
+/// ```
+pub struct DocumentAnalyzeSentimentCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a CloudNaturalLanguage<C, A>,
+    _request: AnalyzeSentimentRequest,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for DocumentAnalyzeSentimentCall<'a, C, A> {}
+
+impl<'a, C, A> DocumentAnalyzeSentimentCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, AnalyzeSentimentResponse)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "language.documents.analyzeSentiment",
+                               http_method: hyper::method::Method::Post });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((3 + self._additional_params.len()));
+        for &field in ["alt"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1beta1/documents:analyzeSentiment";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudLanguage.as_ref().to_string(), ());
+        }
+
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Post, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: AnalyzeSentimentRequest) -> DocumentAnalyzeSentimentCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> DocumentAnalyzeSentimentCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> DocumentAnalyzeSentimentCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudLanguage`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> DocumentAnalyzeSentimentCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// A convenience method that provides all the features that analyzeSentiment,
+/// analyzeEntities, and analyzeSyntax provide in one call.
+///
+/// A builder for the *annotateText* method supported by a *document* resource.
+/// It is not used directly, but through a `DocumentMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_language1_beta1 as language1_beta1;
+/// use language1_beta1::AnnotateTextRequest;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use language1_beta1::CloudNaturalLanguage;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = CloudNaturalLanguage::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = AnnotateTextRequest::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.documents().annotate_text(req)
+///              .doit();
+/// # }
+/// ```
+pub struct DocumentAnnotateTextCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a CloudNaturalLanguage<C, A>,
+    _request: AnnotateTextRequest,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for DocumentAnnotateTextCall<'a, C, A> {}
+
+impl<'a, C, A> DocumentAnnotateTextCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, AnnotateTextResponse)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "language.documents.annotateText",
+                               http_method: hyper::method::Method::Post });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((3 + self._additional_params.len()));
+        for &field in ["alt"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1beta1/documents:annotateText";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudLanguage.as_ref().to_string(), ());
+        }
+
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Post, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: AnnotateTextRequest) -> DocumentAnnotateTextCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> DocumentAnnotateTextCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> DocumentAnnotateTextCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudLanguage`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> DocumentAnnotateTextCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+

--- a/gen/runtimeconfig1-cli/Cargo.toml
+++ b/gen/runtimeconfig1-cli/Cargo.toml
@@ -1,0 +1,40 @@
+# DO NOT EDIT !
+# This file was generated automatically from 'src/mako/Cargo.toml.mako'
+# DO NOT EDIT !
+[package]
+
+name = "google-runtimeconfig1-cli"
+version = "1.0.7+20171030"
+authors = ["Sebastian Thiel <byronimo@gmail.com>"]
+description = "A complete library to interact with Cloud RuntimeConfig (protocol v1)"
+repository = "https://github.com/Byron/google-apis-rs/tree/master/gen/runtimeconfig1-cli"
+homepage = "https://cloud.google.com/deployment-manager/runtime-configurator/"
+documentation = "http://byron.github.io/google-apis-rs/google_runtimeconfig1_cli"
+license = "MIT"
+keywords = ["runtimeconfig", "google", "cli"]
+
+[[bin]]
+name = "runtimeconfig1"
+
+[dev-dependencies]
+hyper-rustls = "^0.6"
+
+[dependencies]
+hyper = "^ 0.10"
+mime = "^ 0.2.0"
+serde = "^ 1.0"
+serde_json = "^ 1.0"
+serde_derive = "^ 1.0"
+yup-oauth2 = "^ 1.0"
+strsim = "^0.5"
+hyper-rustls = "^0.6"
+yup-hyper-mock = "^2.0"
+clap = "^2.0"
+
+[features]
+
+
+
+[dependencies.google-runtimeconfig1]
+path = "../runtimeconfig1"
+version = "1.0.7+20171030"

--- a/gen/runtimeconfig1-cli/LICENSE.md
+++ b/gen/runtimeconfig1-cli/LICENSE.md
@@ -1,0 +1,30 @@
+<!---
+DO NOT EDIT !
+This file was generated automatically from 'src/mako/LICENSE.md.mako'
+DO NOT EDIT !
+-->
+The MIT License (MIT)
+=====================
+
+Copyright © `2015-2016` `Sebastian Thiel`
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the “Software”), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.

--- a/gen/runtimeconfig1-cli/README.md
+++ b/gen/runtimeconfig1-cli/README.md
@@ -1,0 +1,116 @@
+<!---
+DO NOT EDIT !
+This file was generated automatically from 'src/mako/cli/README.md.mako'
+DO NOT EDIT !
+-->
+The `runtimeconfig1` command-line interface *(CLI)* allows to use most features of the *Google Cloud RuntimeConfig* service from the comfort of your terminal.
+
+By default all output is printed to standard out, but flags can be set to direct it into a file independent of your shell's
+capabilities. Errors will be printed to standard error, and cause the program's exit code to be non-zero.
+
+If data-structures are requested, these will be returned as pretty-printed JSON, to be useful as input to other tools.
+
+Everything else about the *Cloud RuntimeConfig* API can be found at the
+[official documentation site](https://cloud.google.com/deployment-manager/runtime-configurator/).
+
+# Installation and Source Code
+
+Install the command-line interface with cargo using:
+
+```bash
+cargo install google-runtimeconfig1-cli
+```
+
+Find the source code [on github](https://github.com/Byron/google-apis-rs/tree/master/gen/runtimeconfig1-cli).
+
+# Usage
+
+This documentation was generated from the *Cloud RuntimeConfig* API at revision *20171030*. The CLI is at version *1.0.7*.
+
+```bash
+runtimeconfig1 [options]
+        operations
+                cancel <name> (-r <kv>)... [-p <v>]... [-o <out>]
+                delete <name> [-p <v>]... [-o <out>]
+                list <name> [-p <v>]... [-o <out>]
+  runtimeconfig1 --help
+
+Configuration:
+  [--scope <url>]...
+            Specify the authentication a method should be executed in. Each scope
+            requires the user to grant this application permission to use it.
+            If unset, it defaults to the shortest scope url for a particular method.
+  --config-dir <folder>
+            A directory into which we will store our persistent data. Defaults to
+            a user-writable directory that we will create during the first invocation.
+            [default: ~/.google-service-cli]
+  --debug
+            Output all server communication to standard error. `tx` and `rx` are placed
+            into the same stream.
+  --debug-auth
+            Output all communication related to authentication to standard error. `tx`
+            and `rx` are placed into the same stream.
+
+```
+
+# Configuration
+
+The program will store all persistent data in the `~/.google-service-cli` directory in *JSON* files prefixed with `runtimeconfig1-`.  You can change the directory used to store configuration with the `--config-dir` flag on a per-invocation basis.
+
+More information about the various kinds of persistent data are given in the following paragraphs.
+
+# Authentication
+
+Most APIs require a user to authenticate any request. If this is the case, the [scope][scopes] determines the 
+set of permissions granted. The granularity of these is usually no more than *read-only* or *full-access*.
+
+If not set, the system will automatically select the smallest feasible scope, e.g. when invoking a
+method that is read-only, it will ask only for a read-only scope. 
+You may use the `--scope` flag to specify a scope directly. 
+All applicable scopes are documented in the respective method's CLI documentation.
+
+The first time a scope is used, the user is asked for permission. Follow the instructions given 
+by the CLI to grant permissions, or to decline.
+
+If a scope was authenticated by the user, the respective information will be stored as *JSON* in the configuration
+directory, e.g. `~/.google-service-cli/runtimeconfig1-token-<scope-hash>.json`. No manual management of these tokens
+is necessary.
+
+To revoke granted authentication, please refer to the [official documentation][revoke-access].
+
+# Application Secrets
+
+In order to allow any application to use Google services, it will need to be registered using the 
+[Google Developer Console][google-dev-console]. APIs the application may use are then enabled for it
+one by one. Most APIs can be used for free and have a daily quota.
+
+To allow more comfortable usage of the CLI without forcing anyone to register an own application, the CLI
+comes with a default application secret that is configured accordingly. This also means that heavy usage
+all around the world may deplete the daily quota.
+
+You can workaround this limitation by putting your own secrets file at this location: 
+`~/.google-service-cli/runtimeconfig1-secret.json`, assuming that the required *runtimeconfig* API 
+was enabled for it. Such a secret file can be downloaded in the *Google Developer Console* at 
+*APIs & auth -> Credentials -> Download JSON* and used as is.
+
+Learn more about how to setup Google projects and enable APIs using the [official documentation][google-project-new].
+
+
+# Debugging
+
+Even though the CLI does its best to provide usable error messages, sometimes it might be desirable to know
+what exactly led to a particular issue. This is done by allowing all client-server communication to be 
+output to standard error *as-is*.
+
+The `--debug` flag will print all client-server communication to standard error, whereas the `--debug-auth` flag
+will cause all communication related to authentication to standard error.
+If the `--debug` flag is set, error-results will be debug-printed, possibly yielding more information about the 
+issue at hand.
+
+You may consider redirecting standard error into a file for ease of use, e.g. `runtimeconfig1 --debug <resource> <method> [options] 2>debug.txt`.
+
+
+[scopes]: https://developers.google.com/+/api/oauth#scopes
+[revoke-access]: http://webapps.stackexchange.com/a/30849
+[google-dev-console]: https://console.developers.google.com/
+[google-project-new]: https://developers.google.com/console/help/new/

--- a/gen/runtimeconfig1-cli/mkdocs.yml
+++ b/gen/runtimeconfig1-cli/mkdocs.yml
@@ -1,0 +1,19 @@
+site_name: Cloud RuntimeConfig v1.0.7+20171030
+site_url: http://byron.github.io/google-apis-rs/google-runtimeconfig1-cli
+site_description: A complete library to interact with Cloud RuntimeConfig (protocol v1)
+
+repo_url: https://github.com/Byron/google-apis-rs/tree/master/gen/runtimeconfig1-cli
+
+docs_dir: docs
+site_dir: build_html
+
+pages:
+- ['index.md', 'Home']
+- ['operations_cancel.md', 'Operations', 'Cancel']
+- ['operations_delete.md', 'Operations', 'Delete']
+- ['operations_list.md', 'Operations', 'List']
+
+theme: readthedocs
+
+copyright: Copyright &copy; 2015-2016, `Sebastian Thiel`
+

--- a/gen/runtimeconfig1-cli/src/cmn.rs
+++ b/gen/runtimeconfig1-cli/src/cmn.rs
@@ -1,0 +1,799 @@
+// COPY OF 'src/rust/cli/cmn.rs'
+// DO NOT EDIT
+use oauth2::{ApplicationSecret, ConsoleApplicationSecret, TokenStorage, Token};
+use serde_json as json;
+use serde_json::value::Value;
+use mime::Mime;
+use clap::{App, SubCommand};
+use strsim;
+
+use std::fs;
+use std::env;
+use std::io;
+use std::error::Error as StdError;
+use std::fmt;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+use std::string::ToString;
+use std::io::{Write, Read, stdout};
+
+use std::default::Default;
+
+const FIELD_SEP: char = '.';
+
+
+pub enum ComplexType {
+    Pod,
+    Vec,
+    Map,
+}
+
+// Null,
+// Bool(bool),
+// I64(i64),
+// U64(u64),
+// F64(f64),
+// String(String),
+
+pub enum JsonType {
+    Boolean,
+    Int,
+    Uint,
+    Float,
+    String,
+}
+
+pub struct JsonTypeInfo {
+    pub jtype: JsonType,
+    pub ctype: ComplexType,
+}
+
+// Based on @erickt user comment. Thanks for the idea !
+// Remove all keys whose values are null from given value (changed in place)
+pub fn remove_json_null_values(value: &mut Value) {
+    match *value {
+        Value::Object(ref mut map) => {
+            let mut for_removal = Vec::new();
+
+            for (key, mut value) in map.iter_mut() {
+                if value.is_null() {
+                    for_removal.push(key.clone());
+                } else {
+                    remove_json_null_values(&mut value);
+                }
+            }
+
+            for key in &for_removal {
+                map.remove(key);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn did_you_mean<'a>(v: &str, possible_values: &[&'a str]) -> Option<&'a str> {
+
+    let mut candidate: Option<(f64, &str)> = None;
+    for pv in possible_values {
+        let confidence = strsim::jaro_winkler(v, pv);
+        if confidence > 0.8 &&
+           (candidate.is_none() || (candidate.as_ref().unwrap().0 < confidence)) {
+            candidate = Some((confidence, pv));
+        }
+    }
+    match candidate {
+        None => None,
+        Some((_, candidate)) => Some(candidate),
+    }
+}
+
+pub enum CallType {
+    Upload(UploadProtocol),
+    Standard,
+}
+
+arg_enum!{
+    pub enum UploadProtocol {
+        Simple,
+        Resumable
+    }
+}
+
+impl AsRef<str> for UploadProtocol {
+    fn as_ref(&self) -> &str {
+        match *self {
+            UploadProtocol::Simple => "simple",
+            UploadProtocol::Resumable => "resumable",
+        }
+    }
+}
+
+impl AsRef<str> for CallType {
+    fn as_ref(&self) -> &str {
+        match *self {
+            CallType::Upload(ref proto) => proto.as_ref(),
+            CallType::Standard => "standard-request",
+        }
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct FieldCursor(Vec<String>);
+
+impl ToString for  FieldCursor {
+    fn to_string(&self) -> String {
+        self.0.join(".")
+    }
+}
+
+impl From<&'static str> for FieldCursor {
+    fn from(value: &'static str) -> FieldCursor {
+        let mut res = FieldCursor::default();
+        res.set(value).unwrap();
+        res
+    }
+}
+
+fn assure_entry<'a, 'b>(m: &'a mut json::Map<String, Value>, k: &'b String) -> &'a mut Value {
+    if m.contains_key(k) {
+        return m.get_mut(k).expect("value to exist");
+    }
+    m.insert(k.to_owned(), Value::Object(Default::default()));
+    m.get_mut(k).expect("value to exist")
+}
+
+impl FieldCursor {
+    pub fn set(&mut self, value: &str) -> Result<(), CLIError> {
+        if value.len() == 0 {
+            return Err(CLIError::Field(FieldError::Empty));
+        }
+
+        let mut first_is_field_sep = false;
+        let mut char_count: usize = 0;
+        let mut last_c = FIELD_SEP;
+        let mut num_conscutive_field_seps = 0;
+
+        let mut field = String::new();
+        let mut fields = self.0.clone();
+
+        let push_field = |fs: &mut Vec<String>, f: &mut String| {
+            if f.len() > 0 {
+                fs.push(f.clone());
+                f.truncate(0);
+            }
+        };
+
+        for (cid, c) in value.chars().enumerate() {
+            char_count += 1;
+
+            if c == FIELD_SEP {
+                if cid == 0 {
+                    first_is_field_sep = true;
+                }
+                num_conscutive_field_seps += 1;
+                if cid > 0 && last_c == FIELD_SEP {
+                    if fields.pop().is_none() {
+                        return Err(CLIError::Field(FieldError::PopOnEmpty(value.to_string())));
+                    }
+                } else {
+                    push_field(&mut fields, &mut field);
+                }
+            } else {
+                num_conscutive_field_seps = 0;
+                if cid == 1 {
+                    if first_is_field_sep {
+                        fields.truncate(0);
+                    }
+                }
+                field.push(c);
+            }
+
+            last_c = c;
+        }
+
+        push_field(&mut fields, &mut field);
+
+        if char_count == 1 && first_is_field_sep {
+            fields.truncate(0);
+        }
+        if char_count > 1 && num_conscutive_field_seps == 1 {
+            return Err(CLIError::Field(FieldError::TrailingFieldSep(value.to_string())));
+        }
+
+        self.0 = fields;
+        Ok(())
+    }
+
+    pub fn did_you_mean(value: &str, possible_values: &[&str]) -> Option<String> {
+        if value.len() == 0 {
+            return None;
+        }
+
+        let mut last_c = FIELD_SEP;
+
+        let mut field = String::new();
+        let mut output = String::new();
+
+        let push_field = |fs: &mut String, f: &mut String| {
+            if f.len() > 0 {
+                fs.push_str(match did_you_mean(&f, possible_values) {
+                    Some(candidate) => candidate,
+                    None => &f,
+                });
+                f.truncate(0);
+            }
+        };
+
+        for (cid, c) in value.chars().enumerate() {
+            if c == FIELD_SEP {
+                if last_c != FIELD_SEP {
+                    push_field(&mut output, &mut field);
+                }
+                output.push(c);
+            } else {
+                field.push(c);
+            }
+
+            last_c = c;
+        }
+
+        push_field(&mut output, &mut field);
+
+        if &output == value {
+            None
+        } else {
+            Some(output)
+        }
+    }
+
+    pub fn set_json_value(&self,
+                          mut object: &mut Value,
+                          value: &str,
+                          type_info: JsonTypeInfo,
+                          err: &mut InvalidOptionsError,
+                          orig_cursor: &FieldCursor) {
+        assert!(self.0.len() > 0);
+
+        for field in &self.0[..self.0.len() - 1] {
+            let tmp = object;
+            object = match *tmp {
+                Value::Object(ref mut mapping) => {
+                    assure_entry(mapping, &field)
+                }
+                _ => panic!("We don't expect non-object Values here ..."),
+            };
+        }
+
+        match *object {
+            Value::Object(ref mut mapping) => {
+                let field = &self.0[self.0.len() - 1];
+                let to_jval = |value: &str,
+                               jtype: JsonType,
+                               err: &mut InvalidOptionsError|
+                               -> Value {
+                    match jtype {
+                        JsonType::Boolean =>
+                            Value::Bool(arg_from_str(value, err, &field, "boolean")),
+                        JsonType::Int =>
+                            Value::Number(json::Number::from_f64(arg_from_str(value,
+                                                                              err,
+                                                                              &field,
+                                                                              "int"))
+                                              .expect("valid f64")),
+                        JsonType::Uint =>
+                            Value::Number(json::Number::from_f64(arg_from_str(value,
+                                                                              err,
+                                                                              &field,
+                                                                              "uint"))
+                                              .expect("valid f64")),
+                        JsonType::Float =>
+                            Value::Number(json::Number::from_f64(arg_from_str(value,
+                                                                              err,
+                                                                              &field,
+                                                                              "float"))
+                                              .expect("valid f64")),
+                        JsonType::String => Value::String(value.to_owned()),
+                    }
+                };
+
+                match type_info.ctype {
+                    ComplexType::Pod => {
+                        if mapping.insert(field.to_owned(), to_jval(value, type_info.jtype, err))
+                                  .is_some() {
+                            err.issues.push(CLIError::Field(FieldError::Duplicate(orig_cursor.to_string())));
+                        }
+                    }
+                    ComplexType::Vec => {
+                        match *assure_entry(mapping, field) {
+                            Value::Array(ref mut values) =>
+                                values.push(to_jval(value, type_info.jtype, err)),
+                            _ => unreachable!(),
+                        }
+                    }
+                    ComplexType::Map => {
+                        let (key, value) = parse_kv_arg(value, err, true);
+                        let jval = to_jval(value.unwrap_or(""), type_info.jtype, err);
+
+                        match *assure_entry(mapping, &field) {
+
+                            Value::Object(ref mut value_map) => {
+                                if value_map.insert(key.to_owned(), jval).is_some() {
+                                    err.issues.push(CLIError::Field(FieldError::Duplicate(orig_cursor.to_string())));
+                                }
+                            }
+                            _ => unreachable!(),
+                        }
+                    }
+                }
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    pub fn num_fields(&self) -> usize {
+        self.0.len()
+    }
+}
+
+pub fn parse_kv_arg<'a>(kv: &'a str,
+                        err: &mut InvalidOptionsError,
+                        for_hashmap: bool)
+                        -> (&'a str, Option<&'a str>) {
+    let mut add_err = || {
+        err.issues.push(CLIError::InvalidKeyValueSyntax(kv.to_string(), for_hashmap))
+    };
+    match kv.find('=') {
+        None => {
+            add_err();
+            return (kv, None);
+        }
+        Some(pos) => {
+            let key = &kv[..pos];
+            if kv.len() <= pos + 1 {
+                add_err();
+                return (key, Some(""));
+            }
+            (key, Some(&kv[pos + 1..]))
+        }
+    }
+}
+
+pub fn calltype_from_str(name: &str,
+                         valid_protocols: Vec<String>,
+                         err: &mut InvalidOptionsError)
+                         -> CallType {
+    CallType::Upload(match UploadProtocol::from_str(name) {
+        Ok(up) => up,
+        Err(msg) => {
+            err.issues.push(CLIError::InvalidUploadProtocol(name.to_string(), valid_protocols));
+            UploadProtocol::Simple
+        }
+    })
+}
+
+pub fn input_file_from_opts(file_path: &str, err: &mut InvalidOptionsError) -> Option<fs::File> {
+    match fs::File::open(file_path) {
+        Ok(f) => Some(f),
+        Err(io_err) => {
+            err.issues.push(CLIError::Input(InputError::Io((file_path.to_string(), io_err))));
+            None
+        }
+    }
+}
+
+pub fn input_mime_from_opts(mime: &str, err: &mut InvalidOptionsError) -> Option<Mime> {
+    match mime.parse() {
+        Ok(m) => Some(m),
+        Err(_) => {
+            err.issues.push(CLIError::Input(InputError::Mime(mime.to_string())));
+            None
+        }
+    }
+}
+
+pub fn writer_from_opts(arg: Option<&str>) -> Result<Box<Write>, io::Error> {
+    let f = arg.unwrap_or("-");
+    match f {
+        "-" => Ok(Box::new(stdout())),
+        _ => match fs::OpenOptions::new().create(true).write(true).open(f) {
+            Ok(f) => Ok(Box::new(f)),
+            Err(io_err) => Err(io_err),
+        },
+    }
+}
+
+
+pub fn arg_from_str<'a, T>(arg: &str,
+                           err: &mut InvalidOptionsError,
+                           arg_name: &'a str,
+                           arg_type: &'a str)
+                           -> T
+    where T: FromStr + Default,
+          <T as FromStr>::Err: fmt::Display
+{
+    match FromStr::from_str(arg) {
+        Err(perr) => {
+            err.issues.push(CLIError::ParseError(arg_name.to_owned(),
+                                                 arg_type.to_owned(),
+                                                 arg.to_string(),
+                                                 format!("{}", perr)));
+            Default::default()
+        }
+        Ok(v) => v,
+    }
+}
+
+pub struct JsonTokenStorage {
+    pub program_name: &'static str,
+    pub db_dir: String,
+}
+
+impl JsonTokenStorage {
+    fn path(&self, scope_hash: u64) -> PathBuf {
+        Path::new(&self.db_dir).join(&format!("{}-token-{}.json", self.program_name, scope_hash))
+    }
+}
+
+
+#[derive(Debug)]
+pub enum TokenStorageError {
+    Json(json::Error),
+    Io(io::Error),
+}
+
+impl fmt::Display for TokenStorageError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            TokenStorageError::Json(ref err) => writeln!(f, "Could not serialize secrets: {}", err),
+            TokenStorageError::Io(ref err) => writeln!(f, "Failed to write secret token: {}", err),
+        }
+    }
+}
+
+impl StdError for TokenStorageError {
+    fn description(&self) -> &str {
+        "Failure when getting or setting the token storage"
+    }
+}
+
+
+impl TokenStorage for JsonTokenStorage {
+    type Error = TokenStorageError;
+
+    // NOTE: logging might be interesting, currently we swallow all errors
+    fn set(&mut self,
+           scope_hash: u64,
+           _: &Vec<&str>,
+           token: Option<Token>)
+           -> Result<(), TokenStorageError> {
+        match token {
+            None => {
+                match fs::remove_file(self.path(scope_hash)) {
+                    Err(err) => match err.kind() {
+                        io::ErrorKind::NotFound => Ok(()),
+                        _ => Err(TokenStorageError::Io(err)),
+                    },
+                    Ok(_) => Ok(()),
+                }
+            }
+            Some(token) => {
+                match fs::OpenOptions::new().create(true).write(true).open(&self.path(scope_hash)) {
+                    Ok(mut f) => {
+                        match json::to_writer_pretty(&mut f, &token) {
+                            Ok(_) => Ok(()),
+                            Err(serde_err) => Err(TokenStorageError::Json(serde_err)),
+                        }
+                    }
+                    Err(io_err) => Err(TokenStorageError::Io(io_err)),
+                }
+            }
+        }
+    }
+
+    fn get(&self, scope_hash: u64, _: &Vec<&str>) -> Result<Option<Token>, TokenStorageError> {
+        match fs::File::open(&self.path(scope_hash)) {
+            Ok(f) => {
+                match json::de::from_reader(f) {
+                    Ok(token) => Ok(Some(token)),
+                    Err(err) => Err(TokenStorageError::Json(err)),
+                }
+            }
+            Err(io_err) => {
+                match io_err.kind() {
+                    io::ErrorKind::NotFound => Ok(None),
+                    _ => Err(TokenStorageError::Io(io_err)),
+                }
+            }
+        }
+    }
+}
+
+
+#[derive(Debug)]
+pub enum ApplicationSecretError {
+    DecoderError((String, json::Error)),
+    FormatError(String),
+}
+
+impl fmt::Display for ApplicationSecretError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            ApplicationSecretError::DecoderError((ref path, ref err)) =>
+                writeln!(f,
+                         "Could not decode file at '{}' with error: {}.",
+                         path,
+                         err),
+            ApplicationSecretError::FormatError(ref path) =>
+                writeln!(f,
+                         "'installed' field is unset in secret file at '{}'.",
+                         path),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum ConfigurationError {
+    DirectoryCreationFailed((String, io::Error)),
+    DirectoryUnset,
+    HomeExpansionFailed(String),
+    Secret(ApplicationSecretError),
+    Io((String, io::Error)),
+}
+
+impl fmt::Display for ConfigurationError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            ConfigurationError::DirectoryCreationFailed((ref dir, ref err)) =>
+                writeln!(f,
+                         "Directory '{}' could not be created with error: {}.",
+                         dir,
+                         err),
+            ConfigurationError::DirectoryUnset => writeln!(f, "--config-dir was unset or empty."),
+            ConfigurationError::HomeExpansionFailed(ref dir) =>
+                writeln!(f,
+                         "Couldn't find HOME directory of current user, failed to expand '{}'.",
+                         dir),
+            ConfigurationError::Secret(ref err) => writeln!(f, "Secret -> {}", err),
+            ConfigurationError::Io((ref path, ref err)) =>
+                writeln!(f,
+                         "IO operation failed on path '{}' with error: {}.",
+                         path,
+                         err),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum InputError {
+    Io((String, io::Error)),
+    Mime(String),
+}
+
+impl fmt::Display for InputError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            InputError::Io((ref file_path, ref io_err)) =>
+                writeln!(f,
+                         "Failed to open '{}' for reading with error: {}.",
+                         file_path,
+                         io_err),
+            InputError::Mime(ref mime) => writeln!(f, "'{}' is not a known mime-type.", mime),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum FieldError {
+    PopOnEmpty(String),
+    TrailingFieldSep(String),
+    Unknown(String, Option<String>, Option<String>),
+    Duplicate(String),
+    Empty,
+}
+
+
+impl fmt::Display for FieldError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            FieldError::PopOnEmpty(ref field) =>
+                writeln!(f, "'{}': Cannot move up on empty field cursor.", field),
+            FieldError::TrailingFieldSep(ref field) =>
+                writeln!(f,
+                         "'{}': Single field separator may not be last character.",
+                         field),
+            FieldError::Unknown(ref field, ref suggestion, ref value) => {
+                let suffix = match *suggestion {
+                    Some(ref s) => {
+                        let kv = match *value {
+                            Some(ref v) => format!("{}={}", s, v),
+                            None => s.clone(),
+                        };
+                        format!(" Did you mean '{}' ?", kv)
+                    }
+                    None => String::new(),
+                };
+                writeln!(f, "Field '{}' does not exist.{}", field, suffix)
+            }
+            FieldError::Duplicate(ref cursor) =>
+                writeln!(f, "Value at '{}' was already set", cursor),
+            FieldError::Empty => writeln!(f, "Field names must not be empty."),
+        }
+    }
+}
+
+
+#[derive(Debug)]
+pub enum CLIError {
+    Configuration(ConfigurationError),
+    ParseError(String, String, String, String),
+    UnknownParameter(String, Vec<&'static str>),
+    InvalidUploadProtocol(String, Vec<String>),
+    InvalidKeyValueSyntax(String, bool),
+    Input(InputError),
+    Field(FieldError),
+    MissingCommandError,
+    MissingMethodError(String),
+}
+
+impl fmt::Display for CLIError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            CLIError::Configuration(ref err) => write!(f, "Configuration -> {}", err),
+            CLIError::Input(ref err) => write!(f, "Input -> {}", err),
+            CLIError::Field(ref err) => write!(f, "Field -> {}", err),
+            CLIError::InvalidUploadProtocol(ref proto_name, ref valid_names) =>
+                writeln!(f,
+                         "'{}' is not a valid upload protocol. Choose from one of {}.",
+                         proto_name,
+                         valid_names.join(", ")),
+            CLIError::ParseError(ref arg_name, ref type_name, ref value, ref err_desc) =>
+                writeln!(f,
+                         "Failed to parse argument '{}' with value '{}' as {} with error: {}.",
+                         arg_name,
+                         value,
+                         type_name,
+                         err_desc),
+            CLIError::UnknownParameter(ref param_name, ref possible_values) => {
+                let suffix = match did_you_mean(param_name, &possible_values) {
+                    Some(v) => format!(" Did you mean '{}' ?", v),
+                    None => String::new(),
+                };
+                write!(f, "Parameter '{}' is unknown.{}\n", param_name, suffix)
+            }
+            CLIError::InvalidKeyValueSyntax(ref kv, is_hashmap) => {
+                let hashmap_info = if is_hashmap {
+                    "hashmap "
+                } else {
+                    ""
+                };
+                writeln!(f,
+                         "'{}' does not match {}pattern <key>=<value>.",
+                         kv,
+                         hashmap_info)
+            }
+            CLIError::MissingCommandError => writeln!(f, "Please specify the main sub-command."),
+            CLIError::MissingMethodError(ref cmd) =>
+                writeln!(f,
+                         "Please specify the method to call on the '{}' command.",
+                         cmd),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct InvalidOptionsError {
+    pub issues: Vec<CLIError>,
+    pub exit_code: i32,
+}
+
+impl fmt::Display for InvalidOptionsError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        for issue in &self.issues {
+            try!(issue.fmt(f));
+        }
+        Ok(())
+    }
+}
+
+impl InvalidOptionsError {
+    pub fn single(err: CLIError, exit_code: i32) -> InvalidOptionsError {
+        InvalidOptionsError {
+            issues: vec![err],
+            exit_code: exit_code,
+        }
+    }
+
+    pub fn new() -> InvalidOptionsError {
+        InvalidOptionsError {
+            issues: Vec::new(),
+            exit_code: 1,
+        }
+    }
+}
+
+pub fn assure_config_dir_exists(dir: &str) -> Result<String, CLIError> {
+    let trdir = dir.trim();
+    if trdir.len() == 0 {
+        return Err(CLIError::Configuration(ConfigurationError::DirectoryUnset));
+    }
+
+    let expanded_config_dir = if trdir.as_bytes()[0] == b'~' {
+        match env::var("HOME").ok().or(env::var("UserProfile").ok()) {
+            None => return Err(CLIError::Configuration(ConfigurationError::HomeExpansionFailed(trdir.to_string()))),
+            Some(mut user) => {
+                user.push_str(&trdir[1..]);
+                user
+            }
+        }
+    } else {
+        trdir.to_string()
+    };
+
+    if let Err(err) = fs::create_dir(&expanded_config_dir) {
+        if err.kind() != io::ErrorKind::AlreadyExists {
+            return Err(CLIError::Configuration(
+                    ConfigurationError::DirectoryCreationFailed((expanded_config_dir, err))));
+        }
+    }
+
+    Ok(expanded_config_dir)
+}
+
+pub fn application_secret_from_directory(dir: &str,
+                                         secret_basename: &str,
+                                         json_console_secret: &str)
+                                         -> Result<ApplicationSecret, CLIError> {
+    let secret_path = Path::new(dir).join(secret_basename);
+    let secret_str = || secret_path.as_path().to_str().unwrap().to_string();
+    let secret_io_error = |io_err: io::Error| {
+        Err(CLIError::Configuration(ConfigurationError::Io((secret_str(), io_err))))
+    };
+
+    for _ in 0..2 {
+        match fs::File::open(&secret_path) {
+            Err(mut err) => {
+                if err.kind() == io::ErrorKind::NotFound {
+                    // Write our built-in one - user may adjust the written file at will
+
+                    err = match fs::OpenOptions::new()
+                                    .create(true)
+                                    .write(true)
+                                    .open(&secret_path) {
+                        Err(cfe) => cfe,
+                        Ok(mut f) => {
+                            // Assure we convert 'ugly' json string into pretty one
+                            let console_secret: ConsoleApplicationSecret =
+                                json::from_str(json_console_secret).unwrap();
+                            match json::to_writer_pretty(&mut f, &console_secret) {
+                                Err(serde_err) =>
+                                    panic!("Unexpected serde error: {:#?}", serde_err),
+                                Ok(_) => continue,
+                            }
+                        }
+                    };
+                    // fall through to IO error handling
+                }
+                return secret_io_error(err);
+            }
+            Ok(f) => {
+                match json::de::from_reader::<_, ConsoleApplicationSecret>(f) {
+                    Err(json_err) =>
+                        return Err(CLIError::Configuration(
+                            ConfigurationError::Secret(
+                                ApplicationSecretError::DecoderError(
+                                                (secret_str(), json_err)
+                                              )))),
+                    Ok(console_secret) => match console_secret.installed {
+                        Some(secret) => return Ok(secret),
+                        None => return Err(
+                                        CLIError::Configuration(
+                                        ConfigurationError::Secret(
+                                        ApplicationSecretError::FormatError(secret_str())
+                                        ))),
+                    },
+                }
+            }
+        }
+    }
+    unreachable!();
+}

--- a/gen/runtimeconfig1-cli/src/main.rs
+++ b/gen/runtimeconfig1-cli/src/main.rs
@@ -1,0 +1,548 @@
+// DO NOT EDIT !
+// This file was generated automatically from 'src/mako/cli/main.rs.mako'
+// DO NOT EDIT !
+#![allow(unused_variables, unused_imports, dead_code, unused_mut)]
+
+#[macro_use]
+extern crate clap;
+extern crate yup_oauth2 as oauth2;
+extern crate yup_hyper_mock as mock;
+extern crate hyper_rustls;
+extern crate serde;
+extern crate serde_json;
+extern crate hyper;
+extern crate mime;
+extern crate strsim;
+extern crate google_runtimeconfig1 as api;
+
+use std::env;
+use std::io::{self, Write};
+use clap::{App, SubCommand, Arg};
+
+mod cmn;
+
+use cmn::{InvalidOptionsError, CLIError, JsonTokenStorage, arg_from_str, writer_from_opts, parse_kv_arg,
+          input_file_from_opts, input_mime_from_opts, FieldCursor, FieldError, CallType, UploadProtocol,
+          calltype_from_str, remove_json_null_values, ComplexType, JsonType, JsonTypeInfo};
+
+use std::default::Default;
+use std::str::FromStr;
+
+use oauth2::{Authenticator, DefaultAuthenticatorDelegate, FlowType};
+use serde_json as json;
+use clap::ArgMatches;
+
+enum DoitError {
+    IoError(String, io::Error),
+    ApiError(api::Error),
+}
+
+struct Engine<'n> {
+    opt: ArgMatches<'n>,
+    hub: api::CloudRuntimeConfig<hyper::Client, Authenticator<DefaultAuthenticatorDelegate, JsonTokenStorage, hyper::Client>>,
+    gp: Vec<&'static str>,
+    gpm: Vec<(&'static str, &'static str)>,
+}
+
+
+impl<'n> Engine<'n> {
+    fn _operations_cancel(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec![]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::CancelOperationRequest = json::value::from_value(object).unwrap();
+        let mut call = self.hub.operations().cancel(request, opt.value_of("name").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _operations_delete(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let mut call = self.hub.operations().delete(opt.value_of("name").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _operations_list(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let mut call = self.hub.operations().list(opt.value_of("name").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                "page-token" => {
+                    call = call.page_token(value.unwrap_or(""));
+                },
+                "page-size" => {
+                    call = call.page_size(arg_from_str(value.unwrap_or("-0"), err, "page-size", "integer"));
+                },
+                "filter" => {
+                    call = call.filter(value.unwrap_or(""));
+                },
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v.extend(["filter", "page-token", "page-size"].iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _doit(&self, dry_run: bool) -> Result<Result<(), DoitError>, Option<InvalidOptionsError>> {
+        let mut err = InvalidOptionsError::new();
+        let mut call_result: Result<(), DoitError> = Ok(());
+        let mut err_opt: Option<InvalidOptionsError> = None;
+        match self.opt.subcommand() {
+            ("operations", Some(opt)) => {
+                match opt.subcommand() {
+                    ("cancel", Some(opt)) => {
+                        call_result = self._operations_cancel(opt, dry_run, &mut err);
+                    },
+                    ("delete", Some(opt)) => {
+                        call_result = self._operations_delete(opt, dry_run, &mut err);
+                    },
+                    ("list", Some(opt)) => {
+                        call_result = self._operations_list(opt, dry_run, &mut err);
+                    },
+                    _ => {
+                        err.issues.push(CLIError::MissingMethodError("operations".to_string()));
+                        writeln!(io::stderr(), "{}\n", opt.usage()).ok();
+                    }
+                }
+            },
+            _ => {
+                err.issues.push(CLIError::MissingCommandError);
+                writeln!(io::stderr(), "{}\n", self.opt.usage()).ok();
+            }
+        }
+
+        if dry_run {
+            if err.issues.len() > 0 {
+                err_opt = Some(err);
+            }
+            Err(err_opt)
+        } else {
+            Ok(call_result)
+        }
+    }
+
+    // Please note that this call will fail if any part of the opt can't be handled
+    fn new(opt: ArgMatches<'n>) -> Result<Engine<'n>, InvalidOptionsError> {
+        let (config_dir, secret) = {
+            let config_dir = match cmn::assure_config_dir_exists(opt.value_of("folder").unwrap_or("~/.google-service-cli")) {
+                Err(e) => return Err(InvalidOptionsError::single(e, 3)),
+                Ok(p) => p,
+            };
+
+            match cmn::application_secret_from_directory(&config_dir, "runtimeconfig1-secret.json",
+                                                         "{\"installed\":{\"auth_uri\":\"https://accounts.google.com/o/oauth2/auth\",\"client_secret\":\"hCsslbCUyfehWMmbkG8vTYxG\",\"token_uri\":\"https://accounts.google.com/o/oauth2/token\",\"client_email\":\"\",\"redirect_uris\":[\"urn:ietf:wg:oauth:2.0:oob\",\"oob\"],\"client_x509_cert_url\":\"\",\"client_id\":\"620010449518-9ngf7o4dhs0dka470npqvor6dc5lqb9b.apps.googleusercontent.com\",\"auth_provider_x509_cert_url\":\"https://www.googleapis.com/oauth2/v1/certs\"}}") {
+                Ok(secret) => (config_dir, secret),
+                Err(e) => return Err(InvalidOptionsError::single(e, 4))
+            }
+        };
+
+        let auth = Authenticator::new(  &secret, DefaultAuthenticatorDelegate,
+                                        if opt.is_present("debug-auth") {
+                                            hyper::Client::with_connector(mock::TeeConnector {
+                                                    connector: hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())
+                                                })
+                                        } else {
+                                            hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new()))
+                                        },
+                                        JsonTokenStorage {
+                                          program_name: "runtimeconfig1",
+                                          db_dir: config_dir.clone(),
+                                        }, Some(FlowType::InstalledRedirect(54324)));
+
+        let client =
+            if opt.is_present("debug") {
+                hyper::Client::with_connector(mock::TeeConnector {
+                        connector: hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())
+                    })
+            } else {
+                hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new()))
+            };
+        let engine = Engine {
+            opt: opt,
+            hub: api::CloudRuntimeConfig::new(client, auth),
+            gp: vec!["$-xgafv", "access-token", "alt", "bearer-token", "callback", "fields", "key", "oauth-token", "pp", "pretty-print", "quota-user", "upload-type", "upload-protocol"],
+            gpm: vec![
+                    ("$-xgafv", "$.xgafv"),
+                    ("access-token", "access_token"),
+                    ("bearer-token", "bearer_token"),
+                    ("oauth-token", "oauth_token"),
+                    ("pretty-print", "prettyPrint"),
+                    ("quota-user", "quotaUser"),
+                    ("upload-type", "uploadType"),
+                    ("upload-protocol", "upload_protocol"),
+                ]
+        };
+
+        match engine._doit(true) {
+            Err(Some(err)) => Err(err),
+            Err(None)      => Ok(engine),
+            Ok(_)          => unreachable!(),
+        }
+    }
+
+    fn doit(&self) -> Result<(), DoitError> {
+        match self._doit(false) {
+            Ok(res) => res,
+            Err(_) => unreachable!(),
+        }
+    }
+}
+
+fn main() {
+    let mut exit_status = 0i32;
+    let arg_data = [
+        ("operations", "methods: 'cancel', 'delete' and 'list'", vec![
+            ("cancel",
+                    Some(r##"Starts asynchronous cancellation on a long-running operation.  The server
+        makes a best effort to cancel the operation, but success is not
+        guaranteed.  If the server doesn't support this method, it returns
+        `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
+        Operations.GetOperation or
+        other methods to check whether the cancellation succeeded or whether the
+        operation completed despite cancellation. On successful cancellation,
+        the operation is not deleted; instead, it becomes an operation with
+        an Operation.error value with a google.rpc.Status.code of 1,
+        corresponding to `Code.CANCELLED`."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_runtimeconfig1_cli/operations_cancel",
+                  vec![
+                    (Some(r##"name"##),
+                     None,
+                     Some(r##"The name of the operation resource to be cancelled."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("delete",
+                    Some(r##"Deletes a long-running operation. This method indicates that the client is
+        no longer interested in the operation result. It does not cancel the
+        operation. If the server doesn't support this method, it returns
+        `google.rpc.Code.UNIMPLEMENTED`."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_runtimeconfig1_cli/operations_delete",
+                  vec![
+                    (Some(r##"name"##),
+                     None,
+                     Some(r##"The name of the operation resource to be deleted."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("list",
+                    Some(r##"Lists operations that match the specified filter in the request. If the
+        server doesn't support this method, it returns `UNIMPLEMENTED`.
+        
+        NOTE: the `name` binding allows API services to override the binding
+        to use different resource name schemes, such as `users/*/operations`. To
+        override the binding, API services can add a binding such as
+        `"/v1/{name=users/*}/operations"` to their service configuration.
+        For backwards compatibility, the default name includes the operations
+        collection id, however overriding users must ensure the name binding
+        is the parent resource, without the operations collection id."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_runtimeconfig1_cli/operations_list",
+                  vec![
+                    (Some(r##"name"##),
+                     None,
+                     Some(r##"The name of the operation's parent resource."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ]),
+        
+    ];
+    
+    let mut app = App::new("runtimeconfig1")
+           .author("Sebastian Thiel <byronimo@gmail.com>")
+           .version("1.0.7+20171030")
+           .about("The Runtime Configurator allows you to dynamically configure and expose variables through Google Cloud Platform. In addition, you can also set Watchers and Waiters that will watch for changes to your data and return based on certain conditions.")
+           .after_help("All documentation details can be found at http://byron.github.io/google-apis-rs/google_runtimeconfig1_cli")
+           .arg(Arg::with_name("url")
+                   .long("scope")
+                   .help("Specify the authentication a method should be executed in. Each scope requires the user to grant this application permission to use it.If unset, it defaults to the shortest scope url for a particular method.")
+                   .multiple(true)
+                   .takes_value(true))
+           .arg(Arg::with_name("folder")
+                   .long("config-dir")
+                   .help("A directory into which we will store our persistent data. Defaults to a user-writable directory that we will create during the first invocation.[default: ~/.google-service-cli")
+                   .multiple(false)
+                   .takes_value(true))
+           .arg(Arg::with_name("debug")
+                   .long("debug")
+                   .help("Output all server communication to standard error. `tx` and `rx` are placed into the same stream.")
+                   .multiple(false)
+                   .takes_value(false))
+           .arg(Arg::with_name("debug-auth")
+                   .long("debug-auth")
+                   .help("Output all communication related to authentication to standard error. `tx` and `rx` are placed into the same stream.")
+                   .multiple(false)
+                   .takes_value(false));
+           
+           for &(main_command_name, about, ref subcommands) in arg_data.iter() {
+               let mut mcmd = SubCommand::with_name(main_command_name).about(about);
+           
+               for &(sub_command_name, ref desc, url_info, ref args) in subcommands {
+                   let mut scmd = SubCommand::with_name(sub_command_name);
+                   if let &Some(desc) = desc {
+                       scmd = scmd.about(desc);
+                   }
+                   scmd = scmd.after_help(url_info);
+           
+                   for &(ref arg_name, ref flag, ref desc, ref required, ref multi) in args {
+                       let arg_name_str =
+                           match (arg_name, flag) {
+                                   (&Some(an), _       ) => an,
+                                   (_        , &Some(f)) => f,
+                                    _                    => unreachable!(),
+                            };
+                       let mut arg = Arg::with_name(arg_name_str)
+                                         .empty_values(false);
+                       if let &Some(short_flag) = flag {
+                           arg = arg.short(short_flag);
+                       }
+                       if let &Some(desc) = desc {
+                           arg = arg.help(desc);
+                       }
+                       if arg_name.is_some() && flag.is_some() {
+                           arg = arg.takes_value(true);
+                       }
+                       if let &Some(required) = required {
+                           arg = arg.required(required);
+                       }
+                       if let &Some(multi) = multi {
+                           arg = arg.multiple(multi);
+                       }
+                       scmd = scmd.arg(arg);
+                   }
+                   mcmd = mcmd.subcommand(scmd);
+               }
+               app = app.subcommand(mcmd);
+           }
+           
+        let matches = app.get_matches();
+
+    let debug = matches.is_present("debug");
+    match Engine::new(matches) {
+        Err(err) => {
+            exit_status = err.exit_code;
+            writeln!(io::stderr(), "{}", err).ok();
+        },
+        Ok(engine) => {
+            if let Err(doit_err) = engine.doit() {
+                exit_status = 1;
+                match doit_err {
+                    DoitError::IoError(path, err) => {
+                        writeln!(io::stderr(), "Failed to open output file '{}': {}", path, err).ok();
+                    },
+                    DoitError::ApiError(err) => {
+                        if debug {
+                            writeln!(io::stderr(), "{:#?}", err).ok();
+                        } else {
+                            writeln!(io::stderr(), "{}", err).ok();
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    std::process::exit(exit_status);
+}

--- a/gen/runtimeconfig1/Cargo.toml
+++ b/gen/runtimeconfig1/Cargo.toml
@@ -1,0 +1,31 @@
+# DO NOT EDIT !
+# This file was generated automatically from 'src/mako/Cargo.toml.mako'
+# DO NOT EDIT !
+[package]
+
+name = "google-runtimeconfig1"
+version = "1.0.7+20171030"
+authors = ["Sebastian Thiel <byronimo@gmail.com>"]
+description = "A complete library to interact with Cloud RuntimeConfig (protocol v1)"
+repository = "https://github.com/Byron/google-apis-rs/tree/master/gen/runtimeconfig1"
+homepage = "https://cloud.google.com/deployment-manager/runtime-configurator/"
+documentation = "https://docs.rs/google-runtimeconfig1/1.0.7+20171030"
+license = "MIT"
+keywords = ["runtimeconfig", "google", "protocol", "web", "api"]
+
+
+[dev-dependencies]
+hyper-rustls = "^0.6"
+
+[dependencies]
+hyper = "^ 0.10"
+mime = "^ 0.2.0"
+serde = "^ 1.0"
+serde_json = "^ 1.0"
+serde_derive = "^ 1.0"
+yup-oauth2 = "^ 1.0"
+url = "= 0.5"
+
+[features]
+
+

--- a/gen/runtimeconfig1/LICENSE.md
+++ b/gen/runtimeconfig1/LICENSE.md
@@ -1,0 +1,30 @@
+<!---
+DO NOT EDIT !
+This file was generated automatically from 'src/mako/LICENSE.md.mako'
+DO NOT EDIT !
+-->
+The MIT License (MIT)
+=====================
+
+Copyright © `2015-2016` `Sebastian Thiel`
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the “Software”), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.

--- a/gen/runtimeconfig1/README.md
+++ b/gen/runtimeconfig1/README.md
@@ -1,0 +1,179 @@
+<!---
+DO NOT EDIT !
+This file was generated automatically from 'src/mako/api/README.md.mako'
+DO NOT EDIT !
+-->
+The `google-runtimeconfig1` library allows access to all features of the *Google Cloud RuntimeConfig* service.
+
+This documentation was generated from *Cloud RuntimeConfig* crate version *1.0.7+20171030*, where *20171030* is the exact revision of the *runtimeconfig:v1* schema built by the [mako](http://www.makotemplates.org/) code generator *v1.0.7*.
+
+Everything else about the *Cloud RuntimeConfig* *v1* API can be found at the
+[official documentation site](https://cloud.google.com/deployment-manager/runtime-configurator/).
+# Features
+
+Handle the following *Resources* with ease from the central [hub](https://docs.rs/google-runtimeconfig1/1.0.7+20171030/google_runtimeconfig1/struct.CloudRuntimeConfig.html) ... 
+
+* [operations](https://docs.rs/google-runtimeconfig1/1.0.7+20171030/google_runtimeconfig1/struct.Operation.html)
+ * [*cancel*](https://docs.rs/google-runtimeconfig1/1.0.7+20171030/google_runtimeconfig1/struct.OperationCancelCall.html), [*delete*](https://docs.rs/google-runtimeconfig1/1.0.7+20171030/google_runtimeconfig1/struct.OperationDeleteCall.html) and [*list*](https://docs.rs/google-runtimeconfig1/1.0.7+20171030/google_runtimeconfig1/struct.OperationListCall.html)
+
+
+
+
+# Structure of this Library
+
+The API is structured into the following primary items:
+
+* **[Hub](https://docs.rs/google-runtimeconfig1/1.0.7+20171030/google_runtimeconfig1/struct.CloudRuntimeConfig.html)**
+    * a central object to maintain state and allow accessing all *Activities*
+    * creates [*Method Builders*](https://docs.rs/google-runtimeconfig1/1.0.7+20171030/google_runtimeconfig1/trait.MethodsBuilder.html) which in turn
+      allow access to individual [*Call Builders*](https://docs.rs/google-runtimeconfig1/1.0.7+20171030/google_runtimeconfig1/trait.CallBuilder.html)
+* **[Resources](https://docs.rs/google-runtimeconfig1/1.0.7+20171030/google_runtimeconfig1/trait.Resource.html)**
+    * primary types that you can apply *Activities* to
+    * a collection of properties and *Parts*
+    * **[Parts](https://docs.rs/google-runtimeconfig1/1.0.7+20171030/google_runtimeconfig1/trait.Part.html)**
+        * a collection of properties
+        * never directly used in *Activities*
+* **[Activities](https://docs.rs/google-runtimeconfig1/1.0.7+20171030/google_runtimeconfig1/trait.CallBuilder.html)**
+    * operations to apply to *Resources*
+
+All *structures* are marked with applicable traits to further categorize them and ease browsing.
+
+Generally speaking, you can invoke *Activities* like this:
+
+```Rust,ignore
+let r = hub.resource().activity(...).doit()
+```
+
+Or specifically ...
+
+```ignore
+let r = hub.operations().list(...).doit()
+let r = hub.operations().delete(...).doit()
+let r = hub.operations().cancel(...).doit()
+```
+
+The `resource()` and `activity(...)` calls create [builders][builder-pattern]. The second one dealing with `Activities` 
+supports various methods to configure the impending operation (not shown here). It is made such that all required arguments have to be 
+specified right away (i.e. `(...)`), whereas all optional ones can be [build up][builder-pattern] as desired.
+The `doit()` method performs the actual communication with the server and returns the respective result.
+
+# Usage
+
+## Setting up your Project
+
+To use this library, you would put the following lines into your `Cargo.toml` file:
+
+```toml
+[dependencies]
+google-runtimeconfig1 = "*"
+```
+
+## A complete example
+
+```Rust
+extern crate hyper;
+extern crate hyper_rustls;
+extern crate yup_oauth2 as oauth2;
+extern crate google_runtimeconfig1 as runtimeconfig1;
+use runtimeconfig1::{Result, Error};
+use std::default::Default;
+use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+use runtimeconfig1::CloudRuntimeConfig;
+
+// Get an ApplicationSecret instance by some means. It contains the `client_id` and 
+// `client_secret`, among other things.
+let secret: ApplicationSecret = Default::default();
+// Instantiate the authenticator. It will choose a suitable authentication flow for you, 
+// unless you replace  `None` with the desired Flow.
+// Provide your own `AuthenticatorDelegate` to adjust the way it operates and get feedback about 
+// what's going on. You probably want to bring in your own `TokenStorage` to persist tokens and
+// retrieve them from storage.
+let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+                              hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+                              <MemoryStorage as Default>::default(), None);
+let mut hub = CloudRuntimeConfig::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+// You can configure optional parameters by calling the respective setters at will, and
+// execute the final call using `doit()`.
+// Values shown here are possibly random and not representative !
+let result = hub.operations().list("name")
+             .page_token("sit")
+             .page_size(-65)
+             .filter("sed")
+             .doit();
+
+match result {
+    Err(e) => match e {
+        // The Error enum provides details about what exactly happened.
+        // You can also just use its `Debug`, `Display` or `Error` traits
+         Error::HttpError(_)
+        |Error::MissingAPIKey
+        |Error::MissingToken(_)
+        |Error::Cancelled
+        |Error::UploadSizeLimitExceeded(_, _)
+        |Error::Failure(_)
+        |Error::BadRequest(_)
+        |Error::FieldClash(_)
+        |Error::JsonDecodeError(_, _) => println!("{}", e),
+    },
+    Ok(res) => println!("Success: {:?}", res),
+}
+
+```
+## Handling Errors
+
+All errors produced by the system are provided either as [Result](https://docs.rs/google-runtimeconfig1/1.0.7+20171030/google_runtimeconfig1/enum.Result.html) enumeration as return value of 
+the doit() methods, or handed as possibly intermediate results to either the 
+[Hub Delegate](https://docs.rs/google-runtimeconfig1/1.0.7+20171030/google_runtimeconfig1/trait.Delegate.html), or the [Authenticator Delegate](https://docs.rs/yup-oauth2/*/yup_oauth2/trait.AuthenticatorDelegate.html).
+
+When delegates handle errors or intermediate values, they may have a chance to instruct the system to retry. This 
+makes the system potentially resilient to all kinds of errors.
+
+## Uploads and Downloads
+If a method supports downloads, the response body, which is part of the [Result](https://docs.rs/google-runtimeconfig1/1.0.7+20171030/google_runtimeconfig1/enum.Result.html), should be
+read by you to obtain the media.
+If such a method also supports a [Response Result](https://docs.rs/google-runtimeconfig1/1.0.7+20171030/google_runtimeconfig1/trait.ResponseResult.html), it will return that by default.
+You can see it as meta-data for the actual media. To trigger a media download, you will have to set up the builder by making
+this call: `.param("alt", "media")`.
+
+Methods supporting uploads can do so using up to 2 different protocols: 
+*simple* and *resumable*. The distinctiveness of each is represented by customized 
+`doit(...)` methods, which are then named `upload(...)` and `upload_resumable(...)` respectively.
+
+## Customization and Callbacks
+
+You may alter the way an `doit()` method is called by providing a [delegate](https://docs.rs/google-runtimeconfig1/1.0.7+20171030/google_runtimeconfig1/trait.Delegate.html) to the 
+[Method Builder](https://docs.rs/google-runtimeconfig1/1.0.7+20171030/google_runtimeconfig1/trait.CallBuilder.html) before making the final `doit()` call. 
+Respective methods will be called to provide progress information, as well as determine whether the system should 
+retry on failure.
+
+The [delegate trait](https://docs.rs/google-runtimeconfig1/1.0.7+20171030/google_runtimeconfig1/trait.Delegate.html) is default-implemented, allowing you to customize it with minimal effort.
+
+## Optional Parts in Server-Requests
+
+All structures provided by this library are made to be [enocodable](https://docs.rs/google-runtimeconfig1/1.0.7+20171030/google_runtimeconfig1/trait.RequestValue.html) and 
+[decodable](https://docs.rs/google-runtimeconfig1/1.0.7+20171030/google_runtimeconfig1/trait.ResponseResult.html) via *json*. Optionals are used to indicate that partial requests are responses 
+are valid.
+Most optionals are are considered [Parts](https://docs.rs/google-runtimeconfig1/1.0.7+20171030/google_runtimeconfig1/trait.Part.html) which are identifiable by name, which will be sent to 
+the server to indicate either the set parts of the request or the desired parts in the response.
+
+## Builder Arguments
+
+Using [method builders](https://docs.rs/google-runtimeconfig1/1.0.7+20171030/google_runtimeconfig1/trait.CallBuilder.html), you are able to prepare an action call by repeatedly calling it's methods.
+These will always take a single argument, for which the following statements are true.
+
+* [PODs][wiki-pod] are handed by copy
+* strings are passed as `&str`
+* [request values](https://docs.rs/google-runtimeconfig1/1.0.7+20171030/google_runtimeconfig1/trait.RequestValue.html) are moved
+
+Arguments will always be copied or cloned into the builder, to make them independent of their original life times.
+
+[wiki-pod]: http://en.wikipedia.org/wiki/Plain_old_data_structure
+[builder-pattern]: http://en.wikipedia.org/wiki/Builder_pattern
+[google-go-api]: https://github.com/google/google-api-go-client
+
+# License
+The **runtimeconfig1** library was generated by Sebastian Thiel, and is placed 
+under the *MIT* license.
+You can read the full text at the repository's [license file][repo-license].
+
+[repo-license]: https://github.com/Byron/google-apis-rsblob/master/LICENSE.md

--- a/gen/runtimeconfig1/src/cmn.rs
+++ b/gen/runtimeconfig1/src/cmn.rs
@@ -1,0 +1,753 @@
+// COPY OF 'src/rust/api/cmn.rs'
+// DO NOT EDIT
+use std::io::{self, Read, Seek, Cursor, Write, SeekFrom};
+use std;
+use std::fmt::{self, Display};
+use std::str::FromStr;
+use std::error;
+use std::thread::sleep;
+use std::time::Duration;
+
+use mime::{Mime, TopLevel, SubLevel, Attr, Value};
+use oauth2::{TokenType, Retry, self};
+use hyper;
+use hyper::header::{ContentType, ContentLength, Headers, UserAgent, Authorization, Header,
+                    HeaderFormat, Bearer};
+use hyper::http::h1::LINE_ENDING;
+use hyper::method::Method;
+use hyper::status::StatusCode;
+
+use serde_json as json;
+
+/// Identifies the Hub. There is only one per library, this trait is supposed
+/// to make intended use more explicit.
+/// The hub allows to access all resource methods more easily.
+pub trait Hub {}
+
+/// Identifies types for building methods of a particular resource type
+pub trait MethodsBuilder {}
+
+/// Identifies types which represent builders for a particular resource method
+pub trait CallBuilder {}
+
+/// Identifies types which can be inserted and deleted.
+/// Types with this trait are most commonly used by clients of this API.
+pub trait Resource {}
+
+/// Identifies types which are used in API responses.
+pub trait ResponseResult {}
+
+/// Identifies types which are used in API requests.
+pub trait RequestValue {}
+
+/// Identifies types which are not actually used by the API
+/// This might be a bug within the google API schema.
+pub trait UnusedType {}
+
+/// Identifies types which are only used as part of other types, which
+/// usually are carrying the `Resource` trait.
+pub trait Part {}
+
+/// Identifies types which are only used by other types internally.
+/// They have no special meaning, this trait just marks them for completeness.
+pub trait NestedType {}
+
+/// A utility to specify reader types which provide seeking capabilities too
+pub trait ReadSeek: Seek + Read {}
+impl<T: Seek + Read> ReadSeek for T {}
+
+/// A trait for all types that can convert themselves into a *parts* string
+pub trait ToParts {
+    fn to_parts(&self) -> String;
+}
+
+/// A utility type which can decode a server response that indicates error
+#[derive(Deserialize)]
+pub struct JsonServerError {
+    pub error: String,
+    pub error_description: Option<String>
+}
+
+/// A utility to represent detailed errors we might see in case there are BadRequests.
+/// The latter happen if the sent parameters or request structures are unsound
+#[derive(Deserialize, Serialize, Debug)]
+pub struct ErrorResponse {
+    error: ServerError,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct ServerError {
+    errors: Vec<ServerMessage>,
+    code: u16,
+    message: String,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct ServerMessage {
+    domain: String,
+    reason: String,
+    message: String,
+    #[serde(rename="locationType")]
+    location_type: Option<String>,
+    location: Option<String>
+}
+
+#[derive(Copy, Clone)]
+pub struct DummyNetworkStream;
+
+impl Read for DummyNetworkStream {
+    fn read(&mut self, _: &mut [u8]) -> io::Result<usize> {
+        Ok(0)
+    }
+}
+
+impl Write for DummyNetworkStream {
+    fn write(&mut self, _: &[u8]) -> io::Result<usize> {
+        Ok(0)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl hyper::net::NetworkStream for DummyNetworkStream {
+    fn peer_addr(&mut self) -> io::Result<std::net::SocketAddr> {
+        Ok("127.0.0.1:1337".parse().unwrap())
+    }
+
+    fn set_read_timeout(&self, _dur: Option<Duration>) -> io::Result<()> {
+        Ok(())
+    }
+
+    fn set_write_timeout(&self, _dur: Option<Duration>) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+
+/// A trait specifying functionality to help controlling any request performed by the API.
+/// The trait has a conservative default implementation.
+///
+/// It contains methods to deal with all common issues, as well with the ones related to
+/// uploading media
+pub trait Delegate {
+
+    /// Called at the beginning of any API request. The delegate should store the method
+    /// information if he is interesting in knowing more context when further calls to it
+    /// are made.
+    /// The matching `finished()` call will always be made, no matter whether or not the API
+    /// request was successful. That way, the delegate may easily maintain a clean state
+    /// between various API calls.
+    fn begin(&mut self, MethodInfo) {}
+
+    /// Called whenever there is an [HttpError](http://hyperium.github.io/hyper/hyper/error/enum.HttpError.html), usually if there are network problems.
+    ///
+    /// If you choose to retry after a duration, the duration should be chosen using the
+    /// [exponential backoff algorithm](http://en.wikipedia.org/wiki/Exponential_backoff).
+    ///
+    /// Return retry information.
+    fn http_error(&mut self, &hyper::Error) -> Retry {
+        Retry::Abort
+    }
+
+    /// Called whenever there is the need for your applications API key after
+    /// the official authenticator implementation didn't provide one, for some reason.
+    /// If this method returns None as well, the underlying operation will fail
+    fn api_key(&mut self) -> Option<String> {
+        None
+    }
+
+    /// Called whenever the Authenticator didn't yield a token. The delegate
+    /// may attempt to provide one, or just take it as a general information about the
+    /// impending failure.
+    /// The given Error provides information about why the token couldn't be acquired in the
+    /// first place
+    fn token(&mut self, err: &error::Error) -> Option<oauth2::Token> {
+        let _ = err;
+        None
+    }
+
+    /// Called during resumable uploads to provide a URL for the impending upload.
+    /// It was saved after a previous call to `store_upload_url(...)`, and if not None,
+    /// will be used instead of asking the server for a new upload URL.
+    /// This is useful in case a previous resumable upload was aborted/canceled, but should now
+    /// be resumed.
+    /// The returned URL will be used exactly once - if it fails again and the delegate allows
+    /// to retry, we will ask the server for a new upload URL.
+    fn upload_url(&mut self) -> Option<String> {
+        None
+    }
+
+    /// Called after we have retrieved a new upload URL for a resumable upload to store it
+    /// in case we fail or cancel. That way, we can attempt to resume the upload later,
+    /// see `upload_url()`.
+    /// It will also be called with None after a successful upload, which allows the delegate
+    /// to forget the URL. That way, we will not attempt to resume an upload that has already
+    /// finished.
+    fn store_upload_url(&mut self, url: Option<&str>) {
+        let _ = url;
+    }
+
+    /// Called whenever a server response could not be decoded from json.
+    /// It's for informational purposes only, the caller will return with an error
+    /// accordingly.
+    ///
+    /// # Arguments
+    ///
+    /// * `json_encoded_value` - The json-encoded value which failed to decode.
+    /// * `json_decode_error`  - The decoder error
+    fn response_json_decode_error(&mut self, json_encoded_value: &str, json_decode_error: &json::Error) {
+        let _ = json_encoded_value;
+        let _ = json_decode_error;
+    }
+
+    /// Called whenever the http request returns with a non-success status code.
+    /// This can involve authentication issues, or anything else that very much
+    /// depends on the used API method.
+    /// The delegate should check the status, header and decoded json error to decide
+    /// whether to retry or not. In the latter case, the underlying call will fail.
+    ///
+    /// If you choose to retry after a duration, the duration should be chosen using the
+    /// [exponential backoff algorithm](http://en.wikipedia.org/wiki/Exponential_backoff).
+    fn http_failure(&mut self, _: &hyper::client::Response, Option<JsonServerError>, _: Option<ServerError>) -> Retry {
+        Retry::Abort
+    }
+
+    /// Called prior to sending the main request of the given method. It can be used to time
+    /// the call or to print progress information.
+    /// It's also useful as you can be sure that a request will definitely be made.
+    fn pre_request(&mut self) { }
+
+    /// Return the size of each chunk of a resumable upload.
+    /// Must be a power of two, with 1<<18 being the smallest allowed chunk size.
+    /// Will be called once before starting any resumable upload.
+    fn chunk_size(&mut self) -> u64 {
+        1 << 23
+    }
+
+    /// Called before the given chunk is uploaded to the server.
+    /// If true is returned, the upload will be interrupted.
+    /// However, it may be resumable if you stored the upload URL in a previous call
+    /// to `store_upload_url()`
+    fn cancel_chunk_upload(&mut self, chunk: &ContentRange) -> bool {
+        let _ = chunk;
+        false
+    }
+
+    /// Called before the API request method returns, in every case. It can be used to clean up
+    /// internal state between calls to the API.
+    /// This call always has a matching call to `begin(...)`.
+    ///
+    /// # Arguments
+    ///
+    /// * `is_success` - a true value indicates the operation was successful. If false, you should
+    ///                  discard all values stored during `store_upload_url`.
+    fn finished(&mut self, is_success: bool) {
+        let _ = is_success;
+    }
+}
+
+/// A delegate with a conservative default implementation, which is used if no other delegate is
+/// set.
+#[derive(Default)]
+pub struct DefaultDelegate;
+
+impl Delegate for DefaultDelegate {}
+
+
+#[derive(Debug)]
+pub enum Error {
+    /// The http connection failed
+    HttpError(hyper::Error),
+
+    /// An attempt was made to upload a resource with size stored in field `.0`
+    /// even though the maximum upload size is what is stored in field `.1`.
+    UploadSizeLimitExceeded(u64, u64),
+
+    /// Represents information about a request that was not understood by the server.
+    /// Details are included.
+    BadRequest(ErrorResponse),
+
+    /// We needed an API key for authentication, but didn't obtain one.
+    /// Neither through the authenticator, nor through the Delegate.
+    MissingAPIKey,
+
+    /// We required a Token, but didn't get one from the Authenticator
+    MissingToken(Box<error::Error>),
+
+    /// The delgate instructed to cancel the operation
+    Cancelled,
+
+    /// An additional, free form field clashed with one of the built-in optional ones
+    FieldClash(&'static str),
+
+    /// Shows that we failed to decode the server response.
+    /// This can happen if the protocol changes in conjunction with strict json decoding.
+    JsonDecodeError(String, json::Error),
+
+    /// Indicates an HTTP repsonse with a non-success status code
+    Failure(hyper::client::Response),
+}
+
+
+impl Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Error::HttpError(ref err) => err.fmt(f),
+            Error::UploadSizeLimitExceeded(ref resource_size, ref max_size) =>
+                writeln!(f, "The media size {} exceeds the maximum allowed upload size of {}"
+                         , resource_size, max_size),
+            Error::MissingAPIKey => {
+                (writeln!(f, "The application's API key was not found in the configuration")).ok();
+                writeln!(f, "It is used as there are no Scopes defined for this method.")
+            },
+            Error::BadRequest(ref err) => {
+                try!(writeln!(f, "Bad Request ({}): {}", err.error.code, err.error.message));
+                for err in err.error.errors.iter() {
+                    try!(writeln!(f, "    {}: {}, {}{}",
+                                            err.domain,
+                                            err.message,
+                                            err.reason,
+                                            match &err.location {
+                                                &Some(ref loc) => format!("@{}", loc),
+                                                &None => String::new(),
+                                            }));
+                }
+                Ok(())
+            },
+            Error::MissingToken(ref err) =>
+                writeln!(f, "Token retrieval failed with error: {}", err),
+            Error::Cancelled =>
+                writeln!(f, "Operation cancelled by delegate"),
+            Error::FieldClash(field) =>
+                writeln!(f, "The custom parameter '{}' is already provided natively by the CallBuilder.", field),
+            Error::JsonDecodeError(ref json_str, ref err)
+                => writeln!(f, "{}: {}", err, json_str),
+            Error::Failure(ref response) =>
+                writeln!(f, "Http status indicates failure: {:?}", response),
+        }
+    }
+}
+
+impl error::Error for Error {
+    fn description(&self) -> &str {
+        match *self {
+            Error::HttpError(ref err) => err.description(),
+            Error::JsonDecodeError(_, ref err) => err.description(),
+            _ => "NO DESCRIPTION POSSIBLE - use `Display.fmt()` instead"
+        }
+    }
+
+    fn cause(&self) -> Option<&error::Error> {
+        match *self {
+            Error::HttpError(ref err) => err.cause(),
+            Error::JsonDecodeError(_, ref err) => err.cause(),
+            _ => None
+        }
+    }
+}
+
+/// A universal result type used as return for all calls.
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Contains information about an API request.
+pub struct MethodInfo {
+    pub id: &'static str,
+    pub http_method: Method,
+}
+
+const BOUNDARY: &'static str = "MDuXWGyeE33QFXGchb2VFWc4Z7945d";
+
+/// Provides a `Read` interface that converts multiple parts into the protocol
+/// identified by [RFC2387](https://tools.ietf.org/html/rfc2387).
+/// **Note**: This implementation is just as rich as it needs to be to perform uploads
+/// to google APIs, and might not be a fully-featured implementation.
+#[derive(Default)]
+pub struct MultiPartReader<'a> {
+    raw_parts: Vec<(Headers, &'a mut Read)>,
+    current_part: Option<(Cursor<Vec<u8>>, &'a mut Read)>,
+    last_part_boundary: Option<Cursor<Vec<u8>>>,
+}
+
+impl<'a> MultiPartReader<'a> {
+
+    /// Reserve memory for exactly the given amount of parts
+    pub fn reserve_exact(&mut self, cap: usize) {
+        self.raw_parts.reserve_exact(cap);
+    }
+
+    /// Add a new part to the queue of parts to be read on the first `read` call.
+    ///
+    /// # Arguments
+    ///
+    /// `headers` - identifying the body of the part. It's similar to the header
+    ///             in an ordinary single-part call, and should thus contain the
+    ///             same information.
+    /// `reader`  - a reader providing the part's body
+    /// `size`    - the amount of bytes provided by the reader. It will be put onto the header as
+    ///             content-size.
+    /// `mime`    - It will be put onto the content type
+    pub fn add_part(&mut self, reader: &'a mut Read, size: u64, mime_type: Mime) -> &mut MultiPartReader<'a> {
+        let mut headers = Headers::new();
+        headers.set(ContentType(mime_type));
+        headers.set(ContentLength(size));
+        self.raw_parts.push((headers, reader));
+        self
+    }
+
+    /// Returns the mime-type representing our multi-part message.
+    /// Use it with the ContentType header.
+    pub fn mime_type(&self) -> Mime {
+        Mime(
+            TopLevel::Multipart,
+            SubLevel::Ext("Related".to_string()),
+            vec![(Attr::Ext("boundary".to_string()), Value::Ext(BOUNDARY.to_string()))],
+        )
+    }
+
+    /// Returns true if we are totally used
+    fn is_depleted(&self) -> bool {
+        self.raw_parts.len() == 0 && self.current_part.is_none() && self.last_part_boundary.is_none()
+    }
+
+    /// Returns true if we are handling our last part
+    fn is_last_part(&self) -> bool {
+        self.raw_parts.len() == 0 && self.current_part.is_some()
+    }
+}
+
+impl<'a> Read for MultiPartReader<'a> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        match (self.raw_parts.len(),
+               self.current_part.is_none(),
+               self.last_part_boundary.is_none()) {
+            (_, _, false) => {
+                let br = self.last_part_boundary.as_mut().unwrap().read(buf).unwrap_or(0);
+                if br < buf.len() {
+                    self.last_part_boundary = None;
+                }
+                return Ok(br)
+            },
+            (0, true, true) => return Ok(0),
+            (n, true, _) if n > 0 => {
+                let (headers, reader) = self.raw_parts.remove(0);
+                let mut c = Cursor::new(Vec::<u8>::new());
+                (write!(&mut c, "{}--{}{}{}{}", LINE_ENDING, BOUNDARY, LINE_ENDING,
+                                                headers, LINE_ENDING)).unwrap();
+                c.seek(SeekFrom::Start(0)).unwrap();
+                self.current_part = Some((c, reader));
+            }
+            _ => {},
+        }
+
+        // read headers as long as possible
+        let (hb, rr) = {
+            let &mut (ref mut c, ref mut reader) = self.current_part.as_mut().unwrap();
+            let b = c.read(buf).unwrap_or(0);
+            (b, reader.read(&mut buf[b..]))
+        };
+
+        match rr {
+            Ok(bytes_read) => {
+                if hb < buf.len() && bytes_read == 0 {
+                    if self.is_last_part() {
+                        // before clearing the last part, we will add the boundary that
+                        // will be written last
+                        self.last_part_boundary = Some(Cursor::new(
+                                                        format!("{}--{}--", LINE_ENDING, BOUNDARY).into_bytes()))
+                    }
+                    // We are depleted - this can trigger the next part to come in
+                    self.current_part = None;
+                }
+                let mut total_bytes_read = hb + bytes_read;
+                while total_bytes_read < buf.len() && !self.is_depleted() {
+                    match self.read(&mut buf[total_bytes_read ..]) {
+                        Ok(br) => total_bytes_read += br,
+                        Err(err) => return Err(err),
+                    }
+                }
+                Ok(total_bytes_read)
+            }
+            Err(err) => {
+                // fail permanently
+                self.current_part = None;
+                self.last_part_boundary = None;
+                self.raw_parts.clear();
+                Err(err)
+            }
+        }
+    }
+}
+
+/// The `X-Upload-Content-Type` header.
+///
+/// Generated via rustc --pretty expanded -Z unstable-options, and manually
+/// processed to be more readable.
+#[derive(PartialEq, Debug, Clone)]
+pub struct XUploadContentType(pub Mime);
+
+impl ::std::ops::Deref for XUploadContentType {
+    type Target = Mime;
+    fn deref<'a>(&'a self) -> &'a Mime { &self.0 }
+}
+impl ::std::ops::DerefMut for XUploadContentType {
+    fn deref_mut<'a>(&'a mut self) -> &'a mut Mime { &mut self.0 }
+}
+impl Header for XUploadContentType {
+    fn header_name() -> &'static str { "X-Upload-Content-Type" }
+    fn parse_header(raw: &[Vec<u8>]) -> hyper::error::Result<Self> {
+        hyper::header::parsing::from_one_raw_str(raw).map(XUploadContentType)
+    }
+}
+impl HeaderFormat for XUploadContentType {
+    fn fmt_header(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        Display::fmt(&**self, f)
+    }
+}
+impl Display for XUploadContentType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(&**self, f)
+    }
+}
+
+#[derive(Clone, PartialEq, Debug)]
+pub struct Chunk {
+    pub first: u64,
+    pub last: u64
+}
+
+impl fmt::Display for Chunk {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        (write!(fmt, "{}-{}", self.first, self.last)).ok();
+        Ok(())
+    }
+}
+
+impl FromStr for Chunk {
+    type Err = &'static str;
+
+    /// NOTE: only implements `%i-%i`, not `*`
+    fn from_str(s: &str) -> std::result::Result<Chunk, &'static str> {
+        let parts: Vec<&str> = s.split('-').collect();
+        if parts.len() != 2 {
+            return Err("Expected two parts: %i-%i")
+        }
+        Ok(
+            Chunk {
+                first: match FromStr::from_str(parts[0]) {
+                    Ok(d) => d,
+                    _ => return Err("Couldn't parse 'first' as digit")
+                },
+                last: match FromStr::from_str(parts[1]) {
+                    Ok(d) => d,
+                    _ => return Err("Couldn't parse 'last' as digit")
+                }
+            }
+        )
+    }
+}
+
+/// Implements the Content-Range header, for serialization only
+#[derive(Clone, PartialEq, Debug)]
+pub struct ContentRange {
+    pub range: Option<Chunk>,
+    pub total_length: u64,
+}
+
+impl Header for ContentRange {
+    fn header_name() -> &'static str {
+        "Content-Range"
+    }
+
+    /// We are not parsable, as parsing is done by the `Range` header
+    fn parse_header(_: &[Vec<u8>]) -> hyper::error::Result<Self> {
+        Err(hyper::error::Error::Method)
+    }
+}
+
+
+impl HeaderFormat for ContentRange {
+    fn fmt_header(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        try!(fmt.write_str("bytes "));
+        match self.range {
+            Some(ref c) => try!(c.fmt(fmt)),
+            None => try!(fmt.write_str("*"))
+        }
+        (write!(fmt, "/{}", self.total_length)).ok();
+        Ok(())
+    }
+}
+
+#[derive(Clone, PartialEq, Debug)]
+pub struct RangeResponseHeader(pub Chunk);
+
+impl Header for RangeResponseHeader {
+    fn header_name() -> &'static str {
+        "Range"
+    }
+
+    fn parse_header(raw: &[Vec<u8>]) -> hyper::error::Result<Self> {
+        if raw.len() > 0 {
+            let v = &raw[0];
+            if let Ok(s) = std::str::from_utf8(v) {
+                const PREFIX: &'static str = "bytes ";
+                if s.starts_with(PREFIX) {
+                    if let Ok(c) = <Chunk as FromStr>::from_str(&s[PREFIX.len()..]) {
+                        return  Ok(RangeResponseHeader(c))
+                    }
+                }
+            }
+        }
+        Err(hyper::error::Error::Method)
+    }
+}
+
+impl HeaderFormat for RangeResponseHeader {
+    /// No implmentation necessary, we just need to parse
+    fn fmt_header(&self, _: &mut fmt::Formatter) -> fmt::Result {
+        Err(fmt::Error)
+    }
+}
+
+/// A utility type to perform a resumable upload from start to end.
+pub struct ResumableUploadHelper<'a, A: 'a> {
+    pub client: &'a mut hyper::client::Client,
+    pub delegate: &'a mut Delegate,
+    pub start_at: Option<u64>,
+    pub auth: &'a mut A,
+    pub user_agent: &'a str,
+    pub auth_header: Authorization<Bearer>,
+    pub url: &'a str,
+    pub reader: &'a mut ReadSeek,
+    pub media_type: Mime,
+    pub content_length: u64
+}
+
+impl<'a, A> ResumableUploadHelper<'a, A>
+    where A: oauth2::GetToken {
+
+    fn query_transfer_status(&mut self) -> std::result::Result<u64, hyper::Result<hyper::client::Response>> {
+        loop {
+            match self.client.post(self.url)
+                .header(UserAgent(self.user_agent.to_string()))
+                .header(ContentRange { range: None, total_length: self.content_length })
+                .header(self.auth_header.clone())
+                .send() {
+                Ok(r) => {
+                    // 308 = resume-incomplete == PermanentRedirect
+                    let headers = r.headers.clone();
+                    let h: &RangeResponseHeader = match headers.get() {
+                        Some(hh) if r.status == StatusCode::PermanentRedirect => hh,
+                        None|Some(_) => {
+                            if let Retry::After(d) = self.delegate.http_failure(&r, None, None) {
+                                sleep(d);
+                                continue;
+                            }
+                            return Err(Ok(r))
+                        }
+                    };
+                    return Ok(h.0.last)
+                }
+                Err(err) => {
+                    if let Retry::After(d) = self.delegate.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    return Err(Err(err))
+                }
+            }
+        }
+    }
+
+    /// returns None if operation was cancelled by delegate, or the HttpResult.
+    /// It can be that we return the result just because we didn't understand the status code -
+    /// caller should check for status himself before assuming it's OK to use
+    pub fn upload(&mut self) -> Option<hyper::Result<hyper::client::Response>> {
+        let mut start = match self.start_at {
+            Some(s) => s,
+            None => match self.query_transfer_status() {
+                Ok(s) => s,
+                Err(result) => return Some(result)
+            }
+        };
+
+        const MIN_CHUNK_SIZE: u64 = 1 << 18;
+        let chunk_size = match self.delegate.chunk_size() {
+            cs if cs > MIN_CHUNK_SIZE => cs,
+            _ => MIN_CHUNK_SIZE
+        };
+
+        self.reader.seek(SeekFrom::Start(start)).unwrap();
+        loop {
+            let request_size = match self.content_length - start {
+                rs if rs > chunk_size => chunk_size,
+                rs => rs
+            };
+
+            let mut section_reader = self.reader.take(request_size);
+            let range_header = ContentRange {
+                range: Some(Chunk {first: start, last: start + request_size - 1}),
+                total_length: self.content_length
+            };
+            start += request_size;
+            if self.delegate.cancel_chunk_upload(&range_header) {
+                return None
+            }
+            let res = self.client.post(self.url)
+                                 .header(range_header)
+                                 .header(ContentType(self.media_type.clone()))
+                                 .header(UserAgent(self.user_agent.to_string()))
+                                 .body(&mut section_reader)
+                                 .send();
+            match res {
+                Ok(mut res) => {
+                    if res.status == StatusCode::PermanentRedirect  {
+                        continue
+                    }
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let Retry::After(d) = self.delegate.http_failure(&res,
+                                                        json::from_str(&json_err).ok(),
+                                                        json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                    }
+                    return Some(Ok(res))
+                },
+                Err(err) => {
+                    if let Retry::After(d) = self.delegate.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    return Some(Err(err))
+                }
+            }
+        }
+    }
+}
+
+// Copy of src/rust/cli/cmn.rs
+// TODO(ST): Allow sharing common code between program types
+pub fn remove_json_null_values(value: &mut json::value::Value) {
+    match *value {
+        json::value::Value::Object(ref mut map) => {
+            let mut for_removal = Vec::new();
+
+            for (key, mut value) in map.iter_mut() {
+                if value.is_null() {
+                    for_removal.push(key.clone());
+                } else {
+                    remove_json_null_values(&mut value);
+                }
+            }
+
+            for key in &for_removal {
+                map.remove(key);
+            }
+        }
+        _ => {}
+    }
+}

--- a/gen/runtimeconfig1/src/lib.rs
+++ b/gen/runtimeconfig1/src/lib.rs
@@ -1,0 +1,1515 @@
+// DO NOT EDIT !
+// This file was generated automatically from 'src/mako/api/lib.rs.mako'
+// DO NOT EDIT !
+
+//! This documentation was generated from *Cloud RuntimeConfig* crate version *1.0.7+20171030*, where *20171030* is the exact revision of the *runtimeconfig:v1* schema built by the [mako](http://www.makotemplates.org/) code generator *v1.0.7*.
+//! 
+//! Everything else about the *Cloud RuntimeConfig* *v1* API can be found at the
+//! [official documentation site](https://cloud.google.com/deployment-manager/runtime-configurator/).
+//! The original source code is [on github](https://github.com/Byron/google-apis-rs/tree/master/gen/runtimeconfig1).
+//! # Features
+//! 
+//! Handle the following *Resources* with ease from the central [hub](struct.CloudRuntimeConfig.html) ... 
+//! 
+//! * [operations](struct.Operation.html)
+//!  * [*cancel*](struct.OperationCancelCall.html), [*delete*](struct.OperationDeleteCall.html) and [*list*](struct.OperationListCall.html)
+//! 
+//! 
+//! 
+//! 
+//! Not what you are looking for ? Find all other Google APIs in their Rust [documentation index](http://byron.github.io/google-apis-rs).
+//! 
+//! # Structure of this Library
+//! 
+//! The API is structured into the following primary items:
+//! 
+//! * **[Hub](struct.CloudRuntimeConfig.html)**
+//!     * a central object to maintain state and allow accessing all *Activities*
+//!     * creates [*Method Builders*](trait.MethodsBuilder.html) which in turn
+//!       allow access to individual [*Call Builders*](trait.CallBuilder.html)
+//! * **[Resources](trait.Resource.html)**
+//!     * primary types that you can apply *Activities* to
+//!     * a collection of properties and *Parts*
+//!     * **[Parts](trait.Part.html)**
+//!         * a collection of properties
+//!         * never directly used in *Activities*
+//! * **[Activities](trait.CallBuilder.html)**
+//!     * operations to apply to *Resources*
+//! 
+//! All *structures* are marked with applicable traits to further categorize them and ease browsing.
+//! 
+//! Generally speaking, you can invoke *Activities* like this:
+//! 
+//! ```Rust,ignore
+//! let r = hub.resource().activity(...).doit()
+//! ```
+//! 
+//! Or specifically ...
+//! 
+//! ```ignore
+//! let r = hub.operations().list(...).doit()
+//! let r = hub.operations().delete(...).doit()
+//! let r = hub.operations().cancel(...).doit()
+//! ```
+//! 
+//! The `resource()` and `activity(...)` calls create [builders][builder-pattern]. The second one dealing with `Activities` 
+//! supports various methods to configure the impending operation (not shown here). It is made such that all required arguments have to be 
+//! specified right away (i.e. `(...)`), whereas all optional ones can be [build up][builder-pattern] as desired.
+//! The `doit()` method performs the actual communication with the server and returns the respective result.
+//! 
+//! # Usage
+//! 
+//! ## Setting up your Project
+//! 
+//! To use this library, you would put the following lines into your `Cargo.toml` file:
+//! 
+//! ```toml
+//! [dependencies]
+//! google-runtimeconfig1 = "*"
+//! ```
+//! 
+//! ## A complete example
+//! 
+//! ```test_harness,no_run
+//! extern crate hyper;
+//! extern crate hyper_rustls;
+//! extern crate yup_oauth2 as oauth2;
+//! extern crate google_runtimeconfig1 as runtimeconfig1;
+//! use runtimeconfig1::{Result, Error};
+//! # #[test] fn egal() {
+//! use std::default::Default;
+//! use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+//! use runtimeconfig1::CloudRuntimeConfig;
+//! 
+//! // Get an ApplicationSecret instance by some means. It contains the `client_id` and 
+//! // `client_secret`, among other things.
+//! let secret: ApplicationSecret = Default::default();
+//! // Instantiate the authenticator. It will choose a suitable authentication flow for you, 
+//! // unless you replace  `None` with the desired Flow.
+//! // Provide your own `AuthenticatorDelegate` to adjust the way it operates and get feedback about 
+//! // what's going on. You probably want to bring in your own `TokenStorage` to persist tokens and
+//! // retrieve them from storage.
+//! let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+//!                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+//!                               <MemoryStorage as Default>::default(), None);
+//! let mut hub = CloudRuntimeConfig::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+//! // You can configure optional parameters by calling the respective setters at will, and
+//! // execute the final call using `doit()`.
+//! // Values shown here are possibly random and not representative !
+//! let result = hub.operations().list("name")
+//!              .page_token("dolores")
+//!              .page_size(-63)
+//!              .filter("accusam")
+//!              .doit();
+//! 
+//! match result {
+//!     Err(e) => match e {
+//!         // The Error enum provides details about what exactly happened.
+//!         // You can also just use its `Debug`, `Display` or `Error` traits
+//!          Error::HttpError(_)
+//!         |Error::MissingAPIKey
+//!         |Error::MissingToken(_)
+//!         |Error::Cancelled
+//!         |Error::UploadSizeLimitExceeded(_, _)
+//!         |Error::Failure(_)
+//!         |Error::BadRequest(_)
+//!         |Error::FieldClash(_)
+//!         |Error::JsonDecodeError(_, _) => println!("{}", e),
+//!     },
+//!     Ok(res) => println!("Success: {:?}", res),
+//! }
+//! # }
+//! ```
+//! ## Handling Errors
+//! 
+//! All errors produced by the system are provided either as [Result](enum.Result.html) enumeration as return value of 
+//! the doit() methods, or handed as possibly intermediate results to either the 
+//! [Hub Delegate](trait.Delegate.html), or the [Authenticator Delegate](https://docs.rs/yup-oauth2/*/yup_oauth2/trait.AuthenticatorDelegate.html).
+//! 
+//! When delegates handle errors or intermediate values, they may have a chance to instruct the system to retry. This 
+//! makes the system potentially resilient to all kinds of errors.
+//! 
+//! ## Uploads and Downloads
+//! If a method supports downloads, the response body, which is part of the [Result](enum.Result.html), should be
+//! read by you to obtain the media.
+//! If such a method also supports a [Response Result](trait.ResponseResult.html), it will return that by default.
+//! You can see it as meta-data for the actual media. To trigger a media download, you will have to set up the builder by making
+//! this call: `.param("alt", "media")`.
+//! 
+//! Methods supporting uploads can do so using up to 2 different protocols: 
+//! *simple* and *resumable*. The distinctiveness of each is represented by customized 
+//! `doit(...)` methods, which are then named `upload(...)` and `upload_resumable(...)` respectively.
+//! 
+//! ## Customization and Callbacks
+//! 
+//! You may alter the way an `doit()` method is called by providing a [delegate](trait.Delegate.html) to the 
+//! [Method Builder](trait.CallBuilder.html) before making the final `doit()` call. 
+//! Respective methods will be called to provide progress information, as well as determine whether the system should 
+//! retry on failure.
+//! 
+//! The [delegate trait](trait.Delegate.html) is default-implemented, allowing you to customize it with minimal effort.
+//! 
+//! ## Optional Parts in Server-Requests
+//! 
+//! All structures provided by this library are made to be [enocodable](trait.RequestValue.html) and 
+//! [decodable](trait.ResponseResult.html) via *json*. Optionals are used to indicate that partial requests are responses 
+//! are valid.
+//! Most optionals are are considered [Parts](trait.Part.html) which are identifiable by name, which will be sent to 
+//! the server to indicate either the set parts of the request or the desired parts in the response.
+//! 
+//! ## Builder Arguments
+//! 
+//! Using [method builders](trait.CallBuilder.html), you are able to prepare an action call by repeatedly calling it's methods.
+//! These will always take a single argument, for which the following statements are true.
+//! 
+//! * [PODs][wiki-pod] are handed by copy
+//! * strings are passed as `&str`
+//! * [request values](trait.RequestValue.html) are moved
+//! 
+//! Arguments will always be copied or cloned into the builder, to make them independent of their original life times.
+//! 
+//! [wiki-pod]: http://en.wikipedia.org/wiki/Plain_old_data_structure
+//! [builder-pattern]: http://en.wikipedia.org/wiki/Builder_pattern
+//! [google-go-api]: https://github.com/google/google-api-go-client
+//! 
+//! 
+
+// Unused attributes happen thanks to defined, but unused structures
+// We don't warn about this, as depending on the API, some data structures or facilities are never used.
+// Instead of pre-determining this, we just disable the lint. It's manually tuned to not have any
+// unused imports in fully featured APIs. Same with unused_mut ... .
+#![allow(unused_imports, unused_mut, dead_code)]
+
+// DO NOT EDIT !
+// This file was generated automatically from 'src/mako/api/lib.rs.mako'
+// DO NOT EDIT !
+
+#[macro_use]
+extern crate serde_derive;
+
+extern crate hyper;
+extern crate serde;
+extern crate serde_json;
+extern crate yup_oauth2 as oauth2;
+extern crate mime;
+extern crate url;
+
+mod cmn;
+
+use std::collections::HashMap;
+use std::cell::RefCell;
+use std::borrow::BorrowMut;
+use std::default::Default;
+use std::collections::BTreeMap;
+use serde_json as json;
+use std::io;
+use std::fs;
+use std::mem;
+use std::thread::sleep;
+use std::time::Duration;
+
+pub use cmn::{MultiPartReader, ToParts, MethodInfo, Result, Error, CallBuilder, Hub, ReadSeek, Part,
+              ResponseResult, RequestValue, NestedType, Delegate, DefaultDelegate, MethodsBuilder,
+              Resource, ErrorResponse, remove_json_null_values};
+
+
+// ##############
+// UTILITIES ###
+// ############
+
+/// Identifies the an OAuth2 authorization scope.
+/// A scope is needed when requesting an
+/// [authorization token](https://developers.google.com/youtube/v3/guides/authentication).
+#[derive(PartialEq, Eq, Hash)]
+pub enum Scope {
+    /// Manage your Google Cloud Platform services' runtime configuration
+    Cloudruntimeconfig,
+
+    /// View and manage your data across Google Cloud Platform services
+    CloudPlatform,
+}
+
+impl AsRef<str> for Scope {
+    fn as_ref(&self) -> &str {
+        match *self {
+            Scope::Cloudruntimeconfig => "https://www.googleapis.com/auth/cloudruntimeconfig",
+            Scope::CloudPlatform => "https://www.googleapis.com/auth/cloud-platform",
+        }
+    }
+}
+
+impl Default for Scope {
+    fn default() -> Scope {
+        Scope::CloudPlatform
+    }
+}
+
+
+
+// ########
+// HUB ###
+// ######
+
+/// Central instance to access all CloudRuntimeConfig related resource activities
+///
+/// # Examples
+///
+/// Instantiate a new hub
+///
+/// ```test_harness,no_run
+/// extern crate hyper;
+/// extern crate hyper_rustls;
+/// extern crate yup_oauth2 as oauth2;
+/// extern crate google_runtimeconfig1 as runtimeconfig1;
+/// use runtimeconfig1::{Result, Error};
+/// # #[test] fn egal() {
+/// use std::default::Default;
+/// use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// use runtimeconfig1::CloudRuntimeConfig;
+/// 
+/// // Get an ApplicationSecret instance by some means. It contains the `client_id` and 
+/// // `client_secret`, among other things.
+/// let secret: ApplicationSecret = Default::default();
+/// // Instantiate the authenticator. It will choose a suitable authentication flow for you, 
+/// // unless you replace  `None` with the desired Flow.
+/// // Provide your own `AuthenticatorDelegate` to adjust the way it operates and get feedback about 
+/// // what's going on. You probably want to bring in your own `TokenStorage` to persist tokens and
+/// // retrieve them from storage.
+/// let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+///                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+///                               <MemoryStorage as Default>::default(), None);
+/// let mut hub = CloudRuntimeConfig::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.operations().list("name")
+///              .page_token("justo")
+///              .page_size(-1)
+///              .filter("erat")
+///              .doit();
+/// 
+/// match result {
+///     Err(e) => match e {
+///         // The Error enum provides details about what exactly happened.
+///         // You can also just use its `Debug`, `Display` or `Error` traits
+///          Error::HttpError(_)
+///         |Error::MissingAPIKey
+///         |Error::MissingToken(_)
+///         |Error::Cancelled
+///         |Error::UploadSizeLimitExceeded(_, _)
+///         |Error::Failure(_)
+///         |Error::BadRequest(_)
+///         |Error::FieldClash(_)
+///         |Error::JsonDecodeError(_, _) => println!("{}", e),
+///     },
+///     Ok(res) => println!("Success: {:?}", res),
+/// }
+/// # }
+/// ```
+pub struct CloudRuntimeConfig<C, A> {
+    client: RefCell<C>,
+    auth: RefCell<A>,
+    _user_agent: String,
+    _base_url: String,
+    _root_url: String,
+}
+
+impl<'a, C, A> Hub for CloudRuntimeConfig<C, A> {}
+
+impl<'a, C, A> CloudRuntimeConfig<C, A>
+    where  C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+    pub fn new(client: C, authenticator: A) -> CloudRuntimeConfig<C, A> {
+        CloudRuntimeConfig {
+            client: RefCell::new(client),
+            auth: RefCell::new(authenticator),
+            _user_agent: "google-api-rust-client/1.0.7".to_string(),
+            _base_url: "https://runtimeconfig.googleapis.com/".to_string(),
+            _root_url: "https://runtimeconfig.googleapis.com/".to_string(),
+        }
+    }
+
+    pub fn operations(&'a self) -> OperationMethods<'a, C, A> {
+        OperationMethods { hub: &self }
+    }
+
+    /// Set the user-agent header field to use in all requests to the server.
+    /// It defaults to `google-api-rust-client/1.0.7`.
+    ///
+    /// Returns the previously set user-agent.
+    pub fn user_agent(&mut self, agent_name: String) -> String {
+        mem::replace(&mut self._user_agent, agent_name)
+    }
+
+    /// Set the base url to use in all requests to the server.
+    /// It defaults to `https://runtimeconfig.googleapis.com/`.
+    ///
+    /// Returns the previously set base url.
+    pub fn base_url(&mut self, new_base_url: String) -> String {
+        mem::replace(&mut self._base_url, new_base_url)
+    }
+
+    /// Set the root url to use in all requests to the server.
+    /// It defaults to `https://runtimeconfig.googleapis.com/`.
+    ///
+    /// Returns the previously set root url.
+    pub fn root_url(&mut self, new_root_url: String) -> String {
+        mem::replace(&mut self._root_url, new_root_url)
+    }
+}
+
+
+// ############
+// SCHEMAS ###
+// ##########
+/// The `Status` type defines a logical error model that is suitable for different
+/// programming environments, including REST APIs and RPC APIs. It is used by
+/// [gRPC](https://github.com/grpc). The error model is designed to be:
+/// 
+/// - Simple to use and understand for most users
+/// - Flexible enough to meet unexpected needs
+/// 
+/// # Overview
+/// 
+/// The `Status` message contains three pieces of data: error code, error message,
+/// and error details. The error code should be an enum value of
+/// google.rpc.Code, but it may accept additional error codes if needed.  The
+/// error message should be a developer-facing English message that helps
+/// developers *understand* and *resolve* the error. If a localized user-facing
+/// error message is needed, put the localized message in the error details or
+/// localize it in the client. The optional error details may contain arbitrary
+/// information about the error. There is a predefined set of error detail types
+/// in the package `google.rpc` that can be used for common error conditions.
+/// 
+/// # Language mapping
+/// 
+/// The `Status` message is the logical representation of the error model, but it
+/// is not necessarily the actual wire format. When the `Status` message is
+/// exposed in different client libraries and different wire protocols, it can be
+/// mapped differently. For example, it will likely be mapped to some exceptions
+/// in Java, but more likely mapped to some error codes in C.
+/// 
+/// # Other uses
+/// 
+/// The error model and the `Status` message can be used in a variety of
+/// environments, either with or without APIs, to provide a
+/// consistent developer experience across different environments.
+/// 
+/// Example uses of this error model include:
+/// 
+/// - Partial errors. If a service needs to return partial errors to the client,
+///     it may embed the `Status` in the normal response to indicate the partial
+///     errors.
+/// 
+/// - Workflow errors. A typical workflow has multiple steps. Each step may
+///     have a `Status` message for error reporting.
+/// 
+/// - Batch operations. If a client uses batch request and batch response, the
+///     `Status` message should be used directly inside batch response, one for
+///     each error sub-response.
+/// 
+/// - Asynchronous operations. If an API call embeds asynchronous operation
+///     results in its response, the status of those operations should be
+///     represented directly using the `Status` message.
+/// 
+/// - Logging. If some API errors are stored in logs, the message `Status` could
+///     be used directly after any stripping needed for security/privacy reasons.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Status {
+    /// A developer-facing error message, which should be in English. Any
+    /// user-facing error message should be localized and sent in the
+    /// google.rpc.Status.details field, or localized by the client.
+    pub message: Option<String>,
+    /// The status code, which should be an enum value of google.rpc.Code.
+    pub code: Option<i32>,
+    /// A list of messages that carry the error details.  There is a common set of
+    /// message types for APIs to use.
+    pub details: Option<Vec<HashMap<String, String>>>,
+}
+
+impl Part for Status {}
+
+
+/// This resource represents a long-running operation that is the result of a
+/// network API call.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [list operations](struct.OperationListCall.html) (none)
+/// * [delete operations](struct.OperationDeleteCall.html) (none)
+/// * [cancel operations](struct.OperationCancelCall.html) (none)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Operation {
+    /// The error result of the operation in case of failure or cancellation.
+    pub error: Option<Status>,
+    /// If the value is `false`, it means the operation is still in progress.
+    /// If `true`, the operation is completed, and either `error` or `response` is
+    /// available.
+    pub done: Option<bool>,
+    /// The normal response of the operation in case of success.  If the original
+    /// method returns no data on success, such as `Delete`, the response is
+    /// `google.protobuf.Empty`.  If the original method is standard
+    /// `Get`/`Create`/`Update`, the response should be the resource.  For other
+    /// methods, the response should have the type `XxxResponse`, where `Xxx`
+    /// is the original method name.  For example, if the original method name
+    /// is `TakeSnapshot()`, the inferred response type is
+    /// `TakeSnapshotResponse`.
+    pub response: Option<HashMap<String, String>>,
+    /// The server-assigned name, which is only unique within the same service that
+    /// originally returns it. If you use the default HTTP mapping, the
+    /// `name` should have the format of `operations/some/unique/name`.
+    pub name: Option<String>,
+    /// Service-specific metadata associated with the operation.  It typically
+    /// contains progress information and common metadata such as create time.
+    /// Some services might not provide such metadata.  Any method that returns a
+    /// long-running operation should document the metadata type, if any.
+    pub metadata: Option<HashMap<String, String>>,
+}
+
+impl Resource for Operation {}
+
+
+/// A generic empty message that you can re-use to avoid defining duplicated
+/// empty messages in your APIs. A typical example is to use it as the request
+/// or the response type of an API method. For instance:
+/// 
+///     service Foo {
+///       rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
+///     }
+/// 
+/// The JSON representation for `Empty` is empty JSON object `{}`.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [delete operations](struct.OperationDeleteCall.html) (response)
+/// * [cancel operations](struct.OperationCancelCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Empty { _never_set: Option<bool> }
+
+impl ResponseResult for Empty {}
+
+
+/// The request message for Operations.CancelOperation.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [cancel operations](struct.OperationCancelCall.html) (request)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct CancelOperationRequest { _never_set: Option<bool> }
+
+impl RequestValue for CancelOperationRequest {}
+
+
+/// The response message for Operations.ListOperations.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [list operations](struct.OperationListCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct ListOperationsResponse {
+    /// A list of operations that matches the specified filter in the request.
+    pub operations: Option<Vec<Operation>>,
+    /// The standard List next-page token.
+    #[serde(rename="nextPageToken")]
+    pub next_page_token: Option<String>,
+}
+
+impl ResponseResult for ListOperationsResponse {}
+
+
+
+// ###################
+// MethodBuilders ###
+// #################
+
+/// A builder providing access to all methods supported on *operation* resources.
+/// It is not used directly, but through the `CloudRuntimeConfig` hub.
+///
+/// # Example
+///
+/// Instantiate a resource builder
+///
+/// ```test_harness,no_run
+/// extern crate hyper;
+/// extern crate hyper_rustls;
+/// extern crate yup_oauth2 as oauth2;
+/// extern crate google_runtimeconfig1 as runtimeconfig1;
+/// 
+/// # #[test] fn egal() {
+/// use std::default::Default;
+/// use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// use runtimeconfig1::CloudRuntimeConfig;
+/// 
+/// let secret: ApplicationSecret = Default::default();
+/// let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+///                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+///                               <MemoryStorage as Default>::default(), None);
+/// let mut hub = CloudRuntimeConfig::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // Usually you wouldn't bind this to a variable, but keep calling *CallBuilders*
+/// // like `cancel(...)`, `delete(...)` and `list(...)`
+/// // to build up your call.
+/// let rb = hub.operations();
+/// # }
+/// ```
+pub struct OperationMethods<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a CloudRuntimeConfig<C, A>,
+}
+
+impl<'a, C, A> MethodsBuilder for OperationMethods<'a, C, A> {}
+
+impl<'a, C, A> OperationMethods<'a, C, A> {
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Lists operations that match the specified filter in the request. If the
+    /// server doesn't support this method, it returns `UNIMPLEMENTED`.
+    /// 
+    /// NOTE: the `name` binding allows API services to override the binding
+    /// to use different resource name schemes, such as `users/*/operations`. To
+    /// override the binding, API services can add a binding such as
+    /// `"/v1/{name=users/*}/operations"` to their service configuration.
+    /// For backwards compatibility, the default name includes the operations
+    /// collection id, however overriding users must ensure the name binding
+    /// is the parent resource, without the operations collection id.
+    /// 
+    /// # Arguments
+    ///
+    /// * `name` - The name of the operation's parent resource.
+    pub fn list(&self, name: &str) -> OperationListCall<'a, C, A> {
+        OperationListCall {
+            hub: self.hub,
+            _name: name.to_string(),
+            _page_token: Default::default(),
+            _page_size: Default::default(),
+            _filter: Default::default(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Deletes a long-running operation. This method indicates that the client is
+    /// no longer interested in the operation result. It does not cancel the
+    /// operation. If the server doesn't support this method, it returns
+    /// `google.rpc.Code.UNIMPLEMENTED`.
+    /// 
+    /// # Arguments
+    ///
+    /// * `name` - The name of the operation resource to be deleted.
+    pub fn delete(&self, name: &str) -> OperationDeleteCall<'a, C, A> {
+        OperationDeleteCall {
+            hub: self.hub,
+            _name: name.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Starts asynchronous cancellation on a long-running operation.  The server
+    /// makes a best effort to cancel the operation, but success is not
+    /// guaranteed.  If the server doesn't support this method, it returns
+    /// `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
+    /// Operations.GetOperation or
+    /// other methods to check whether the cancellation succeeded or whether the
+    /// operation completed despite cancellation. On successful cancellation,
+    /// the operation is not deleted; instead, it becomes an operation with
+    /// an Operation.error value with a google.rpc.Status.code of 1,
+    /// corresponding to `Code.CANCELLED`.
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    /// * `name` - The name of the operation resource to be cancelled.
+    pub fn cancel(&self, request: CancelOperationRequest, name: &str) -> OperationCancelCall<'a, C, A> {
+        OperationCancelCall {
+            hub: self.hub,
+            _request: request,
+            _name: name.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+}
+
+
+
+
+
+// ###################
+// CallBuilders   ###
+// #################
+
+/// Lists operations that match the specified filter in the request. If the
+/// server doesn't support this method, it returns `UNIMPLEMENTED`.
+/// 
+/// NOTE: the `name` binding allows API services to override the binding
+/// to use different resource name schemes, such as `users/*/operations`. To
+/// override the binding, API services can add a binding such as
+/// `"/v1/{name=users/*}/operations"` to their service configuration.
+/// For backwards compatibility, the default name includes the operations
+/// collection id, however overriding users must ensure the name binding
+/// is the parent resource, without the operations collection id.
+///
+/// A builder for the *list* method supported by a *operation* resource.
+/// It is not used directly, but through a `OperationMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_runtimeconfig1 as runtimeconfig1;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use runtimeconfig1::CloudRuntimeConfig;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = CloudRuntimeConfig::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.operations().list("name")
+///              .page_token("sea")
+///              .page_size(-90)
+///              .filter("dolores")
+///              .doit();
+/// # }
+/// ```
+pub struct OperationListCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a CloudRuntimeConfig<C, A>,
+    _name: String,
+    _page_token: Option<String>,
+    _page_size: Option<i32>,
+    _filter: Option<String>,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for OperationListCall<'a, C, A> {}
+
+impl<'a, C, A> OperationListCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, ListOperationsResponse)> {
+        use url::percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "runtimeconfig.operations.list",
+                               http_method: hyper::method::Method::Get });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((6 + self._additional_params.len()));
+        params.push(("name", self._name.to_string()));
+        if let Some(value) = self._page_token {
+            params.push(("pageToken", value.to_string()));
+        }
+        if let Some(value) = self._page_size {
+            params.push(("pageSize", value.to_string()));
+        }
+        if let Some(value) = self._filter {
+            params.push(("filter", value.to_string()));
+        }
+        for &field in ["alt", "name", "pageToken", "pageSize", "filter"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1/{+name}";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{+name}", "name")].iter() {
+            let mut replace_with = String::new();
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = value.to_string();
+                    break;
+                }
+            }
+            if find_this.as_bytes()[1] == '+' as u8 {
+                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET);
+            }
+            url = url.replace(find_this, &replace_with);
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["name"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Get, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    /// The name of the operation's parent resource.
+    ///
+    /// Sets the *name* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn name(mut self, new_value: &str) -> OperationListCall<'a, C, A> {
+        self._name = new_value.to_string();
+        self
+    }
+    /// The standard list page token.
+    ///
+    /// Sets the *page token* query property to the given value.
+    pub fn page_token(mut self, new_value: &str) -> OperationListCall<'a, C, A> {
+        self._page_token = Some(new_value.to_string());
+        self
+    }
+    /// The standard list page size.
+    ///
+    /// Sets the *page size* query property to the given value.
+    pub fn page_size(mut self, new_value: i32) -> OperationListCall<'a, C, A> {
+        self._page_size = Some(new_value);
+        self
+    }
+    /// The standard list filter.
+    ///
+    /// Sets the *filter* query property to the given value.
+    pub fn filter(mut self, new_value: &str) -> OperationListCall<'a, C, A> {
+        self._filter = Some(new_value.to_string());
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> OperationListCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> OperationListCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> OperationListCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Deletes a long-running operation. This method indicates that the client is
+/// no longer interested in the operation result. It does not cancel the
+/// operation. If the server doesn't support this method, it returns
+/// `google.rpc.Code.UNIMPLEMENTED`.
+///
+/// A builder for the *delete* method supported by a *operation* resource.
+/// It is not used directly, but through a `OperationMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_runtimeconfig1 as runtimeconfig1;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use runtimeconfig1::CloudRuntimeConfig;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = CloudRuntimeConfig::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.operations().delete("name")
+///              .doit();
+/// # }
+/// ```
+pub struct OperationDeleteCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a CloudRuntimeConfig<C, A>,
+    _name: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for OperationDeleteCall<'a, C, A> {}
+
+impl<'a, C, A> OperationDeleteCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, Empty)> {
+        use url::percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "runtimeconfig.operations.delete",
+                               http_method: hyper::method::Method::Delete });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((3 + self._additional_params.len()));
+        params.push(("name", self._name.to_string()));
+        for &field in ["alt", "name"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1/{+name}";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{+name}", "name")].iter() {
+            let mut replace_with = String::new();
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = value.to_string();
+                    break;
+                }
+            }
+            if find_this.as_bytes()[1] == '+' as u8 {
+                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET);
+            }
+            url = url.replace(find_this, &replace_with);
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["name"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Delete, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    /// The name of the operation resource to be deleted.
+    ///
+    /// Sets the *name* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn name(mut self, new_value: &str) -> OperationDeleteCall<'a, C, A> {
+        self._name = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> OperationDeleteCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> OperationDeleteCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> OperationDeleteCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Starts asynchronous cancellation on a long-running operation.  The server
+/// makes a best effort to cancel the operation, but success is not
+/// guaranteed.  If the server doesn't support this method, it returns
+/// `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
+/// Operations.GetOperation or
+/// other methods to check whether the cancellation succeeded or whether the
+/// operation completed despite cancellation. On successful cancellation,
+/// the operation is not deleted; instead, it becomes an operation with
+/// an Operation.error value with a google.rpc.Status.code of 1,
+/// corresponding to `Code.CANCELLED`.
+///
+/// A builder for the *cancel* method supported by a *operation* resource.
+/// It is not used directly, but through a `OperationMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_runtimeconfig1 as runtimeconfig1;
+/// use runtimeconfig1::CancelOperationRequest;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use runtimeconfig1::CloudRuntimeConfig;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = CloudRuntimeConfig::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = CancelOperationRequest::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.operations().cancel(req, "name")
+///              .doit();
+/// # }
+/// ```
+pub struct OperationCancelCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a CloudRuntimeConfig<C, A>,
+    _request: CancelOperationRequest,
+    _name: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for OperationCancelCall<'a, C, A> {}
+
+impl<'a, C, A> OperationCancelCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, Empty)> {
+        use url::percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "runtimeconfig.operations.cancel",
+                               http_method: hyper::method::Method::Post });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((4 + self._additional_params.len()));
+        params.push(("name", self._name.to_string()));
+        for &field in ["alt", "name"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1/{+name}:cancel";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{+name}", "name")].iter() {
+            let mut replace_with = String::new();
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = value.to_string();
+                    break;
+                }
+            }
+            if find_this.as_bytes()[1] == '+' as u8 {
+                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET);
+            }
+            url = url.replace(find_this, &replace_with);
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["name"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Post, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: CancelOperationRequest) -> OperationCancelCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// The name of the operation resource to be cancelled.
+    ///
+    /// Sets the *name* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn name(mut self, new_value: &str) -> OperationCancelCall<'a, C, A> {
+        self._name = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> OperationCancelCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> OperationCancelCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> OperationCancelCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+

--- a/gen/runtimeconfig1_beta1-cli/Cargo.toml
+++ b/gen/runtimeconfig1_beta1-cli/Cargo.toml
@@ -1,0 +1,40 @@
+# DO NOT EDIT !
+# This file was generated automatically from 'src/mako/Cargo.toml.mako'
+# DO NOT EDIT !
+[package]
+
+name = "google-runtimeconfig1_beta1-cli"
+version = "1.0.7+20171030"
+authors = ["Sebastian Thiel <byronimo@gmail.com>"]
+description = "A complete library to interact with Cloud RuntimeConfig (protocol v1beta1)"
+repository = "https://github.com/Byron/google-apis-rs/tree/master/gen/runtimeconfig1_beta1-cli"
+homepage = "https://cloud.google.com/deployment-manager/runtime-configurator/"
+documentation = "http://byron.github.io/google-apis-rs/google_runtimeconfig1_beta1_cli"
+license = "MIT"
+keywords = ["runtimeconfig", "google", "cli"]
+
+[[bin]]
+name = "runtimeconfig1-beta1"
+
+[dev-dependencies]
+hyper-rustls = "^0.6"
+
+[dependencies]
+hyper = "^ 0.10"
+mime = "^ 0.2.0"
+serde = "^ 1.0"
+serde_json = "^ 1.0"
+serde_derive = "^ 1.0"
+yup-oauth2 = "^ 1.0"
+strsim = "^0.5"
+hyper-rustls = "^0.6"
+yup-hyper-mock = "^2.0"
+clap = "^2.0"
+
+[features]
+
+
+
+[dependencies.google-runtimeconfig1_beta1]
+path = "../runtimeconfig1_beta1"
+version = "1.0.7+20171030"

--- a/gen/runtimeconfig1_beta1-cli/LICENSE.md
+++ b/gen/runtimeconfig1_beta1-cli/LICENSE.md
@@ -1,0 +1,30 @@
+<!---
+DO NOT EDIT !
+This file was generated automatically from 'src/mako/LICENSE.md.mako'
+DO NOT EDIT !
+-->
+The MIT License (MIT)
+=====================
+
+Copyright © `2015-2016` `Sebastian Thiel`
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the “Software”), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.

--- a/gen/runtimeconfig1_beta1-cli/README.md
+++ b/gen/runtimeconfig1_beta1-cli/README.md
@@ -1,0 +1,135 @@
+<!---
+DO NOT EDIT !
+This file was generated automatically from 'src/mako/cli/README.md.mako'
+DO NOT EDIT !
+-->
+The `runtimeconfig1-beta1` command-line interface *(CLI)* allows to use most features of the *Google Cloud RuntimeConfig* service from the comfort of your terminal.
+
+By default all output is printed to standard out, but flags can be set to direct it into a file independent of your shell's
+capabilities. Errors will be printed to standard error, and cause the program's exit code to be non-zero.
+
+If data-structures are requested, these will be returned as pretty-printed JSON, to be useful as input to other tools.
+
+Everything else about the *Cloud RuntimeConfig* API can be found at the
+[official documentation site](https://cloud.google.com/deployment-manager/runtime-configurator/).
+
+# Installation and Source Code
+
+Install the command-line interface with cargo using:
+
+```bash
+cargo install google-runtimeconfig1_beta1-cli
+```
+
+Find the source code [on github](https://github.com/Byron/google-apis-rs/tree/master/gen/runtimeconfig1_beta1-cli).
+
+# Usage
+
+This documentation was generated from the *Cloud RuntimeConfig* API at revision *20171030*. The CLI is at version *1.0.7*.
+
+```bash
+runtimeconfig1-beta1 [options]
+        projects
+                configs-create <parent> (-r <kv>)... [-p <v>]... [-o <out>]
+                configs-delete <name> [-p <v>]... [-o <out>]
+                configs-get <name> [-p <v>]... [-o <out>]
+                configs-get-iam-policy <resource> [-p <v>]... [-o <out>]
+                configs-list <parent> [-p <v>]... [-o <out>]
+                configs-operations-get <name> [-p <v>]... [-o <out>]
+                configs-operations-test-iam-permissions <resource> (-r <kv>)... [-p <v>]... [-o <out>]
+                configs-set-iam-policy <resource> (-r <kv>)... [-p <v>]... [-o <out>]
+                configs-test-iam-permissions <resource> (-r <kv>)... [-p <v>]... [-o <out>]
+                configs-update <name> (-r <kv>)... [-p <v>]... [-o <out>]
+                configs-variables-create <parent> (-r <kv>)... [-p <v>]... [-o <out>]
+                configs-variables-delete <name> [-p <v>]... [-o <out>]
+                configs-variables-get <name> [-p <v>]... [-o <out>]
+                configs-variables-list <parent> [-p <v>]... [-o <out>]
+                configs-variables-test-iam-permissions <resource> (-r <kv>)... [-p <v>]... [-o <out>]
+                configs-variables-update <name> (-r <kv>)... [-p <v>]... [-o <out>]
+                configs-variables-watch <name> (-r <kv>)... [-p <v>]... [-o <out>]
+                configs-waiters-create <parent> (-r <kv>)... [-p <v>]... [-o <out>]
+                configs-waiters-delete <name> [-p <v>]... [-o <out>]
+                configs-waiters-get <name> [-p <v>]... [-o <out>]
+                configs-waiters-list <parent> [-p <v>]... [-o <out>]
+                configs-waiters-test-iam-permissions <resource> (-r <kv>)... [-p <v>]... [-o <out>]
+  runtimeconfig1-beta1 --help
+
+Configuration:
+  [--scope <url>]...
+            Specify the authentication a method should be executed in. Each scope
+            requires the user to grant this application permission to use it.
+            If unset, it defaults to the shortest scope url for a particular method.
+  --config-dir <folder>
+            A directory into which we will store our persistent data. Defaults to
+            a user-writable directory that we will create during the first invocation.
+            [default: ~/.google-service-cli]
+  --debug
+            Output all server communication to standard error. `tx` and `rx` are placed
+            into the same stream.
+  --debug-auth
+            Output all communication related to authentication to standard error. `tx`
+            and `rx` are placed into the same stream.
+
+```
+
+# Configuration
+
+The program will store all persistent data in the `~/.google-service-cli` directory in *JSON* files prefixed with `runtimeconfig1-beta1-`.  You can change the directory used to store configuration with the `--config-dir` flag on a per-invocation basis.
+
+More information about the various kinds of persistent data are given in the following paragraphs.
+
+# Authentication
+
+Most APIs require a user to authenticate any request. If this is the case, the [scope][scopes] determines the 
+set of permissions granted. The granularity of these is usually no more than *read-only* or *full-access*.
+
+If not set, the system will automatically select the smallest feasible scope, e.g. when invoking a
+method that is read-only, it will ask only for a read-only scope. 
+You may use the `--scope` flag to specify a scope directly. 
+All applicable scopes are documented in the respective method's CLI documentation.
+
+The first time a scope is used, the user is asked for permission. Follow the instructions given 
+by the CLI to grant permissions, or to decline.
+
+If a scope was authenticated by the user, the respective information will be stored as *JSON* in the configuration
+directory, e.g. `~/.google-service-cli/runtimeconfig1-beta1-token-<scope-hash>.json`. No manual management of these tokens
+is necessary.
+
+To revoke granted authentication, please refer to the [official documentation][revoke-access].
+
+# Application Secrets
+
+In order to allow any application to use Google services, it will need to be registered using the 
+[Google Developer Console][google-dev-console]. APIs the application may use are then enabled for it
+one by one. Most APIs can be used for free and have a daily quota.
+
+To allow more comfortable usage of the CLI without forcing anyone to register an own application, the CLI
+comes with a default application secret that is configured accordingly. This also means that heavy usage
+all around the world may deplete the daily quota.
+
+You can workaround this limitation by putting your own secrets file at this location: 
+`~/.google-service-cli/runtimeconfig1-beta1-secret.json`, assuming that the required *runtimeconfig* API 
+was enabled for it. Such a secret file can be downloaded in the *Google Developer Console* at 
+*APIs & auth -> Credentials -> Download JSON* and used as is.
+
+Learn more about how to setup Google projects and enable APIs using the [official documentation][google-project-new].
+
+
+# Debugging
+
+Even though the CLI does its best to provide usable error messages, sometimes it might be desirable to know
+what exactly led to a particular issue. This is done by allowing all client-server communication to be 
+output to standard error *as-is*.
+
+The `--debug` flag will print all client-server communication to standard error, whereas the `--debug-auth` flag
+will cause all communication related to authentication to standard error.
+If the `--debug` flag is set, error-results will be debug-printed, possibly yielding more information about the 
+issue at hand.
+
+You may consider redirecting standard error into a file for ease of use, e.g. `runtimeconfig1-beta1 --debug <resource> <method> [options] 2>debug.txt`.
+
+
+[scopes]: https://developers.google.com/+/api/oauth#scopes
+[revoke-access]: http://webapps.stackexchange.com/a/30849
+[google-dev-console]: https://console.developers.google.com/
+[google-project-new]: https://developers.google.com/console/help/new/

--- a/gen/runtimeconfig1_beta1-cli/mkdocs.yml
+++ b/gen/runtimeconfig1_beta1-cli/mkdocs.yml
@@ -1,0 +1,38 @@
+site_name: Cloud RuntimeConfig v1.0.7+20171030
+site_url: http://byron.github.io/google-apis-rs/google-runtimeconfig1_beta1-cli
+site_description: A complete library to interact with Cloud RuntimeConfig (protocol v1beta1)
+
+repo_url: https://github.com/Byron/google-apis-rs/tree/master/gen/runtimeconfig1_beta1-cli
+
+docs_dir: docs
+site_dir: build_html
+
+pages:
+- ['index.md', 'Home']
+- ['projects_configs-create.md', 'Projects', 'Configs Create']
+- ['projects_configs-delete.md', 'Projects', 'Configs Delete']
+- ['projects_configs-get.md', 'Projects', 'Configs Get']
+- ['projects_configs-get-iam-policy.md', 'Projects', 'Configs Get Iam Policy']
+- ['projects_configs-list.md', 'Projects', 'Configs List']
+- ['projects_configs-operations-get.md', 'Projects', 'Configs Operations Get']
+- ['projects_configs-operations-test-iam-permissions.md', 'Projects', 'Configs Operations Test Iam Permissions']
+- ['projects_configs-set-iam-policy.md', 'Projects', 'Configs Set Iam Policy']
+- ['projects_configs-test-iam-permissions.md', 'Projects', 'Configs Test Iam Permissions']
+- ['projects_configs-update.md', 'Projects', 'Configs Update']
+- ['projects_configs-variables-create.md', 'Projects', 'Configs Variables Create']
+- ['projects_configs-variables-delete.md', 'Projects', 'Configs Variables Delete']
+- ['projects_configs-variables-get.md', 'Projects', 'Configs Variables Get']
+- ['projects_configs-variables-list.md', 'Projects', 'Configs Variables List']
+- ['projects_configs-variables-test-iam-permissions.md', 'Projects', 'Configs Variables Test Iam Permissions']
+- ['projects_configs-variables-update.md', 'Projects', 'Configs Variables Update']
+- ['projects_configs-variables-watch.md', 'Projects', 'Configs Variables Watch']
+- ['projects_configs-waiters-create.md', 'Projects', 'Configs Waiters Create']
+- ['projects_configs-waiters-delete.md', 'Projects', 'Configs Waiters Delete']
+- ['projects_configs-waiters-get.md', 'Projects', 'Configs Waiters Get']
+- ['projects_configs-waiters-list.md', 'Projects', 'Configs Waiters List']
+- ['projects_configs-waiters-test-iam-permissions.md', 'Projects', 'Configs Waiters Test Iam Permissions']
+
+theme: readthedocs
+
+copyright: Copyright &copy; 2015-2016, `Sebastian Thiel`
+

--- a/gen/runtimeconfig1_beta1-cli/src/cmn.rs
+++ b/gen/runtimeconfig1_beta1-cli/src/cmn.rs
@@ -1,0 +1,799 @@
+// COPY OF 'src/rust/cli/cmn.rs'
+// DO NOT EDIT
+use oauth2::{ApplicationSecret, ConsoleApplicationSecret, TokenStorage, Token};
+use serde_json as json;
+use serde_json::value::Value;
+use mime::Mime;
+use clap::{App, SubCommand};
+use strsim;
+
+use std::fs;
+use std::env;
+use std::io;
+use std::error::Error as StdError;
+use std::fmt;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+use std::string::ToString;
+use std::io::{Write, Read, stdout};
+
+use std::default::Default;
+
+const FIELD_SEP: char = '.';
+
+
+pub enum ComplexType {
+    Pod,
+    Vec,
+    Map,
+}
+
+// Null,
+// Bool(bool),
+// I64(i64),
+// U64(u64),
+// F64(f64),
+// String(String),
+
+pub enum JsonType {
+    Boolean,
+    Int,
+    Uint,
+    Float,
+    String,
+}
+
+pub struct JsonTypeInfo {
+    pub jtype: JsonType,
+    pub ctype: ComplexType,
+}
+
+// Based on @erickt user comment. Thanks for the idea !
+// Remove all keys whose values are null from given value (changed in place)
+pub fn remove_json_null_values(value: &mut Value) {
+    match *value {
+        Value::Object(ref mut map) => {
+            let mut for_removal = Vec::new();
+
+            for (key, mut value) in map.iter_mut() {
+                if value.is_null() {
+                    for_removal.push(key.clone());
+                } else {
+                    remove_json_null_values(&mut value);
+                }
+            }
+
+            for key in &for_removal {
+                map.remove(key);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn did_you_mean<'a>(v: &str, possible_values: &[&'a str]) -> Option<&'a str> {
+
+    let mut candidate: Option<(f64, &str)> = None;
+    for pv in possible_values {
+        let confidence = strsim::jaro_winkler(v, pv);
+        if confidence > 0.8 &&
+           (candidate.is_none() || (candidate.as_ref().unwrap().0 < confidence)) {
+            candidate = Some((confidence, pv));
+        }
+    }
+    match candidate {
+        None => None,
+        Some((_, candidate)) => Some(candidate),
+    }
+}
+
+pub enum CallType {
+    Upload(UploadProtocol),
+    Standard,
+}
+
+arg_enum!{
+    pub enum UploadProtocol {
+        Simple,
+        Resumable
+    }
+}
+
+impl AsRef<str> for UploadProtocol {
+    fn as_ref(&self) -> &str {
+        match *self {
+            UploadProtocol::Simple => "simple",
+            UploadProtocol::Resumable => "resumable",
+        }
+    }
+}
+
+impl AsRef<str> for CallType {
+    fn as_ref(&self) -> &str {
+        match *self {
+            CallType::Upload(ref proto) => proto.as_ref(),
+            CallType::Standard => "standard-request",
+        }
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct FieldCursor(Vec<String>);
+
+impl ToString for  FieldCursor {
+    fn to_string(&self) -> String {
+        self.0.join(".")
+    }
+}
+
+impl From<&'static str> for FieldCursor {
+    fn from(value: &'static str) -> FieldCursor {
+        let mut res = FieldCursor::default();
+        res.set(value).unwrap();
+        res
+    }
+}
+
+fn assure_entry<'a, 'b>(m: &'a mut json::Map<String, Value>, k: &'b String) -> &'a mut Value {
+    if m.contains_key(k) {
+        return m.get_mut(k).expect("value to exist");
+    }
+    m.insert(k.to_owned(), Value::Object(Default::default()));
+    m.get_mut(k).expect("value to exist")
+}
+
+impl FieldCursor {
+    pub fn set(&mut self, value: &str) -> Result<(), CLIError> {
+        if value.len() == 0 {
+            return Err(CLIError::Field(FieldError::Empty));
+        }
+
+        let mut first_is_field_sep = false;
+        let mut char_count: usize = 0;
+        let mut last_c = FIELD_SEP;
+        let mut num_conscutive_field_seps = 0;
+
+        let mut field = String::new();
+        let mut fields = self.0.clone();
+
+        let push_field = |fs: &mut Vec<String>, f: &mut String| {
+            if f.len() > 0 {
+                fs.push(f.clone());
+                f.truncate(0);
+            }
+        };
+
+        for (cid, c) in value.chars().enumerate() {
+            char_count += 1;
+
+            if c == FIELD_SEP {
+                if cid == 0 {
+                    first_is_field_sep = true;
+                }
+                num_conscutive_field_seps += 1;
+                if cid > 0 && last_c == FIELD_SEP {
+                    if fields.pop().is_none() {
+                        return Err(CLIError::Field(FieldError::PopOnEmpty(value.to_string())));
+                    }
+                } else {
+                    push_field(&mut fields, &mut field);
+                }
+            } else {
+                num_conscutive_field_seps = 0;
+                if cid == 1 {
+                    if first_is_field_sep {
+                        fields.truncate(0);
+                    }
+                }
+                field.push(c);
+            }
+
+            last_c = c;
+        }
+
+        push_field(&mut fields, &mut field);
+
+        if char_count == 1 && first_is_field_sep {
+            fields.truncate(0);
+        }
+        if char_count > 1 && num_conscutive_field_seps == 1 {
+            return Err(CLIError::Field(FieldError::TrailingFieldSep(value.to_string())));
+        }
+
+        self.0 = fields;
+        Ok(())
+    }
+
+    pub fn did_you_mean(value: &str, possible_values: &[&str]) -> Option<String> {
+        if value.len() == 0 {
+            return None;
+        }
+
+        let mut last_c = FIELD_SEP;
+
+        let mut field = String::new();
+        let mut output = String::new();
+
+        let push_field = |fs: &mut String, f: &mut String| {
+            if f.len() > 0 {
+                fs.push_str(match did_you_mean(&f, possible_values) {
+                    Some(candidate) => candidate,
+                    None => &f,
+                });
+                f.truncate(0);
+            }
+        };
+
+        for (cid, c) in value.chars().enumerate() {
+            if c == FIELD_SEP {
+                if last_c != FIELD_SEP {
+                    push_field(&mut output, &mut field);
+                }
+                output.push(c);
+            } else {
+                field.push(c);
+            }
+
+            last_c = c;
+        }
+
+        push_field(&mut output, &mut field);
+
+        if &output == value {
+            None
+        } else {
+            Some(output)
+        }
+    }
+
+    pub fn set_json_value(&self,
+                          mut object: &mut Value,
+                          value: &str,
+                          type_info: JsonTypeInfo,
+                          err: &mut InvalidOptionsError,
+                          orig_cursor: &FieldCursor) {
+        assert!(self.0.len() > 0);
+
+        for field in &self.0[..self.0.len() - 1] {
+            let tmp = object;
+            object = match *tmp {
+                Value::Object(ref mut mapping) => {
+                    assure_entry(mapping, &field)
+                }
+                _ => panic!("We don't expect non-object Values here ..."),
+            };
+        }
+
+        match *object {
+            Value::Object(ref mut mapping) => {
+                let field = &self.0[self.0.len() - 1];
+                let to_jval = |value: &str,
+                               jtype: JsonType,
+                               err: &mut InvalidOptionsError|
+                               -> Value {
+                    match jtype {
+                        JsonType::Boolean =>
+                            Value::Bool(arg_from_str(value, err, &field, "boolean")),
+                        JsonType::Int =>
+                            Value::Number(json::Number::from_f64(arg_from_str(value,
+                                                                              err,
+                                                                              &field,
+                                                                              "int"))
+                                              .expect("valid f64")),
+                        JsonType::Uint =>
+                            Value::Number(json::Number::from_f64(arg_from_str(value,
+                                                                              err,
+                                                                              &field,
+                                                                              "uint"))
+                                              .expect("valid f64")),
+                        JsonType::Float =>
+                            Value::Number(json::Number::from_f64(arg_from_str(value,
+                                                                              err,
+                                                                              &field,
+                                                                              "float"))
+                                              .expect("valid f64")),
+                        JsonType::String => Value::String(value.to_owned()),
+                    }
+                };
+
+                match type_info.ctype {
+                    ComplexType::Pod => {
+                        if mapping.insert(field.to_owned(), to_jval(value, type_info.jtype, err))
+                                  .is_some() {
+                            err.issues.push(CLIError::Field(FieldError::Duplicate(orig_cursor.to_string())));
+                        }
+                    }
+                    ComplexType::Vec => {
+                        match *assure_entry(mapping, field) {
+                            Value::Array(ref mut values) =>
+                                values.push(to_jval(value, type_info.jtype, err)),
+                            _ => unreachable!(),
+                        }
+                    }
+                    ComplexType::Map => {
+                        let (key, value) = parse_kv_arg(value, err, true);
+                        let jval = to_jval(value.unwrap_or(""), type_info.jtype, err);
+
+                        match *assure_entry(mapping, &field) {
+
+                            Value::Object(ref mut value_map) => {
+                                if value_map.insert(key.to_owned(), jval).is_some() {
+                                    err.issues.push(CLIError::Field(FieldError::Duplicate(orig_cursor.to_string())));
+                                }
+                            }
+                            _ => unreachable!(),
+                        }
+                    }
+                }
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    pub fn num_fields(&self) -> usize {
+        self.0.len()
+    }
+}
+
+pub fn parse_kv_arg<'a>(kv: &'a str,
+                        err: &mut InvalidOptionsError,
+                        for_hashmap: bool)
+                        -> (&'a str, Option<&'a str>) {
+    let mut add_err = || {
+        err.issues.push(CLIError::InvalidKeyValueSyntax(kv.to_string(), for_hashmap))
+    };
+    match kv.find('=') {
+        None => {
+            add_err();
+            return (kv, None);
+        }
+        Some(pos) => {
+            let key = &kv[..pos];
+            if kv.len() <= pos + 1 {
+                add_err();
+                return (key, Some(""));
+            }
+            (key, Some(&kv[pos + 1..]))
+        }
+    }
+}
+
+pub fn calltype_from_str(name: &str,
+                         valid_protocols: Vec<String>,
+                         err: &mut InvalidOptionsError)
+                         -> CallType {
+    CallType::Upload(match UploadProtocol::from_str(name) {
+        Ok(up) => up,
+        Err(msg) => {
+            err.issues.push(CLIError::InvalidUploadProtocol(name.to_string(), valid_protocols));
+            UploadProtocol::Simple
+        }
+    })
+}
+
+pub fn input_file_from_opts(file_path: &str, err: &mut InvalidOptionsError) -> Option<fs::File> {
+    match fs::File::open(file_path) {
+        Ok(f) => Some(f),
+        Err(io_err) => {
+            err.issues.push(CLIError::Input(InputError::Io((file_path.to_string(), io_err))));
+            None
+        }
+    }
+}
+
+pub fn input_mime_from_opts(mime: &str, err: &mut InvalidOptionsError) -> Option<Mime> {
+    match mime.parse() {
+        Ok(m) => Some(m),
+        Err(_) => {
+            err.issues.push(CLIError::Input(InputError::Mime(mime.to_string())));
+            None
+        }
+    }
+}
+
+pub fn writer_from_opts(arg: Option<&str>) -> Result<Box<Write>, io::Error> {
+    let f = arg.unwrap_or("-");
+    match f {
+        "-" => Ok(Box::new(stdout())),
+        _ => match fs::OpenOptions::new().create(true).write(true).open(f) {
+            Ok(f) => Ok(Box::new(f)),
+            Err(io_err) => Err(io_err),
+        },
+    }
+}
+
+
+pub fn arg_from_str<'a, T>(arg: &str,
+                           err: &mut InvalidOptionsError,
+                           arg_name: &'a str,
+                           arg_type: &'a str)
+                           -> T
+    where T: FromStr + Default,
+          <T as FromStr>::Err: fmt::Display
+{
+    match FromStr::from_str(arg) {
+        Err(perr) => {
+            err.issues.push(CLIError::ParseError(arg_name.to_owned(),
+                                                 arg_type.to_owned(),
+                                                 arg.to_string(),
+                                                 format!("{}", perr)));
+            Default::default()
+        }
+        Ok(v) => v,
+    }
+}
+
+pub struct JsonTokenStorage {
+    pub program_name: &'static str,
+    pub db_dir: String,
+}
+
+impl JsonTokenStorage {
+    fn path(&self, scope_hash: u64) -> PathBuf {
+        Path::new(&self.db_dir).join(&format!("{}-token-{}.json", self.program_name, scope_hash))
+    }
+}
+
+
+#[derive(Debug)]
+pub enum TokenStorageError {
+    Json(json::Error),
+    Io(io::Error),
+}
+
+impl fmt::Display for TokenStorageError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            TokenStorageError::Json(ref err) => writeln!(f, "Could not serialize secrets: {}", err),
+            TokenStorageError::Io(ref err) => writeln!(f, "Failed to write secret token: {}", err),
+        }
+    }
+}
+
+impl StdError for TokenStorageError {
+    fn description(&self) -> &str {
+        "Failure when getting or setting the token storage"
+    }
+}
+
+
+impl TokenStorage for JsonTokenStorage {
+    type Error = TokenStorageError;
+
+    // NOTE: logging might be interesting, currently we swallow all errors
+    fn set(&mut self,
+           scope_hash: u64,
+           _: &Vec<&str>,
+           token: Option<Token>)
+           -> Result<(), TokenStorageError> {
+        match token {
+            None => {
+                match fs::remove_file(self.path(scope_hash)) {
+                    Err(err) => match err.kind() {
+                        io::ErrorKind::NotFound => Ok(()),
+                        _ => Err(TokenStorageError::Io(err)),
+                    },
+                    Ok(_) => Ok(()),
+                }
+            }
+            Some(token) => {
+                match fs::OpenOptions::new().create(true).write(true).open(&self.path(scope_hash)) {
+                    Ok(mut f) => {
+                        match json::to_writer_pretty(&mut f, &token) {
+                            Ok(_) => Ok(()),
+                            Err(serde_err) => Err(TokenStorageError::Json(serde_err)),
+                        }
+                    }
+                    Err(io_err) => Err(TokenStorageError::Io(io_err)),
+                }
+            }
+        }
+    }
+
+    fn get(&self, scope_hash: u64, _: &Vec<&str>) -> Result<Option<Token>, TokenStorageError> {
+        match fs::File::open(&self.path(scope_hash)) {
+            Ok(f) => {
+                match json::de::from_reader(f) {
+                    Ok(token) => Ok(Some(token)),
+                    Err(err) => Err(TokenStorageError::Json(err)),
+                }
+            }
+            Err(io_err) => {
+                match io_err.kind() {
+                    io::ErrorKind::NotFound => Ok(None),
+                    _ => Err(TokenStorageError::Io(io_err)),
+                }
+            }
+        }
+    }
+}
+
+
+#[derive(Debug)]
+pub enum ApplicationSecretError {
+    DecoderError((String, json::Error)),
+    FormatError(String),
+}
+
+impl fmt::Display for ApplicationSecretError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            ApplicationSecretError::DecoderError((ref path, ref err)) =>
+                writeln!(f,
+                         "Could not decode file at '{}' with error: {}.",
+                         path,
+                         err),
+            ApplicationSecretError::FormatError(ref path) =>
+                writeln!(f,
+                         "'installed' field is unset in secret file at '{}'.",
+                         path),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum ConfigurationError {
+    DirectoryCreationFailed((String, io::Error)),
+    DirectoryUnset,
+    HomeExpansionFailed(String),
+    Secret(ApplicationSecretError),
+    Io((String, io::Error)),
+}
+
+impl fmt::Display for ConfigurationError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            ConfigurationError::DirectoryCreationFailed((ref dir, ref err)) =>
+                writeln!(f,
+                         "Directory '{}' could not be created with error: {}.",
+                         dir,
+                         err),
+            ConfigurationError::DirectoryUnset => writeln!(f, "--config-dir was unset or empty."),
+            ConfigurationError::HomeExpansionFailed(ref dir) =>
+                writeln!(f,
+                         "Couldn't find HOME directory of current user, failed to expand '{}'.",
+                         dir),
+            ConfigurationError::Secret(ref err) => writeln!(f, "Secret -> {}", err),
+            ConfigurationError::Io((ref path, ref err)) =>
+                writeln!(f,
+                         "IO operation failed on path '{}' with error: {}.",
+                         path,
+                         err),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum InputError {
+    Io((String, io::Error)),
+    Mime(String),
+}
+
+impl fmt::Display for InputError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            InputError::Io((ref file_path, ref io_err)) =>
+                writeln!(f,
+                         "Failed to open '{}' for reading with error: {}.",
+                         file_path,
+                         io_err),
+            InputError::Mime(ref mime) => writeln!(f, "'{}' is not a known mime-type.", mime),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum FieldError {
+    PopOnEmpty(String),
+    TrailingFieldSep(String),
+    Unknown(String, Option<String>, Option<String>),
+    Duplicate(String),
+    Empty,
+}
+
+
+impl fmt::Display for FieldError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            FieldError::PopOnEmpty(ref field) =>
+                writeln!(f, "'{}': Cannot move up on empty field cursor.", field),
+            FieldError::TrailingFieldSep(ref field) =>
+                writeln!(f,
+                         "'{}': Single field separator may not be last character.",
+                         field),
+            FieldError::Unknown(ref field, ref suggestion, ref value) => {
+                let suffix = match *suggestion {
+                    Some(ref s) => {
+                        let kv = match *value {
+                            Some(ref v) => format!("{}={}", s, v),
+                            None => s.clone(),
+                        };
+                        format!(" Did you mean '{}' ?", kv)
+                    }
+                    None => String::new(),
+                };
+                writeln!(f, "Field '{}' does not exist.{}", field, suffix)
+            }
+            FieldError::Duplicate(ref cursor) =>
+                writeln!(f, "Value at '{}' was already set", cursor),
+            FieldError::Empty => writeln!(f, "Field names must not be empty."),
+        }
+    }
+}
+
+
+#[derive(Debug)]
+pub enum CLIError {
+    Configuration(ConfigurationError),
+    ParseError(String, String, String, String),
+    UnknownParameter(String, Vec<&'static str>),
+    InvalidUploadProtocol(String, Vec<String>),
+    InvalidKeyValueSyntax(String, bool),
+    Input(InputError),
+    Field(FieldError),
+    MissingCommandError,
+    MissingMethodError(String),
+}
+
+impl fmt::Display for CLIError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            CLIError::Configuration(ref err) => write!(f, "Configuration -> {}", err),
+            CLIError::Input(ref err) => write!(f, "Input -> {}", err),
+            CLIError::Field(ref err) => write!(f, "Field -> {}", err),
+            CLIError::InvalidUploadProtocol(ref proto_name, ref valid_names) =>
+                writeln!(f,
+                         "'{}' is not a valid upload protocol. Choose from one of {}.",
+                         proto_name,
+                         valid_names.join(", ")),
+            CLIError::ParseError(ref arg_name, ref type_name, ref value, ref err_desc) =>
+                writeln!(f,
+                         "Failed to parse argument '{}' with value '{}' as {} with error: {}.",
+                         arg_name,
+                         value,
+                         type_name,
+                         err_desc),
+            CLIError::UnknownParameter(ref param_name, ref possible_values) => {
+                let suffix = match did_you_mean(param_name, &possible_values) {
+                    Some(v) => format!(" Did you mean '{}' ?", v),
+                    None => String::new(),
+                };
+                write!(f, "Parameter '{}' is unknown.{}\n", param_name, suffix)
+            }
+            CLIError::InvalidKeyValueSyntax(ref kv, is_hashmap) => {
+                let hashmap_info = if is_hashmap {
+                    "hashmap "
+                } else {
+                    ""
+                };
+                writeln!(f,
+                         "'{}' does not match {}pattern <key>=<value>.",
+                         kv,
+                         hashmap_info)
+            }
+            CLIError::MissingCommandError => writeln!(f, "Please specify the main sub-command."),
+            CLIError::MissingMethodError(ref cmd) =>
+                writeln!(f,
+                         "Please specify the method to call on the '{}' command.",
+                         cmd),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct InvalidOptionsError {
+    pub issues: Vec<CLIError>,
+    pub exit_code: i32,
+}
+
+impl fmt::Display for InvalidOptionsError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        for issue in &self.issues {
+            try!(issue.fmt(f));
+        }
+        Ok(())
+    }
+}
+
+impl InvalidOptionsError {
+    pub fn single(err: CLIError, exit_code: i32) -> InvalidOptionsError {
+        InvalidOptionsError {
+            issues: vec![err],
+            exit_code: exit_code,
+        }
+    }
+
+    pub fn new() -> InvalidOptionsError {
+        InvalidOptionsError {
+            issues: Vec::new(),
+            exit_code: 1,
+        }
+    }
+}
+
+pub fn assure_config_dir_exists(dir: &str) -> Result<String, CLIError> {
+    let trdir = dir.trim();
+    if trdir.len() == 0 {
+        return Err(CLIError::Configuration(ConfigurationError::DirectoryUnset));
+    }
+
+    let expanded_config_dir = if trdir.as_bytes()[0] == b'~' {
+        match env::var("HOME").ok().or(env::var("UserProfile").ok()) {
+            None => return Err(CLIError::Configuration(ConfigurationError::HomeExpansionFailed(trdir.to_string()))),
+            Some(mut user) => {
+                user.push_str(&trdir[1..]);
+                user
+            }
+        }
+    } else {
+        trdir.to_string()
+    };
+
+    if let Err(err) = fs::create_dir(&expanded_config_dir) {
+        if err.kind() != io::ErrorKind::AlreadyExists {
+            return Err(CLIError::Configuration(
+                    ConfigurationError::DirectoryCreationFailed((expanded_config_dir, err))));
+        }
+    }
+
+    Ok(expanded_config_dir)
+}
+
+pub fn application_secret_from_directory(dir: &str,
+                                         secret_basename: &str,
+                                         json_console_secret: &str)
+                                         -> Result<ApplicationSecret, CLIError> {
+    let secret_path = Path::new(dir).join(secret_basename);
+    let secret_str = || secret_path.as_path().to_str().unwrap().to_string();
+    let secret_io_error = |io_err: io::Error| {
+        Err(CLIError::Configuration(ConfigurationError::Io((secret_str(), io_err))))
+    };
+
+    for _ in 0..2 {
+        match fs::File::open(&secret_path) {
+            Err(mut err) => {
+                if err.kind() == io::ErrorKind::NotFound {
+                    // Write our built-in one - user may adjust the written file at will
+
+                    err = match fs::OpenOptions::new()
+                                    .create(true)
+                                    .write(true)
+                                    .open(&secret_path) {
+                        Err(cfe) => cfe,
+                        Ok(mut f) => {
+                            // Assure we convert 'ugly' json string into pretty one
+                            let console_secret: ConsoleApplicationSecret =
+                                json::from_str(json_console_secret).unwrap();
+                            match json::to_writer_pretty(&mut f, &console_secret) {
+                                Err(serde_err) =>
+                                    panic!("Unexpected serde error: {:#?}", serde_err),
+                                Ok(_) => continue,
+                            }
+                        }
+                    };
+                    // fall through to IO error handling
+                }
+                return secret_io_error(err);
+            }
+            Ok(f) => {
+                match json::de::from_reader::<_, ConsoleApplicationSecret>(f) {
+                    Err(json_err) =>
+                        return Err(CLIError::Configuration(
+                            ConfigurationError::Secret(
+                                ApplicationSecretError::DecoderError(
+                                                (secret_str(), json_err)
+                                              )))),
+                    Ok(console_secret) => match console_secret.installed {
+                        Some(secret) => return Ok(secret),
+                        None => return Err(
+                                        CLIError::Configuration(
+                                        ConfigurationError::Secret(
+                                        ApplicationSecretError::FormatError(secret_str())
+                                        ))),
+                    },
+                }
+            }
+        }
+    }
+    unreachable!();
+}

--- a/gen/runtimeconfig1_beta1-cli/src/main.rs
+++ b/gen/runtimeconfig1_beta1-cli/src/main.rs
@@ -1,0 +1,2533 @@
+// DO NOT EDIT !
+// This file was generated automatically from 'src/mako/cli/main.rs.mako'
+// DO NOT EDIT !
+#![allow(unused_variables, unused_imports, dead_code, unused_mut)]
+
+#[macro_use]
+extern crate clap;
+extern crate yup_oauth2 as oauth2;
+extern crate yup_hyper_mock as mock;
+extern crate hyper_rustls;
+extern crate serde;
+extern crate serde_json;
+extern crate hyper;
+extern crate mime;
+extern crate strsim;
+extern crate google_runtimeconfig1_beta1 as api;
+
+use std::env;
+use std::io::{self, Write};
+use clap::{App, SubCommand, Arg};
+
+mod cmn;
+
+use cmn::{InvalidOptionsError, CLIError, JsonTokenStorage, arg_from_str, writer_from_opts, parse_kv_arg,
+          input_file_from_opts, input_mime_from_opts, FieldCursor, FieldError, CallType, UploadProtocol,
+          calltype_from_str, remove_json_null_values, ComplexType, JsonType, JsonTypeInfo};
+
+use std::default::Default;
+use std::str::FromStr;
+
+use oauth2::{Authenticator, DefaultAuthenticatorDelegate, FlowType};
+use serde_json as json;
+use clap::ArgMatches;
+
+enum DoitError {
+    IoError(String, io::Error),
+    ApiError(api::Error),
+}
+
+struct Engine<'n> {
+    opt: ArgMatches<'n>,
+    hub: api::CloudRuntimeConfig<hyper::Client, Authenticator<DefaultAuthenticatorDelegate, JsonTokenStorage, hyper::Client>>,
+    gp: Vec<&'static str>,
+    gpm: Vec<(&'static str, &'static str)>,
+}
+
+
+impl<'n> Engine<'n> {
+    fn _projects_configs_create(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    "name" => Some(("name", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "description" => Some(("description", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec!["description", "name"]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::RuntimeConfig = json::value::from_value(object).unwrap();
+        let mut call = self.hub.projects().configs_create(request, opt.value_of("parent").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                "request-id" => {
+                    call = call.request_id(value.unwrap_or(""));
+                },
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v.extend(["request-id"].iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _projects_configs_delete(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let mut call = self.hub.projects().configs_delete(opt.value_of("name").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _projects_configs_get(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let mut call = self.hub.projects().configs_get(opt.value_of("name").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _projects_configs_get_iam_policy(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let mut call = self.hub.projects().configs_get_iam_policy(opt.value_of("resource").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _projects_configs_list(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let mut call = self.hub.projects().configs_list(opt.value_of("parent").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                "page-token" => {
+                    call = call.page_token(value.unwrap_or(""));
+                },
+                "page-size" => {
+                    call = call.page_size(arg_from_str(value.unwrap_or("-0"), err, "page-size", "integer"));
+                },
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v.extend(["page-token", "page-size"].iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _projects_configs_operations_get(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let mut call = self.hub.projects().configs_operations_get(opt.value_of("name").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _projects_configs_operations_test_iam_permissions(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    "permissions" => Some(("permissions", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Vec })),
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec!["permissions"]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::TestIamPermissionsRequest = json::value::from_value(object).unwrap();
+        let mut call = self.hub.projects().configs_operations_test_iam_permissions(request, opt.value_of("resource").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _projects_configs_set_iam_policy(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    "policy.etag" => Some(("policy.etag", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "policy.version" => Some(("policy.version", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Pod })),
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec!["etag", "policy", "version"]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::SetIamPolicyRequest = json::value::from_value(object).unwrap();
+        let mut call = self.hub.projects().configs_set_iam_policy(request, opt.value_of("resource").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _projects_configs_test_iam_permissions(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    "permissions" => Some(("permissions", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Vec })),
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec!["permissions"]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::TestIamPermissionsRequest = json::value::from_value(object).unwrap();
+        let mut call = self.hub.projects().configs_test_iam_permissions(request, opt.value_of("resource").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _projects_configs_update(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    "name" => Some(("name", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "description" => Some(("description", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec!["description", "name"]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::RuntimeConfig = json::value::from_value(object).unwrap();
+        let mut call = self.hub.projects().configs_update(request, opt.value_of("name").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _projects_configs_variables_create(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    "text" => Some(("text", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "update-time" => Some(("updateTime", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "state" => Some(("state", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "value" => Some(("value", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "name" => Some(("name", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec!["name", "state", "text", "update-time", "value"]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::Variable = json::value::from_value(object).unwrap();
+        let mut call = self.hub.projects().configs_variables_create(request, opt.value_of("parent").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                "request-id" => {
+                    call = call.request_id(value.unwrap_or(""));
+                },
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v.extend(["request-id"].iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _projects_configs_variables_delete(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let mut call = self.hub.projects().configs_variables_delete(opt.value_of("name").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                "recursive" => {
+                    call = call.recursive(arg_from_str(value.unwrap_or("false"), err, "recursive", "boolean"));
+                },
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v.extend(["recursive"].iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _projects_configs_variables_get(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let mut call = self.hub.projects().configs_variables_get(opt.value_of("name").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _projects_configs_variables_list(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let mut call = self.hub.projects().configs_variables_list(opt.value_of("parent").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                "return-values" => {
+                    call = call.return_values(arg_from_str(value.unwrap_or("false"), err, "return-values", "boolean"));
+                },
+                "page-token" => {
+                    call = call.page_token(value.unwrap_or(""));
+                },
+                "page-size" => {
+                    call = call.page_size(arg_from_str(value.unwrap_or("-0"), err, "page-size", "integer"));
+                },
+                "filter" => {
+                    call = call.filter(value.unwrap_or(""));
+                },
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v.extend(["return-values", "page-token", "filter", "page-size"].iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _projects_configs_variables_test_iam_permissions(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    "permissions" => Some(("permissions", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Vec })),
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec!["permissions"]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::TestIamPermissionsRequest = json::value::from_value(object).unwrap();
+        let mut call = self.hub.projects().configs_variables_test_iam_permissions(request, opt.value_of("resource").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _projects_configs_variables_update(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    "text" => Some(("text", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "update-time" => Some(("updateTime", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "state" => Some(("state", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "value" => Some(("value", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "name" => Some(("name", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec!["name", "state", "text", "update-time", "value"]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::Variable = json::value::from_value(object).unwrap();
+        let mut call = self.hub.projects().configs_variables_update(request, opt.value_of("name").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _projects_configs_variables_watch(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    "newer-than" => Some(("newerThan", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec!["newer-than"]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::WatchVariableRequest = json::value::from_value(object).unwrap();
+        let mut call = self.hub.projects().configs_variables_watch(request, opt.value_of("name").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _projects_configs_waiters_create(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    "name" => Some(("name", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "success.cardinality.path" => Some(("success.cardinality.path", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "success.cardinality.number" => Some(("success.cardinality.number", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Pod })),
+                    "failure.cardinality.path" => Some(("failure.cardinality.path", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "failure.cardinality.number" => Some(("failure.cardinality.number", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Pod })),
+                    "done" => Some(("done", JsonTypeInfo { jtype: JsonType::Boolean, ctype: ComplexType::Pod })),
+                    "timeout" => Some(("timeout", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "error.message" => Some(("error.message", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "error.code" => Some(("error.code", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Pod })),
+                    "create-time" => Some(("createTime", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec!["cardinality", "code", "create-time", "done", "error", "failure", "message", "name", "number", "path", "success", "timeout"]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::Waiter = json::value::from_value(object).unwrap();
+        let mut call = self.hub.projects().configs_waiters_create(request, opt.value_of("parent").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                "request-id" => {
+                    call = call.request_id(value.unwrap_or(""));
+                },
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v.extend(["request-id"].iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _projects_configs_waiters_delete(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let mut call = self.hub.projects().configs_waiters_delete(opt.value_of("name").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _projects_configs_waiters_get(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let mut call = self.hub.projects().configs_waiters_get(opt.value_of("name").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _projects_configs_waiters_list(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let mut call = self.hub.projects().configs_waiters_list(opt.value_of("parent").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                "page-token" => {
+                    call = call.page_token(value.unwrap_or(""));
+                },
+                "page-size" => {
+                    call = call.page_size(arg_from_str(value.unwrap_or("-0"), err, "page-size", "integer"));
+                },
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v.extend(["page-token", "page-size"].iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _projects_configs_waiters_test_iam_permissions(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    "permissions" => Some(("permissions", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Vec })),
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec!["permissions"]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::TestIamPermissionsRequest = json::value::from_value(object).unwrap();
+        let mut call = self.hub.projects().configs_waiters_test_iam_permissions(request, opt.value_of("resource").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _doit(&self, dry_run: bool) -> Result<Result<(), DoitError>, Option<InvalidOptionsError>> {
+        let mut err = InvalidOptionsError::new();
+        let mut call_result: Result<(), DoitError> = Ok(());
+        let mut err_opt: Option<InvalidOptionsError> = None;
+        match self.opt.subcommand() {
+            ("projects", Some(opt)) => {
+                match opt.subcommand() {
+                    ("configs-create", Some(opt)) => {
+                        call_result = self._projects_configs_create(opt, dry_run, &mut err);
+                    },
+                    ("configs-delete", Some(opt)) => {
+                        call_result = self._projects_configs_delete(opt, dry_run, &mut err);
+                    },
+                    ("configs-get", Some(opt)) => {
+                        call_result = self._projects_configs_get(opt, dry_run, &mut err);
+                    },
+                    ("configs-get-iam-policy", Some(opt)) => {
+                        call_result = self._projects_configs_get_iam_policy(opt, dry_run, &mut err);
+                    },
+                    ("configs-list", Some(opt)) => {
+                        call_result = self._projects_configs_list(opt, dry_run, &mut err);
+                    },
+                    ("configs-operations-get", Some(opt)) => {
+                        call_result = self._projects_configs_operations_get(opt, dry_run, &mut err);
+                    },
+                    ("configs-operations-test-iam-permissions", Some(opt)) => {
+                        call_result = self._projects_configs_operations_test_iam_permissions(opt, dry_run, &mut err);
+                    },
+                    ("configs-set-iam-policy", Some(opt)) => {
+                        call_result = self._projects_configs_set_iam_policy(opt, dry_run, &mut err);
+                    },
+                    ("configs-test-iam-permissions", Some(opt)) => {
+                        call_result = self._projects_configs_test_iam_permissions(opt, dry_run, &mut err);
+                    },
+                    ("configs-update", Some(opt)) => {
+                        call_result = self._projects_configs_update(opt, dry_run, &mut err);
+                    },
+                    ("configs-variables-create", Some(opt)) => {
+                        call_result = self._projects_configs_variables_create(opt, dry_run, &mut err);
+                    },
+                    ("configs-variables-delete", Some(opt)) => {
+                        call_result = self._projects_configs_variables_delete(opt, dry_run, &mut err);
+                    },
+                    ("configs-variables-get", Some(opt)) => {
+                        call_result = self._projects_configs_variables_get(opt, dry_run, &mut err);
+                    },
+                    ("configs-variables-list", Some(opt)) => {
+                        call_result = self._projects_configs_variables_list(opt, dry_run, &mut err);
+                    },
+                    ("configs-variables-test-iam-permissions", Some(opt)) => {
+                        call_result = self._projects_configs_variables_test_iam_permissions(opt, dry_run, &mut err);
+                    },
+                    ("configs-variables-update", Some(opt)) => {
+                        call_result = self._projects_configs_variables_update(opt, dry_run, &mut err);
+                    },
+                    ("configs-variables-watch", Some(opt)) => {
+                        call_result = self._projects_configs_variables_watch(opt, dry_run, &mut err);
+                    },
+                    ("configs-waiters-create", Some(opt)) => {
+                        call_result = self._projects_configs_waiters_create(opt, dry_run, &mut err);
+                    },
+                    ("configs-waiters-delete", Some(opt)) => {
+                        call_result = self._projects_configs_waiters_delete(opt, dry_run, &mut err);
+                    },
+                    ("configs-waiters-get", Some(opt)) => {
+                        call_result = self._projects_configs_waiters_get(opt, dry_run, &mut err);
+                    },
+                    ("configs-waiters-list", Some(opt)) => {
+                        call_result = self._projects_configs_waiters_list(opt, dry_run, &mut err);
+                    },
+                    ("configs-waiters-test-iam-permissions", Some(opt)) => {
+                        call_result = self._projects_configs_waiters_test_iam_permissions(opt, dry_run, &mut err);
+                    },
+                    _ => {
+                        err.issues.push(CLIError::MissingMethodError("projects".to_string()));
+                        writeln!(io::stderr(), "{}\n", opt.usage()).ok();
+                    }
+                }
+            },
+            _ => {
+                err.issues.push(CLIError::MissingCommandError);
+                writeln!(io::stderr(), "{}\n", self.opt.usage()).ok();
+            }
+        }
+
+        if dry_run {
+            if err.issues.len() > 0 {
+                err_opt = Some(err);
+            }
+            Err(err_opt)
+        } else {
+            Ok(call_result)
+        }
+    }
+
+    // Please note that this call will fail if any part of the opt can't be handled
+    fn new(opt: ArgMatches<'n>) -> Result<Engine<'n>, InvalidOptionsError> {
+        let (config_dir, secret) = {
+            let config_dir = match cmn::assure_config_dir_exists(opt.value_of("folder").unwrap_or("~/.google-service-cli")) {
+                Err(e) => return Err(InvalidOptionsError::single(e, 3)),
+                Ok(p) => p,
+            };
+
+            match cmn::application_secret_from_directory(&config_dir, "runtimeconfig1-beta1-secret.json",
+                                                         "{\"installed\":{\"auth_uri\":\"https://accounts.google.com/o/oauth2/auth\",\"client_secret\":\"hCsslbCUyfehWMmbkG8vTYxG\",\"token_uri\":\"https://accounts.google.com/o/oauth2/token\",\"client_email\":\"\",\"redirect_uris\":[\"urn:ietf:wg:oauth:2.0:oob\",\"oob\"],\"client_x509_cert_url\":\"\",\"client_id\":\"620010449518-9ngf7o4dhs0dka470npqvor6dc5lqb9b.apps.googleusercontent.com\",\"auth_provider_x509_cert_url\":\"https://www.googleapis.com/oauth2/v1/certs\"}}") {
+                Ok(secret) => (config_dir, secret),
+                Err(e) => return Err(InvalidOptionsError::single(e, 4))
+            }
+        };
+
+        let auth = Authenticator::new(  &secret, DefaultAuthenticatorDelegate,
+                                        if opt.is_present("debug-auth") {
+                                            hyper::Client::with_connector(mock::TeeConnector {
+                                                    connector: hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())
+                                                })
+                                        } else {
+                                            hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new()))
+                                        },
+                                        JsonTokenStorage {
+                                          program_name: "runtimeconfig1-beta1",
+                                          db_dir: config_dir.clone(),
+                                        }, Some(FlowType::InstalledRedirect(54324)));
+
+        let client =
+            if opt.is_present("debug") {
+                hyper::Client::with_connector(mock::TeeConnector {
+                        connector: hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())
+                    })
+            } else {
+                hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new()))
+            };
+        let engine = Engine {
+            opt: opt,
+            hub: api::CloudRuntimeConfig::new(client, auth),
+            gp: vec!["$-xgafv", "access-token", "alt", "bearer-token", "callback", "fields", "key", "oauth-token", "pp", "pretty-print", "quota-user", "upload-type", "upload-protocol"],
+            gpm: vec![
+                    ("$-xgafv", "$.xgafv"),
+                    ("access-token", "access_token"),
+                    ("bearer-token", "bearer_token"),
+                    ("oauth-token", "oauth_token"),
+                    ("pretty-print", "prettyPrint"),
+                    ("quota-user", "quotaUser"),
+                    ("upload-type", "uploadType"),
+                    ("upload-protocol", "upload_protocol"),
+                ]
+        };
+
+        match engine._doit(true) {
+            Err(Some(err)) => Err(err),
+            Err(None)      => Ok(engine),
+            Ok(_)          => unreachable!(),
+        }
+    }
+
+    fn doit(&self) -> Result<(), DoitError> {
+        match self._doit(false) {
+            Ok(res) => res,
+            Err(_) => unreachable!(),
+        }
+    }
+}
+
+fn main() {
+    let mut exit_status = 0i32;
+    let arg_data = [
+        ("projects", "methods: 'configs-create', 'configs-delete', 'configs-get', 'configs-get-iam-policy', 'configs-list', 'configs-operations-get', 'configs-operations-test-iam-permissions', 'configs-set-iam-policy', 'configs-test-iam-permissions', 'configs-update', 'configs-variables-create', 'configs-variables-delete', 'configs-variables-get', 'configs-variables-list', 'configs-variables-test-iam-permissions', 'configs-variables-update', 'configs-variables-watch', 'configs-waiters-create', 'configs-waiters-delete', 'configs-waiters-get', 'configs-waiters-list' and 'configs-waiters-test-iam-permissions'", vec![
+            ("configs-create",
+                    Some(r##"Creates a new RuntimeConfig resource. The configuration name must be
+        unique within project."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_runtimeconfig1_beta1_cli/projects_configs-create",
+                  vec![
+                    (Some(r##"parent"##),
+                     None,
+                     Some(r##"The [project ID](https://support.google.com/cloud/answer/6158840?hl=en&ref_topic=6158848)
+        for this request, in the format `projects/[PROJECT_ID]`."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("configs-delete",
+                    Some(r##"Deletes a RuntimeConfig resource."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_runtimeconfig1_beta1_cli/projects_configs-delete",
+                  vec![
+                    (Some(r##"name"##),
+                     None,
+                     Some(r##"The RuntimeConfig resource to delete, in the format:
+        
+        `projects/[PROJECT_ID]/configs/[CONFIG_NAME]`"##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("configs-get",
+                    Some(r##"Gets information about a RuntimeConfig resource."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_runtimeconfig1_beta1_cli/projects_configs-get",
+                  vec![
+                    (Some(r##"name"##),
+                     None,
+                     Some(r##"The name of the RuntimeConfig resource to retrieve, in the format:
+        
+        `projects/[PROJECT_ID]/configs/[CONFIG_NAME]`"##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("configs-get-iam-policy",
+                    Some(r##"Gets the access control policy for a resource.
+        Returns an empty policy if the resource exists and does not have a policy
+        set."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_runtimeconfig1_beta1_cli/projects_configs-get-iam-policy",
+                  vec![
+                    (Some(r##"resource"##),
+                     None,
+                     Some(r##"REQUIRED: The resource for which the policy is being requested.
+        See the operation documentation for the appropriate value for this field."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("configs-list",
+                    Some(r##"Lists all the RuntimeConfig resources within project."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_runtimeconfig1_beta1_cli/projects_configs-list",
+                  vec![
+                    (Some(r##"parent"##),
+                     None,
+                     Some(r##"The [project ID](https://support.google.com/cloud/answer/6158840?hl=en&ref_topic=6158848)
+        for this request, in the format `projects/[PROJECT_ID]`."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("configs-operations-get",
+                    Some(r##"Gets the latest state of a long-running operation.  Clients can use this
+        method to poll the operation result at intervals as recommended by the API
+        service."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_runtimeconfig1_beta1_cli/projects_configs-operations-get",
+                  vec![
+                    (Some(r##"name"##),
+                     None,
+                     Some(r##"The name of the operation resource."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("configs-operations-test-iam-permissions",
+                    Some(r##"Returns permissions that a caller has on the specified resource.
+        If the resource does not exist, this will return an empty set of
+        permissions, not a NOT_FOUND error.
+        
+        Note: This operation is designed to be used for building permission-aware
+        UIs and command-line tools, not for authorization checking. This operation
+        may "fail open" without warning."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_runtimeconfig1_beta1_cli/projects_configs-operations-test-iam-permissions",
+                  vec![
+                    (Some(r##"resource"##),
+                     None,
+                     Some(r##"REQUIRED: The resource for which the policy detail is being requested.
+        See the operation documentation for the appropriate value for this field."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("configs-set-iam-policy",
+                    Some(r##"Sets the access control policy on the specified resource. Replaces any
+        existing policy."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_runtimeconfig1_beta1_cli/projects_configs-set-iam-policy",
+                  vec![
+                    (Some(r##"resource"##),
+                     None,
+                     Some(r##"REQUIRED: The resource for which the policy is being specified.
+        See the operation documentation for the appropriate value for this field."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("configs-test-iam-permissions",
+                    Some(r##"Returns permissions that a caller has on the specified resource.
+        If the resource does not exist, this will return an empty set of
+        permissions, not a NOT_FOUND error.
+        
+        Note: This operation is designed to be used for building permission-aware
+        UIs and command-line tools, not for authorization checking. This operation
+        may "fail open" without warning."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_runtimeconfig1_beta1_cli/projects_configs-test-iam-permissions",
+                  vec![
+                    (Some(r##"resource"##),
+                     None,
+                     Some(r##"REQUIRED: The resource for which the policy detail is being requested.
+        See the operation documentation for the appropriate value for this field."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("configs-update",
+                    Some(r##"Updates a RuntimeConfig resource. The configuration must exist beforehand."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_runtimeconfig1_beta1_cli/projects_configs-update",
+                  vec![
+                    (Some(r##"name"##),
+                     None,
+                     Some(r##"The name of the RuntimeConfig resource to update, in the format:
+        
+        `projects/[PROJECT_ID]/configs/[CONFIG_NAME]`"##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("configs-variables-create",
+                    Some(r##"Creates a variable within the given configuration. You cannot create
+        a variable with a name that is a prefix of an existing variable name, or a
+        name that has an existing variable name as a prefix.
+        
+        To learn more about creating a variable, read the
+        [Setting and Getting Data](/deployment-manager/runtime-configurator/set-and-get-variables)
+        documentation."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_runtimeconfig1_beta1_cli/projects_configs-variables-create",
+                  vec![
+                    (Some(r##"parent"##),
+                     None,
+                     Some(r##"The path to the RutimeConfig resource that this variable should belong to.
+        The configuration must exist beforehand; the path must be in the format:
+        
+        `projects/[PROJECT_ID]/configs/[CONFIG_NAME]`"##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("configs-variables-delete",
+                    Some(r##"Deletes a variable or multiple variables.
+        
+        If you specify a variable name, then that variable is deleted. If you
+        specify a prefix and `recursive` is true, then all variables with that
+        prefix are deleted. You must set a `recursive` to true if you delete
+        variables by prefix."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_runtimeconfig1_beta1_cli/projects_configs-variables-delete",
+                  vec![
+                    (Some(r##"name"##),
+                     None,
+                     Some(r##"The name of the variable to delete, in the format:
+        
+        `projects/[PROJECT_ID]/configs/[CONFIG_NAME]/variables/[VARIABLE_NAME]`"##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("configs-variables-get",
+                    Some(r##"Gets information about a single variable."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_runtimeconfig1_beta1_cli/projects_configs-variables-get",
+                  vec![
+                    (Some(r##"name"##),
+                     None,
+                     Some(r##"The name of the variable to return, in the format:
+        
+        `projects/[PROJECT_ID]/configs/[CONFIG_NAME]/variables/[VARIBLE_NAME]`"##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("configs-variables-list",
+                    Some(r##"Lists variables within given a configuration, matching any provided filters.
+        This only lists variable names, not the values, unless `return_values` is
+        true, in which case only variables that user has IAM permission to GetVariable
+        will be returned."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_runtimeconfig1_beta1_cli/projects_configs-variables-list",
+                  vec![
+                    (Some(r##"parent"##),
+                     None,
+                     Some(r##"The path to the RuntimeConfig resource for which you want to list variables.
+        The configuration must exist beforehand; the path must be in the format:
+        
+        `projects/[PROJECT_ID]/configs/[CONFIG_NAME]`"##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("configs-variables-test-iam-permissions",
+                    Some(r##"Returns permissions that a caller has on the specified resource.
+        If the resource does not exist, this will return an empty set of
+        permissions, not a NOT_FOUND error.
+        
+        Note: This operation is designed to be used for building permission-aware
+        UIs and command-line tools, not for authorization checking. This operation
+        may "fail open" without warning."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_runtimeconfig1_beta1_cli/projects_configs-variables-test-iam-permissions",
+                  vec![
+                    (Some(r##"resource"##),
+                     None,
+                     Some(r##"REQUIRED: The resource for which the policy detail is being requested.
+        See the operation documentation for the appropriate value for this field."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("configs-variables-update",
+                    Some(r##"Updates an existing variable with a new value."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_runtimeconfig1_beta1_cli/projects_configs-variables-update",
+                  vec![
+                    (Some(r##"name"##),
+                     None,
+                     Some(r##"The name of the variable to update, in the format:
+        
+        `projects/[PROJECT_ID]/configs/[CONFIG_NAME]/variables/[VARIABLE_NAME]`"##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("configs-variables-watch",
+                    Some(r##"Watches a specific variable and waits for a change in the variable's value.
+        When there is a change, this method returns the new value or times out.
+        
+        If a variable is deleted while being watched, the `variableState` state is
+        set to `DELETED` and the method returns the last known variable `value`.
+        
+        If you set the deadline for watching to a larger value than internal timeout
+        (60 seconds), the current variable value is returned and the `variableState`
+        will be `VARIABLE_STATE_UNSPECIFIED`.
+        
+        To learn more about creating a watcher, read the
+        [Watching a Variable for Changes](/deployment-manager/runtime-configurator/watching-a-variable)
+        documentation."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_runtimeconfig1_beta1_cli/projects_configs-variables-watch",
+                  vec![
+                    (Some(r##"name"##),
+                     None,
+                     Some(r##"The name of the variable to watch, in the format:
+        
+        `projects/[PROJECT_ID]/configs/[CONFIG_NAME]`"##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("configs-waiters-create",
+                    Some(r##"Creates a Waiter resource. This operation returns a long-running Operation
+        resource which can be polled for completion. However, a waiter with the
+        given name will exist (and can be retrieved) prior to the operation
+        completing. If the operation fails, the failed Waiter resource will
+        still exist and must be deleted prior to subsequent creation attempts."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_runtimeconfig1_beta1_cli/projects_configs-waiters-create",
+                  vec![
+                    (Some(r##"parent"##),
+                     None,
+                     Some(r##"The path to the configuration that will own the waiter.
+        The configuration must exist beforehand; the path must be in the format:
+        
+        `projects/[PROJECT_ID]/configs/[CONFIG_NAME]`."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("configs-waiters-delete",
+                    Some(r##"Deletes the waiter with the specified name."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_runtimeconfig1_beta1_cli/projects_configs-waiters-delete",
+                  vec![
+                    (Some(r##"name"##),
+                     None,
+                     Some(r##"The Waiter resource to delete, in the format:
+        
+         `projects/[PROJECT_ID]/configs/[CONFIG_NAME]/waiters/[WAITER_NAME]`"##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("configs-waiters-get",
+                    Some(r##"Gets information about a single waiter."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_runtimeconfig1_beta1_cli/projects_configs-waiters-get",
+                  vec![
+                    (Some(r##"name"##),
+                     None,
+                     Some(r##"The fully-qualified name of the Waiter resource object to retrieve, in the
+        format:
+        
+        `projects/[PROJECT_ID]/configs/[CONFIG_NAME]/waiters/[WAITER_NAME]`"##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("configs-waiters-list",
+                    Some(r##"List waiters within the given configuration."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_runtimeconfig1_beta1_cli/projects_configs-waiters-list",
+                  vec![
+                    (Some(r##"parent"##),
+                     None,
+                     Some(r##"The path to the configuration for which you want to get a list of waiters.
+        The configuration must exist beforehand; the path must be in the format:
+        
+        `projects/[PROJECT_ID]/configs/[CONFIG_NAME]`"##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("configs-waiters-test-iam-permissions",
+                    Some(r##"Returns permissions that a caller has on the specified resource.
+        If the resource does not exist, this will return an empty set of
+        permissions, not a NOT_FOUND error.
+        
+        Note: This operation is designed to be used for building permission-aware
+        UIs and command-line tools, not for authorization checking. This operation
+        may "fail open" without warning."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_runtimeconfig1_beta1_cli/projects_configs-waiters-test-iam-permissions",
+                  vec![
+                    (Some(r##"resource"##),
+                     None,
+                     Some(r##"REQUIRED: The resource for which the policy detail is being requested.
+        See the operation documentation for the appropriate value for this field."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ]),
+        
+    ];
+    
+    let mut app = App::new("runtimeconfig1-beta1")
+           .author("Sebastian Thiel <byronimo@gmail.com>")
+           .version("1.0.7+20171030")
+           .about("The Runtime Configurator allows you to dynamically configure and expose variables through Google Cloud Platform. In addition, you can also set Watchers and Waiters that will watch for changes to your data and return based on certain conditions.")
+           .after_help("All documentation details can be found at http://byron.github.io/google-apis-rs/google_runtimeconfig1_beta1_cli")
+           .arg(Arg::with_name("url")
+                   .long("scope")
+                   .help("Specify the authentication a method should be executed in. Each scope requires the user to grant this application permission to use it.If unset, it defaults to the shortest scope url for a particular method.")
+                   .multiple(true)
+                   .takes_value(true))
+           .arg(Arg::with_name("folder")
+                   .long("config-dir")
+                   .help("A directory into which we will store our persistent data. Defaults to a user-writable directory that we will create during the first invocation.[default: ~/.google-service-cli")
+                   .multiple(false)
+                   .takes_value(true))
+           .arg(Arg::with_name("debug")
+                   .long("debug")
+                   .help("Output all server communication to standard error. `tx` and `rx` are placed into the same stream.")
+                   .multiple(false)
+                   .takes_value(false))
+           .arg(Arg::with_name("debug-auth")
+                   .long("debug-auth")
+                   .help("Output all communication related to authentication to standard error. `tx` and `rx` are placed into the same stream.")
+                   .multiple(false)
+                   .takes_value(false));
+           
+           for &(main_command_name, about, ref subcommands) in arg_data.iter() {
+               let mut mcmd = SubCommand::with_name(main_command_name).about(about);
+           
+               for &(sub_command_name, ref desc, url_info, ref args) in subcommands {
+                   let mut scmd = SubCommand::with_name(sub_command_name);
+                   if let &Some(desc) = desc {
+                       scmd = scmd.about(desc);
+                   }
+                   scmd = scmd.after_help(url_info);
+           
+                   for &(ref arg_name, ref flag, ref desc, ref required, ref multi) in args {
+                       let arg_name_str =
+                           match (arg_name, flag) {
+                                   (&Some(an), _       ) => an,
+                                   (_        , &Some(f)) => f,
+                                    _                    => unreachable!(),
+                            };
+                       let mut arg = Arg::with_name(arg_name_str)
+                                         .empty_values(false);
+                       if let &Some(short_flag) = flag {
+                           arg = arg.short(short_flag);
+                       }
+                       if let &Some(desc) = desc {
+                           arg = arg.help(desc);
+                       }
+                       if arg_name.is_some() && flag.is_some() {
+                           arg = arg.takes_value(true);
+                       }
+                       if let &Some(required) = required {
+                           arg = arg.required(required);
+                       }
+                       if let &Some(multi) = multi {
+                           arg = arg.multiple(multi);
+                       }
+                       scmd = scmd.arg(arg);
+                   }
+                   mcmd = mcmd.subcommand(scmd);
+               }
+               app = app.subcommand(mcmd);
+           }
+           
+        let matches = app.get_matches();
+
+    let debug = matches.is_present("debug");
+    match Engine::new(matches) {
+        Err(err) => {
+            exit_status = err.exit_code;
+            writeln!(io::stderr(), "{}", err).ok();
+        },
+        Ok(engine) => {
+            if let Err(doit_err) = engine.doit() {
+                exit_status = 1;
+                match doit_err {
+                    DoitError::IoError(path, err) => {
+                        writeln!(io::stderr(), "Failed to open output file '{}': {}", path, err).ok();
+                    },
+                    DoitError::ApiError(err) => {
+                        if debug {
+                            writeln!(io::stderr(), "{:#?}", err).ok();
+                        } else {
+                            writeln!(io::stderr(), "{}", err).ok();
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    std::process::exit(exit_status);
+}

--- a/gen/runtimeconfig1_beta1/Cargo.toml
+++ b/gen/runtimeconfig1_beta1/Cargo.toml
@@ -1,0 +1,31 @@
+# DO NOT EDIT !
+# This file was generated automatically from 'src/mako/Cargo.toml.mako'
+# DO NOT EDIT !
+[package]
+
+name = "google-runtimeconfig1_beta1"
+version = "1.0.7+20171030"
+authors = ["Sebastian Thiel <byronimo@gmail.com>"]
+description = "A complete library to interact with Cloud RuntimeConfig (protocol v1beta1)"
+repository = "https://github.com/Byron/google-apis-rs/tree/master/gen/runtimeconfig1_beta1"
+homepage = "https://cloud.google.com/deployment-manager/runtime-configurator/"
+documentation = "https://docs.rs/google-runtimeconfig1_beta1/1.0.7+20171030"
+license = "MIT"
+keywords = ["runtimeconfig", "google", "protocol", "web", "api"]
+
+
+[dev-dependencies]
+hyper-rustls = "^0.6"
+
+[dependencies]
+hyper = "^ 0.10"
+mime = "^ 0.2.0"
+serde = "^ 1.0"
+serde_json = "^ 1.0"
+serde_derive = "^ 1.0"
+yup-oauth2 = "^ 1.0"
+url = "= 0.5"
+
+[features]
+
+

--- a/gen/runtimeconfig1_beta1/LICENSE.md
+++ b/gen/runtimeconfig1_beta1/LICENSE.md
@@ -1,0 +1,30 @@
+<!---
+DO NOT EDIT !
+This file was generated automatically from 'src/mako/LICENSE.md.mako'
+DO NOT EDIT !
+-->
+The MIT License (MIT)
+=====================
+
+Copyright © `2015-2016` `Sebastian Thiel`
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the “Software”), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.

--- a/gen/runtimeconfig1_beta1/README.md
+++ b/gen/runtimeconfig1_beta1/README.md
@@ -1,0 +1,184 @@
+<!---
+DO NOT EDIT !
+This file was generated automatically from 'src/mako/api/README.md.mako'
+DO NOT EDIT !
+-->
+The `google-runtimeconfig1_beta1` library allows access to all features of the *Google Cloud RuntimeConfig* service.
+
+This documentation was generated from *Cloud RuntimeConfig* crate version *1.0.7+20171030*, where *20171030* is the exact revision of the *runtimeconfig:v1beta1* schema built by the [mako](http://www.makotemplates.org/) code generator *v1.0.7*.
+
+Everything else about the *Cloud RuntimeConfig* *v1_beta1* API can be found at the
+[official documentation site](https://cloud.google.com/deployment-manager/runtime-configurator/).
+# Features
+
+Handle the following *Resources* with ease from the central [hub](https://docs.rs/google-runtimeconfig1_beta1/1.0.7+20171030/google_runtimeconfig1_beta1/struct.CloudRuntimeConfig.html) ... 
+
+* projects
+ * [*configs create*](https://docs.rs/google-runtimeconfig1_beta1/1.0.7+20171030/google_runtimeconfig1_beta1/struct.ProjectConfigCreateCall.html), [*configs delete*](https://docs.rs/google-runtimeconfig1_beta1/1.0.7+20171030/google_runtimeconfig1_beta1/struct.ProjectConfigDeleteCall.html), [*configs get*](https://docs.rs/google-runtimeconfig1_beta1/1.0.7+20171030/google_runtimeconfig1_beta1/struct.ProjectConfigGetCall.html), [*configs get iam policy*](https://docs.rs/google-runtimeconfig1_beta1/1.0.7+20171030/google_runtimeconfig1_beta1/struct.ProjectConfigGetIamPolicyCall.html), [*configs list*](https://docs.rs/google-runtimeconfig1_beta1/1.0.7+20171030/google_runtimeconfig1_beta1/struct.ProjectConfigListCall.html), [*configs operations get*](https://docs.rs/google-runtimeconfig1_beta1/1.0.7+20171030/google_runtimeconfig1_beta1/struct.ProjectConfigOperationGetCall.html), [*configs operations test iam permissions*](https://docs.rs/google-runtimeconfig1_beta1/1.0.7+20171030/google_runtimeconfig1_beta1/struct.ProjectConfigOperationTestIamPermissionCall.html), [*configs set iam policy*](https://docs.rs/google-runtimeconfig1_beta1/1.0.7+20171030/google_runtimeconfig1_beta1/struct.ProjectConfigSetIamPolicyCall.html), [*configs test iam permissions*](https://docs.rs/google-runtimeconfig1_beta1/1.0.7+20171030/google_runtimeconfig1_beta1/struct.ProjectConfigTestIamPermissionCall.html), [*configs update*](https://docs.rs/google-runtimeconfig1_beta1/1.0.7+20171030/google_runtimeconfig1_beta1/struct.ProjectConfigUpdateCall.html), [*configs variables create*](https://docs.rs/google-runtimeconfig1_beta1/1.0.7+20171030/google_runtimeconfig1_beta1/struct.ProjectConfigVariableCreateCall.html), [*configs variables delete*](https://docs.rs/google-runtimeconfig1_beta1/1.0.7+20171030/google_runtimeconfig1_beta1/struct.ProjectConfigVariableDeleteCall.html), [*configs variables get*](https://docs.rs/google-runtimeconfig1_beta1/1.0.7+20171030/google_runtimeconfig1_beta1/struct.ProjectConfigVariableGetCall.html), [*configs variables list*](https://docs.rs/google-runtimeconfig1_beta1/1.0.7+20171030/google_runtimeconfig1_beta1/struct.ProjectConfigVariableListCall.html), [*configs variables test iam permissions*](https://docs.rs/google-runtimeconfig1_beta1/1.0.7+20171030/google_runtimeconfig1_beta1/struct.ProjectConfigVariableTestIamPermissionCall.html), [*configs variables update*](https://docs.rs/google-runtimeconfig1_beta1/1.0.7+20171030/google_runtimeconfig1_beta1/struct.ProjectConfigVariableUpdateCall.html), [*configs variables watch*](https://docs.rs/google-runtimeconfig1_beta1/1.0.7+20171030/google_runtimeconfig1_beta1/struct.ProjectConfigVariableWatchCall.html), [*configs waiters create*](https://docs.rs/google-runtimeconfig1_beta1/1.0.7+20171030/google_runtimeconfig1_beta1/struct.ProjectConfigWaiterCreateCall.html), [*configs waiters delete*](https://docs.rs/google-runtimeconfig1_beta1/1.0.7+20171030/google_runtimeconfig1_beta1/struct.ProjectConfigWaiterDeleteCall.html), [*configs waiters get*](https://docs.rs/google-runtimeconfig1_beta1/1.0.7+20171030/google_runtimeconfig1_beta1/struct.ProjectConfigWaiterGetCall.html), [*configs waiters list*](https://docs.rs/google-runtimeconfig1_beta1/1.0.7+20171030/google_runtimeconfig1_beta1/struct.ProjectConfigWaiterListCall.html) and [*configs waiters test iam permissions*](https://docs.rs/google-runtimeconfig1_beta1/1.0.7+20171030/google_runtimeconfig1_beta1/struct.ProjectConfigWaiterTestIamPermissionCall.html)
+
+
+
+
+# Structure of this Library
+
+The API is structured into the following primary items:
+
+* **[Hub](https://docs.rs/google-runtimeconfig1_beta1/1.0.7+20171030/google_runtimeconfig1_beta1/struct.CloudRuntimeConfig.html)**
+    * a central object to maintain state and allow accessing all *Activities*
+    * creates [*Method Builders*](https://docs.rs/google-runtimeconfig1_beta1/1.0.7+20171030/google_runtimeconfig1_beta1/trait.MethodsBuilder.html) which in turn
+      allow access to individual [*Call Builders*](https://docs.rs/google-runtimeconfig1_beta1/1.0.7+20171030/google_runtimeconfig1_beta1/trait.CallBuilder.html)
+* **[Resources](https://docs.rs/google-runtimeconfig1_beta1/1.0.7+20171030/google_runtimeconfig1_beta1/trait.Resource.html)**
+    * primary types that you can apply *Activities* to
+    * a collection of properties and *Parts*
+    * **[Parts](https://docs.rs/google-runtimeconfig1_beta1/1.0.7+20171030/google_runtimeconfig1_beta1/trait.Part.html)**
+        * a collection of properties
+        * never directly used in *Activities*
+* **[Activities](https://docs.rs/google-runtimeconfig1_beta1/1.0.7+20171030/google_runtimeconfig1_beta1/trait.CallBuilder.html)**
+    * operations to apply to *Resources*
+
+All *structures* are marked with applicable traits to further categorize them and ease browsing.
+
+Generally speaking, you can invoke *Activities* like this:
+
+```Rust,ignore
+let r = hub.resource().activity(...).doit()
+```
+
+Or specifically ...
+
+```ignore
+let r = hub.projects().configs_variables_watch(...).doit()
+let r = hub.projects().configs_variables_get(...).doit()
+let r = hub.projects().configs_variables_update(...).doit()
+let r = hub.projects().configs_variables_create(...).doit()
+```
+
+The `resource()` and `activity(...)` calls create [builders][builder-pattern]. The second one dealing with `Activities` 
+supports various methods to configure the impending operation (not shown here). It is made such that all required arguments have to be 
+specified right away (i.e. `(...)`), whereas all optional ones can be [build up][builder-pattern] as desired.
+The `doit()` method performs the actual communication with the server and returns the respective result.
+
+# Usage
+
+## Setting up your Project
+
+To use this library, you would put the following lines into your `Cargo.toml` file:
+
+```toml
+[dependencies]
+google-runtimeconfig1_beta1 = "*"
+```
+
+## A complete example
+
+```Rust
+extern crate hyper;
+extern crate hyper_rustls;
+extern crate yup_oauth2 as oauth2;
+extern crate google_runtimeconfig1_beta1 as runtimeconfig1_beta1;
+use runtimeconfig1_beta1::Variable;
+use runtimeconfig1_beta1::{Result, Error};
+use std::default::Default;
+use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+use runtimeconfig1_beta1::CloudRuntimeConfig;
+
+// Get an ApplicationSecret instance by some means. It contains the `client_id` and 
+// `client_secret`, among other things.
+let secret: ApplicationSecret = Default::default();
+// Instantiate the authenticator. It will choose a suitable authentication flow for you, 
+// unless you replace  `None` with the desired Flow.
+// Provide your own `AuthenticatorDelegate` to adjust the way it operates and get feedback about 
+// what's going on. You probably want to bring in your own `TokenStorage` to persist tokens and
+// retrieve them from storage.
+let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+                              hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+                              <MemoryStorage as Default>::default(), None);
+let mut hub = CloudRuntimeConfig::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+// As the method needs a request, you would usually fill it with the desired information
+// into the respective structure. Some of the parts shown here might not be applicable !
+// Values shown here are possibly random and not representative !
+let mut req = Variable::default();
+
+// You can configure optional parameters by calling the respective setters at will, and
+// execute the final call using `doit()`.
+// Values shown here are possibly random and not representative !
+let result = hub.projects().configs_variables_create(req, "parent")
+             .request_id("sit")
+             .doit();
+
+match result {
+    Err(e) => match e {
+        // The Error enum provides details about what exactly happened.
+        // You can also just use its `Debug`, `Display` or `Error` traits
+         Error::HttpError(_)
+        |Error::MissingAPIKey
+        |Error::MissingToken(_)
+        |Error::Cancelled
+        |Error::UploadSizeLimitExceeded(_, _)
+        |Error::Failure(_)
+        |Error::BadRequest(_)
+        |Error::FieldClash(_)
+        |Error::JsonDecodeError(_, _) => println!("{}", e),
+    },
+    Ok(res) => println!("Success: {:?}", res),
+}
+
+```
+## Handling Errors
+
+All errors produced by the system are provided either as [Result](https://docs.rs/google-runtimeconfig1_beta1/1.0.7+20171030/google_runtimeconfig1_beta1/enum.Result.html) enumeration as return value of 
+the doit() methods, or handed as possibly intermediate results to either the 
+[Hub Delegate](https://docs.rs/google-runtimeconfig1_beta1/1.0.7+20171030/google_runtimeconfig1_beta1/trait.Delegate.html), or the [Authenticator Delegate](https://docs.rs/yup-oauth2/*/yup_oauth2/trait.AuthenticatorDelegate.html).
+
+When delegates handle errors or intermediate values, they may have a chance to instruct the system to retry. This 
+makes the system potentially resilient to all kinds of errors.
+
+## Uploads and Downloads
+If a method supports downloads, the response body, which is part of the [Result](https://docs.rs/google-runtimeconfig1_beta1/1.0.7+20171030/google_runtimeconfig1_beta1/enum.Result.html), should be
+read by you to obtain the media.
+If such a method also supports a [Response Result](https://docs.rs/google-runtimeconfig1_beta1/1.0.7+20171030/google_runtimeconfig1_beta1/trait.ResponseResult.html), it will return that by default.
+You can see it as meta-data for the actual media. To trigger a media download, you will have to set up the builder by making
+this call: `.param("alt", "media")`.
+
+Methods supporting uploads can do so using up to 2 different protocols: 
+*simple* and *resumable*. The distinctiveness of each is represented by customized 
+`doit(...)` methods, which are then named `upload(...)` and `upload_resumable(...)` respectively.
+
+## Customization and Callbacks
+
+You may alter the way an `doit()` method is called by providing a [delegate](https://docs.rs/google-runtimeconfig1_beta1/1.0.7+20171030/google_runtimeconfig1_beta1/trait.Delegate.html) to the 
+[Method Builder](https://docs.rs/google-runtimeconfig1_beta1/1.0.7+20171030/google_runtimeconfig1_beta1/trait.CallBuilder.html) before making the final `doit()` call. 
+Respective methods will be called to provide progress information, as well as determine whether the system should 
+retry on failure.
+
+The [delegate trait](https://docs.rs/google-runtimeconfig1_beta1/1.0.7+20171030/google_runtimeconfig1_beta1/trait.Delegate.html) is default-implemented, allowing you to customize it with minimal effort.
+
+## Optional Parts in Server-Requests
+
+All structures provided by this library are made to be [enocodable](https://docs.rs/google-runtimeconfig1_beta1/1.0.7+20171030/google_runtimeconfig1_beta1/trait.RequestValue.html) and 
+[decodable](https://docs.rs/google-runtimeconfig1_beta1/1.0.7+20171030/google_runtimeconfig1_beta1/trait.ResponseResult.html) via *json*. Optionals are used to indicate that partial requests are responses 
+are valid.
+Most optionals are are considered [Parts](https://docs.rs/google-runtimeconfig1_beta1/1.0.7+20171030/google_runtimeconfig1_beta1/trait.Part.html) which are identifiable by name, which will be sent to 
+the server to indicate either the set parts of the request or the desired parts in the response.
+
+## Builder Arguments
+
+Using [method builders](https://docs.rs/google-runtimeconfig1_beta1/1.0.7+20171030/google_runtimeconfig1_beta1/trait.CallBuilder.html), you are able to prepare an action call by repeatedly calling it's methods.
+These will always take a single argument, for which the following statements are true.
+
+* [PODs][wiki-pod] are handed by copy
+* strings are passed as `&str`
+* [request values](https://docs.rs/google-runtimeconfig1_beta1/1.0.7+20171030/google_runtimeconfig1_beta1/trait.RequestValue.html) are moved
+
+Arguments will always be copied or cloned into the builder, to make them independent of their original life times.
+
+[wiki-pod]: http://en.wikipedia.org/wiki/Plain_old_data_structure
+[builder-pattern]: http://en.wikipedia.org/wiki/Builder_pattern
+[google-go-api]: https://github.com/google/google-api-go-client
+
+# License
+The **runtimeconfig1_beta1** library was generated by Sebastian Thiel, and is placed 
+under the *MIT* license.
+You can read the full text at the repository's [license file][repo-license].
+
+[repo-license]: https://github.com/Byron/google-apis-rsblob/master/LICENSE.md

--- a/gen/runtimeconfig1_beta1/src/cmn.rs
+++ b/gen/runtimeconfig1_beta1/src/cmn.rs
@@ -1,0 +1,753 @@
+// COPY OF 'src/rust/api/cmn.rs'
+// DO NOT EDIT
+use std::io::{self, Read, Seek, Cursor, Write, SeekFrom};
+use std;
+use std::fmt::{self, Display};
+use std::str::FromStr;
+use std::error;
+use std::thread::sleep;
+use std::time::Duration;
+
+use mime::{Mime, TopLevel, SubLevel, Attr, Value};
+use oauth2::{TokenType, Retry, self};
+use hyper;
+use hyper::header::{ContentType, ContentLength, Headers, UserAgent, Authorization, Header,
+                    HeaderFormat, Bearer};
+use hyper::http::h1::LINE_ENDING;
+use hyper::method::Method;
+use hyper::status::StatusCode;
+
+use serde_json as json;
+
+/// Identifies the Hub. There is only one per library, this trait is supposed
+/// to make intended use more explicit.
+/// The hub allows to access all resource methods more easily.
+pub trait Hub {}
+
+/// Identifies types for building methods of a particular resource type
+pub trait MethodsBuilder {}
+
+/// Identifies types which represent builders for a particular resource method
+pub trait CallBuilder {}
+
+/// Identifies types which can be inserted and deleted.
+/// Types with this trait are most commonly used by clients of this API.
+pub trait Resource {}
+
+/// Identifies types which are used in API responses.
+pub trait ResponseResult {}
+
+/// Identifies types which are used in API requests.
+pub trait RequestValue {}
+
+/// Identifies types which are not actually used by the API
+/// This might be a bug within the google API schema.
+pub trait UnusedType {}
+
+/// Identifies types which are only used as part of other types, which
+/// usually are carrying the `Resource` trait.
+pub trait Part {}
+
+/// Identifies types which are only used by other types internally.
+/// They have no special meaning, this trait just marks them for completeness.
+pub trait NestedType {}
+
+/// A utility to specify reader types which provide seeking capabilities too
+pub trait ReadSeek: Seek + Read {}
+impl<T: Seek + Read> ReadSeek for T {}
+
+/// A trait for all types that can convert themselves into a *parts* string
+pub trait ToParts {
+    fn to_parts(&self) -> String;
+}
+
+/// A utility type which can decode a server response that indicates error
+#[derive(Deserialize)]
+pub struct JsonServerError {
+    pub error: String,
+    pub error_description: Option<String>
+}
+
+/// A utility to represent detailed errors we might see in case there are BadRequests.
+/// The latter happen if the sent parameters or request structures are unsound
+#[derive(Deserialize, Serialize, Debug)]
+pub struct ErrorResponse {
+    error: ServerError,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct ServerError {
+    errors: Vec<ServerMessage>,
+    code: u16,
+    message: String,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct ServerMessage {
+    domain: String,
+    reason: String,
+    message: String,
+    #[serde(rename="locationType")]
+    location_type: Option<String>,
+    location: Option<String>
+}
+
+#[derive(Copy, Clone)]
+pub struct DummyNetworkStream;
+
+impl Read for DummyNetworkStream {
+    fn read(&mut self, _: &mut [u8]) -> io::Result<usize> {
+        Ok(0)
+    }
+}
+
+impl Write for DummyNetworkStream {
+    fn write(&mut self, _: &[u8]) -> io::Result<usize> {
+        Ok(0)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl hyper::net::NetworkStream for DummyNetworkStream {
+    fn peer_addr(&mut self) -> io::Result<std::net::SocketAddr> {
+        Ok("127.0.0.1:1337".parse().unwrap())
+    }
+
+    fn set_read_timeout(&self, _dur: Option<Duration>) -> io::Result<()> {
+        Ok(())
+    }
+
+    fn set_write_timeout(&self, _dur: Option<Duration>) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+
+/// A trait specifying functionality to help controlling any request performed by the API.
+/// The trait has a conservative default implementation.
+///
+/// It contains methods to deal with all common issues, as well with the ones related to
+/// uploading media
+pub trait Delegate {
+
+    /// Called at the beginning of any API request. The delegate should store the method
+    /// information if he is interesting in knowing more context when further calls to it
+    /// are made.
+    /// The matching `finished()` call will always be made, no matter whether or not the API
+    /// request was successful. That way, the delegate may easily maintain a clean state
+    /// between various API calls.
+    fn begin(&mut self, MethodInfo) {}
+
+    /// Called whenever there is an [HttpError](http://hyperium.github.io/hyper/hyper/error/enum.HttpError.html), usually if there are network problems.
+    ///
+    /// If you choose to retry after a duration, the duration should be chosen using the
+    /// [exponential backoff algorithm](http://en.wikipedia.org/wiki/Exponential_backoff).
+    ///
+    /// Return retry information.
+    fn http_error(&mut self, &hyper::Error) -> Retry {
+        Retry::Abort
+    }
+
+    /// Called whenever there is the need for your applications API key after
+    /// the official authenticator implementation didn't provide one, for some reason.
+    /// If this method returns None as well, the underlying operation will fail
+    fn api_key(&mut self) -> Option<String> {
+        None
+    }
+
+    /// Called whenever the Authenticator didn't yield a token. The delegate
+    /// may attempt to provide one, or just take it as a general information about the
+    /// impending failure.
+    /// The given Error provides information about why the token couldn't be acquired in the
+    /// first place
+    fn token(&mut self, err: &error::Error) -> Option<oauth2::Token> {
+        let _ = err;
+        None
+    }
+
+    /// Called during resumable uploads to provide a URL for the impending upload.
+    /// It was saved after a previous call to `store_upload_url(...)`, and if not None,
+    /// will be used instead of asking the server for a new upload URL.
+    /// This is useful in case a previous resumable upload was aborted/canceled, but should now
+    /// be resumed.
+    /// The returned URL will be used exactly once - if it fails again and the delegate allows
+    /// to retry, we will ask the server for a new upload URL.
+    fn upload_url(&mut self) -> Option<String> {
+        None
+    }
+
+    /// Called after we have retrieved a new upload URL for a resumable upload to store it
+    /// in case we fail or cancel. That way, we can attempt to resume the upload later,
+    /// see `upload_url()`.
+    /// It will also be called with None after a successful upload, which allows the delegate
+    /// to forget the URL. That way, we will not attempt to resume an upload that has already
+    /// finished.
+    fn store_upload_url(&mut self, url: Option<&str>) {
+        let _ = url;
+    }
+
+    /// Called whenever a server response could not be decoded from json.
+    /// It's for informational purposes only, the caller will return with an error
+    /// accordingly.
+    ///
+    /// # Arguments
+    ///
+    /// * `json_encoded_value` - The json-encoded value which failed to decode.
+    /// * `json_decode_error`  - The decoder error
+    fn response_json_decode_error(&mut self, json_encoded_value: &str, json_decode_error: &json::Error) {
+        let _ = json_encoded_value;
+        let _ = json_decode_error;
+    }
+
+    /// Called whenever the http request returns with a non-success status code.
+    /// This can involve authentication issues, or anything else that very much
+    /// depends on the used API method.
+    /// The delegate should check the status, header and decoded json error to decide
+    /// whether to retry or not. In the latter case, the underlying call will fail.
+    ///
+    /// If you choose to retry after a duration, the duration should be chosen using the
+    /// [exponential backoff algorithm](http://en.wikipedia.org/wiki/Exponential_backoff).
+    fn http_failure(&mut self, _: &hyper::client::Response, Option<JsonServerError>, _: Option<ServerError>) -> Retry {
+        Retry::Abort
+    }
+
+    /// Called prior to sending the main request of the given method. It can be used to time
+    /// the call or to print progress information.
+    /// It's also useful as you can be sure that a request will definitely be made.
+    fn pre_request(&mut self) { }
+
+    /// Return the size of each chunk of a resumable upload.
+    /// Must be a power of two, with 1<<18 being the smallest allowed chunk size.
+    /// Will be called once before starting any resumable upload.
+    fn chunk_size(&mut self) -> u64 {
+        1 << 23
+    }
+
+    /// Called before the given chunk is uploaded to the server.
+    /// If true is returned, the upload will be interrupted.
+    /// However, it may be resumable if you stored the upload URL in a previous call
+    /// to `store_upload_url()`
+    fn cancel_chunk_upload(&mut self, chunk: &ContentRange) -> bool {
+        let _ = chunk;
+        false
+    }
+
+    /// Called before the API request method returns, in every case. It can be used to clean up
+    /// internal state between calls to the API.
+    /// This call always has a matching call to `begin(...)`.
+    ///
+    /// # Arguments
+    ///
+    /// * `is_success` - a true value indicates the operation was successful. If false, you should
+    ///                  discard all values stored during `store_upload_url`.
+    fn finished(&mut self, is_success: bool) {
+        let _ = is_success;
+    }
+}
+
+/// A delegate with a conservative default implementation, which is used if no other delegate is
+/// set.
+#[derive(Default)]
+pub struct DefaultDelegate;
+
+impl Delegate for DefaultDelegate {}
+
+
+#[derive(Debug)]
+pub enum Error {
+    /// The http connection failed
+    HttpError(hyper::Error),
+
+    /// An attempt was made to upload a resource with size stored in field `.0`
+    /// even though the maximum upload size is what is stored in field `.1`.
+    UploadSizeLimitExceeded(u64, u64),
+
+    /// Represents information about a request that was not understood by the server.
+    /// Details are included.
+    BadRequest(ErrorResponse),
+
+    /// We needed an API key for authentication, but didn't obtain one.
+    /// Neither through the authenticator, nor through the Delegate.
+    MissingAPIKey,
+
+    /// We required a Token, but didn't get one from the Authenticator
+    MissingToken(Box<error::Error>),
+
+    /// The delgate instructed to cancel the operation
+    Cancelled,
+
+    /// An additional, free form field clashed with one of the built-in optional ones
+    FieldClash(&'static str),
+
+    /// Shows that we failed to decode the server response.
+    /// This can happen if the protocol changes in conjunction with strict json decoding.
+    JsonDecodeError(String, json::Error),
+
+    /// Indicates an HTTP repsonse with a non-success status code
+    Failure(hyper::client::Response),
+}
+
+
+impl Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Error::HttpError(ref err) => err.fmt(f),
+            Error::UploadSizeLimitExceeded(ref resource_size, ref max_size) =>
+                writeln!(f, "The media size {} exceeds the maximum allowed upload size of {}"
+                         , resource_size, max_size),
+            Error::MissingAPIKey => {
+                (writeln!(f, "The application's API key was not found in the configuration")).ok();
+                writeln!(f, "It is used as there are no Scopes defined for this method.")
+            },
+            Error::BadRequest(ref err) => {
+                try!(writeln!(f, "Bad Request ({}): {}", err.error.code, err.error.message));
+                for err in err.error.errors.iter() {
+                    try!(writeln!(f, "    {}: {}, {}{}",
+                                            err.domain,
+                                            err.message,
+                                            err.reason,
+                                            match &err.location {
+                                                &Some(ref loc) => format!("@{}", loc),
+                                                &None => String::new(),
+                                            }));
+                }
+                Ok(())
+            },
+            Error::MissingToken(ref err) =>
+                writeln!(f, "Token retrieval failed with error: {}", err),
+            Error::Cancelled =>
+                writeln!(f, "Operation cancelled by delegate"),
+            Error::FieldClash(field) =>
+                writeln!(f, "The custom parameter '{}' is already provided natively by the CallBuilder.", field),
+            Error::JsonDecodeError(ref json_str, ref err)
+                => writeln!(f, "{}: {}", err, json_str),
+            Error::Failure(ref response) =>
+                writeln!(f, "Http status indicates failure: {:?}", response),
+        }
+    }
+}
+
+impl error::Error for Error {
+    fn description(&self) -> &str {
+        match *self {
+            Error::HttpError(ref err) => err.description(),
+            Error::JsonDecodeError(_, ref err) => err.description(),
+            _ => "NO DESCRIPTION POSSIBLE - use `Display.fmt()` instead"
+        }
+    }
+
+    fn cause(&self) -> Option<&error::Error> {
+        match *self {
+            Error::HttpError(ref err) => err.cause(),
+            Error::JsonDecodeError(_, ref err) => err.cause(),
+            _ => None
+        }
+    }
+}
+
+/// A universal result type used as return for all calls.
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Contains information about an API request.
+pub struct MethodInfo {
+    pub id: &'static str,
+    pub http_method: Method,
+}
+
+const BOUNDARY: &'static str = "MDuXWGyeE33QFXGchb2VFWc4Z7945d";
+
+/// Provides a `Read` interface that converts multiple parts into the protocol
+/// identified by [RFC2387](https://tools.ietf.org/html/rfc2387).
+/// **Note**: This implementation is just as rich as it needs to be to perform uploads
+/// to google APIs, and might not be a fully-featured implementation.
+#[derive(Default)]
+pub struct MultiPartReader<'a> {
+    raw_parts: Vec<(Headers, &'a mut Read)>,
+    current_part: Option<(Cursor<Vec<u8>>, &'a mut Read)>,
+    last_part_boundary: Option<Cursor<Vec<u8>>>,
+}
+
+impl<'a> MultiPartReader<'a> {
+
+    /// Reserve memory for exactly the given amount of parts
+    pub fn reserve_exact(&mut self, cap: usize) {
+        self.raw_parts.reserve_exact(cap);
+    }
+
+    /// Add a new part to the queue of parts to be read on the first `read` call.
+    ///
+    /// # Arguments
+    ///
+    /// `headers` - identifying the body of the part. It's similar to the header
+    ///             in an ordinary single-part call, and should thus contain the
+    ///             same information.
+    /// `reader`  - a reader providing the part's body
+    /// `size`    - the amount of bytes provided by the reader. It will be put onto the header as
+    ///             content-size.
+    /// `mime`    - It will be put onto the content type
+    pub fn add_part(&mut self, reader: &'a mut Read, size: u64, mime_type: Mime) -> &mut MultiPartReader<'a> {
+        let mut headers = Headers::new();
+        headers.set(ContentType(mime_type));
+        headers.set(ContentLength(size));
+        self.raw_parts.push((headers, reader));
+        self
+    }
+
+    /// Returns the mime-type representing our multi-part message.
+    /// Use it with the ContentType header.
+    pub fn mime_type(&self) -> Mime {
+        Mime(
+            TopLevel::Multipart,
+            SubLevel::Ext("Related".to_string()),
+            vec![(Attr::Ext("boundary".to_string()), Value::Ext(BOUNDARY.to_string()))],
+        )
+    }
+
+    /// Returns true if we are totally used
+    fn is_depleted(&self) -> bool {
+        self.raw_parts.len() == 0 && self.current_part.is_none() && self.last_part_boundary.is_none()
+    }
+
+    /// Returns true if we are handling our last part
+    fn is_last_part(&self) -> bool {
+        self.raw_parts.len() == 0 && self.current_part.is_some()
+    }
+}
+
+impl<'a> Read for MultiPartReader<'a> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        match (self.raw_parts.len(),
+               self.current_part.is_none(),
+               self.last_part_boundary.is_none()) {
+            (_, _, false) => {
+                let br = self.last_part_boundary.as_mut().unwrap().read(buf).unwrap_or(0);
+                if br < buf.len() {
+                    self.last_part_boundary = None;
+                }
+                return Ok(br)
+            },
+            (0, true, true) => return Ok(0),
+            (n, true, _) if n > 0 => {
+                let (headers, reader) = self.raw_parts.remove(0);
+                let mut c = Cursor::new(Vec::<u8>::new());
+                (write!(&mut c, "{}--{}{}{}{}", LINE_ENDING, BOUNDARY, LINE_ENDING,
+                                                headers, LINE_ENDING)).unwrap();
+                c.seek(SeekFrom::Start(0)).unwrap();
+                self.current_part = Some((c, reader));
+            }
+            _ => {},
+        }
+
+        // read headers as long as possible
+        let (hb, rr) = {
+            let &mut (ref mut c, ref mut reader) = self.current_part.as_mut().unwrap();
+            let b = c.read(buf).unwrap_or(0);
+            (b, reader.read(&mut buf[b..]))
+        };
+
+        match rr {
+            Ok(bytes_read) => {
+                if hb < buf.len() && bytes_read == 0 {
+                    if self.is_last_part() {
+                        // before clearing the last part, we will add the boundary that
+                        // will be written last
+                        self.last_part_boundary = Some(Cursor::new(
+                                                        format!("{}--{}--", LINE_ENDING, BOUNDARY).into_bytes()))
+                    }
+                    // We are depleted - this can trigger the next part to come in
+                    self.current_part = None;
+                }
+                let mut total_bytes_read = hb + bytes_read;
+                while total_bytes_read < buf.len() && !self.is_depleted() {
+                    match self.read(&mut buf[total_bytes_read ..]) {
+                        Ok(br) => total_bytes_read += br,
+                        Err(err) => return Err(err),
+                    }
+                }
+                Ok(total_bytes_read)
+            }
+            Err(err) => {
+                // fail permanently
+                self.current_part = None;
+                self.last_part_boundary = None;
+                self.raw_parts.clear();
+                Err(err)
+            }
+        }
+    }
+}
+
+/// The `X-Upload-Content-Type` header.
+///
+/// Generated via rustc --pretty expanded -Z unstable-options, and manually
+/// processed to be more readable.
+#[derive(PartialEq, Debug, Clone)]
+pub struct XUploadContentType(pub Mime);
+
+impl ::std::ops::Deref for XUploadContentType {
+    type Target = Mime;
+    fn deref<'a>(&'a self) -> &'a Mime { &self.0 }
+}
+impl ::std::ops::DerefMut for XUploadContentType {
+    fn deref_mut<'a>(&'a mut self) -> &'a mut Mime { &mut self.0 }
+}
+impl Header for XUploadContentType {
+    fn header_name() -> &'static str { "X-Upload-Content-Type" }
+    fn parse_header(raw: &[Vec<u8>]) -> hyper::error::Result<Self> {
+        hyper::header::parsing::from_one_raw_str(raw).map(XUploadContentType)
+    }
+}
+impl HeaderFormat for XUploadContentType {
+    fn fmt_header(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        Display::fmt(&**self, f)
+    }
+}
+impl Display for XUploadContentType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(&**self, f)
+    }
+}
+
+#[derive(Clone, PartialEq, Debug)]
+pub struct Chunk {
+    pub first: u64,
+    pub last: u64
+}
+
+impl fmt::Display for Chunk {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        (write!(fmt, "{}-{}", self.first, self.last)).ok();
+        Ok(())
+    }
+}
+
+impl FromStr for Chunk {
+    type Err = &'static str;
+
+    /// NOTE: only implements `%i-%i`, not `*`
+    fn from_str(s: &str) -> std::result::Result<Chunk, &'static str> {
+        let parts: Vec<&str> = s.split('-').collect();
+        if parts.len() != 2 {
+            return Err("Expected two parts: %i-%i")
+        }
+        Ok(
+            Chunk {
+                first: match FromStr::from_str(parts[0]) {
+                    Ok(d) => d,
+                    _ => return Err("Couldn't parse 'first' as digit")
+                },
+                last: match FromStr::from_str(parts[1]) {
+                    Ok(d) => d,
+                    _ => return Err("Couldn't parse 'last' as digit")
+                }
+            }
+        )
+    }
+}
+
+/// Implements the Content-Range header, for serialization only
+#[derive(Clone, PartialEq, Debug)]
+pub struct ContentRange {
+    pub range: Option<Chunk>,
+    pub total_length: u64,
+}
+
+impl Header for ContentRange {
+    fn header_name() -> &'static str {
+        "Content-Range"
+    }
+
+    /// We are not parsable, as parsing is done by the `Range` header
+    fn parse_header(_: &[Vec<u8>]) -> hyper::error::Result<Self> {
+        Err(hyper::error::Error::Method)
+    }
+}
+
+
+impl HeaderFormat for ContentRange {
+    fn fmt_header(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        try!(fmt.write_str("bytes "));
+        match self.range {
+            Some(ref c) => try!(c.fmt(fmt)),
+            None => try!(fmt.write_str("*"))
+        }
+        (write!(fmt, "/{}", self.total_length)).ok();
+        Ok(())
+    }
+}
+
+#[derive(Clone, PartialEq, Debug)]
+pub struct RangeResponseHeader(pub Chunk);
+
+impl Header for RangeResponseHeader {
+    fn header_name() -> &'static str {
+        "Range"
+    }
+
+    fn parse_header(raw: &[Vec<u8>]) -> hyper::error::Result<Self> {
+        if raw.len() > 0 {
+            let v = &raw[0];
+            if let Ok(s) = std::str::from_utf8(v) {
+                const PREFIX: &'static str = "bytes ";
+                if s.starts_with(PREFIX) {
+                    if let Ok(c) = <Chunk as FromStr>::from_str(&s[PREFIX.len()..]) {
+                        return  Ok(RangeResponseHeader(c))
+                    }
+                }
+            }
+        }
+        Err(hyper::error::Error::Method)
+    }
+}
+
+impl HeaderFormat for RangeResponseHeader {
+    /// No implmentation necessary, we just need to parse
+    fn fmt_header(&self, _: &mut fmt::Formatter) -> fmt::Result {
+        Err(fmt::Error)
+    }
+}
+
+/// A utility type to perform a resumable upload from start to end.
+pub struct ResumableUploadHelper<'a, A: 'a> {
+    pub client: &'a mut hyper::client::Client,
+    pub delegate: &'a mut Delegate,
+    pub start_at: Option<u64>,
+    pub auth: &'a mut A,
+    pub user_agent: &'a str,
+    pub auth_header: Authorization<Bearer>,
+    pub url: &'a str,
+    pub reader: &'a mut ReadSeek,
+    pub media_type: Mime,
+    pub content_length: u64
+}
+
+impl<'a, A> ResumableUploadHelper<'a, A>
+    where A: oauth2::GetToken {
+
+    fn query_transfer_status(&mut self) -> std::result::Result<u64, hyper::Result<hyper::client::Response>> {
+        loop {
+            match self.client.post(self.url)
+                .header(UserAgent(self.user_agent.to_string()))
+                .header(ContentRange { range: None, total_length: self.content_length })
+                .header(self.auth_header.clone())
+                .send() {
+                Ok(r) => {
+                    // 308 = resume-incomplete == PermanentRedirect
+                    let headers = r.headers.clone();
+                    let h: &RangeResponseHeader = match headers.get() {
+                        Some(hh) if r.status == StatusCode::PermanentRedirect => hh,
+                        None|Some(_) => {
+                            if let Retry::After(d) = self.delegate.http_failure(&r, None, None) {
+                                sleep(d);
+                                continue;
+                            }
+                            return Err(Ok(r))
+                        }
+                    };
+                    return Ok(h.0.last)
+                }
+                Err(err) => {
+                    if let Retry::After(d) = self.delegate.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    return Err(Err(err))
+                }
+            }
+        }
+    }
+
+    /// returns None if operation was cancelled by delegate, or the HttpResult.
+    /// It can be that we return the result just because we didn't understand the status code -
+    /// caller should check for status himself before assuming it's OK to use
+    pub fn upload(&mut self) -> Option<hyper::Result<hyper::client::Response>> {
+        let mut start = match self.start_at {
+            Some(s) => s,
+            None => match self.query_transfer_status() {
+                Ok(s) => s,
+                Err(result) => return Some(result)
+            }
+        };
+
+        const MIN_CHUNK_SIZE: u64 = 1 << 18;
+        let chunk_size = match self.delegate.chunk_size() {
+            cs if cs > MIN_CHUNK_SIZE => cs,
+            _ => MIN_CHUNK_SIZE
+        };
+
+        self.reader.seek(SeekFrom::Start(start)).unwrap();
+        loop {
+            let request_size = match self.content_length - start {
+                rs if rs > chunk_size => chunk_size,
+                rs => rs
+            };
+
+            let mut section_reader = self.reader.take(request_size);
+            let range_header = ContentRange {
+                range: Some(Chunk {first: start, last: start + request_size - 1}),
+                total_length: self.content_length
+            };
+            start += request_size;
+            if self.delegate.cancel_chunk_upload(&range_header) {
+                return None
+            }
+            let res = self.client.post(self.url)
+                                 .header(range_header)
+                                 .header(ContentType(self.media_type.clone()))
+                                 .header(UserAgent(self.user_agent.to_string()))
+                                 .body(&mut section_reader)
+                                 .send();
+            match res {
+                Ok(mut res) => {
+                    if res.status == StatusCode::PermanentRedirect  {
+                        continue
+                    }
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let Retry::After(d) = self.delegate.http_failure(&res,
+                                                        json::from_str(&json_err).ok(),
+                                                        json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                    }
+                    return Some(Ok(res))
+                },
+                Err(err) => {
+                    if let Retry::After(d) = self.delegate.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    return Some(Err(err))
+                }
+            }
+        }
+    }
+}
+
+// Copy of src/rust/cli/cmn.rs
+// TODO(ST): Allow sharing common code between program types
+pub fn remove_json_null_values(value: &mut json::value::Value) {
+    match *value {
+        json::value::Value::Object(ref mut map) => {
+            let mut for_removal = Vec::new();
+
+            for (key, mut value) in map.iter_mut() {
+                if value.is_null() {
+                    for_removal.push(key.clone());
+                } else {
+                    remove_json_null_values(&mut value);
+                }
+            }
+
+            for key in &for_removal {
+                map.remove(key);
+            }
+        }
+        _ => {}
+    }
+}

--- a/gen/runtimeconfig1_beta1/src/lib.rs
+++ b/gen/runtimeconfig1_beta1/src/lib.rs
@@ -1,0 +1,7727 @@
+// DO NOT EDIT !
+// This file was generated automatically from 'src/mako/api/lib.rs.mako'
+// DO NOT EDIT !
+
+//! This documentation was generated from *Cloud RuntimeConfig* crate version *1.0.7+20171030*, where *20171030* is the exact revision of the *runtimeconfig:v1beta1* schema built by the [mako](http://www.makotemplates.org/) code generator *v1.0.7*.
+//! 
+//! Everything else about the *Cloud RuntimeConfig* *v1_beta1* API can be found at the
+//! [official documentation site](https://cloud.google.com/deployment-manager/runtime-configurator/).
+//! The original source code is [on github](https://github.com/Byron/google-apis-rs/tree/master/gen/runtimeconfig1_beta1).
+//! # Features
+//! 
+//! Handle the following *Resources* with ease from the central [hub](struct.CloudRuntimeConfig.html) ... 
+//! 
+//! * projects
+//!  * [*configs create*](struct.ProjectConfigCreateCall.html), [*configs delete*](struct.ProjectConfigDeleteCall.html), [*configs get*](struct.ProjectConfigGetCall.html), [*configs get iam policy*](struct.ProjectConfigGetIamPolicyCall.html), [*configs list*](struct.ProjectConfigListCall.html), [*configs operations get*](struct.ProjectConfigOperationGetCall.html), [*configs operations test iam permissions*](struct.ProjectConfigOperationTestIamPermissionCall.html), [*configs set iam policy*](struct.ProjectConfigSetIamPolicyCall.html), [*configs test iam permissions*](struct.ProjectConfigTestIamPermissionCall.html), [*configs update*](struct.ProjectConfigUpdateCall.html), [*configs variables create*](struct.ProjectConfigVariableCreateCall.html), [*configs variables delete*](struct.ProjectConfigVariableDeleteCall.html), [*configs variables get*](struct.ProjectConfigVariableGetCall.html), [*configs variables list*](struct.ProjectConfigVariableListCall.html), [*configs variables test iam permissions*](struct.ProjectConfigVariableTestIamPermissionCall.html), [*configs variables update*](struct.ProjectConfigVariableUpdateCall.html), [*configs variables watch*](struct.ProjectConfigVariableWatchCall.html), [*configs waiters create*](struct.ProjectConfigWaiterCreateCall.html), [*configs waiters delete*](struct.ProjectConfigWaiterDeleteCall.html), [*configs waiters get*](struct.ProjectConfigWaiterGetCall.html), [*configs waiters list*](struct.ProjectConfigWaiterListCall.html) and [*configs waiters test iam permissions*](struct.ProjectConfigWaiterTestIamPermissionCall.html)
+//! 
+//! 
+//! 
+//! 
+//! Not what you are looking for ? Find all other Google APIs in their Rust [documentation index](http://byron.github.io/google-apis-rs).
+//! 
+//! # Structure of this Library
+//! 
+//! The API is structured into the following primary items:
+//! 
+//! * **[Hub](struct.CloudRuntimeConfig.html)**
+//!     * a central object to maintain state and allow accessing all *Activities*
+//!     * creates [*Method Builders*](trait.MethodsBuilder.html) which in turn
+//!       allow access to individual [*Call Builders*](trait.CallBuilder.html)
+//! * **[Resources](trait.Resource.html)**
+//!     * primary types that you can apply *Activities* to
+//!     * a collection of properties and *Parts*
+//!     * **[Parts](trait.Part.html)**
+//!         * a collection of properties
+//!         * never directly used in *Activities*
+//! * **[Activities](trait.CallBuilder.html)**
+//!     * operations to apply to *Resources*
+//! 
+//! All *structures* are marked with applicable traits to further categorize them and ease browsing.
+//! 
+//! Generally speaking, you can invoke *Activities* like this:
+//! 
+//! ```Rust,ignore
+//! let r = hub.resource().activity(...).doit()
+//! ```
+//! 
+//! Or specifically ...
+//! 
+//! ```ignore
+//! let r = hub.projects().configs_variables_watch(...).doit()
+//! let r = hub.projects().configs_variables_get(...).doit()
+//! let r = hub.projects().configs_variables_update(...).doit()
+//! let r = hub.projects().configs_variables_create(...).doit()
+//! ```
+//! 
+//! The `resource()` and `activity(...)` calls create [builders][builder-pattern]. The second one dealing with `Activities` 
+//! supports various methods to configure the impending operation (not shown here). It is made such that all required arguments have to be 
+//! specified right away (i.e. `(...)`), whereas all optional ones can be [build up][builder-pattern] as desired.
+//! The `doit()` method performs the actual communication with the server and returns the respective result.
+//! 
+//! # Usage
+//! 
+//! ## Setting up your Project
+//! 
+//! To use this library, you would put the following lines into your `Cargo.toml` file:
+//! 
+//! ```toml
+//! [dependencies]
+//! google-runtimeconfig1_beta1 = "*"
+//! ```
+//! 
+//! ## A complete example
+//! 
+//! ```test_harness,no_run
+//! extern crate hyper;
+//! extern crate hyper_rustls;
+//! extern crate yup_oauth2 as oauth2;
+//! extern crate google_runtimeconfig1_beta1 as runtimeconfig1_beta1;
+//! use runtimeconfig1_beta1::Variable;
+//! use runtimeconfig1_beta1::{Result, Error};
+//! # #[test] fn egal() {
+//! use std::default::Default;
+//! use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+//! use runtimeconfig1_beta1::CloudRuntimeConfig;
+//! 
+//! // Get an ApplicationSecret instance by some means. It contains the `client_id` and 
+//! // `client_secret`, among other things.
+//! let secret: ApplicationSecret = Default::default();
+//! // Instantiate the authenticator. It will choose a suitable authentication flow for you, 
+//! // unless you replace  `None` with the desired Flow.
+//! // Provide your own `AuthenticatorDelegate` to adjust the way it operates and get feedback about 
+//! // what's going on. You probably want to bring in your own `TokenStorage` to persist tokens and
+//! // retrieve them from storage.
+//! let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+//!                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+//!                               <MemoryStorage as Default>::default(), None);
+//! let mut hub = CloudRuntimeConfig::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+//! // As the method needs a request, you would usually fill it with the desired information
+//! // into the respective structure. Some of the parts shown here might not be applicable !
+//! // Values shown here are possibly random and not representative !
+//! let mut req = Variable::default();
+//! 
+//! // You can configure optional parameters by calling the respective setters at will, and
+//! // execute the final call using `doit()`.
+//! // Values shown here are possibly random and not representative !
+//! let result = hub.projects().configs_variables_create(req, "parent")
+//!              .request_id("sed")
+//!              .doit();
+//! 
+//! match result {
+//!     Err(e) => match e {
+//!         // The Error enum provides details about what exactly happened.
+//!         // You can also just use its `Debug`, `Display` or `Error` traits
+//!          Error::HttpError(_)
+//!         |Error::MissingAPIKey
+//!         |Error::MissingToken(_)
+//!         |Error::Cancelled
+//!         |Error::UploadSizeLimitExceeded(_, _)
+//!         |Error::Failure(_)
+//!         |Error::BadRequest(_)
+//!         |Error::FieldClash(_)
+//!         |Error::JsonDecodeError(_, _) => println!("{}", e),
+//!     },
+//!     Ok(res) => println!("Success: {:?}", res),
+//! }
+//! # }
+//! ```
+//! ## Handling Errors
+//! 
+//! All errors produced by the system are provided either as [Result](enum.Result.html) enumeration as return value of 
+//! the doit() methods, or handed as possibly intermediate results to either the 
+//! [Hub Delegate](trait.Delegate.html), or the [Authenticator Delegate](https://docs.rs/yup-oauth2/*/yup_oauth2/trait.AuthenticatorDelegate.html).
+//! 
+//! When delegates handle errors or intermediate values, they may have a chance to instruct the system to retry. This 
+//! makes the system potentially resilient to all kinds of errors.
+//! 
+//! ## Uploads and Downloads
+//! If a method supports downloads, the response body, which is part of the [Result](enum.Result.html), should be
+//! read by you to obtain the media.
+//! If such a method also supports a [Response Result](trait.ResponseResult.html), it will return that by default.
+//! You can see it as meta-data for the actual media. To trigger a media download, you will have to set up the builder by making
+//! this call: `.param("alt", "media")`.
+//! 
+//! Methods supporting uploads can do so using up to 2 different protocols: 
+//! *simple* and *resumable*. The distinctiveness of each is represented by customized 
+//! `doit(...)` methods, which are then named `upload(...)` and `upload_resumable(...)` respectively.
+//! 
+//! ## Customization and Callbacks
+//! 
+//! You may alter the way an `doit()` method is called by providing a [delegate](trait.Delegate.html) to the 
+//! [Method Builder](trait.CallBuilder.html) before making the final `doit()` call. 
+//! Respective methods will be called to provide progress information, as well as determine whether the system should 
+//! retry on failure.
+//! 
+//! The [delegate trait](trait.Delegate.html) is default-implemented, allowing you to customize it with minimal effort.
+//! 
+//! ## Optional Parts in Server-Requests
+//! 
+//! All structures provided by this library are made to be [enocodable](trait.RequestValue.html) and 
+//! [decodable](trait.ResponseResult.html) via *json*. Optionals are used to indicate that partial requests are responses 
+//! are valid.
+//! Most optionals are are considered [Parts](trait.Part.html) which are identifiable by name, which will be sent to 
+//! the server to indicate either the set parts of the request or the desired parts in the response.
+//! 
+//! ## Builder Arguments
+//! 
+//! Using [method builders](trait.CallBuilder.html), you are able to prepare an action call by repeatedly calling it's methods.
+//! These will always take a single argument, for which the following statements are true.
+//! 
+//! * [PODs][wiki-pod] are handed by copy
+//! * strings are passed as `&str`
+//! * [request values](trait.RequestValue.html) are moved
+//! 
+//! Arguments will always be copied or cloned into the builder, to make them independent of their original life times.
+//! 
+//! [wiki-pod]: http://en.wikipedia.org/wiki/Plain_old_data_structure
+//! [builder-pattern]: http://en.wikipedia.org/wiki/Builder_pattern
+//! [google-go-api]: https://github.com/google/google-api-go-client
+//! 
+//! 
+
+// Unused attributes happen thanks to defined, but unused structures
+// We don't warn about this, as depending on the API, some data structures or facilities are never used.
+// Instead of pre-determining this, we just disable the lint. It's manually tuned to not have any
+// unused imports in fully featured APIs. Same with unused_mut ... .
+#![allow(unused_imports, unused_mut, dead_code)]
+
+// DO NOT EDIT !
+// This file was generated automatically from 'src/mako/api/lib.rs.mako'
+// DO NOT EDIT !
+
+#[macro_use]
+extern crate serde_derive;
+
+extern crate hyper;
+extern crate serde;
+extern crate serde_json;
+extern crate yup_oauth2 as oauth2;
+extern crate mime;
+extern crate url;
+
+mod cmn;
+
+use std::collections::HashMap;
+use std::cell::RefCell;
+use std::borrow::BorrowMut;
+use std::default::Default;
+use std::collections::BTreeMap;
+use serde_json as json;
+use std::io;
+use std::fs;
+use std::mem;
+use std::thread::sleep;
+use std::time::Duration;
+
+pub use cmn::{MultiPartReader, ToParts, MethodInfo, Result, Error, CallBuilder, Hub, ReadSeek, Part,
+              ResponseResult, RequestValue, NestedType, Delegate, DefaultDelegate, MethodsBuilder,
+              Resource, ErrorResponse, remove_json_null_values};
+
+
+// ##############
+// UTILITIES ###
+// ############
+
+/// Identifies the an OAuth2 authorization scope.
+/// A scope is needed when requesting an
+/// [authorization token](https://developers.google.com/youtube/v3/guides/authentication).
+#[derive(PartialEq, Eq, Hash)]
+pub enum Scope {
+    /// Manage your Google Cloud Platform services' runtime configuration
+    Cloudruntimeconfig,
+
+    /// View and manage your data across Google Cloud Platform services
+    CloudPlatform,
+}
+
+impl AsRef<str> for Scope {
+    fn as_ref(&self) -> &str {
+        match *self {
+            Scope::Cloudruntimeconfig => "https://www.googleapis.com/auth/cloudruntimeconfig",
+            Scope::CloudPlatform => "https://www.googleapis.com/auth/cloud-platform",
+        }
+    }
+}
+
+impl Default for Scope {
+    fn default() -> Scope {
+        Scope::CloudPlatform
+    }
+}
+
+
+
+// ########
+// HUB ###
+// ######
+
+/// Central instance to access all CloudRuntimeConfig related resource activities
+///
+/// # Examples
+///
+/// Instantiate a new hub
+///
+/// ```test_harness,no_run
+/// extern crate hyper;
+/// extern crate hyper_rustls;
+/// extern crate yup_oauth2 as oauth2;
+/// extern crate google_runtimeconfig1_beta1 as runtimeconfig1_beta1;
+/// use runtimeconfig1_beta1::Variable;
+/// use runtimeconfig1_beta1::{Result, Error};
+/// # #[test] fn egal() {
+/// use std::default::Default;
+/// use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// use runtimeconfig1_beta1::CloudRuntimeConfig;
+/// 
+/// // Get an ApplicationSecret instance by some means. It contains the `client_id` and 
+/// // `client_secret`, among other things.
+/// let secret: ApplicationSecret = Default::default();
+/// // Instantiate the authenticator. It will choose a suitable authentication flow for you, 
+/// // unless you replace  `None` with the desired Flow.
+/// // Provide your own `AuthenticatorDelegate` to adjust the way it operates and get feedback about 
+/// // what's going on. You probably want to bring in your own `TokenStorage` to persist tokens and
+/// // retrieve them from storage.
+/// let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+///                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+///                               <MemoryStorage as Default>::default(), None);
+/// let mut hub = CloudRuntimeConfig::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = Variable::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.projects().configs_variables_create(req, "parent")
+///              .request_id("dolores")
+///              .doit();
+/// 
+/// match result {
+///     Err(e) => match e {
+///         // The Error enum provides details about what exactly happened.
+///         // You can also just use its `Debug`, `Display` or `Error` traits
+///          Error::HttpError(_)
+///         |Error::MissingAPIKey
+///         |Error::MissingToken(_)
+///         |Error::Cancelled
+///         |Error::UploadSizeLimitExceeded(_, _)
+///         |Error::Failure(_)
+///         |Error::BadRequest(_)
+///         |Error::FieldClash(_)
+///         |Error::JsonDecodeError(_, _) => println!("{}", e),
+///     },
+///     Ok(res) => println!("Success: {:?}", res),
+/// }
+/// # }
+/// ```
+pub struct CloudRuntimeConfig<C, A> {
+    client: RefCell<C>,
+    auth: RefCell<A>,
+    _user_agent: String,
+    _base_url: String,
+    _root_url: String,
+}
+
+impl<'a, C, A> Hub for CloudRuntimeConfig<C, A> {}
+
+impl<'a, C, A> CloudRuntimeConfig<C, A>
+    where  C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+    pub fn new(client: C, authenticator: A) -> CloudRuntimeConfig<C, A> {
+        CloudRuntimeConfig {
+            client: RefCell::new(client),
+            auth: RefCell::new(authenticator),
+            _user_agent: "google-api-rust-client/1.0.7".to_string(),
+            _base_url: "https://runtimeconfig.googleapis.com/".to_string(),
+            _root_url: "https://runtimeconfig.googleapis.com/".to_string(),
+        }
+    }
+
+    pub fn projects(&'a self) -> ProjectMethods<'a, C, A> {
+        ProjectMethods { hub: &self }
+    }
+
+    /// Set the user-agent header field to use in all requests to the server.
+    /// It defaults to `google-api-rust-client/1.0.7`.
+    ///
+    /// Returns the previously set user-agent.
+    pub fn user_agent(&mut self, agent_name: String) -> String {
+        mem::replace(&mut self._user_agent, agent_name)
+    }
+
+    /// Set the base url to use in all requests to the server.
+    /// It defaults to `https://runtimeconfig.googleapis.com/`.
+    ///
+    /// Returns the previously set base url.
+    pub fn base_url(&mut self, new_base_url: String) -> String {
+        mem::replace(&mut self._base_url, new_base_url)
+    }
+
+    /// Set the root url to use in all requests to the server.
+    /// It defaults to `https://runtimeconfig.googleapis.com/`.
+    ///
+    /// Returns the previously set root url.
+    pub fn root_url(&mut self, new_root_url: String) -> String {
+        mem::replace(&mut self._root_url, new_root_url)
+    }
+}
+
+
+// ############
+// SCHEMAS ###
+// ##########
+/// Request message for `TestIamPermissions` method.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [configs waiters test iam permissions projects](struct.ProjectConfigWaiterTestIamPermissionCall.html) (request)
+/// * [configs variables test iam permissions projects](struct.ProjectConfigVariableTestIamPermissionCall.html) (request)
+/// * [configs operations test iam permissions projects](struct.ProjectConfigOperationTestIamPermissionCall.html) (request)
+/// * [configs test iam permissions projects](struct.ProjectConfigTestIamPermissionCall.html) (request)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct TestIamPermissionsRequest {
+    /// The set of permissions to check for the `resource`. Permissions with
+    /// wildcards (such as '*' or 'storage.*') are not allowed. For more
+    /// information see
+    /// [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
+    pub permissions: Option<Vec<String>>,
+}
+
+impl RequestValue for TestIamPermissionsRequest {}
+
+
+/// Request message for `SetIamPolicy` method.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [configs set iam policy projects](struct.ProjectConfigSetIamPolicyCall.html) (request)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct SetIamPolicyRequest {
+    /// REQUIRED: The complete policy to be applied to the `resource`. The size of
+    /// the policy is limited to a few 10s of KB. An empty policy is a
+    /// valid policy but certain Cloud Platform services (such as Projects)
+    /// might reject them.
+    pub policy: Option<Policy>,
+}
+
+impl RequestValue for SetIamPolicyRequest {}
+
+
+/// A Waiter resource waits for some end condition within a RuntimeConfig resource
+/// to be met before it returns. For example, assume you have a distributed
+/// system where each node writes to a Variable resource indidicating the node's
+/// readiness as part of the startup process.
+/// 
+/// You then configure a Waiter resource with the success condition set to wait
+/// until some number of nodes have checked in. Afterwards, your application
+/// runs some arbitrary code after the condition has been met and the waiter
+/// returns successfully.
+/// 
+/// Once created, a Waiter resource is immutable.
+/// 
+/// To learn more about using waiters, read the
+/// [Creating a Waiter](/deployment-manager/runtime-configurator/creating-a-waiter)
+/// documentation.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [configs waiters get projects](struct.ProjectConfigWaiterGetCall.html) (response)
+/// * [configs waiters create projects](struct.ProjectConfigWaiterCreateCall.html) (request)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Waiter {
+    /// [Optional] The failure condition of this waiter. If this condition is met,
+    /// `done` will be set to `true` and the `error` code will be set to `ABORTED`.
+    /// The failure condition takes precedence over the success condition. If both
+    /// conditions are met, a failure will be indicated. This value is optional; if
+    /// no failure condition is set, the only failure scenario will be a timeout.
+    pub failure: Option<EndCondition>,
+    /// [Output Only] If the value is `false`, it means the waiter is still waiting
+    /// for one of its conditions to be met.
+    /// 
+    /// If true, the waiter has finished. If the waiter finished due to a timeout
+    /// or failure, `error` will be set.
+    pub done: Option<bool>,
+    /// The name of the Waiter resource, in the format:
+    /// 
+    ///     projects/[PROJECT_ID]/configs/[CONFIG_NAME]/waiters/[WAITER_NAME]
+    /// 
+    /// The `[PROJECT_ID]` must be a valid Google Cloud project ID,
+    /// the `[CONFIG_NAME]` must be a valid RuntimeConfig resource, the
+    /// `[WAITER_NAME]` must match RFC 1035 segment specification, and the length
+    /// of `[WAITER_NAME]` must be less than 64 bytes.
+    /// 
+    /// After you create a Waiter resource, you cannot change the resource name.
+    pub name: Option<String>,
+    /// [Required] The success condition. If this condition is met, `done` will be
+    /// set to `true` and the `error` value will remain unset. The failure condition
+    /// takes precedence over the success condition. If both conditions are met, a
+    /// failure will be indicated.
+    pub success: Option<EndCondition>,
+    /// [Output Only] If the waiter ended due to a failure or timeout, this value
+    /// will be set.
+    pub error: Option<Status>,
+    /// [Required] Specifies the timeout of the waiter in seconds, beginning from
+    /// the instant that `waiters().create` method is called. If this time elapses
+    /// before the success or failure conditions are met, the waiter fails and sets
+    /// the `error` code to `DEADLINE_EXCEEDED`.
+    pub timeout: Option<String>,
+    /// [Output Only] The instant at which this Waiter resource was created. Adding
+    /// the value of `timeout` to this instant yields the timeout deadline for the
+    /// waiter.
+    #[serde(rename="createTime")]
+    pub create_time: Option<String>,
+}
+
+impl RequestValue for Waiter {}
+impl ResponseResult for Waiter {}
+
+
+/// Response for the `ListVariables()` method.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [configs variables list projects](struct.ProjectConfigVariableListCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct ListVariablesResponse {
+    /// This token allows you to get the next page of results for list requests.
+    /// If the number of results is larger than `pageSize`, use the `nextPageToken`
+    /// as a value for the query parameter `pageToken` in the next list request.
+    /// Subsequent list requests will have their own `nextPageToken` to continue
+    /// paging through the results
+    #[serde(rename="nextPageToken")]
+    pub next_page_token: Option<String>,
+    /// A list of variables and their values. The order of returned variable
+    /// objects is arbitrary.
+    pub variables: Option<Vec<Variable>>,
+}
+
+impl ResponseResult for ListVariablesResponse {}
+
+
+/// Defines an Identity and Access Management (IAM) policy. It is used to
+/// specify access control policies for Cloud Platform resources.
+/// 
+/// 
+/// A `Policy` consists of a list of `bindings`. A `Binding` binds a list of
+/// `members` to a `role`, where the members can be user accounts, Google groups,
+/// Google domains, and service accounts. A `role` is a named list of permissions
+/// defined by IAM.
+/// 
+/// **Example**
+/// 
+///     {
+///       "bindings": [
+///         {
+///           "role": "roles/owner",
+///           "members": [
+///             "user:mike@example.com",
+///             "group:admins@example.com",
+///             "domain:google.com",
+///             "serviceAccount:my-other-app@appspot.gserviceaccount.com",
+///           ]
+///         },
+///         {
+///           "role": "roles/viewer",
+///           "members": ["user:sean@example.com"]
+///         }
+///       ]
+///     }
+/// 
+/// For a description of IAM and its features, see the
+/// [IAM developer's guide](https://cloud.google.com/iam).
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [configs get iam policy projects](struct.ProjectConfigGetIamPolicyCall.html) (response)
+/// * [configs set iam policy projects](struct.ProjectConfigSetIamPolicyCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Policy {
+    /// Associates a list of `members` to a `role`.
+    /// `bindings` with no members will result in an error.
+    pub bindings: Option<Vec<Binding>>,
+    /// `etag` is used for optimistic concurrency control as a way to help
+    /// prevent simultaneous updates of a policy from overwriting each other.
+    /// It is strongly suggested that systems make use of the `etag` in the
+    /// read-modify-write cycle to perform policy updates in order to avoid race
+    /// conditions: An `etag` is returned in the response to `getIamPolicy`, and
+    /// systems are expected to put that etag in the request to `setIamPolicy` to
+    /// ensure that their change will be applied to the same version of the policy.
+    /// 
+    /// If no `etag` is provided in the call to `setIamPolicy`, then the existing
+    /// policy is overwritten blindly.
+    pub etag: Option<String>,
+    /// Version of the `Policy`. The default version is 0.
+    pub version: Option<i32>,
+}
+
+impl ResponseResult for Policy {}
+
+
+/// A generic empty message that you can re-use to avoid defining duplicated
+/// empty messages in your APIs. A typical example is to use it as the request
+/// or the response type of an API method. For instance:
+/// 
+///     service Foo {
+///       rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
+///     }
+/// 
+/// The JSON representation for `Empty` is empty JSON object `{}`.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [configs waiters delete projects](struct.ProjectConfigWaiterDeleteCall.html) (response)
+/// * [configs variables delete projects](struct.ProjectConfigVariableDeleteCall.html) (response)
+/// * [configs delete projects](struct.ProjectConfigDeleteCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Empty { _never_set: Option<bool> }
+
+impl ResponseResult for Empty {}
+
+
+/// The `Status` type defines a logical error model that is suitable for different
+/// programming environments, including REST APIs and RPC APIs. It is used by
+/// [gRPC](https://github.com/grpc). The error model is designed to be:
+/// 
+/// - Simple to use and understand for most users
+/// - Flexible enough to meet unexpected needs
+/// 
+/// # Overview
+/// 
+/// The `Status` message contains three pieces of data: error code, error message,
+/// and error details. The error code should be an enum value of
+/// google.rpc.Code, but it may accept additional error codes if needed.  The
+/// error message should be a developer-facing English message that helps
+/// developers *understand* and *resolve* the error. If a localized user-facing
+/// error message is needed, put the localized message in the error details or
+/// localize it in the client. The optional error details may contain arbitrary
+/// information about the error. There is a predefined set of error detail types
+/// in the package `google.rpc` that can be used for common error conditions.
+/// 
+/// # Language mapping
+/// 
+/// The `Status` message is the logical representation of the error model, but it
+/// is not necessarily the actual wire format. When the `Status` message is
+/// exposed in different client libraries and different wire protocols, it can be
+/// mapped differently. For example, it will likely be mapped to some exceptions
+/// in Java, but more likely mapped to some error codes in C.
+/// 
+/// # Other uses
+/// 
+/// The error model and the `Status` message can be used in a variety of
+/// environments, either with or without APIs, to provide a
+/// consistent developer experience across different environments.
+/// 
+/// Example uses of this error model include:
+/// 
+/// - Partial errors. If a service needs to return partial errors to the client,
+///     it may embed the `Status` in the normal response to indicate the partial
+///     errors.
+/// 
+/// - Workflow errors. A typical workflow has multiple steps. Each step may
+///     have a `Status` message for error reporting.
+/// 
+/// - Batch operations. If a client uses batch request and batch response, the
+///     `Status` message should be used directly inside batch response, one for
+///     each error sub-response.
+/// 
+/// - Asynchronous operations. If an API call embeds asynchronous operation
+///     results in its response, the status of those operations should be
+///     represented directly using the `Status` message.
+/// 
+/// - Logging. If some API errors are stored in logs, the message `Status` could
+///     be used directly after any stripping needed for security/privacy reasons.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Status {
+    /// A developer-facing error message, which should be in English. Any
+    /// user-facing error message should be localized and sent in the
+    /// google.rpc.Status.details field, or localized by the client.
+    pub message: Option<String>,
+    /// The status code, which should be an enum value of google.rpc.Code.
+    pub code: Option<i32>,
+    /// A list of messages that carry the error details.  There is a common set of
+    /// message types for APIs to use.
+    pub details: Option<Vec<HashMap<String, String>>>,
+}
+
+impl Part for Status {}
+
+
+/// Response message for `TestIamPermissions` method.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [configs waiters test iam permissions projects](struct.ProjectConfigWaiterTestIamPermissionCall.html) (response)
+/// * [configs variables test iam permissions projects](struct.ProjectConfigVariableTestIamPermissionCall.html) (response)
+/// * [configs operations test iam permissions projects](struct.ProjectConfigOperationTestIamPermissionCall.html) (response)
+/// * [configs test iam permissions projects](struct.ProjectConfigTestIamPermissionCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct TestIamPermissionsResponse {
+    /// A subset of `TestPermissionsRequest.permissions` that the caller is
+    /// allowed.
+    pub permissions: Option<Vec<String>>,
+}
+
+impl ResponseResult for TestIamPermissionsResponse {}
+
+
+/// Response for the `ListWaiters()` method.
+/// Order of returned waiter objects is arbitrary.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [configs waiters list projects](struct.ProjectConfigWaiterListCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct ListWaitersResponse {
+    /// This token allows you to get the next page of results for list requests.
+    /// If the number of results is larger than `pageSize`, use the `nextPageToken`
+    /// as a value for the query parameter `pageToken` in the next list request.
+    /// Subsequent list requests will have their own `nextPageToken` to continue
+    /// paging through the results
+    #[serde(rename="nextPageToken")]
+    pub next_page_token: Option<String>,
+    /// Found waiters in the project.
+    pub waiters: Option<Vec<Waiter>>,
+}
+
+impl ResponseResult for ListWaitersResponse {}
+
+
+/// `ListConfigs()` returns the following response. The order of returned
+/// objects is arbitrary; that is, it is not ordered in any particular way.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [configs list projects](struct.ProjectConfigListCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct ListConfigsResponse {
+    /// This token allows you to get the next page of results for list requests.
+    /// If the number of results is larger than `pageSize`, use the `nextPageToken`
+    /// as a value for the query parameter `pageToken` in the next list request.
+    /// Subsequent list requests will have their own `nextPageToken` to continue
+    /// paging through the results
+    #[serde(rename="nextPageToken")]
+    pub next_page_token: Option<String>,
+    /// A list of the configurations in the project. The order of returned
+    /// objects is arbitrary; that is, it is not ordered in any particular way.
+    pub configs: Option<Vec<RuntimeConfig>>,
+}
+
+impl ResponseResult for ListConfigsResponse {}
+
+
+/// A RuntimeConfig resource is the primary resource in the Cloud RuntimeConfig
+/// service. A RuntimeConfig resource consists of metadata and a hierarchy of
+/// variables.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [configs update projects](struct.ProjectConfigUpdateCall.html) (request|response)
+/// * [configs create projects](struct.ProjectConfigCreateCall.html) (request|response)
+/// * [configs get projects](struct.ProjectConfigGetCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct RuntimeConfig {
+    /// The resource name of a runtime config. The name must have the format:
+    /// 
+    ///     projects/[PROJECT_ID]/configs/[CONFIG_NAME]
+    /// 
+    /// The `[PROJECT_ID]` must be a valid project ID, and `[CONFIG_NAME]` is an
+    /// arbitrary name that matches
+    /// [0-9A-Za-z](?:[_.A-Za-z0-9-]{0,62}[_.A-Za-z0-9])? regular expression.
+    /// The length of `[CONFIG_NAME]` must be less than 64 characters.
+    /// 
+    /// You pick the RuntimeConfig resource name, but the server will validate that
+    /// the name adheres to this format. After you create the resource, you cannot
+    /// change the resource's name.
+    pub name: Option<String>,
+    /// An optional description of the RuntimeConfig object.
+    pub description: Option<String>,
+}
+
+impl RequestValue for RuntimeConfig {}
+impl ResponseResult for RuntimeConfig {}
+
+
+/// Associates `members` with a `role`.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Binding {
+    /// Role that is assigned to `members`.
+    /// For example, `roles/viewer`, `roles/editor`, or `roles/owner`.
+    /// Required
+    pub role: Option<String>,
+    /// Specifies the identities requesting access for a Cloud Platform resource.
+    /// `members` can have the following values:
+    /// 
+    /// * `allUsers`: A special identifier that represents anyone who is
+    ///    on the internet; with or without a Google account.
+    /// 
+    /// * `allAuthenticatedUsers`: A special identifier that represents anyone
+    ///    who is authenticated with a Google account or a service account.
+    /// 
+    /// * `user:{emailid}`: An email address that represents a specific Google
+    ///    account. For example, `alice@gmail.com` or `joe@example.com`.
+    /// 
+    /// 
+    /// * `serviceAccount:{emailid}`: An email address that represents a service
+    ///    account. For example, `my-other-app@appspot.gserviceaccount.com`.
+    /// 
+    /// * `group:{emailid}`: An email address that represents a Google group.
+    ///    For example, `admins@example.com`.
+    /// 
+    /// 
+    /// * `domain:{domain}`: A Google Apps domain name that represents all the
+    ///    users of that domain. For example, `google.com` or `example.com`.
+    /// 
+    /// 
+    pub members: Option<Vec<String>>,
+}
+
+impl Part for Binding {}
+
+
+/// The condition that a Waiter resource is waiting for.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct EndCondition {
+    /// The cardinality of the `EndCondition`.
+    pub cardinality: Option<Cardinality>,
+}
+
+impl Part for EndCondition {}
+
+
+/// Describes a single variable within a RuntimeConfig resource.
+/// The name denotes the hierarchical variable name. For example,
+/// `ports/serving_port` is a valid variable name. The variable value is an
+/// opaque string and only leaf variables can have values (that is, variables
+/// that do not have any child variables).
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [configs variables watch projects](struct.ProjectConfigVariableWatchCall.html) (response)
+/// * [configs variables get projects](struct.ProjectConfigVariableGetCall.html) (response)
+/// * [configs variables update projects](struct.ProjectConfigVariableUpdateCall.html) (request|response)
+/// * [configs variables create projects](struct.ProjectConfigVariableCreateCall.html) (request|response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Variable {
+    /// The string value of the variable. The length of the value must be less
+    /// than 4096 bytes. Empty values are also accepted. For example,
+    /// `text: "my text value"`. The string must be valid UTF-8.
+    pub text: Option<String>,
+    /// [Output Only] The time of the last variable update.
+    #[serde(rename="updateTime")]
+    pub update_time: Option<String>,
+    /// [Ouput only] The current state of the variable. The variable state indicates
+    /// the outcome of the `variables().watch` call and is visible through the
+    /// `get` and `list` calls.
+    pub state: Option<String>,
+    /// The binary value of the variable. The length of the value must be less
+    /// than 4096 bytes. Empty values are also accepted. The value must be
+    /// base64 encoded. Only one of `value` or `text` can be set.
+    pub value: Option<String>,
+    /// The name of the variable resource, in the format:
+    /// 
+    ///     projects/[PROJECT_ID]/configs/[CONFIG_NAME]/variables/[VARIABLE_NAME]
+    /// 
+    /// The `[PROJECT_ID]` must be a valid project ID, `[CONFIG_NAME]` must be a
+    /// valid RuntimeConfig reource and `[VARIABLE_NAME]` follows Unix file system
+    /// file path naming.
+    /// 
+    /// The `[VARIABLE_NAME]` can contain ASCII letters, numbers, slashes and
+    /// dashes. Slashes are used as path element separators and are not part of the
+    /// `[VARIABLE_NAME]` itself, so `[VARIABLE_NAME]` must contain at least one
+    /// non-slash character. Multiple slashes are coalesced into single slash
+    /// character. Each path segment should match
+    /// [0-9A-Za-z](?:[_.A-Za-z0-9-]{0,62}[_.A-Za-z0-9])? regular expression.
+    /// The length of a `[VARIABLE_NAME]` must be less than 256 characters.
+    /// 
+    /// Once you create a variable, you cannot change the variable name.
+    pub name: Option<String>,
+}
+
+impl RequestValue for Variable {}
+impl ResponseResult for Variable {}
+
+
+/// This resource represents a long-running operation that is the result of a
+/// network API call.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [configs operations get projects](struct.ProjectConfigOperationGetCall.html) (response)
+/// * [configs waiters create projects](struct.ProjectConfigWaiterCreateCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Operation {
+    /// Service-specific metadata associated with the operation.  It typically
+    /// contains progress information and common metadata such as create time.
+    /// Some services might not provide such metadata.  Any method that returns a
+    /// long-running operation should document the metadata type, if any.
+    pub metadata: Option<HashMap<String, String>>,
+    /// If the value is `false`, it means the operation is still in progress.
+    /// If `true`, the operation is completed, and either `error` or `response` is
+    /// available.
+    pub done: Option<bool>,
+    /// The normal response of the operation in case of success.  If the original
+    /// method returns no data on success, such as `Delete`, the response is
+    /// `google.protobuf.Empty`.  If the original method is standard
+    /// `Get`/`Create`/`Update`, the response should be the resource.  For other
+    /// methods, the response should have the type `XxxResponse`, where `Xxx`
+    /// is the original method name.  For example, if the original method name
+    /// is `TakeSnapshot()`, the inferred response type is
+    /// `TakeSnapshotResponse`.
+    pub response: Option<HashMap<String, String>>,
+    /// The server-assigned name, which is only unique within the same service that
+    /// originally returns it. If you use the default HTTP mapping, the
+    /// `name` should have the format of `operations/some/unique/name`.
+    pub name: Option<String>,
+    /// The error result of the operation in case of failure or cancellation.
+    pub error: Option<Status>,
+}
+
+impl ResponseResult for Operation {}
+
+
+/// A Cardinality condition for the Waiter resource. A cardinality condition is
+/// met when the number of variables under a specified path prefix reaches a
+/// predefined number. For example, if you set a Cardinality condition where
+/// the `path` is set to `/foo` and the number of paths is set to 2, the
+/// following variables would meet the condition in a RuntimeConfig resource:
+/// 
+/// + `/foo/variable1 = "value1"`
+/// + `/foo/variable2 = "value2"`
+/// + `/bar/variable3 = "value3"`
+/// 
+/// It would not would not satisify the same condition with the `number` set to
+/// 3, however, because there is only 2 paths that start with `/foo`.
+/// Cardinality conditions are recursive; all subtrees under the specific
+/// path prefix are counted.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Cardinality {
+    /// The root of the variable subtree to monitor. For example, `/foo`.
+    pub path: Option<String>,
+    /// The number variables under the `path` that must exist to meet this
+    /// condition. Defaults to 1 if not specified.
+    pub number: Option<i32>,
+}
+
+impl Part for Cardinality {}
+
+
+/// Request for the `WatchVariable()` method.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [configs variables watch projects](struct.ProjectConfigVariableWatchCall.html) (request)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct WatchVariableRequest {
+    /// If specified, checks the current timestamp of the variable and if the
+    /// current timestamp is newer than `newerThan` timestamp, the method returns
+    /// immediately.
+    /// 
+    /// If not specified or the variable has an older timestamp, the watcher waits
+    /// for a the value to change before returning.
+    #[serde(rename="newerThan")]
+    pub newer_than: Option<String>,
+}
+
+impl RequestValue for WatchVariableRequest {}
+
+
+
+// ###################
+// MethodBuilders ###
+// #################
+
+/// A builder providing access to all methods supported on *project* resources.
+/// It is not used directly, but through the `CloudRuntimeConfig` hub.
+///
+/// # Example
+///
+/// Instantiate a resource builder
+///
+/// ```test_harness,no_run
+/// extern crate hyper;
+/// extern crate hyper_rustls;
+/// extern crate yup_oauth2 as oauth2;
+/// extern crate google_runtimeconfig1_beta1 as runtimeconfig1_beta1;
+/// 
+/// # #[test] fn egal() {
+/// use std::default::Default;
+/// use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// use runtimeconfig1_beta1::CloudRuntimeConfig;
+/// 
+/// let secret: ApplicationSecret = Default::default();
+/// let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+///                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+///                               <MemoryStorage as Default>::default(), None);
+/// let mut hub = CloudRuntimeConfig::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // Usually you wouldn't bind this to a variable, but keep calling *CallBuilders*
+/// // like `configs_create(...)`, `configs_delete(...)`, `configs_get(...)`, `configs_get_iam_policy(...)`, `configs_list(...)`, `configs_operations_get(...)`, `configs_operations_test_iam_permissions(...)`, `configs_set_iam_policy(...)`, `configs_test_iam_permissions(...)`, `configs_update(...)`, `configs_variables_create(...)`, `configs_variables_delete(...)`, `configs_variables_get(...)`, `configs_variables_list(...)`, `configs_variables_test_iam_permissions(...)`, `configs_variables_update(...)`, `configs_variables_watch(...)`, `configs_waiters_create(...)`, `configs_waiters_delete(...)`, `configs_waiters_get(...)`, `configs_waiters_list(...)` and `configs_waiters_test_iam_permissions(...)`
+/// // to build up your call.
+/// let rb = hub.projects();
+/// # }
+/// ```
+pub struct ProjectMethods<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a CloudRuntimeConfig<C, A>,
+}
+
+impl<'a, C, A> MethodsBuilder for ProjectMethods<'a, C, A> {}
+
+impl<'a, C, A> ProjectMethods<'a, C, A> {
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Watches a specific variable and waits for a change in the variable's value.
+    /// When there is a change, this method returns the new value or times out.
+    /// 
+    /// If a variable is deleted while being watched, the `variableState` state is
+    /// set to `DELETED` and the method returns the last known variable `value`.
+    /// 
+    /// If you set the deadline for watching to a larger value than internal timeout
+    /// (60 seconds), the current variable value is returned and the `variableState`
+    /// will be `VARIABLE_STATE_UNSPECIFIED`.
+    /// 
+    /// To learn more about creating a watcher, read the
+    /// [Watching a Variable for Changes](/deployment-manager/runtime-configurator/watching-a-variable)
+    /// documentation.
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    /// * `name` - The name of the variable to watch, in the format:
+    ///            `projects/[PROJECT_ID]/configs/[CONFIG_NAME]`
+    pub fn configs_variables_watch(&self, request: WatchVariableRequest, name: &str) -> ProjectConfigVariableWatchCall<'a, C, A> {
+        ProjectConfigVariableWatchCall {
+            hub: self.hub,
+            _request: request,
+            _name: name.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Returns permissions that a caller has on the specified resource.
+    /// If the resource does not exist, this will return an empty set of
+    /// permissions, not a NOT_FOUND error.
+    /// 
+    /// Note: This operation is designed to be used for building permission-aware
+    /// UIs and command-line tools, not for authorization checking. This operation
+    /// may "fail open" without warning.
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    /// * `resource` - REQUIRED: The resource for which the policy detail is being requested.
+    ///                See the operation documentation for the appropriate value for this field.
+    pub fn configs_variables_test_iam_permissions(&self, request: TestIamPermissionsRequest, resource: &str) -> ProjectConfigVariableTestIamPermissionCall<'a, C, A> {
+        ProjectConfigVariableTestIamPermissionCall {
+            hub: self.hub,
+            _request: request,
+            _resource: resource.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Updates a RuntimeConfig resource. The configuration must exist beforehand.
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    /// * `name` - The name of the RuntimeConfig resource to update, in the format:
+    ///            `projects/[PROJECT_ID]/configs/[CONFIG_NAME]`
+    pub fn configs_update(&self, request: RuntimeConfig, name: &str) -> ProjectConfigUpdateCall<'a, C, A> {
+        ProjectConfigUpdateCall {
+            hub: self.hub,
+            _request: request,
+            _name: name.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Returns permissions that a caller has on the specified resource.
+    /// If the resource does not exist, this will return an empty set of
+    /// permissions, not a NOT_FOUND error.
+    /// 
+    /// Note: This operation is designed to be used for building permission-aware
+    /// UIs and command-line tools, not for authorization checking. This operation
+    /// may "fail open" without warning.
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    /// * `resource` - REQUIRED: The resource for which the policy detail is being requested.
+    ///                See the operation documentation for the appropriate value for this field.
+    pub fn configs_waiters_test_iam_permissions(&self, request: TestIamPermissionsRequest, resource: &str) -> ProjectConfigWaiterTestIamPermissionCall<'a, C, A> {
+        ProjectConfigWaiterTestIamPermissionCall {
+            hub: self.hub,
+            _request: request,
+            _resource: resource.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Sets the access control policy on the specified resource. Replaces any
+    /// existing policy.
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    /// * `resource` - REQUIRED: The resource for which the policy is being specified.
+    ///                See the operation documentation for the appropriate value for this field.
+    pub fn configs_set_iam_policy(&self, request: SetIamPolicyRequest, resource: &str) -> ProjectConfigSetIamPolicyCall<'a, C, A> {
+        ProjectConfigSetIamPolicyCall {
+            hub: self.hub,
+            _request: request,
+            _resource: resource.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Gets information about a RuntimeConfig resource.
+    /// 
+    /// # Arguments
+    ///
+    /// * `name` - The name of the RuntimeConfig resource to retrieve, in the format:
+    ///            `projects/[PROJECT_ID]/configs/[CONFIG_NAME]`
+    pub fn configs_get(&self, name: &str) -> ProjectConfigGetCall<'a, C, A> {
+        ProjectConfigGetCall {
+            hub: self.hub,
+            _name: name.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Gets the access control policy for a resource.
+    /// Returns an empty policy if the resource exists and does not have a policy
+    /// set.
+    /// 
+    /// # Arguments
+    ///
+    /// * `resource` - REQUIRED: The resource for which the policy is being requested.
+    ///                See the operation documentation for the appropriate value for this field.
+    pub fn configs_get_iam_policy(&self, resource: &str) -> ProjectConfigGetIamPolicyCall<'a, C, A> {
+        ProjectConfigGetIamPolicyCall {
+            hub: self.hub,
+            _resource: resource.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Deletes the waiter with the specified name.
+    /// 
+    /// # Arguments
+    ///
+    /// * `name` - The Waiter resource to delete, in the format:
+    ///             `projects/[PROJECT_ID]/configs/[CONFIG_NAME]/waiters/[WAITER_NAME]`
+    pub fn configs_waiters_delete(&self, name: &str) -> ProjectConfigWaiterDeleteCall<'a, C, A> {
+        ProjectConfigWaiterDeleteCall {
+            hub: self.hub,
+            _name: name.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Creates a variable within the given configuration. You cannot create
+    /// a variable with a name that is a prefix of an existing variable name, or a
+    /// name that has an existing variable name as a prefix.
+    /// 
+    /// To learn more about creating a variable, read the
+    /// [Setting and Getting Data](/deployment-manager/runtime-configurator/set-and-get-variables)
+    /// documentation.
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    /// * `parent` - The path to the RutimeConfig resource that this variable should belong to.
+    ///              The configuration must exist beforehand; the path must be in the format:
+    ///              `projects/[PROJECT_ID]/configs/[CONFIG_NAME]`
+    pub fn configs_variables_create(&self, request: Variable, parent: &str) -> ProjectConfigVariableCreateCall<'a, C, A> {
+        ProjectConfigVariableCreateCall {
+            hub: self.hub,
+            _request: request,
+            _parent: parent.to_string(),
+            _request_id: Default::default(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// List waiters within the given configuration.
+    /// 
+    /// # Arguments
+    ///
+    /// * `parent` - The path to the configuration for which you want to get a list of waiters.
+    ///              The configuration must exist beforehand; the path must be in the format:
+    ///              `projects/[PROJECT_ID]/configs/[CONFIG_NAME]`
+    pub fn configs_waiters_list(&self, parent: &str) -> ProjectConfigWaiterListCall<'a, C, A> {
+        ProjectConfigWaiterListCall {
+            hub: self.hub,
+            _parent: parent.to_string(),
+            _page_token: Default::default(),
+            _page_size: Default::default(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Creates a Waiter resource. This operation returns a long-running Operation
+    /// resource which can be polled for completion. However, a waiter with the
+    /// given name will exist (and can be retrieved) prior to the operation
+    /// completing. If the operation fails, the failed Waiter resource will
+    /// still exist and must be deleted prior to subsequent creation attempts.
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    /// * `parent` - The path to the configuration that will own the waiter.
+    ///              The configuration must exist beforehand; the path must be in the format:
+    ///              `projects/[PROJECT_ID]/configs/[CONFIG_NAME]`.
+    pub fn configs_waiters_create(&self, request: Waiter, parent: &str) -> ProjectConfigWaiterCreateCall<'a, C, A> {
+        ProjectConfigWaiterCreateCall {
+            hub: self.hub,
+            _request: request,
+            _parent: parent.to_string(),
+            _request_id: Default::default(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Gets the latest state of a long-running operation.  Clients can use this
+    /// method to poll the operation result at intervals as recommended by the API
+    /// service.
+    /// 
+    /// # Arguments
+    ///
+    /// * `name` - The name of the operation resource.
+    pub fn configs_operations_get(&self, name: &str) -> ProjectConfigOperationGetCall<'a, C, A> {
+        ProjectConfigOperationGetCall {
+            hub: self.hub,
+            _name: name.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Gets information about a single variable.
+    /// 
+    /// # Arguments
+    ///
+    /// * `name` - The name of the variable to return, in the format:
+    ///            `projects/[PROJECT_ID]/configs/[CONFIG_NAME]/variables/[VARIBLE_NAME]`
+    pub fn configs_variables_get(&self, name: &str) -> ProjectConfigVariableGetCall<'a, C, A> {
+        ProjectConfigVariableGetCall {
+            hub: self.hub,
+            _name: name.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Deletes a RuntimeConfig resource.
+    /// 
+    /// # Arguments
+    ///
+    /// * `name` - The RuntimeConfig resource to delete, in the format:
+    ///            `projects/[PROJECT_ID]/configs/[CONFIG_NAME]`
+    pub fn configs_delete(&self, name: &str) -> ProjectConfigDeleteCall<'a, C, A> {
+        ProjectConfigDeleteCall {
+            hub: self.hub,
+            _name: name.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Returns permissions that a caller has on the specified resource.
+    /// If the resource does not exist, this will return an empty set of
+    /// permissions, not a NOT_FOUND error.
+    /// 
+    /// Note: This operation is designed to be used for building permission-aware
+    /// UIs and command-line tools, not for authorization checking. This operation
+    /// may "fail open" without warning.
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    /// * `resource` - REQUIRED: The resource for which the policy detail is being requested.
+    ///                See the operation documentation for the appropriate value for this field.
+    pub fn configs_operations_test_iam_permissions(&self, request: TestIamPermissionsRequest, resource: &str) -> ProjectConfigOperationTestIamPermissionCall<'a, C, A> {
+        ProjectConfigOperationTestIamPermissionCall {
+            hub: self.hub,
+            _request: request,
+            _resource: resource.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Returns permissions that a caller has on the specified resource.
+    /// If the resource does not exist, this will return an empty set of
+    /// permissions, not a NOT_FOUND error.
+    /// 
+    /// Note: This operation is designed to be used for building permission-aware
+    /// UIs and command-line tools, not for authorization checking. This operation
+    /// may "fail open" without warning.
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    /// * `resource` - REQUIRED: The resource for which the policy detail is being requested.
+    ///                See the operation documentation for the appropriate value for this field.
+    pub fn configs_test_iam_permissions(&self, request: TestIamPermissionsRequest, resource: &str) -> ProjectConfigTestIamPermissionCall<'a, C, A> {
+        ProjectConfigTestIamPermissionCall {
+            hub: self.hub,
+            _request: request,
+            _resource: resource.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Lists all the RuntimeConfig resources within project.
+    /// 
+    /// # Arguments
+    ///
+    /// * `parent` - The [project ID](https://support.google.com/cloud/answer/6158840?hl=en&ref_topic=6158848)
+    ///              for this request, in the format `projects/[PROJECT_ID]`.
+    pub fn configs_list(&self, parent: &str) -> ProjectConfigListCall<'a, C, A> {
+        ProjectConfigListCall {
+            hub: self.hub,
+            _parent: parent.to_string(),
+            _page_token: Default::default(),
+            _page_size: Default::default(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Deletes a variable or multiple variables.
+    /// 
+    /// If you specify a variable name, then that variable is deleted. If you
+    /// specify a prefix and `recursive` is true, then all variables with that
+    /// prefix are deleted. You must set a `recursive` to true if you delete
+    /// variables by prefix.
+    /// 
+    /// # Arguments
+    ///
+    /// * `name` - The name of the variable to delete, in the format:
+    ///            `projects/[PROJECT_ID]/configs/[CONFIG_NAME]/variables/[VARIABLE_NAME]`
+    pub fn configs_variables_delete(&self, name: &str) -> ProjectConfigVariableDeleteCall<'a, C, A> {
+        ProjectConfigVariableDeleteCall {
+            hub: self.hub,
+            _name: name.to_string(),
+            _recursive: Default::default(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Updates an existing variable with a new value.
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    /// * `name` - The name of the variable to update, in the format:
+    ///            `projects/[PROJECT_ID]/configs/[CONFIG_NAME]/variables/[VARIABLE_NAME]`
+    pub fn configs_variables_update(&self, request: Variable, name: &str) -> ProjectConfigVariableUpdateCall<'a, C, A> {
+        ProjectConfigVariableUpdateCall {
+            hub: self.hub,
+            _request: request,
+            _name: name.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Gets information about a single waiter.
+    /// 
+    /// # Arguments
+    ///
+    /// * `name` - The fully-qualified name of the Waiter resource object to retrieve, in the
+    ///            format:
+    ///            `projects/[PROJECT_ID]/configs/[CONFIG_NAME]/waiters/[WAITER_NAME]`
+    pub fn configs_waiters_get(&self, name: &str) -> ProjectConfigWaiterGetCall<'a, C, A> {
+        ProjectConfigWaiterGetCall {
+            hub: self.hub,
+            _name: name.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Lists variables within given a configuration, matching any provided filters.
+    /// This only lists variable names, not the values, unless `return_values` is
+    /// true, in which case only variables that user has IAM permission to GetVariable
+    /// will be returned.
+    /// 
+    /// # Arguments
+    ///
+    /// * `parent` - The path to the RuntimeConfig resource for which you want to list variables.
+    ///              The configuration must exist beforehand; the path must be in the format:
+    ///              `projects/[PROJECT_ID]/configs/[CONFIG_NAME]`
+    pub fn configs_variables_list(&self, parent: &str) -> ProjectConfigVariableListCall<'a, C, A> {
+        ProjectConfigVariableListCall {
+            hub: self.hub,
+            _parent: parent.to_string(),
+            _return_values: Default::default(),
+            _page_token: Default::default(),
+            _page_size: Default::default(),
+            _filter: Default::default(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Creates a new RuntimeConfig resource. The configuration name must be
+    /// unique within project.
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    /// * `parent` - The [project ID](https://support.google.com/cloud/answer/6158840?hl=en&ref_topic=6158848)
+    ///              for this request, in the format `projects/[PROJECT_ID]`.
+    pub fn configs_create(&self, request: RuntimeConfig, parent: &str) -> ProjectConfigCreateCall<'a, C, A> {
+        ProjectConfigCreateCall {
+            hub: self.hub,
+            _request: request,
+            _parent: parent.to_string(),
+            _request_id: Default::default(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+}
+
+
+
+
+
+// ###################
+// CallBuilders   ###
+// #################
+
+/// Watches a specific variable and waits for a change in the variable's value.
+/// When there is a change, this method returns the new value or times out.
+/// 
+/// If a variable is deleted while being watched, the `variableState` state is
+/// set to `DELETED` and the method returns the last known variable `value`.
+/// 
+/// If you set the deadline for watching to a larger value than internal timeout
+/// (60 seconds), the current variable value is returned and the `variableState`
+/// will be `VARIABLE_STATE_UNSPECIFIED`.
+/// 
+/// To learn more about creating a watcher, read the
+/// [Watching a Variable for Changes](/deployment-manager/runtime-configurator/watching-a-variable)
+/// documentation.
+///
+/// A builder for the *configs.variables.watch* method supported by a *project* resource.
+/// It is not used directly, but through a `ProjectMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_runtimeconfig1_beta1 as runtimeconfig1_beta1;
+/// use runtimeconfig1_beta1::WatchVariableRequest;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use runtimeconfig1_beta1::CloudRuntimeConfig;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = CloudRuntimeConfig::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = WatchVariableRequest::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.projects().configs_variables_watch(req, "name")
+///              .doit();
+/// # }
+/// ```
+pub struct ProjectConfigVariableWatchCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a CloudRuntimeConfig<C, A>,
+    _request: WatchVariableRequest,
+    _name: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for ProjectConfigVariableWatchCall<'a, C, A> {}
+
+impl<'a, C, A> ProjectConfigVariableWatchCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, Variable)> {
+        use url::percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "runtimeconfig.projects.configs.variables.watch",
+                               http_method: hyper::method::Method::Post });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((4 + self._additional_params.len()));
+        params.push(("name", self._name.to_string()));
+        for &field in ["alt", "name"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1beta1/{+name}:watch";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{+name}", "name")].iter() {
+            let mut replace_with = String::new();
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = value.to_string();
+                    break;
+                }
+            }
+            if find_this.as_bytes()[1] == '+' as u8 {
+                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET);
+            }
+            url = url.replace(find_this, &replace_with);
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["name"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Post, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: WatchVariableRequest) -> ProjectConfigVariableWatchCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// The name of the variable to watch, in the format:
+    /// 
+    /// `projects/[PROJECT_ID]/configs/[CONFIG_NAME]`
+    ///
+    /// Sets the *name* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn name(mut self, new_value: &str) -> ProjectConfigVariableWatchCall<'a, C, A> {
+        self._name = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> ProjectConfigVariableWatchCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> ProjectConfigVariableWatchCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> ProjectConfigVariableWatchCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Returns permissions that a caller has on the specified resource.
+/// If the resource does not exist, this will return an empty set of
+/// permissions, not a NOT_FOUND error.
+/// 
+/// Note: This operation is designed to be used for building permission-aware
+/// UIs and command-line tools, not for authorization checking. This operation
+/// may "fail open" without warning.
+///
+/// A builder for the *configs.variables.testIamPermissions* method supported by a *project* resource.
+/// It is not used directly, but through a `ProjectMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_runtimeconfig1_beta1 as runtimeconfig1_beta1;
+/// use runtimeconfig1_beta1::TestIamPermissionsRequest;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use runtimeconfig1_beta1::CloudRuntimeConfig;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = CloudRuntimeConfig::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = TestIamPermissionsRequest::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.projects().configs_variables_test_iam_permissions(req, "resource")
+///              .doit();
+/// # }
+/// ```
+pub struct ProjectConfigVariableTestIamPermissionCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a CloudRuntimeConfig<C, A>,
+    _request: TestIamPermissionsRequest,
+    _resource: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for ProjectConfigVariableTestIamPermissionCall<'a, C, A> {}
+
+impl<'a, C, A> ProjectConfigVariableTestIamPermissionCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, TestIamPermissionsResponse)> {
+        use url::percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "runtimeconfig.projects.configs.variables.testIamPermissions",
+                               http_method: hyper::method::Method::Post });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((4 + self._additional_params.len()));
+        params.push(("resource", self._resource.to_string()));
+        for &field in ["alt", "resource"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1beta1/{+resource}:testIamPermissions";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{+resource}", "resource")].iter() {
+            let mut replace_with = String::new();
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = value.to_string();
+                    break;
+                }
+            }
+            if find_this.as_bytes()[1] == '+' as u8 {
+                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET);
+            }
+            url = url.replace(find_this, &replace_with);
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["resource"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Post, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: TestIamPermissionsRequest) -> ProjectConfigVariableTestIamPermissionCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// REQUIRED: The resource for which the policy detail is being requested.
+    /// See the operation documentation for the appropriate value for this field.
+    ///
+    /// Sets the *resource* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn resource(mut self, new_value: &str) -> ProjectConfigVariableTestIamPermissionCall<'a, C, A> {
+        self._resource = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> ProjectConfigVariableTestIamPermissionCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> ProjectConfigVariableTestIamPermissionCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> ProjectConfigVariableTestIamPermissionCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Updates a RuntimeConfig resource. The configuration must exist beforehand.
+///
+/// A builder for the *configs.update* method supported by a *project* resource.
+/// It is not used directly, but through a `ProjectMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_runtimeconfig1_beta1 as runtimeconfig1_beta1;
+/// use runtimeconfig1_beta1::RuntimeConfig;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use runtimeconfig1_beta1::CloudRuntimeConfig;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = CloudRuntimeConfig::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = RuntimeConfig::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.projects().configs_update(req, "name")
+///              .doit();
+/// # }
+/// ```
+pub struct ProjectConfigUpdateCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a CloudRuntimeConfig<C, A>,
+    _request: RuntimeConfig,
+    _name: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for ProjectConfigUpdateCall<'a, C, A> {}
+
+impl<'a, C, A> ProjectConfigUpdateCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, RuntimeConfig)> {
+        use url::percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "runtimeconfig.projects.configs.update",
+                               http_method: hyper::method::Method::Put });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((4 + self._additional_params.len()));
+        params.push(("name", self._name.to_string()));
+        for &field in ["alt", "name"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1beta1/{+name}";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{+name}", "name")].iter() {
+            let mut replace_with = String::new();
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = value.to_string();
+                    break;
+                }
+            }
+            if find_this.as_bytes()[1] == '+' as u8 {
+                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET);
+            }
+            url = url.replace(find_this, &replace_with);
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["name"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Put, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: RuntimeConfig) -> ProjectConfigUpdateCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// The name of the RuntimeConfig resource to update, in the format:
+    /// 
+    /// `projects/[PROJECT_ID]/configs/[CONFIG_NAME]`
+    ///
+    /// Sets the *name* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn name(mut self, new_value: &str) -> ProjectConfigUpdateCall<'a, C, A> {
+        self._name = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> ProjectConfigUpdateCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> ProjectConfigUpdateCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> ProjectConfigUpdateCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Returns permissions that a caller has on the specified resource.
+/// If the resource does not exist, this will return an empty set of
+/// permissions, not a NOT_FOUND error.
+/// 
+/// Note: This operation is designed to be used for building permission-aware
+/// UIs and command-line tools, not for authorization checking. This operation
+/// may "fail open" without warning.
+///
+/// A builder for the *configs.waiters.testIamPermissions* method supported by a *project* resource.
+/// It is not used directly, but through a `ProjectMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_runtimeconfig1_beta1 as runtimeconfig1_beta1;
+/// use runtimeconfig1_beta1::TestIamPermissionsRequest;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use runtimeconfig1_beta1::CloudRuntimeConfig;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = CloudRuntimeConfig::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = TestIamPermissionsRequest::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.projects().configs_waiters_test_iam_permissions(req, "resource")
+///              .doit();
+/// # }
+/// ```
+pub struct ProjectConfigWaiterTestIamPermissionCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a CloudRuntimeConfig<C, A>,
+    _request: TestIamPermissionsRequest,
+    _resource: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for ProjectConfigWaiterTestIamPermissionCall<'a, C, A> {}
+
+impl<'a, C, A> ProjectConfigWaiterTestIamPermissionCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, TestIamPermissionsResponse)> {
+        use url::percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "runtimeconfig.projects.configs.waiters.testIamPermissions",
+                               http_method: hyper::method::Method::Post });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((4 + self._additional_params.len()));
+        params.push(("resource", self._resource.to_string()));
+        for &field in ["alt", "resource"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1beta1/{+resource}:testIamPermissions";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{+resource}", "resource")].iter() {
+            let mut replace_with = String::new();
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = value.to_string();
+                    break;
+                }
+            }
+            if find_this.as_bytes()[1] == '+' as u8 {
+                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET);
+            }
+            url = url.replace(find_this, &replace_with);
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["resource"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Post, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: TestIamPermissionsRequest) -> ProjectConfigWaiterTestIamPermissionCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// REQUIRED: The resource for which the policy detail is being requested.
+    /// See the operation documentation for the appropriate value for this field.
+    ///
+    /// Sets the *resource* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn resource(mut self, new_value: &str) -> ProjectConfigWaiterTestIamPermissionCall<'a, C, A> {
+        self._resource = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> ProjectConfigWaiterTestIamPermissionCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> ProjectConfigWaiterTestIamPermissionCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> ProjectConfigWaiterTestIamPermissionCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Sets the access control policy on the specified resource. Replaces any
+/// existing policy.
+///
+/// A builder for the *configs.setIamPolicy* method supported by a *project* resource.
+/// It is not used directly, but through a `ProjectMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_runtimeconfig1_beta1 as runtimeconfig1_beta1;
+/// use runtimeconfig1_beta1::SetIamPolicyRequest;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use runtimeconfig1_beta1::CloudRuntimeConfig;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = CloudRuntimeConfig::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = SetIamPolicyRequest::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.projects().configs_set_iam_policy(req, "resource")
+///              .doit();
+/// # }
+/// ```
+pub struct ProjectConfigSetIamPolicyCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a CloudRuntimeConfig<C, A>,
+    _request: SetIamPolicyRequest,
+    _resource: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for ProjectConfigSetIamPolicyCall<'a, C, A> {}
+
+impl<'a, C, A> ProjectConfigSetIamPolicyCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, Policy)> {
+        use url::percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "runtimeconfig.projects.configs.setIamPolicy",
+                               http_method: hyper::method::Method::Post });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((4 + self._additional_params.len()));
+        params.push(("resource", self._resource.to_string()));
+        for &field in ["alt", "resource"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1beta1/{+resource}:setIamPolicy";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{+resource}", "resource")].iter() {
+            let mut replace_with = String::new();
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = value.to_string();
+                    break;
+                }
+            }
+            if find_this.as_bytes()[1] == '+' as u8 {
+                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET);
+            }
+            url = url.replace(find_this, &replace_with);
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["resource"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Post, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: SetIamPolicyRequest) -> ProjectConfigSetIamPolicyCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// REQUIRED: The resource for which the policy is being specified.
+    /// See the operation documentation for the appropriate value for this field.
+    ///
+    /// Sets the *resource* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn resource(mut self, new_value: &str) -> ProjectConfigSetIamPolicyCall<'a, C, A> {
+        self._resource = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> ProjectConfigSetIamPolicyCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> ProjectConfigSetIamPolicyCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> ProjectConfigSetIamPolicyCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Gets information about a RuntimeConfig resource.
+///
+/// A builder for the *configs.get* method supported by a *project* resource.
+/// It is not used directly, but through a `ProjectMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_runtimeconfig1_beta1 as runtimeconfig1_beta1;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use runtimeconfig1_beta1::CloudRuntimeConfig;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = CloudRuntimeConfig::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.projects().configs_get("name")
+///              .doit();
+/// # }
+/// ```
+pub struct ProjectConfigGetCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a CloudRuntimeConfig<C, A>,
+    _name: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for ProjectConfigGetCall<'a, C, A> {}
+
+impl<'a, C, A> ProjectConfigGetCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, RuntimeConfig)> {
+        use url::percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "runtimeconfig.projects.configs.get",
+                               http_method: hyper::method::Method::Get });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((3 + self._additional_params.len()));
+        params.push(("name", self._name.to_string()));
+        for &field in ["alt", "name"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1beta1/{+name}";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{+name}", "name")].iter() {
+            let mut replace_with = String::new();
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = value.to_string();
+                    break;
+                }
+            }
+            if find_this.as_bytes()[1] == '+' as u8 {
+                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET);
+            }
+            url = url.replace(find_this, &replace_with);
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["name"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Get, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    /// The name of the RuntimeConfig resource to retrieve, in the format:
+    /// 
+    /// `projects/[PROJECT_ID]/configs/[CONFIG_NAME]`
+    ///
+    /// Sets the *name* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn name(mut self, new_value: &str) -> ProjectConfigGetCall<'a, C, A> {
+        self._name = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> ProjectConfigGetCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> ProjectConfigGetCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> ProjectConfigGetCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Gets the access control policy for a resource.
+/// Returns an empty policy if the resource exists and does not have a policy
+/// set.
+///
+/// A builder for the *configs.getIamPolicy* method supported by a *project* resource.
+/// It is not used directly, but through a `ProjectMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_runtimeconfig1_beta1 as runtimeconfig1_beta1;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use runtimeconfig1_beta1::CloudRuntimeConfig;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = CloudRuntimeConfig::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.projects().configs_get_iam_policy("resource")
+///              .doit();
+/// # }
+/// ```
+pub struct ProjectConfigGetIamPolicyCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a CloudRuntimeConfig<C, A>,
+    _resource: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for ProjectConfigGetIamPolicyCall<'a, C, A> {}
+
+impl<'a, C, A> ProjectConfigGetIamPolicyCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, Policy)> {
+        use url::percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "runtimeconfig.projects.configs.getIamPolicy",
+                               http_method: hyper::method::Method::Get });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((3 + self._additional_params.len()));
+        params.push(("resource", self._resource.to_string()));
+        for &field in ["alt", "resource"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1beta1/{+resource}:getIamPolicy";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{+resource}", "resource")].iter() {
+            let mut replace_with = String::new();
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = value.to_string();
+                    break;
+                }
+            }
+            if find_this.as_bytes()[1] == '+' as u8 {
+                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET);
+            }
+            url = url.replace(find_this, &replace_with);
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["resource"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Get, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    /// REQUIRED: The resource for which the policy is being requested.
+    /// See the operation documentation for the appropriate value for this field.
+    ///
+    /// Sets the *resource* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn resource(mut self, new_value: &str) -> ProjectConfigGetIamPolicyCall<'a, C, A> {
+        self._resource = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> ProjectConfigGetIamPolicyCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> ProjectConfigGetIamPolicyCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> ProjectConfigGetIamPolicyCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Deletes the waiter with the specified name.
+///
+/// A builder for the *configs.waiters.delete* method supported by a *project* resource.
+/// It is not used directly, but through a `ProjectMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_runtimeconfig1_beta1 as runtimeconfig1_beta1;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use runtimeconfig1_beta1::CloudRuntimeConfig;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = CloudRuntimeConfig::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.projects().configs_waiters_delete("name")
+///              .doit();
+/// # }
+/// ```
+pub struct ProjectConfigWaiterDeleteCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a CloudRuntimeConfig<C, A>,
+    _name: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for ProjectConfigWaiterDeleteCall<'a, C, A> {}
+
+impl<'a, C, A> ProjectConfigWaiterDeleteCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, Empty)> {
+        use url::percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "runtimeconfig.projects.configs.waiters.delete",
+                               http_method: hyper::method::Method::Delete });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((3 + self._additional_params.len()));
+        params.push(("name", self._name.to_string()));
+        for &field in ["alt", "name"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1beta1/{+name}";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{+name}", "name")].iter() {
+            let mut replace_with = String::new();
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = value.to_string();
+                    break;
+                }
+            }
+            if find_this.as_bytes()[1] == '+' as u8 {
+                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET);
+            }
+            url = url.replace(find_this, &replace_with);
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["name"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Delete, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    /// The Waiter resource to delete, in the format:
+    /// 
+    ///  `projects/[PROJECT_ID]/configs/[CONFIG_NAME]/waiters/[WAITER_NAME]`
+    ///
+    /// Sets the *name* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn name(mut self, new_value: &str) -> ProjectConfigWaiterDeleteCall<'a, C, A> {
+        self._name = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> ProjectConfigWaiterDeleteCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> ProjectConfigWaiterDeleteCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> ProjectConfigWaiterDeleteCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Creates a variable within the given configuration. You cannot create
+/// a variable with a name that is a prefix of an existing variable name, or a
+/// name that has an existing variable name as a prefix.
+/// 
+/// To learn more about creating a variable, read the
+/// [Setting and Getting Data](/deployment-manager/runtime-configurator/set-and-get-variables)
+/// documentation.
+///
+/// A builder for the *configs.variables.create* method supported by a *project* resource.
+/// It is not used directly, but through a `ProjectMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_runtimeconfig1_beta1 as runtimeconfig1_beta1;
+/// use runtimeconfig1_beta1::Variable;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use runtimeconfig1_beta1::CloudRuntimeConfig;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = CloudRuntimeConfig::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = Variable::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.projects().configs_variables_create(req, "parent")
+///              .request_id("dolores")
+///              .doit();
+/// # }
+/// ```
+pub struct ProjectConfigVariableCreateCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a CloudRuntimeConfig<C, A>,
+    _request: Variable,
+    _parent: String,
+    _request_id: Option<String>,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for ProjectConfigVariableCreateCall<'a, C, A> {}
+
+impl<'a, C, A> ProjectConfigVariableCreateCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, Variable)> {
+        use url::percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "runtimeconfig.projects.configs.variables.create",
+                               http_method: hyper::method::Method::Post });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((5 + self._additional_params.len()));
+        params.push(("parent", self._parent.to_string()));
+        if let Some(value) = self._request_id {
+            params.push(("requestId", value.to_string()));
+        }
+        for &field in ["alt", "parent", "requestId"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1beta1/{+parent}/variables";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{+parent}", "parent")].iter() {
+            let mut replace_with = String::new();
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = value.to_string();
+                    break;
+                }
+            }
+            if find_this.as_bytes()[1] == '+' as u8 {
+                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET);
+            }
+            url = url.replace(find_this, &replace_with);
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["parent"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Post, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: Variable) -> ProjectConfigVariableCreateCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// The path to the RutimeConfig resource that this variable should belong to.
+    /// The configuration must exist beforehand; the path must be in the format:
+    /// 
+    /// `projects/[PROJECT_ID]/configs/[CONFIG_NAME]`
+    ///
+    /// Sets the *parent* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn parent(mut self, new_value: &str) -> ProjectConfigVariableCreateCall<'a, C, A> {
+        self._parent = new_value.to_string();
+        self
+    }
+    /// An optional but recommended unique `request_id`. If the server
+    /// receives two `create()` requests  with the same
+    /// `request_id`, then the second request will be ignored and the
+    /// first resource created and stored in the backend is returned.
+    /// Empty `request_id` fields are ignored.
+    /// 
+    /// It is responsibility of the client to ensure uniqueness of the
+    /// `request_id` strings.
+    /// 
+    /// `request_id` strings are limited to 64 characters.
+    ///
+    /// Sets the *request id* query property to the given value.
+    pub fn request_id(mut self, new_value: &str) -> ProjectConfigVariableCreateCall<'a, C, A> {
+        self._request_id = Some(new_value.to_string());
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> ProjectConfigVariableCreateCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> ProjectConfigVariableCreateCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> ProjectConfigVariableCreateCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// List waiters within the given configuration.
+///
+/// A builder for the *configs.waiters.list* method supported by a *project* resource.
+/// It is not used directly, but through a `ProjectMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_runtimeconfig1_beta1 as runtimeconfig1_beta1;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use runtimeconfig1_beta1::CloudRuntimeConfig;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = CloudRuntimeConfig::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.projects().configs_waiters_list("parent")
+///              .page_token("sadipscing")
+///              .page_size(-31)
+///              .doit();
+/// # }
+/// ```
+pub struct ProjectConfigWaiterListCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a CloudRuntimeConfig<C, A>,
+    _parent: String,
+    _page_token: Option<String>,
+    _page_size: Option<i32>,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for ProjectConfigWaiterListCall<'a, C, A> {}
+
+impl<'a, C, A> ProjectConfigWaiterListCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, ListWaitersResponse)> {
+        use url::percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "runtimeconfig.projects.configs.waiters.list",
+                               http_method: hyper::method::Method::Get });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((5 + self._additional_params.len()));
+        params.push(("parent", self._parent.to_string()));
+        if let Some(value) = self._page_token {
+            params.push(("pageToken", value.to_string()));
+        }
+        if let Some(value) = self._page_size {
+            params.push(("pageSize", value.to_string()));
+        }
+        for &field in ["alt", "parent", "pageToken", "pageSize"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1beta1/{+parent}/waiters";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{+parent}", "parent")].iter() {
+            let mut replace_with = String::new();
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = value.to_string();
+                    break;
+                }
+            }
+            if find_this.as_bytes()[1] == '+' as u8 {
+                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET);
+            }
+            url = url.replace(find_this, &replace_with);
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["parent"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Get, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    /// The path to the configuration for which you want to get a list of waiters.
+    /// The configuration must exist beforehand; the path must be in the format:
+    /// 
+    /// `projects/[PROJECT_ID]/configs/[CONFIG_NAME]`
+    ///
+    /// Sets the *parent* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn parent(mut self, new_value: &str) -> ProjectConfigWaiterListCall<'a, C, A> {
+        self._parent = new_value.to_string();
+        self
+    }
+    /// Specifies a page token to use. Set `pageToken` to a `nextPageToken`
+    /// returned by a previous list request to get the next page of results.
+    ///
+    /// Sets the *page token* query property to the given value.
+    pub fn page_token(mut self, new_value: &str) -> ProjectConfigWaiterListCall<'a, C, A> {
+        self._page_token = Some(new_value.to_string());
+        self
+    }
+    /// Specifies the number of results to return per page. If there are fewer
+    /// elements than the specified number, returns all elements.
+    ///
+    /// Sets the *page size* query property to the given value.
+    pub fn page_size(mut self, new_value: i32) -> ProjectConfigWaiterListCall<'a, C, A> {
+        self._page_size = Some(new_value);
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> ProjectConfigWaiterListCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> ProjectConfigWaiterListCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> ProjectConfigWaiterListCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Creates a Waiter resource. This operation returns a long-running Operation
+/// resource which can be polled for completion. However, a waiter with the
+/// given name will exist (and can be retrieved) prior to the operation
+/// completing. If the operation fails, the failed Waiter resource will
+/// still exist and must be deleted prior to subsequent creation attempts.
+///
+/// A builder for the *configs.waiters.create* method supported by a *project* resource.
+/// It is not used directly, but through a `ProjectMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_runtimeconfig1_beta1 as runtimeconfig1_beta1;
+/// use runtimeconfig1_beta1::Waiter;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use runtimeconfig1_beta1::CloudRuntimeConfig;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = CloudRuntimeConfig::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = Waiter::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.projects().configs_waiters_create(req, "parent")
+///              .request_id("no")
+///              .doit();
+/// # }
+/// ```
+pub struct ProjectConfigWaiterCreateCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a CloudRuntimeConfig<C, A>,
+    _request: Waiter,
+    _parent: String,
+    _request_id: Option<String>,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for ProjectConfigWaiterCreateCall<'a, C, A> {}
+
+impl<'a, C, A> ProjectConfigWaiterCreateCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, Operation)> {
+        use url::percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "runtimeconfig.projects.configs.waiters.create",
+                               http_method: hyper::method::Method::Post });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((5 + self._additional_params.len()));
+        params.push(("parent", self._parent.to_string()));
+        if let Some(value) = self._request_id {
+            params.push(("requestId", value.to_string()));
+        }
+        for &field in ["alt", "parent", "requestId"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1beta1/{+parent}/waiters";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{+parent}", "parent")].iter() {
+            let mut replace_with = String::new();
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = value.to_string();
+                    break;
+                }
+            }
+            if find_this.as_bytes()[1] == '+' as u8 {
+                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET);
+            }
+            url = url.replace(find_this, &replace_with);
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["parent"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Post, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: Waiter) -> ProjectConfigWaiterCreateCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// The path to the configuration that will own the waiter.
+    /// The configuration must exist beforehand; the path must be in the format:
+    /// 
+    /// `projects/[PROJECT_ID]/configs/[CONFIG_NAME]`.
+    ///
+    /// Sets the *parent* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn parent(mut self, new_value: &str) -> ProjectConfigWaiterCreateCall<'a, C, A> {
+        self._parent = new_value.to_string();
+        self
+    }
+    /// An optional but recommended unique `request_id`. If the server
+    /// receives two `create()` requests  with the same
+    /// `request_id`, then the second request will be ignored and the
+    /// first resource created and stored in the backend is returned.
+    /// Empty `request_id` fields are ignored.
+    /// 
+    /// It is responsibility of the client to ensure uniqueness of the
+    /// `request_id` strings.
+    /// 
+    /// `request_id` strings are limited to 64 characters.
+    ///
+    /// Sets the *request id* query property to the given value.
+    pub fn request_id(mut self, new_value: &str) -> ProjectConfigWaiterCreateCall<'a, C, A> {
+        self._request_id = Some(new_value.to_string());
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> ProjectConfigWaiterCreateCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> ProjectConfigWaiterCreateCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> ProjectConfigWaiterCreateCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Gets the latest state of a long-running operation.  Clients can use this
+/// method to poll the operation result at intervals as recommended by the API
+/// service.
+///
+/// A builder for the *configs.operations.get* method supported by a *project* resource.
+/// It is not used directly, but through a `ProjectMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_runtimeconfig1_beta1 as runtimeconfig1_beta1;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use runtimeconfig1_beta1::CloudRuntimeConfig;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = CloudRuntimeConfig::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.projects().configs_operations_get("name")
+///              .doit();
+/// # }
+/// ```
+pub struct ProjectConfigOperationGetCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a CloudRuntimeConfig<C, A>,
+    _name: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for ProjectConfigOperationGetCall<'a, C, A> {}
+
+impl<'a, C, A> ProjectConfigOperationGetCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, Operation)> {
+        use url::percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "runtimeconfig.projects.configs.operations.get",
+                               http_method: hyper::method::Method::Get });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((3 + self._additional_params.len()));
+        params.push(("name", self._name.to_string()));
+        for &field in ["alt", "name"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1beta1/{+name}";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{+name}", "name")].iter() {
+            let mut replace_with = String::new();
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = value.to_string();
+                    break;
+                }
+            }
+            if find_this.as_bytes()[1] == '+' as u8 {
+                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET);
+            }
+            url = url.replace(find_this, &replace_with);
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["name"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Get, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    /// The name of the operation resource.
+    ///
+    /// Sets the *name* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn name(mut self, new_value: &str) -> ProjectConfigOperationGetCall<'a, C, A> {
+        self._name = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> ProjectConfigOperationGetCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> ProjectConfigOperationGetCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> ProjectConfigOperationGetCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Gets information about a single variable.
+///
+/// A builder for the *configs.variables.get* method supported by a *project* resource.
+/// It is not used directly, but through a `ProjectMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_runtimeconfig1_beta1 as runtimeconfig1_beta1;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use runtimeconfig1_beta1::CloudRuntimeConfig;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = CloudRuntimeConfig::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.projects().configs_variables_get("name")
+///              .doit();
+/// # }
+/// ```
+pub struct ProjectConfigVariableGetCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a CloudRuntimeConfig<C, A>,
+    _name: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for ProjectConfigVariableGetCall<'a, C, A> {}
+
+impl<'a, C, A> ProjectConfigVariableGetCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, Variable)> {
+        use url::percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "runtimeconfig.projects.configs.variables.get",
+                               http_method: hyper::method::Method::Get });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((3 + self._additional_params.len()));
+        params.push(("name", self._name.to_string()));
+        for &field in ["alt", "name"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1beta1/{+name}";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{+name}", "name")].iter() {
+            let mut replace_with = String::new();
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = value.to_string();
+                    break;
+                }
+            }
+            if find_this.as_bytes()[1] == '+' as u8 {
+                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET);
+            }
+            url = url.replace(find_this, &replace_with);
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["name"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Get, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    /// The name of the variable to return, in the format:
+    /// 
+    /// `projects/[PROJECT_ID]/configs/[CONFIG_NAME]/variables/[VARIBLE_NAME]`
+    ///
+    /// Sets the *name* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn name(mut self, new_value: &str) -> ProjectConfigVariableGetCall<'a, C, A> {
+        self._name = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> ProjectConfigVariableGetCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> ProjectConfigVariableGetCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> ProjectConfigVariableGetCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Deletes a RuntimeConfig resource.
+///
+/// A builder for the *configs.delete* method supported by a *project* resource.
+/// It is not used directly, but through a `ProjectMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_runtimeconfig1_beta1 as runtimeconfig1_beta1;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use runtimeconfig1_beta1::CloudRuntimeConfig;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = CloudRuntimeConfig::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.projects().configs_delete("name")
+///              .doit();
+/// # }
+/// ```
+pub struct ProjectConfigDeleteCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a CloudRuntimeConfig<C, A>,
+    _name: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for ProjectConfigDeleteCall<'a, C, A> {}
+
+impl<'a, C, A> ProjectConfigDeleteCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, Empty)> {
+        use url::percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "runtimeconfig.projects.configs.delete",
+                               http_method: hyper::method::Method::Delete });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((3 + self._additional_params.len()));
+        params.push(("name", self._name.to_string()));
+        for &field in ["alt", "name"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1beta1/{+name}";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{+name}", "name")].iter() {
+            let mut replace_with = String::new();
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = value.to_string();
+                    break;
+                }
+            }
+            if find_this.as_bytes()[1] == '+' as u8 {
+                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET);
+            }
+            url = url.replace(find_this, &replace_with);
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["name"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Delete, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    /// The RuntimeConfig resource to delete, in the format:
+    /// 
+    /// `projects/[PROJECT_ID]/configs/[CONFIG_NAME]`
+    ///
+    /// Sets the *name* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn name(mut self, new_value: &str) -> ProjectConfigDeleteCall<'a, C, A> {
+        self._name = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> ProjectConfigDeleteCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> ProjectConfigDeleteCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> ProjectConfigDeleteCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Returns permissions that a caller has on the specified resource.
+/// If the resource does not exist, this will return an empty set of
+/// permissions, not a NOT_FOUND error.
+/// 
+/// Note: This operation is designed to be used for building permission-aware
+/// UIs and command-line tools, not for authorization checking. This operation
+/// may "fail open" without warning.
+///
+/// A builder for the *configs.operations.testIamPermissions* method supported by a *project* resource.
+/// It is not used directly, but through a `ProjectMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_runtimeconfig1_beta1 as runtimeconfig1_beta1;
+/// use runtimeconfig1_beta1::TestIamPermissionsRequest;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use runtimeconfig1_beta1::CloudRuntimeConfig;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = CloudRuntimeConfig::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = TestIamPermissionsRequest::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.projects().configs_operations_test_iam_permissions(req, "resource")
+///              .doit();
+/// # }
+/// ```
+pub struct ProjectConfigOperationTestIamPermissionCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a CloudRuntimeConfig<C, A>,
+    _request: TestIamPermissionsRequest,
+    _resource: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for ProjectConfigOperationTestIamPermissionCall<'a, C, A> {}
+
+impl<'a, C, A> ProjectConfigOperationTestIamPermissionCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, TestIamPermissionsResponse)> {
+        use url::percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "runtimeconfig.projects.configs.operations.testIamPermissions",
+                               http_method: hyper::method::Method::Post });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((4 + self._additional_params.len()));
+        params.push(("resource", self._resource.to_string()));
+        for &field in ["alt", "resource"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1beta1/{+resource}:testIamPermissions";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{+resource}", "resource")].iter() {
+            let mut replace_with = String::new();
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = value.to_string();
+                    break;
+                }
+            }
+            if find_this.as_bytes()[1] == '+' as u8 {
+                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET);
+            }
+            url = url.replace(find_this, &replace_with);
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["resource"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Post, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: TestIamPermissionsRequest) -> ProjectConfigOperationTestIamPermissionCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// REQUIRED: The resource for which the policy detail is being requested.
+    /// See the operation documentation for the appropriate value for this field.
+    ///
+    /// Sets the *resource* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn resource(mut self, new_value: &str) -> ProjectConfigOperationTestIamPermissionCall<'a, C, A> {
+        self._resource = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> ProjectConfigOperationTestIamPermissionCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> ProjectConfigOperationTestIamPermissionCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> ProjectConfigOperationTestIamPermissionCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Returns permissions that a caller has on the specified resource.
+/// If the resource does not exist, this will return an empty set of
+/// permissions, not a NOT_FOUND error.
+/// 
+/// Note: This operation is designed to be used for building permission-aware
+/// UIs and command-line tools, not for authorization checking. This operation
+/// may "fail open" without warning.
+///
+/// A builder for the *configs.testIamPermissions* method supported by a *project* resource.
+/// It is not used directly, but through a `ProjectMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_runtimeconfig1_beta1 as runtimeconfig1_beta1;
+/// use runtimeconfig1_beta1::TestIamPermissionsRequest;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use runtimeconfig1_beta1::CloudRuntimeConfig;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = CloudRuntimeConfig::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = TestIamPermissionsRequest::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.projects().configs_test_iam_permissions(req, "resource")
+///              .doit();
+/// # }
+/// ```
+pub struct ProjectConfigTestIamPermissionCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a CloudRuntimeConfig<C, A>,
+    _request: TestIamPermissionsRequest,
+    _resource: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for ProjectConfigTestIamPermissionCall<'a, C, A> {}
+
+impl<'a, C, A> ProjectConfigTestIamPermissionCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, TestIamPermissionsResponse)> {
+        use url::percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "runtimeconfig.projects.configs.testIamPermissions",
+                               http_method: hyper::method::Method::Post });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((4 + self._additional_params.len()));
+        params.push(("resource", self._resource.to_string()));
+        for &field in ["alt", "resource"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1beta1/{+resource}:testIamPermissions";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{+resource}", "resource")].iter() {
+            let mut replace_with = String::new();
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = value.to_string();
+                    break;
+                }
+            }
+            if find_this.as_bytes()[1] == '+' as u8 {
+                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET);
+            }
+            url = url.replace(find_this, &replace_with);
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["resource"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Post, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: TestIamPermissionsRequest) -> ProjectConfigTestIamPermissionCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// REQUIRED: The resource for which the policy detail is being requested.
+    /// See the operation documentation for the appropriate value for this field.
+    ///
+    /// Sets the *resource* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn resource(mut self, new_value: &str) -> ProjectConfigTestIamPermissionCall<'a, C, A> {
+        self._resource = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> ProjectConfigTestIamPermissionCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> ProjectConfigTestIamPermissionCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> ProjectConfigTestIamPermissionCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Lists all the RuntimeConfig resources within project.
+///
+/// A builder for the *configs.list* method supported by a *project* resource.
+/// It is not used directly, but through a `ProjectMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_runtimeconfig1_beta1 as runtimeconfig1_beta1;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use runtimeconfig1_beta1::CloudRuntimeConfig;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = CloudRuntimeConfig::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.projects().configs_list("parent")
+///              .page_token("Lorem")
+///              .page_size(-21)
+///              .doit();
+/// # }
+/// ```
+pub struct ProjectConfigListCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a CloudRuntimeConfig<C, A>,
+    _parent: String,
+    _page_token: Option<String>,
+    _page_size: Option<i32>,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for ProjectConfigListCall<'a, C, A> {}
+
+impl<'a, C, A> ProjectConfigListCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, ListConfigsResponse)> {
+        use url::percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "runtimeconfig.projects.configs.list",
+                               http_method: hyper::method::Method::Get });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((5 + self._additional_params.len()));
+        params.push(("parent", self._parent.to_string()));
+        if let Some(value) = self._page_token {
+            params.push(("pageToken", value.to_string()));
+        }
+        if let Some(value) = self._page_size {
+            params.push(("pageSize", value.to_string()));
+        }
+        for &field in ["alt", "parent", "pageToken", "pageSize"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1beta1/{+parent}/configs";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{+parent}", "parent")].iter() {
+            let mut replace_with = String::new();
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = value.to_string();
+                    break;
+                }
+            }
+            if find_this.as_bytes()[1] == '+' as u8 {
+                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET);
+            }
+            url = url.replace(find_this, &replace_with);
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["parent"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Get, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    /// The [project ID](https://support.google.com/cloud/answer/6158840?hl=en&ref_topic=6158848)
+    /// for this request, in the format `projects/[PROJECT_ID]`.
+    ///
+    /// Sets the *parent* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn parent(mut self, new_value: &str) -> ProjectConfigListCall<'a, C, A> {
+        self._parent = new_value.to_string();
+        self
+    }
+    /// Specifies a page token to use. Set `pageToken` to a `nextPageToken`
+    /// returned by a previous list request to get the next page of results.
+    ///
+    /// Sets the *page token* query property to the given value.
+    pub fn page_token(mut self, new_value: &str) -> ProjectConfigListCall<'a, C, A> {
+        self._page_token = Some(new_value.to_string());
+        self
+    }
+    /// Specifies the number of results to return per page. If there are fewer
+    /// elements than the specified number, returns all elements.
+    ///
+    /// Sets the *page size* query property to the given value.
+    pub fn page_size(mut self, new_value: i32) -> ProjectConfigListCall<'a, C, A> {
+        self._page_size = Some(new_value);
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> ProjectConfigListCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> ProjectConfigListCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> ProjectConfigListCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Deletes a variable or multiple variables.
+/// 
+/// If you specify a variable name, then that variable is deleted. If you
+/// specify a prefix and `recursive` is true, then all variables with that
+/// prefix are deleted. You must set a `recursive` to true if you delete
+/// variables by prefix.
+///
+/// A builder for the *configs.variables.delete* method supported by a *project* resource.
+/// It is not used directly, but through a `ProjectMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_runtimeconfig1_beta1 as runtimeconfig1_beta1;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use runtimeconfig1_beta1::CloudRuntimeConfig;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = CloudRuntimeConfig::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.projects().configs_variables_delete("name")
+///              .recursive(true)
+///              .doit();
+/// # }
+/// ```
+pub struct ProjectConfigVariableDeleteCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a CloudRuntimeConfig<C, A>,
+    _name: String,
+    _recursive: Option<bool>,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for ProjectConfigVariableDeleteCall<'a, C, A> {}
+
+impl<'a, C, A> ProjectConfigVariableDeleteCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, Empty)> {
+        use url::percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "runtimeconfig.projects.configs.variables.delete",
+                               http_method: hyper::method::Method::Delete });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((4 + self._additional_params.len()));
+        params.push(("name", self._name.to_string()));
+        if let Some(value) = self._recursive {
+            params.push(("recursive", value.to_string()));
+        }
+        for &field in ["alt", "name", "recursive"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1beta1/{+name}";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{+name}", "name")].iter() {
+            let mut replace_with = String::new();
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = value.to_string();
+                    break;
+                }
+            }
+            if find_this.as_bytes()[1] == '+' as u8 {
+                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET);
+            }
+            url = url.replace(find_this, &replace_with);
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["name"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Delete, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    /// The name of the variable to delete, in the format:
+    /// 
+    /// `projects/[PROJECT_ID]/configs/[CONFIG_NAME]/variables/[VARIABLE_NAME]`
+    ///
+    /// Sets the *name* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn name(mut self, new_value: &str) -> ProjectConfigVariableDeleteCall<'a, C, A> {
+        self._name = new_value.to_string();
+        self
+    }
+    /// Set to `true` to recursively delete multiple variables with the same
+    /// prefix.
+    ///
+    /// Sets the *recursive* query property to the given value.
+    pub fn recursive(mut self, new_value: bool) -> ProjectConfigVariableDeleteCall<'a, C, A> {
+        self._recursive = Some(new_value);
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> ProjectConfigVariableDeleteCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> ProjectConfigVariableDeleteCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> ProjectConfigVariableDeleteCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Updates an existing variable with a new value.
+///
+/// A builder for the *configs.variables.update* method supported by a *project* resource.
+/// It is not used directly, but through a `ProjectMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_runtimeconfig1_beta1 as runtimeconfig1_beta1;
+/// use runtimeconfig1_beta1::Variable;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use runtimeconfig1_beta1::CloudRuntimeConfig;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = CloudRuntimeConfig::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = Variable::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.projects().configs_variables_update(req, "name")
+///              .doit();
+/// # }
+/// ```
+pub struct ProjectConfigVariableUpdateCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a CloudRuntimeConfig<C, A>,
+    _request: Variable,
+    _name: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for ProjectConfigVariableUpdateCall<'a, C, A> {}
+
+impl<'a, C, A> ProjectConfigVariableUpdateCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, Variable)> {
+        use url::percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "runtimeconfig.projects.configs.variables.update",
+                               http_method: hyper::method::Method::Put });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((4 + self._additional_params.len()));
+        params.push(("name", self._name.to_string()));
+        for &field in ["alt", "name"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1beta1/{+name}";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{+name}", "name")].iter() {
+            let mut replace_with = String::new();
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = value.to_string();
+                    break;
+                }
+            }
+            if find_this.as_bytes()[1] == '+' as u8 {
+                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET);
+            }
+            url = url.replace(find_this, &replace_with);
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["name"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Put, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: Variable) -> ProjectConfigVariableUpdateCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// The name of the variable to update, in the format:
+    /// 
+    /// `projects/[PROJECT_ID]/configs/[CONFIG_NAME]/variables/[VARIABLE_NAME]`
+    ///
+    /// Sets the *name* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn name(mut self, new_value: &str) -> ProjectConfigVariableUpdateCall<'a, C, A> {
+        self._name = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> ProjectConfigVariableUpdateCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> ProjectConfigVariableUpdateCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> ProjectConfigVariableUpdateCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Gets information about a single waiter.
+///
+/// A builder for the *configs.waiters.get* method supported by a *project* resource.
+/// It is not used directly, but through a `ProjectMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_runtimeconfig1_beta1 as runtimeconfig1_beta1;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use runtimeconfig1_beta1::CloudRuntimeConfig;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = CloudRuntimeConfig::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.projects().configs_waiters_get("name")
+///              .doit();
+/// # }
+/// ```
+pub struct ProjectConfigWaiterGetCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a CloudRuntimeConfig<C, A>,
+    _name: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for ProjectConfigWaiterGetCall<'a, C, A> {}
+
+impl<'a, C, A> ProjectConfigWaiterGetCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, Waiter)> {
+        use url::percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "runtimeconfig.projects.configs.waiters.get",
+                               http_method: hyper::method::Method::Get });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((3 + self._additional_params.len()));
+        params.push(("name", self._name.to_string()));
+        for &field in ["alt", "name"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1beta1/{+name}";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{+name}", "name")].iter() {
+            let mut replace_with = String::new();
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = value.to_string();
+                    break;
+                }
+            }
+            if find_this.as_bytes()[1] == '+' as u8 {
+                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET);
+            }
+            url = url.replace(find_this, &replace_with);
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["name"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Get, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    /// The fully-qualified name of the Waiter resource object to retrieve, in the
+    /// format:
+    /// 
+    /// `projects/[PROJECT_ID]/configs/[CONFIG_NAME]/waiters/[WAITER_NAME]`
+    ///
+    /// Sets the *name* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn name(mut self, new_value: &str) -> ProjectConfigWaiterGetCall<'a, C, A> {
+        self._name = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> ProjectConfigWaiterGetCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> ProjectConfigWaiterGetCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> ProjectConfigWaiterGetCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Lists variables within given a configuration, matching any provided filters.
+/// This only lists variable names, not the values, unless `return_values` is
+/// true, in which case only variables that user has IAM permission to GetVariable
+/// will be returned.
+///
+/// A builder for the *configs.variables.list* method supported by a *project* resource.
+/// It is not used directly, but through a `ProjectMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_runtimeconfig1_beta1 as runtimeconfig1_beta1;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use runtimeconfig1_beta1::CloudRuntimeConfig;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = CloudRuntimeConfig::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.projects().configs_variables_list("parent")
+///              .return_values(false)
+///              .page_token("sadipscing")
+///              .page_size(-48)
+///              .filter("eirmod")
+///              .doit();
+/// # }
+/// ```
+pub struct ProjectConfigVariableListCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a CloudRuntimeConfig<C, A>,
+    _parent: String,
+    _return_values: Option<bool>,
+    _page_token: Option<String>,
+    _page_size: Option<i32>,
+    _filter: Option<String>,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for ProjectConfigVariableListCall<'a, C, A> {}
+
+impl<'a, C, A> ProjectConfigVariableListCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, ListVariablesResponse)> {
+        use url::percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "runtimeconfig.projects.configs.variables.list",
+                               http_method: hyper::method::Method::Get });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((7 + self._additional_params.len()));
+        params.push(("parent", self._parent.to_string()));
+        if let Some(value) = self._return_values {
+            params.push(("returnValues", value.to_string()));
+        }
+        if let Some(value) = self._page_token {
+            params.push(("pageToken", value.to_string()));
+        }
+        if let Some(value) = self._page_size {
+            params.push(("pageSize", value.to_string()));
+        }
+        if let Some(value) = self._filter {
+            params.push(("filter", value.to_string()));
+        }
+        for &field in ["alt", "parent", "returnValues", "pageToken", "pageSize", "filter"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1beta1/{+parent}/variables";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{+parent}", "parent")].iter() {
+            let mut replace_with = String::new();
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = value.to_string();
+                    break;
+                }
+            }
+            if find_this.as_bytes()[1] == '+' as u8 {
+                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET);
+            }
+            url = url.replace(find_this, &replace_with);
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["parent"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Get, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    /// The path to the RuntimeConfig resource for which you want to list variables.
+    /// The configuration must exist beforehand; the path must be in the format:
+    /// 
+    /// `projects/[PROJECT_ID]/configs/[CONFIG_NAME]`
+    ///
+    /// Sets the *parent* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn parent(mut self, new_value: &str) -> ProjectConfigVariableListCall<'a, C, A> {
+        self._parent = new_value.to_string();
+        self
+    }
+    /// The flag indicates whether the user wants to return values of variables.
+    /// If true, then only those variables that user has IAM GetVariable permission
+    /// will be returned along with their values.
+    ///
+    /// Sets the *return values* query property to the given value.
+    pub fn return_values(mut self, new_value: bool) -> ProjectConfigVariableListCall<'a, C, A> {
+        self._return_values = Some(new_value);
+        self
+    }
+    /// Specifies a page token to use. Set `pageToken` to a `nextPageToken`
+    /// returned by a previous list request to get the next page of results.
+    ///
+    /// Sets the *page token* query property to the given value.
+    pub fn page_token(mut self, new_value: &str) -> ProjectConfigVariableListCall<'a, C, A> {
+        self._page_token = Some(new_value.to_string());
+        self
+    }
+    /// Specifies the number of results to return per page. If there are fewer
+    /// elements than the specified number, returns all elements.
+    ///
+    /// Sets the *page size* query property to the given value.
+    pub fn page_size(mut self, new_value: i32) -> ProjectConfigVariableListCall<'a, C, A> {
+        self._page_size = Some(new_value);
+        self
+    }
+    /// Filters variables by matching the specified filter. For example:
+    /// 
+    /// `projects/example-project/config/[CONFIG_NAME]/variables/example-variable`.
+    ///
+    /// Sets the *filter* query property to the given value.
+    pub fn filter(mut self, new_value: &str) -> ProjectConfigVariableListCall<'a, C, A> {
+        self._filter = Some(new_value.to_string());
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> ProjectConfigVariableListCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> ProjectConfigVariableListCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> ProjectConfigVariableListCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Creates a new RuntimeConfig resource. The configuration name must be
+/// unique within project.
+///
+/// A builder for the *configs.create* method supported by a *project* resource.
+/// It is not used directly, but through a `ProjectMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_runtimeconfig1_beta1 as runtimeconfig1_beta1;
+/// use runtimeconfig1_beta1::RuntimeConfig;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use runtimeconfig1_beta1::CloudRuntimeConfig;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = CloudRuntimeConfig::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = RuntimeConfig::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.projects().configs_create(req, "parent")
+///              .request_id("amet")
+///              .doit();
+/// # }
+/// ```
+pub struct ProjectConfigCreateCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a CloudRuntimeConfig<C, A>,
+    _request: RuntimeConfig,
+    _parent: String,
+    _request_id: Option<String>,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for ProjectConfigCreateCall<'a, C, A> {}
+
+impl<'a, C, A> ProjectConfigCreateCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, RuntimeConfig)> {
+        use url::percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "runtimeconfig.projects.configs.create",
+                               http_method: hyper::method::Method::Post });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((5 + self._additional_params.len()));
+        params.push(("parent", self._parent.to_string()));
+        if let Some(value) = self._request_id {
+            params.push(("requestId", value.to_string()));
+        }
+        for &field in ["alt", "parent", "requestId"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1beta1/{+parent}/configs";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{+parent}", "parent")].iter() {
+            let mut replace_with = String::new();
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = value.to_string();
+                    break;
+                }
+            }
+            if find_this.as_bytes()[1] == '+' as u8 {
+                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET);
+            }
+            url = url.replace(find_this, &replace_with);
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["parent"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Post, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: RuntimeConfig) -> ProjectConfigCreateCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// The [project ID](https://support.google.com/cloud/answer/6158840?hl=en&ref_topic=6158848)
+    /// for this request, in the format `projects/[PROJECT_ID]`.
+    ///
+    /// Sets the *parent* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn parent(mut self, new_value: &str) -> ProjectConfigCreateCall<'a, C, A> {
+        self._parent = new_value.to_string();
+        self
+    }
+    /// An optional but recommended unique `request_id`. If the server
+    /// receives two `create()` requests  with the same
+    /// `request_id`, then the second request will be ignored and the
+    /// first resource created and stored in the backend is returned.
+    /// Empty `request_id` fields are ignored.
+    /// 
+    /// It is responsibility of the client to ensure uniqueness of the
+    /// `request_id` strings.
+    /// 
+    /// `request_id` strings are limited to 64 characters.
+    ///
+    /// Sets the *request id* query property to the given value.
+    pub fn request_id(mut self, new_value: &str) -> ProjectConfigCreateCall<'a, C, A> {
+        self._request_id = Some(new_value.to_string());
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> ProjectConfigCreateCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> ProjectConfigCreateCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> ProjectConfigCreateCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+

--- a/gen/servicecontrol1-cli/Cargo.toml
+++ b/gen/servicecontrol1-cli/Cargo.toml
@@ -1,0 +1,40 @@
+# DO NOT EDIT !
+# This file was generated automatically from 'src/mako/Cargo.toml.mako'
+# DO NOT EDIT !
+[package]
+
+name = "google-servicecontrol1-cli"
+version = "1.0.7+20171202"
+authors = ["Sebastian Thiel <byronimo@gmail.com>"]
+description = "A complete library to interact with Service Control (protocol v1)"
+repository = "https://github.com/Byron/google-apis-rs/tree/master/gen/servicecontrol1-cli"
+homepage = "https://cloud.google.com/service-control/"
+documentation = "http://byron.github.io/google-apis-rs/google_servicecontrol1_cli"
+license = "MIT"
+keywords = ["servicecontrol", "google", "cli"]
+
+[[bin]]
+name = "servicecontrol1"
+
+[dev-dependencies]
+hyper-rustls = "^0.6"
+
+[dependencies]
+hyper = "^ 0.10"
+mime = "^ 0.2.0"
+serde = "^ 1.0"
+serde_json = "^ 1.0"
+serde_derive = "^ 1.0"
+yup-oauth2 = "^ 1.0"
+strsim = "^0.5"
+hyper-rustls = "^0.6"
+yup-hyper-mock = "^2.0"
+clap = "^2.0"
+
+[features]
+
+
+
+[dependencies.google-servicecontrol1]
+path = "../servicecontrol1"
+version = "1.0.7+20171202"

--- a/gen/servicecontrol1-cli/LICENSE.md
+++ b/gen/servicecontrol1-cli/LICENSE.md
@@ -1,0 +1,30 @@
+<!---
+DO NOT EDIT !
+This file was generated automatically from 'src/mako/LICENSE.md.mako'
+DO NOT EDIT !
+-->
+The MIT License (MIT)
+=====================
+
+Copyright © `2015-2016` `Sebastian Thiel`
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the “Software”), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.

--- a/gen/servicecontrol1-cli/README.md
+++ b/gen/servicecontrol1-cli/README.md
@@ -1,0 +1,119 @@
+<!---
+DO NOT EDIT !
+This file was generated automatically from 'src/mako/cli/README.md.mako'
+DO NOT EDIT !
+-->
+The `servicecontrol1` command-line interface *(CLI)* allows to use most features of the *Google Service Control* service from the comfort of your terminal.
+
+By default all output is printed to standard out, but flags can be set to direct it into a file independent of your shell's
+capabilities. Errors will be printed to standard error, and cause the program's exit code to be non-zero.
+
+If data-structures are requested, these will be returned as pretty-printed JSON, to be useful as input to other tools.
+
+Everything else about the *Service Control* API can be found at the
+[official documentation site](https://cloud.google.com/service-control/).
+
+# Installation and Source Code
+
+Install the command-line interface with cargo using:
+
+```bash
+cargo install google-servicecontrol1-cli
+```
+
+Find the source code [on github](https://github.com/Byron/google-apis-rs/tree/master/gen/servicecontrol1-cli).
+
+# Usage
+
+This documentation was generated from the *Service Control* API at revision *20171202*. The CLI is at version *1.0.7*.
+
+```bash
+servicecontrol1 [options]
+        services
+                allocate-quota <service-name> (-r <kv>)... [-p <v>]... [-o <out>]
+                check <service-name> (-r <kv>)... [-p <v>]... [-o <out>]
+                end-reconciliation <service-name> (-r <kv>)... [-p <v>]... [-o <out>]
+                release-quota <service-name> (-r <kv>)... [-p <v>]... [-o <out>]
+                report <service-name> (-r <kv>)... [-p <v>]... [-o <out>]
+                start-reconciliation <service-name> (-r <kv>)... [-p <v>]... [-o <out>]
+  servicecontrol1 --help
+
+Configuration:
+  [--scope <url>]...
+            Specify the authentication a method should be executed in. Each scope
+            requires the user to grant this application permission to use it.
+            If unset, it defaults to the shortest scope url for a particular method.
+  --config-dir <folder>
+            A directory into which we will store our persistent data. Defaults to
+            a user-writable directory that we will create during the first invocation.
+            [default: ~/.google-service-cli]
+  --debug
+            Output all server communication to standard error. `tx` and `rx` are placed
+            into the same stream.
+  --debug-auth
+            Output all communication related to authentication to standard error. `tx`
+            and `rx` are placed into the same stream.
+
+```
+
+# Configuration
+
+The program will store all persistent data in the `~/.google-service-cli` directory in *JSON* files prefixed with `servicecontrol1-`.  You can change the directory used to store configuration with the `--config-dir` flag on a per-invocation basis.
+
+More information about the various kinds of persistent data are given in the following paragraphs.
+
+# Authentication
+
+Most APIs require a user to authenticate any request. If this is the case, the [scope][scopes] determines the 
+set of permissions granted. The granularity of these is usually no more than *read-only* or *full-access*.
+
+If not set, the system will automatically select the smallest feasible scope, e.g. when invoking a
+method that is read-only, it will ask only for a read-only scope. 
+You may use the `--scope` flag to specify a scope directly. 
+All applicable scopes are documented in the respective method's CLI documentation.
+
+The first time a scope is used, the user is asked for permission. Follow the instructions given 
+by the CLI to grant permissions, or to decline.
+
+If a scope was authenticated by the user, the respective information will be stored as *JSON* in the configuration
+directory, e.g. `~/.google-service-cli/servicecontrol1-token-<scope-hash>.json`. No manual management of these tokens
+is necessary.
+
+To revoke granted authentication, please refer to the [official documentation][revoke-access].
+
+# Application Secrets
+
+In order to allow any application to use Google services, it will need to be registered using the 
+[Google Developer Console][google-dev-console]. APIs the application may use are then enabled for it
+one by one. Most APIs can be used for free and have a daily quota.
+
+To allow more comfortable usage of the CLI without forcing anyone to register an own application, the CLI
+comes with a default application secret that is configured accordingly. This also means that heavy usage
+all around the world may deplete the daily quota.
+
+You can workaround this limitation by putting your own secrets file at this location: 
+`~/.google-service-cli/servicecontrol1-secret.json`, assuming that the required *servicecontrol* API 
+was enabled for it. Such a secret file can be downloaded in the *Google Developer Console* at 
+*APIs & auth -> Credentials -> Download JSON* and used as is.
+
+Learn more about how to setup Google projects and enable APIs using the [official documentation][google-project-new].
+
+
+# Debugging
+
+Even though the CLI does its best to provide usable error messages, sometimes it might be desirable to know
+what exactly led to a particular issue. This is done by allowing all client-server communication to be 
+output to standard error *as-is*.
+
+The `--debug` flag will print all client-server communication to standard error, whereas the `--debug-auth` flag
+will cause all communication related to authentication to standard error.
+If the `--debug` flag is set, error-results will be debug-printed, possibly yielding more information about the 
+issue at hand.
+
+You may consider redirecting standard error into a file for ease of use, e.g. `servicecontrol1 --debug <resource> <method> [options] 2>debug.txt`.
+
+
+[scopes]: https://developers.google.com/+/api/oauth#scopes
+[revoke-access]: http://webapps.stackexchange.com/a/30849
+[google-dev-console]: https://console.developers.google.com/
+[google-project-new]: https://developers.google.com/console/help/new/

--- a/gen/servicecontrol1-cli/mkdocs.yml
+++ b/gen/servicecontrol1-cli/mkdocs.yml
@@ -1,0 +1,22 @@
+site_name: Service Control v1.0.7+20171202
+site_url: http://byron.github.io/google-apis-rs/google-servicecontrol1-cli
+site_description: A complete library to interact with Service Control (protocol v1)
+
+repo_url: https://github.com/Byron/google-apis-rs/tree/master/gen/servicecontrol1-cli
+
+docs_dir: docs
+site_dir: build_html
+
+pages:
+- ['index.md', 'Home']
+- ['services_allocate-quota.md', 'Services', 'Allocate Quota']
+- ['services_check.md', 'Services', 'Check']
+- ['services_end-reconciliation.md', 'Services', 'End Reconciliation']
+- ['services_release-quota.md', 'Services', 'Release Quota']
+- ['services_report.md', 'Services', 'Report']
+- ['services_start-reconciliation.md', 'Services', 'Start Reconciliation']
+
+theme: readthedocs
+
+copyright: Copyright &copy; 2015-2016, `Sebastian Thiel`
+

--- a/gen/servicecontrol1-cli/src/cmn.rs
+++ b/gen/servicecontrol1-cli/src/cmn.rs
@@ -1,0 +1,799 @@
+// COPY OF 'src/rust/cli/cmn.rs'
+// DO NOT EDIT
+use oauth2::{ApplicationSecret, ConsoleApplicationSecret, TokenStorage, Token};
+use serde_json as json;
+use serde_json::value::Value;
+use mime::Mime;
+use clap::{App, SubCommand};
+use strsim;
+
+use std::fs;
+use std::env;
+use std::io;
+use std::error::Error as StdError;
+use std::fmt;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+use std::string::ToString;
+use std::io::{Write, Read, stdout};
+
+use std::default::Default;
+
+const FIELD_SEP: char = '.';
+
+
+pub enum ComplexType {
+    Pod,
+    Vec,
+    Map,
+}
+
+// Null,
+// Bool(bool),
+// I64(i64),
+// U64(u64),
+// F64(f64),
+// String(String),
+
+pub enum JsonType {
+    Boolean,
+    Int,
+    Uint,
+    Float,
+    String,
+}
+
+pub struct JsonTypeInfo {
+    pub jtype: JsonType,
+    pub ctype: ComplexType,
+}
+
+// Based on @erickt user comment. Thanks for the idea !
+// Remove all keys whose values are null from given value (changed in place)
+pub fn remove_json_null_values(value: &mut Value) {
+    match *value {
+        Value::Object(ref mut map) => {
+            let mut for_removal = Vec::new();
+
+            for (key, mut value) in map.iter_mut() {
+                if value.is_null() {
+                    for_removal.push(key.clone());
+                } else {
+                    remove_json_null_values(&mut value);
+                }
+            }
+
+            for key in &for_removal {
+                map.remove(key);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn did_you_mean<'a>(v: &str, possible_values: &[&'a str]) -> Option<&'a str> {
+
+    let mut candidate: Option<(f64, &str)> = None;
+    for pv in possible_values {
+        let confidence = strsim::jaro_winkler(v, pv);
+        if confidence > 0.8 &&
+           (candidate.is_none() || (candidate.as_ref().unwrap().0 < confidence)) {
+            candidate = Some((confidence, pv));
+        }
+    }
+    match candidate {
+        None => None,
+        Some((_, candidate)) => Some(candidate),
+    }
+}
+
+pub enum CallType {
+    Upload(UploadProtocol),
+    Standard,
+}
+
+arg_enum!{
+    pub enum UploadProtocol {
+        Simple,
+        Resumable
+    }
+}
+
+impl AsRef<str> for UploadProtocol {
+    fn as_ref(&self) -> &str {
+        match *self {
+            UploadProtocol::Simple => "simple",
+            UploadProtocol::Resumable => "resumable",
+        }
+    }
+}
+
+impl AsRef<str> for CallType {
+    fn as_ref(&self) -> &str {
+        match *self {
+            CallType::Upload(ref proto) => proto.as_ref(),
+            CallType::Standard => "standard-request",
+        }
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct FieldCursor(Vec<String>);
+
+impl ToString for  FieldCursor {
+    fn to_string(&self) -> String {
+        self.0.join(".")
+    }
+}
+
+impl From<&'static str> for FieldCursor {
+    fn from(value: &'static str) -> FieldCursor {
+        let mut res = FieldCursor::default();
+        res.set(value).unwrap();
+        res
+    }
+}
+
+fn assure_entry<'a, 'b>(m: &'a mut json::Map<String, Value>, k: &'b String) -> &'a mut Value {
+    if m.contains_key(k) {
+        return m.get_mut(k).expect("value to exist");
+    }
+    m.insert(k.to_owned(), Value::Object(Default::default()));
+    m.get_mut(k).expect("value to exist")
+}
+
+impl FieldCursor {
+    pub fn set(&mut self, value: &str) -> Result<(), CLIError> {
+        if value.len() == 0 {
+            return Err(CLIError::Field(FieldError::Empty));
+        }
+
+        let mut first_is_field_sep = false;
+        let mut char_count: usize = 0;
+        let mut last_c = FIELD_SEP;
+        let mut num_conscutive_field_seps = 0;
+
+        let mut field = String::new();
+        let mut fields = self.0.clone();
+
+        let push_field = |fs: &mut Vec<String>, f: &mut String| {
+            if f.len() > 0 {
+                fs.push(f.clone());
+                f.truncate(0);
+            }
+        };
+
+        for (cid, c) in value.chars().enumerate() {
+            char_count += 1;
+
+            if c == FIELD_SEP {
+                if cid == 0 {
+                    first_is_field_sep = true;
+                }
+                num_conscutive_field_seps += 1;
+                if cid > 0 && last_c == FIELD_SEP {
+                    if fields.pop().is_none() {
+                        return Err(CLIError::Field(FieldError::PopOnEmpty(value.to_string())));
+                    }
+                } else {
+                    push_field(&mut fields, &mut field);
+                }
+            } else {
+                num_conscutive_field_seps = 0;
+                if cid == 1 {
+                    if first_is_field_sep {
+                        fields.truncate(0);
+                    }
+                }
+                field.push(c);
+            }
+
+            last_c = c;
+        }
+
+        push_field(&mut fields, &mut field);
+
+        if char_count == 1 && first_is_field_sep {
+            fields.truncate(0);
+        }
+        if char_count > 1 && num_conscutive_field_seps == 1 {
+            return Err(CLIError::Field(FieldError::TrailingFieldSep(value.to_string())));
+        }
+
+        self.0 = fields;
+        Ok(())
+    }
+
+    pub fn did_you_mean(value: &str, possible_values: &[&str]) -> Option<String> {
+        if value.len() == 0 {
+            return None;
+        }
+
+        let mut last_c = FIELD_SEP;
+
+        let mut field = String::new();
+        let mut output = String::new();
+
+        let push_field = |fs: &mut String, f: &mut String| {
+            if f.len() > 0 {
+                fs.push_str(match did_you_mean(&f, possible_values) {
+                    Some(candidate) => candidate,
+                    None => &f,
+                });
+                f.truncate(0);
+            }
+        };
+
+        for (cid, c) in value.chars().enumerate() {
+            if c == FIELD_SEP {
+                if last_c != FIELD_SEP {
+                    push_field(&mut output, &mut field);
+                }
+                output.push(c);
+            } else {
+                field.push(c);
+            }
+
+            last_c = c;
+        }
+
+        push_field(&mut output, &mut field);
+
+        if &output == value {
+            None
+        } else {
+            Some(output)
+        }
+    }
+
+    pub fn set_json_value(&self,
+                          mut object: &mut Value,
+                          value: &str,
+                          type_info: JsonTypeInfo,
+                          err: &mut InvalidOptionsError,
+                          orig_cursor: &FieldCursor) {
+        assert!(self.0.len() > 0);
+
+        for field in &self.0[..self.0.len() - 1] {
+            let tmp = object;
+            object = match *tmp {
+                Value::Object(ref mut mapping) => {
+                    assure_entry(mapping, &field)
+                }
+                _ => panic!("We don't expect non-object Values here ..."),
+            };
+        }
+
+        match *object {
+            Value::Object(ref mut mapping) => {
+                let field = &self.0[self.0.len() - 1];
+                let to_jval = |value: &str,
+                               jtype: JsonType,
+                               err: &mut InvalidOptionsError|
+                               -> Value {
+                    match jtype {
+                        JsonType::Boolean =>
+                            Value::Bool(arg_from_str(value, err, &field, "boolean")),
+                        JsonType::Int =>
+                            Value::Number(json::Number::from_f64(arg_from_str(value,
+                                                                              err,
+                                                                              &field,
+                                                                              "int"))
+                                              .expect("valid f64")),
+                        JsonType::Uint =>
+                            Value::Number(json::Number::from_f64(arg_from_str(value,
+                                                                              err,
+                                                                              &field,
+                                                                              "uint"))
+                                              .expect("valid f64")),
+                        JsonType::Float =>
+                            Value::Number(json::Number::from_f64(arg_from_str(value,
+                                                                              err,
+                                                                              &field,
+                                                                              "float"))
+                                              .expect("valid f64")),
+                        JsonType::String => Value::String(value.to_owned()),
+                    }
+                };
+
+                match type_info.ctype {
+                    ComplexType::Pod => {
+                        if mapping.insert(field.to_owned(), to_jval(value, type_info.jtype, err))
+                                  .is_some() {
+                            err.issues.push(CLIError::Field(FieldError::Duplicate(orig_cursor.to_string())));
+                        }
+                    }
+                    ComplexType::Vec => {
+                        match *assure_entry(mapping, field) {
+                            Value::Array(ref mut values) =>
+                                values.push(to_jval(value, type_info.jtype, err)),
+                            _ => unreachable!(),
+                        }
+                    }
+                    ComplexType::Map => {
+                        let (key, value) = parse_kv_arg(value, err, true);
+                        let jval = to_jval(value.unwrap_or(""), type_info.jtype, err);
+
+                        match *assure_entry(mapping, &field) {
+
+                            Value::Object(ref mut value_map) => {
+                                if value_map.insert(key.to_owned(), jval).is_some() {
+                                    err.issues.push(CLIError::Field(FieldError::Duplicate(orig_cursor.to_string())));
+                                }
+                            }
+                            _ => unreachable!(),
+                        }
+                    }
+                }
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    pub fn num_fields(&self) -> usize {
+        self.0.len()
+    }
+}
+
+pub fn parse_kv_arg<'a>(kv: &'a str,
+                        err: &mut InvalidOptionsError,
+                        for_hashmap: bool)
+                        -> (&'a str, Option<&'a str>) {
+    let mut add_err = || {
+        err.issues.push(CLIError::InvalidKeyValueSyntax(kv.to_string(), for_hashmap))
+    };
+    match kv.find('=') {
+        None => {
+            add_err();
+            return (kv, None);
+        }
+        Some(pos) => {
+            let key = &kv[..pos];
+            if kv.len() <= pos + 1 {
+                add_err();
+                return (key, Some(""));
+            }
+            (key, Some(&kv[pos + 1..]))
+        }
+    }
+}
+
+pub fn calltype_from_str(name: &str,
+                         valid_protocols: Vec<String>,
+                         err: &mut InvalidOptionsError)
+                         -> CallType {
+    CallType::Upload(match UploadProtocol::from_str(name) {
+        Ok(up) => up,
+        Err(msg) => {
+            err.issues.push(CLIError::InvalidUploadProtocol(name.to_string(), valid_protocols));
+            UploadProtocol::Simple
+        }
+    })
+}
+
+pub fn input_file_from_opts(file_path: &str, err: &mut InvalidOptionsError) -> Option<fs::File> {
+    match fs::File::open(file_path) {
+        Ok(f) => Some(f),
+        Err(io_err) => {
+            err.issues.push(CLIError::Input(InputError::Io((file_path.to_string(), io_err))));
+            None
+        }
+    }
+}
+
+pub fn input_mime_from_opts(mime: &str, err: &mut InvalidOptionsError) -> Option<Mime> {
+    match mime.parse() {
+        Ok(m) => Some(m),
+        Err(_) => {
+            err.issues.push(CLIError::Input(InputError::Mime(mime.to_string())));
+            None
+        }
+    }
+}
+
+pub fn writer_from_opts(arg: Option<&str>) -> Result<Box<Write>, io::Error> {
+    let f = arg.unwrap_or("-");
+    match f {
+        "-" => Ok(Box::new(stdout())),
+        _ => match fs::OpenOptions::new().create(true).write(true).open(f) {
+            Ok(f) => Ok(Box::new(f)),
+            Err(io_err) => Err(io_err),
+        },
+    }
+}
+
+
+pub fn arg_from_str<'a, T>(arg: &str,
+                           err: &mut InvalidOptionsError,
+                           arg_name: &'a str,
+                           arg_type: &'a str)
+                           -> T
+    where T: FromStr + Default,
+          <T as FromStr>::Err: fmt::Display
+{
+    match FromStr::from_str(arg) {
+        Err(perr) => {
+            err.issues.push(CLIError::ParseError(arg_name.to_owned(),
+                                                 arg_type.to_owned(),
+                                                 arg.to_string(),
+                                                 format!("{}", perr)));
+            Default::default()
+        }
+        Ok(v) => v,
+    }
+}
+
+pub struct JsonTokenStorage {
+    pub program_name: &'static str,
+    pub db_dir: String,
+}
+
+impl JsonTokenStorage {
+    fn path(&self, scope_hash: u64) -> PathBuf {
+        Path::new(&self.db_dir).join(&format!("{}-token-{}.json", self.program_name, scope_hash))
+    }
+}
+
+
+#[derive(Debug)]
+pub enum TokenStorageError {
+    Json(json::Error),
+    Io(io::Error),
+}
+
+impl fmt::Display for TokenStorageError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            TokenStorageError::Json(ref err) => writeln!(f, "Could not serialize secrets: {}", err),
+            TokenStorageError::Io(ref err) => writeln!(f, "Failed to write secret token: {}", err),
+        }
+    }
+}
+
+impl StdError for TokenStorageError {
+    fn description(&self) -> &str {
+        "Failure when getting or setting the token storage"
+    }
+}
+
+
+impl TokenStorage for JsonTokenStorage {
+    type Error = TokenStorageError;
+
+    // NOTE: logging might be interesting, currently we swallow all errors
+    fn set(&mut self,
+           scope_hash: u64,
+           _: &Vec<&str>,
+           token: Option<Token>)
+           -> Result<(), TokenStorageError> {
+        match token {
+            None => {
+                match fs::remove_file(self.path(scope_hash)) {
+                    Err(err) => match err.kind() {
+                        io::ErrorKind::NotFound => Ok(()),
+                        _ => Err(TokenStorageError::Io(err)),
+                    },
+                    Ok(_) => Ok(()),
+                }
+            }
+            Some(token) => {
+                match fs::OpenOptions::new().create(true).write(true).open(&self.path(scope_hash)) {
+                    Ok(mut f) => {
+                        match json::to_writer_pretty(&mut f, &token) {
+                            Ok(_) => Ok(()),
+                            Err(serde_err) => Err(TokenStorageError::Json(serde_err)),
+                        }
+                    }
+                    Err(io_err) => Err(TokenStorageError::Io(io_err)),
+                }
+            }
+        }
+    }
+
+    fn get(&self, scope_hash: u64, _: &Vec<&str>) -> Result<Option<Token>, TokenStorageError> {
+        match fs::File::open(&self.path(scope_hash)) {
+            Ok(f) => {
+                match json::de::from_reader(f) {
+                    Ok(token) => Ok(Some(token)),
+                    Err(err) => Err(TokenStorageError::Json(err)),
+                }
+            }
+            Err(io_err) => {
+                match io_err.kind() {
+                    io::ErrorKind::NotFound => Ok(None),
+                    _ => Err(TokenStorageError::Io(io_err)),
+                }
+            }
+        }
+    }
+}
+
+
+#[derive(Debug)]
+pub enum ApplicationSecretError {
+    DecoderError((String, json::Error)),
+    FormatError(String),
+}
+
+impl fmt::Display for ApplicationSecretError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            ApplicationSecretError::DecoderError((ref path, ref err)) =>
+                writeln!(f,
+                         "Could not decode file at '{}' with error: {}.",
+                         path,
+                         err),
+            ApplicationSecretError::FormatError(ref path) =>
+                writeln!(f,
+                         "'installed' field is unset in secret file at '{}'.",
+                         path),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum ConfigurationError {
+    DirectoryCreationFailed((String, io::Error)),
+    DirectoryUnset,
+    HomeExpansionFailed(String),
+    Secret(ApplicationSecretError),
+    Io((String, io::Error)),
+}
+
+impl fmt::Display for ConfigurationError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            ConfigurationError::DirectoryCreationFailed((ref dir, ref err)) =>
+                writeln!(f,
+                         "Directory '{}' could not be created with error: {}.",
+                         dir,
+                         err),
+            ConfigurationError::DirectoryUnset => writeln!(f, "--config-dir was unset or empty."),
+            ConfigurationError::HomeExpansionFailed(ref dir) =>
+                writeln!(f,
+                         "Couldn't find HOME directory of current user, failed to expand '{}'.",
+                         dir),
+            ConfigurationError::Secret(ref err) => writeln!(f, "Secret -> {}", err),
+            ConfigurationError::Io((ref path, ref err)) =>
+                writeln!(f,
+                         "IO operation failed on path '{}' with error: {}.",
+                         path,
+                         err),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum InputError {
+    Io((String, io::Error)),
+    Mime(String),
+}
+
+impl fmt::Display for InputError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            InputError::Io((ref file_path, ref io_err)) =>
+                writeln!(f,
+                         "Failed to open '{}' for reading with error: {}.",
+                         file_path,
+                         io_err),
+            InputError::Mime(ref mime) => writeln!(f, "'{}' is not a known mime-type.", mime),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum FieldError {
+    PopOnEmpty(String),
+    TrailingFieldSep(String),
+    Unknown(String, Option<String>, Option<String>),
+    Duplicate(String),
+    Empty,
+}
+
+
+impl fmt::Display for FieldError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            FieldError::PopOnEmpty(ref field) =>
+                writeln!(f, "'{}': Cannot move up on empty field cursor.", field),
+            FieldError::TrailingFieldSep(ref field) =>
+                writeln!(f,
+                         "'{}': Single field separator may not be last character.",
+                         field),
+            FieldError::Unknown(ref field, ref suggestion, ref value) => {
+                let suffix = match *suggestion {
+                    Some(ref s) => {
+                        let kv = match *value {
+                            Some(ref v) => format!("{}={}", s, v),
+                            None => s.clone(),
+                        };
+                        format!(" Did you mean '{}' ?", kv)
+                    }
+                    None => String::new(),
+                };
+                writeln!(f, "Field '{}' does not exist.{}", field, suffix)
+            }
+            FieldError::Duplicate(ref cursor) =>
+                writeln!(f, "Value at '{}' was already set", cursor),
+            FieldError::Empty => writeln!(f, "Field names must not be empty."),
+        }
+    }
+}
+
+
+#[derive(Debug)]
+pub enum CLIError {
+    Configuration(ConfigurationError),
+    ParseError(String, String, String, String),
+    UnknownParameter(String, Vec<&'static str>),
+    InvalidUploadProtocol(String, Vec<String>),
+    InvalidKeyValueSyntax(String, bool),
+    Input(InputError),
+    Field(FieldError),
+    MissingCommandError,
+    MissingMethodError(String),
+}
+
+impl fmt::Display for CLIError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            CLIError::Configuration(ref err) => write!(f, "Configuration -> {}", err),
+            CLIError::Input(ref err) => write!(f, "Input -> {}", err),
+            CLIError::Field(ref err) => write!(f, "Field -> {}", err),
+            CLIError::InvalidUploadProtocol(ref proto_name, ref valid_names) =>
+                writeln!(f,
+                         "'{}' is not a valid upload protocol. Choose from one of {}.",
+                         proto_name,
+                         valid_names.join(", ")),
+            CLIError::ParseError(ref arg_name, ref type_name, ref value, ref err_desc) =>
+                writeln!(f,
+                         "Failed to parse argument '{}' with value '{}' as {} with error: {}.",
+                         arg_name,
+                         value,
+                         type_name,
+                         err_desc),
+            CLIError::UnknownParameter(ref param_name, ref possible_values) => {
+                let suffix = match did_you_mean(param_name, &possible_values) {
+                    Some(v) => format!(" Did you mean '{}' ?", v),
+                    None => String::new(),
+                };
+                write!(f, "Parameter '{}' is unknown.{}\n", param_name, suffix)
+            }
+            CLIError::InvalidKeyValueSyntax(ref kv, is_hashmap) => {
+                let hashmap_info = if is_hashmap {
+                    "hashmap "
+                } else {
+                    ""
+                };
+                writeln!(f,
+                         "'{}' does not match {}pattern <key>=<value>.",
+                         kv,
+                         hashmap_info)
+            }
+            CLIError::MissingCommandError => writeln!(f, "Please specify the main sub-command."),
+            CLIError::MissingMethodError(ref cmd) =>
+                writeln!(f,
+                         "Please specify the method to call on the '{}' command.",
+                         cmd),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct InvalidOptionsError {
+    pub issues: Vec<CLIError>,
+    pub exit_code: i32,
+}
+
+impl fmt::Display for InvalidOptionsError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        for issue in &self.issues {
+            try!(issue.fmt(f));
+        }
+        Ok(())
+    }
+}
+
+impl InvalidOptionsError {
+    pub fn single(err: CLIError, exit_code: i32) -> InvalidOptionsError {
+        InvalidOptionsError {
+            issues: vec![err],
+            exit_code: exit_code,
+        }
+    }
+
+    pub fn new() -> InvalidOptionsError {
+        InvalidOptionsError {
+            issues: Vec::new(),
+            exit_code: 1,
+        }
+    }
+}
+
+pub fn assure_config_dir_exists(dir: &str) -> Result<String, CLIError> {
+    let trdir = dir.trim();
+    if trdir.len() == 0 {
+        return Err(CLIError::Configuration(ConfigurationError::DirectoryUnset));
+    }
+
+    let expanded_config_dir = if trdir.as_bytes()[0] == b'~' {
+        match env::var("HOME").ok().or(env::var("UserProfile").ok()) {
+            None => return Err(CLIError::Configuration(ConfigurationError::HomeExpansionFailed(trdir.to_string()))),
+            Some(mut user) => {
+                user.push_str(&trdir[1..]);
+                user
+            }
+        }
+    } else {
+        trdir.to_string()
+    };
+
+    if let Err(err) = fs::create_dir(&expanded_config_dir) {
+        if err.kind() != io::ErrorKind::AlreadyExists {
+            return Err(CLIError::Configuration(
+                    ConfigurationError::DirectoryCreationFailed((expanded_config_dir, err))));
+        }
+    }
+
+    Ok(expanded_config_dir)
+}
+
+pub fn application_secret_from_directory(dir: &str,
+                                         secret_basename: &str,
+                                         json_console_secret: &str)
+                                         -> Result<ApplicationSecret, CLIError> {
+    let secret_path = Path::new(dir).join(secret_basename);
+    let secret_str = || secret_path.as_path().to_str().unwrap().to_string();
+    let secret_io_error = |io_err: io::Error| {
+        Err(CLIError::Configuration(ConfigurationError::Io((secret_str(), io_err))))
+    };
+
+    for _ in 0..2 {
+        match fs::File::open(&secret_path) {
+            Err(mut err) => {
+                if err.kind() == io::ErrorKind::NotFound {
+                    // Write our built-in one - user may adjust the written file at will
+
+                    err = match fs::OpenOptions::new()
+                                    .create(true)
+                                    .write(true)
+                                    .open(&secret_path) {
+                        Err(cfe) => cfe,
+                        Ok(mut f) => {
+                            // Assure we convert 'ugly' json string into pretty one
+                            let console_secret: ConsoleApplicationSecret =
+                                json::from_str(json_console_secret).unwrap();
+                            match json::to_writer_pretty(&mut f, &console_secret) {
+                                Err(serde_err) =>
+                                    panic!("Unexpected serde error: {:#?}", serde_err),
+                                Ok(_) => continue,
+                            }
+                        }
+                    };
+                    // fall through to IO error handling
+                }
+                return secret_io_error(err);
+            }
+            Ok(f) => {
+                match json::de::from_reader::<_, ConsoleApplicationSecret>(f) {
+                    Err(json_err) =>
+                        return Err(CLIError::Configuration(
+                            ConfigurationError::Secret(
+                                ApplicationSecretError::DecoderError(
+                                                (secret_str(), json_err)
+                                              )))),
+                    Ok(console_secret) => match console_secret.installed {
+                        Some(secret) => return Ok(secret),
+                        None => return Err(
+                                        CLIError::Configuration(
+                                        ConfigurationError::Secret(
+                                        ApplicationSecretError::FormatError(secret_str())
+                                        ))),
+                    },
+                }
+            }
+        }
+    }
+    unreachable!();
+}

--- a/gen/servicecontrol1-cli/src/main.rs
+++ b/gen/servicecontrol1-cli/src/main.rs
@@ -1,0 +1,1072 @@
+// DO NOT EDIT !
+// This file was generated automatically from 'src/mako/cli/main.rs.mako'
+// DO NOT EDIT !
+#![allow(unused_variables, unused_imports, dead_code, unused_mut)]
+
+#[macro_use]
+extern crate clap;
+extern crate yup_oauth2 as oauth2;
+extern crate yup_hyper_mock as mock;
+extern crate hyper_rustls;
+extern crate serde;
+extern crate serde_json;
+extern crate hyper;
+extern crate mime;
+extern crate strsim;
+extern crate google_servicecontrol1 as api;
+
+use std::env;
+use std::io::{self, Write};
+use clap::{App, SubCommand, Arg};
+
+mod cmn;
+
+use cmn::{InvalidOptionsError, CLIError, JsonTokenStorage, arg_from_str, writer_from_opts, parse_kv_arg,
+          input_file_from_opts, input_mime_from_opts, FieldCursor, FieldError, CallType, UploadProtocol,
+          calltype_from_str, remove_json_null_values, ComplexType, JsonType, JsonTypeInfo};
+
+use std::default::Default;
+use std::str::FromStr;
+
+use oauth2::{Authenticator, DefaultAuthenticatorDelegate, FlowType};
+use serde_json as json;
+use clap::ArgMatches;
+
+enum DoitError {
+    IoError(String, io::Error),
+    ApiError(api::Error),
+}
+
+struct Engine<'n> {
+    opt: ArgMatches<'n>,
+    hub: api::ServiceControl<hyper::Client, Authenticator<DefaultAuthenticatorDelegate, JsonTokenStorage, hyper::Client>>,
+    gp: Vec<&'static str>,
+    gpm: Vec<(&'static str, &'static str)>,
+}
+
+
+impl<'n> Engine<'n> {
+    fn _services_allocate_quota(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    "service-config-id" => Some(("serviceConfigId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "allocate-operation.quota-mode" => Some(("allocateOperation.quotaMode", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "allocate-operation.consumer-id" => Some(("allocateOperation.consumerId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "allocate-operation.labels" => Some(("allocateOperation.labels", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Map })),
+                    "allocate-operation.method-name" => Some(("allocateOperation.methodName", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "allocate-operation.operation-id" => Some(("allocateOperation.operationId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec!["allocate-operation", "consumer-id", "labels", "method-name", "operation-id", "quota-mode", "service-config-id"]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::AllocateQuotaRequest = json::value::from_value(object).unwrap();
+        let mut call = self.hub.services().allocate_quota(request, opt.value_of("service-name").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _services_check(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    "skip-activation-check" => Some(("skipActivationCheck", JsonTypeInfo { jtype: JsonType::Boolean, ctype: ComplexType::Pod })),
+                    "operation.operation-name" => Some(("operation.operationName", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "operation.consumer-id" => Some(("operation.consumerId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "operation.importance" => Some(("operation.importance", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "operation.labels" => Some(("operation.labels", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Map })),
+                    "operation.quota-properties.quota-mode" => Some(("operation.quotaProperties.quotaMode", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "operation.resource-container" => Some(("operation.resourceContainer", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "operation.user-labels" => Some(("operation.userLabels", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Map })),
+                    "operation.start-time" => Some(("operation.startTime", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "operation.end-time" => Some(("operation.endTime", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "operation.operation-id" => Some(("operation.operationId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "service-config-id" => Some(("serviceConfigId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "request-project-settings" => Some(("requestProjectSettings", JsonTypeInfo { jtype: JsonType::Boolean, ctype: ComplexType::Pod })),
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec!["consumer-id", "end-time", "importance", "labels", "operation", "operation-id", "operation-name", "quota-mode", "quota-properties", "request-project-settings", "resource-container", "service-config-id", "skip-activation-check", "start-time", "user-labels"]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::CheckRequest = json::value::from_value(object).unwrap();
+        let mut call = self.hub.services().check(request, opt.value_of("service-name").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _services_end_reconciliation(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    "service-config-id" => Some(("serviceConfigId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "reconciliation-operation.quota-mode" => Some(("reconciliationOperation.quotaMode", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "reconciliation-operation.consumer-id" => Some(("reconciliationOperation.consumerId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "reconciliation-operation.labels" => Some(("reconciliationOperation.labels", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Map })),
+                    "reconciliation-operation.method-name" => Some(("reconciliationOperation.methodName", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "reconciliation-operation.operation-id" => Some(("reconciliationOperation.operationId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec!["consumer-id", "labels", "method-name", "operation-id", "quota-mode", "reconciliation-operation", "service-config-id"]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::EndReconciliationRequest = json::value::from_value(object).unwrap();
+        let mut call = self.hub.services().end_reconciliation(request, opt.value_of("service-name").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _services_release_quota(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    "release-operation.quota-mode" => Some(("releaseOperation.quotaMode", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "release-operation.consumer-id" => Some(("releaseOperation.consumerId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "release-operation.labels" => Some(("releaseOperation.labels", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Map })),
+                    "release-operation.method-name" => Some(("releaseOperation.methodName", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "release-operation.operation-id" => Some(("releaseOperation.operationId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "service-config-id" => Some(("serviceConfigId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec!["consumer-id", "labels", "method-name", "operation-id", "quota-mode", "release-operation", "service-config-id"]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::ReleaseQuotaRequest = json::value::from_value(object).unwrap();
+        let mut call = self.hub.services().release_quota(request, opt.value_of("service-name").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _services_report(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    "service-config-id" => Some(("serviceConfigId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec!["service-config-id"]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::ReportRequest = json::value::from_value(object).unwrap();
+        let mut call = self.hub.services().report(request, opt.value_of("service-name").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _services_start_reconciliation(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    "service-config-id" => Some(("serviceConfigId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "reconciliation-operation.quota-mode" => Some(("reconciliationOperation.quotaMode", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "reconciliation-operation.consumer-id" => Some(("reconciliationOperation.consumerId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "reconciliation-operation.labels" => Some(("reconciliationOperation.labels", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Map })),
+                    "reconciliation-operation.method-name" => Some(("reconciliationOperation.methodName", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "reconciliation-operation.operation-id" => Some(("reconciliationOperation.operationId", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec!["consumer-id", "labels", "method-name", "operation-id", "quota-mode", "reconciliation-operation", "service-config-id"]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::StartReconciliationRequest = json::value::from_value(object).unwrap();
+        let mut call = self.hub.services().start_reconciliation(request, opt.value_of("service-name").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _doit(&self, dry_run: bool) -> Result<Result<(), DoitError>, Option<InvalidOptionsError>> {
+        let mut err = InvalidOptionsError::new();
+        let mut call_result: Result<(), DoitError> = Ok(());
+        let mut err_opt: Option<InvalidOptionsError> = None;
+        match self.opt.subcommand() {
+            ("services", Some(opt)) => {
+                match opt.subcommand() {
+                    ("allocate-quota", Some(opt)) => {
+                        call_result = self._services_allocate_quota(opt, dry_run, &mut err);
+                    },
+                    ("check", Some(opt)) => {
+                        call_result = self._services_check(opt, dry_run, &mut err);
+                    },
+                    ("end-reconciliation", Some(opt)) => {
+                        call_result = self._services_end_reconciliation(opt, dry_run, &mut err);
+                    },
+                    ("release-quota", Some(opt)) => {
+                        call_result = self._services_release_quota(opt, dry_run, &mut err);
+                    },
+                    ("report", Some(opt)) => {
+                        call_result = self._services_report(opt, dry_run, &mut err);
+                    },
+                    ("start-reconciliation", Some(opt)) => {
+                        call_result = self._services_start_reconciliation(opt, dry_run, &mut err);
+                    },
+                    _ => {
+                        err.issues.push(CLIError::MissingMethodError("services".to_string()));
+                        writeln!(io::stderr(), "{}\n", opt.usage()).ok();
+                    }
+                }
+            },
+            _ => {
+                err.issues.push(CLIError::MissingCommandError);
+                writeln!(io::stderr(), "{}\n", self.opt.usage()).ok();
+            }
+        }
+
+        if dry_run {
+            if err.issues.len() > 0 {
+                err_opt = Some(err);
+            }
+            Err(err_opt)
+        } else {
+            Ok(call_result)
+        }
+    }
+
+    // Please note that this call will fail if any part of the opt can't be handled
+    fn new(opt: ArgMatches<'n>) -> Result<Engine<'n>, InvalidOptionsError> {
+        let (config_dir, secret) = {
+            let config_dir = match cmn::assure_config_dir_exists(opt.value_of("folder").unwrap_or("~/.google-service-cli")) {
+                Err(e) => return Err(InvalidOptionsError::single(e, 3)),
+                Ok(p) => p,
+            };
+
+            match cmn::application_secret_from_directory(&config_dir, "servicecontrol1-secret.json",
+                                                         "{\"installed\":{\"auth_uri\":\"https://accounts.google.com/o/oauth2/auth\",\"client_secret\":\"hCsslbCUyfehWMmbkG8vTYxG\",\"token_uri\":\"https://accounts.google.com/o/oauth2/token\",\"client_email\":\"\",\"redirect_uris\":[\"urn:ietf:wg:oauth:2.0:oob\",\"oob\"],\"client_x509_cert_url\":\"\",\"client_id\":\"620010449518-9ngf7o4dhs0dka470npqvor6dc5lqb9b.apps.googleusercontent.com\",\"auth_provider_x509_cert_url\":\"https://www.googleapis.com/oauth2/v1/certs\"}}") {
+                Ok(secret) => (config_dir, secret),
+                Err(e) => return Err(InvalidOptionsError::single(e, 4))
+            }
+        };
+
+        let auth = Authenticator::new(  &secret, DefaultAuthenticatorDelegate,
+                                        if opt.is_present("debug-auth") {
+                                            hyper::Client::with_connector(mock::TeeConnector {
+                                                    connector: hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())
+                                                })
+                                        } else {
+                                            hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new()))
+                                        },
+                                        JsonTokenStorage {
+                                          program_name: "servicecontrol1",
+                                          db_dir: config_dir.clone(),
+                                        }, Some(FlowType::InstalledRedirect(54324)));
+
+        let client =
+            if opt.is_present("debug") {
+                hyper::Client::with_connector(mock::TeeConnector {
+                        connector: hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())
+                    })
+            } else {
+                hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new()))
+            };
+        let engine = Engine {
+            opt: opt,
+            hub: api::ServiceControl::new(client, auth),
+            gp: vec!["$-xgafv", "access-token", "alt", "bearer-token", "callback", "fields", "key", "oauth-token", "pp", "pretty-print", "quota-user", "upload-type", "upload-protocol"],
+            gpm: vec![
+                    ("$-xgafv", "$.xgafv"),
+                    ("access-token", "access_token"),
+                    ("bearer-token", "bearer_token"),
+                    ("oauth-token", "oauth_token"),
+                    ("pretty-print", "prettyPrint"),
+                    ("quota-user", "quotaUser"),
+                    ("upload-type", "uploadType"),
+                    ("upload-protocol", "upload_protocol"),
+                ]
+        };
+
+        match engine._doit(true) {
+            Err(Some(err)) => Err(err),
+            Err(None)      => Ok(engine),
+            Ok(_)          => unreachable!(),
+        }
+    }
+
+    fn doit(&self) -> Result<(), DoitError> {
+        match self._doit(false) {
+            Ok(res) => res,
+            Err(_) => unreachable!(),
+        }
+    }
+}
+
+fn main() {
+    let mut exit_status = 0i32;
+    let arg_data = [
+        ("services", "methods: 'allocate-quota', 'check', 'end-reconciliation', 'release-quota', 'report' and 'start-reconciliation'", vec![
+            ("allocate-quota",
+                    Some(r##"Attempts to allocate quota for the specified consumer. It should be called
+        before the operation is executed.
+        
+        This method requires the `servicemanagement.services.quota`
+        permission on the specified service. For more information, see
+        [Cloud IAM](https://cloud.google.com/iam).
+        
+        **NOTE:** The client **must** fail-open on server errors `INTERNAL`,
+        `UNKNOWN`, `DEADLINE_EXCEEDED`, and `UNAVAILABLE`. To ensure system
+        reliability, the server may inject these errors to prohibit any hard
+        dependency on the quota functionality."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_servicecontrol1_cli/services_allocate-quota",
+                  vec![
+                    (Some(r##"service-name"##),
+                     None,
+                     Some(r##"Name of the service as specified in the service configuration. For example,
+        `"pubsub.googleapis.com"`.
+        
+        See google.api.Service for the definition of a service name."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("check",
+                    Some(r##"Checks an operation with Google Service Control to decide whether
+        the given operation should proceed. It should be called before the
+        operation is executed.
+        
+        If feasible, the client should cache the check results and reuse them for
+        60 seconds. In case of server errors, the client can rely on the cached
+        results for longer time.
+        
+        NOTE: the CheckRequest has the size limit of 64KB.
+        
+        This method requires the `servicemanagement.services.check` permission
+        on the specified service. For more information, see
+        [Google Cloud IAM](https://cloud.google.com/iam)."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_servicecontrol1_cli/services_check",
+                  vec![
+                    (Some(r##"service-name"##),
+                     None,
+                     Some(r##"The service name as specified in its service configuration. For example,
+        `"pubsub.googleapis.com"`.
+        
+        See
+        [google.api.Service](https://cloud.google.com/service-management/reference/rpc/google.api#google.api.Service)
+        for the definition of a service name."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("end-reconciliation",
+                    Some(r##"Signals the quota controller that service ends the ongoing usage
+        reconciliation.
+        
+        This method requires the `servicemanagement.services.quota`
+        permission on the specified service. For more information, see
+        [Google Cloud IAM](https://cloud.google.com/iam)."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_servicecontrol1_cli/services_end-reconciliation",
+                  vec![
+                    (Some(r##"service-name"##),
+                     None,
+                     Some(r##"Name of the service as specified in the service configuration. For example,
+        `"pubsub.googleapis.com"`.
+        
+        See google.api.Service for the definition of a service name."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("release-quota",
+                    Some(r##"Releases previously allocated quota done through AllocateQuota method.
+        
+        This method requires the `servicemanagement.services.quota`
+        permission on the specified service. For more information, see
+        [Cloud IAM](https://cloud.google.com/iam).
+        
+        
+        **NOTE:** The client **must** fail-open on server errors `INTERNAL`,
+        `UNKNOWN`, `DEADLINE_EXCEEDED`, and `UNAVAILABLE`. To ensure system
+        reliability, the server may inject these errors to prohibit any hard
+        dependency on the quota functionality."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_servicecontrol1_cli/services_release-quota",
+                  vec![
+                    (Some(r##"service-name"##),
+                     None,
+                     Some(r##"Name of the service as specified in the service configuration. For example,
+        `"pubsub.googleapis.com"`.
+        
+        See google.api.Service for the definition of a service name."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("report",
+                    Some(r##"Reports operation results to Google Service Control, such as logs and
+        metrics. It should be called after an operation is completed.
+        
+        If feasible, the client should aggregate reporting data for up to 5
+        seconds to reduce API traffic. Limiting aggregation to 5 seconds is to
+        reduce data loss during client crashes. Clients should carefully choose
+        the aggregation time window to avoid data loss risk more than 0.01%
+        for business and compliance reasons.
+        
+        NOTE: the ReportRequest has the size limit of 1MB.
+        
+        This method requires the `servicemanagement.services.report` permission
+        on the specified service. For more information, see
+        [Google Cloud IAM](https://cloud.google.com/iam)."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_servicecontrol1_cli/services_report",
+                  vec![
+                    (Some(r##"service-name"##),
+                     None,
+                     Some(r##"The service name as specified in its service configuration. For example,
+        `"pubsub.googleapis.com"`.
+        
+        See
+        [google.api.Service](https://cloud.google.com/service-management/reference/rpc/google.api#google.api.Service)
+        for the definition of a service name."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("start-reconciliation",
+                    Some(r##"Unlike rate quota, allocation quota does not get refilled periodically.
+        So, it is possible that the quota usage as seen by the service differs from
+        what the One Platform considers the usage is. This is expected to happen
+        only rarely, but over time this can accumulate. Services can invoke
+        StartReconciliation and EndReconciliation to correct this usage drift, as
+        described below:
+        1. Service sends StartReconciliation with a timestamp in future for each
+           metric that needs to be reconciled. The timestamp being in future allows
+           to account for in-flight AllocateQuota and ReleaseQuota requests for the
+           same metric.
+        2. One Platform records this timestamp and starts tracking subsequent
+           AllocateQuota and ReleaseQuota requests until EndReconciliation is
+           called.
+        3. At or after the time specified in the StartReconciliation, service
+           sends EndReconciliation with the usage that needs to be reconciled to.
+        4. One Platform adjusts its own record of usage for that metric to the
+           value specified in EndReconciliation by taking in to account any
+           allocation or release between StartReconciliation and EndReconciliation.
+        
+        Signals the quota controller that the service wants to perform a usage
+        reconciliation as specified in the request.
+        
+        This method requires the `servicemanagement.services.quota`
+        permission on the specified service. For more information, see
+        [Google Cloud IAM](https://cloud.google.com/iam)."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_servicecontrol1_cli/services_start-reconciliation",
+                  vec![
+                    (Some(r##"service-name"##),
+                     None,
+                     Some(r##"Name of the service as specified in the service configuration. For example,
+        `"pubsub.googleapis.com"`.
+        
+        See google.api.Service for the definition of a service name."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ]),
+        
+    ];
+    
+    let mut app = App::new("servicecontrol1")
+           .author("Sebastian Thiel <byronimo@gmail.com>")
+           .version("1.0.7+20171202")
+           .about("Google Service Control provides control plane functionality to managed services, such as logging, monitoring, and status checks.")
+           .after_help("All documentation details can be found at http://byron.github.io/google-apis-rs/google_servicecontrol1_cli")
+           .arg(Arg::with_name("url")
+                   .long("scope")
+                   .help("Specify the authentication a method should be executed in. Each scope requires the user to grant this application permission to use it.If unset, it defaults to the shortest scope url for a particular method.")
+                   .multiple(true)
+                   .takes_value(true))
+           .arg(Arg::with_name("folder")
+                   .long("config-dir")
+                   .help("A directory into which we will store our persistent data. Defaults to a user-writable directory that we will create during the first invocation.[default: ~/.google-service-cli")
+                   .multiple(false)
+                   .takes_value(true))
+           .arg(Arg::with_name("debug")
+                   .long("debug")
+                   .help("Output all server communication to standard error. `tx` and `rx` are placed into the same stream.")
+                   .multiple(false)
+                   .takes_value(false))
+           .arg(Arg::with_name("debug-auth")
+                   .long("debug-auth")
+                   .help("Output all communication related to authentication to standard error. `tx` and `rx` are placed into the same stream.")
+                   .multiple(false)
+                   .takes_value(false));
+           
+           for &(main_command_name, about, ref subcommands) in arg_data.iter() {
+               let mut mcmd = SubCommand::with_name(main_command_name).about(about);
+           
+               for &(sub_command_name, ref desc, url_info, ref args) in subcommands {
+                   let mut scmd = SubCommand::with_name(sub_command_name);
+                   if let &Some(desc) = desc {
+                       scmd = scmd.about(desc);
+                   }
+                   scmd = scmd.after_help(url_info);
+           
+                   for &(ref arg_name, ref flag, ref desc, ref required, ref multi) in args {
+                       let arg_name_str =
+                           match (arg_name, flag) {
+                                   (&Some(an), _       ) => an,
+                                   (_        , &Some(f)) => f,
+                                    _                    => unreachable!(),
+                            };
+                       let mut arg = Arg::with_name(arg_name_str)
+                                         .empty_values(false);
+                       if let &Some(short_flag) = flag {
+                           arg = arg.short(short_flag);
+                       }
+                       if let &Some(desc) = desc {
+                           arg = arg.help(desc);
+                       }
+                       if arg_name.is_some() && flag.is_some() {
+                           arg = arg.takes_value(true);
+                       }
+                       if let &Some(required) = required {
+                           arg = arg.required(required);
+                       }
+                       if let &Some(multi) = multi {
+                           arg = arg.multiple(multi);
+                       }
+                       scmd = scmd.arg(arg);
+                   }
+                   mcmd = mcmd.subcommand(scmd);
+               }
+               app = app.subcommand(mcmd);
+           }
+           
+        let matches = app.get_matches();
+
+    let debug = matches.is_present("debug");
+    match Engine::new(matches) {
+        Err(err) => {
+            exit_status = err.exit_code;
+            writeln!(io::stderr(), "{}", err).ok();
+        },
+        Ok(engine) => {
+            if let Err(doit_err) = engine.doit() {
+                exit_status = 1;
+                match doit_err {
+                    DoitError::IoError(path, err) => {
+                        writeln!(io::stderr(), "Failed to open output file '{}': {}", path, err).ok();
+                    },
+                    DoitError::ApiError(err) => {
+                        if debug {
+                            writeln!(io::stderr(), "{:#?}", err).ok();
+                        } else {
+                            writeln!(io::stderr(), "{}", err).ok();
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    std::process::exit(exit_status);
+}

--- a/gen/servicecontrol1/Cargo.toml
+++ b/gen/servicecontrol1/Cargo.toml
@@ -1,0 +1,31 @@
+# DO NOT EDIT !
+# This file was generated automatically from 'src/mako/Cargo.toml.mako'
+# DO NOT EDIT !
+[package]
+
+name = "google-servicecontrol1"
+version = "1.0.7+20171202"
+authors = ["Sebastian Thiel <byronimo@gmail.com>"]
+description = "A complete library to interact with Service Control (protocol v1)"
+repository = "https://github.com/Byron/google-apis-rs/tree/master/gen/servicecontrol1"
+homepage = "https://cloud.google.com/service-control/"
+documentation = "https://docs.rs/google-servicecontrol1/1.0.7+20171202"
+license = "MIT"
+keywords = ["servicecontrol", "google", "protocol", "web", "api"]
+
+
+[dev-dependencies]
+hyper-rustls = "^0.6"
+
+[dependencies]
+hyper = "^ 0.10"
+mime = "^ 0.2.0"
+serde = "^ 1.0"
+serde_json = "^ 1.0"
+serde_derive = "^ 1.0"
+yup-oauth2 = "^ 1.0"
+url = "= 0.5"
+
+[features]
+
+

--- a/gen/servicecontrol1/LICENSE.md
+++ b/gen/servicecontrol1/LICENSE.md
@@ -1,0 +1,30 @@
+<!---
+DO NOT EDIT !
+This file was generated automatically from 'src/mako/LICENSE.md.mako'
+DO NOT EDIT !
+-->
+The MIT License (MIT)
+=====================
+
+Copyright © `2015-2016` `Sebastian Thiel`
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the “Software”), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.

--- a/gen/servicecontrol1/README.md
+++ b/gen/servicecontrol1/README.md
@@ -1,0 +1,180 @@
+<!---
+DO NOT EDIT !
+This file was generated automatically from 'src/mako/api/README.md.mako'
+DO NOT EDIT !
+-->
+The `google-servicecontrol1` library allows access to all features of the *Google Service Control* service.
+
+This documentation was generated from *Service Control* crate version *1.0.7+20171202*, where *20171202* is the exact revision of the *servicecontrol:v1* schema built by the [mako](http://www.makotemplates.org/) code generator *v1.0.7*.
+
+Everything else about the *Service Control* *v1* API can be found at the
+[official documentation site](https://cloud.google.com/service-control/).
+# Features
+
+Handle the following *Resources* with ease from the central [hub](https://docs.rs/google-servicecontrol1/1.0.7+20171202/google_servicecontrol1/struct.ServiceControl.html) ... 
+
+* services
+ * [*allocate quota*](https://docs.rs/google-servicecontrol1/1.0.7+20171202/google_servicecontrol1/struct.ServiceAllocateQuotaCall.html), [*check*](https://docs.rs/google-servicecontrol1/1.0.7+20171202/google_servicecontrol1/struct.ServiceCheckCall.html), [*end reconciliation*](https://docs.rs/google-servicecontrol1/1.0.7+20171202/google_servicecontrol1/struct.ServiceEndReconciliationCall.html), [*release quota*](https://docs.rs/google-servicecontrol1/1.0.7+20171202/google_servicecontrol1/struct.ServiceReleaseQuotaCall.html), [*report*](https://docs.rs/google-servicecontrol1/1.0.7+20171202/google_servicecontrol1/struct.ServiceReportCall.html) and [*start reconciliation*](https://docs.rs/google-servicecontrol1/1.0.7+20171202/google_servicecontrol1/struct.ServiceStartReconciliationCall.html)
+
+
+
+
+# Structure of this Library
+
+The API is structured into the following primary items:
+
+* **[Hub](https://docs.rs/google-servicecontrol1/1.0.7+20171202/google_servicecontrol1/struct.ServiceControl.html)**
+    * a central object to maintain state and allow accessing all *Activities*
+    * creates [*Method Builders*](https://docs.rs/google-servicecontrol1/1.0.7+20171202/google_servicecontrol1/trait.MethodsBuilder.html) which in turn
+      allow access to individual [*Call Builders*](https://docs.rs/google-servicecontrol1/1.0.7+20171202/google_servicecontrol1/trait.CallBuilder.html)
+* **[Resources](https://docs.rs/google-servicecontrol1/1.0.7+20171202/google_servicecontrol1/trait.Resource.html)**
+    * primary types that you can apply *Activities* to
+    * a collection of properties and *Parts*
+    * **[Parts](https://docs.rs/google-servicecontrol1/1.0.7+20171202/google_servicecontrol1/trait.Part.html)**
+        * a collection of properties
+        * never directly used in *Activities*
+* **[Activities](https://docs.rs/google-servicecontrol1/1.0.7+20171202/google_servicecontrol1/trait.CallBuilder.html)**
+    * operations to apply to *Resources*
+
+All *structures* are marked with applicable traits to further categorize them and ease browsing.
+
+Generally speaking, you can invoke *Activities* like this:
+
+```Rust,ignore
+let r = hub.resource().activity(...).doit()
+```
+
+Or specifically ...
+
+```ignore
+let r = hub.services().check(...).doit()
+```
+
+The `resource()` and `activity(...)` calls create [builders][builder-pattern]. The second one dealing with `Activities` 
+supports various methods to configure the impending operation (not shown here). It is made such that all required arguments have to be 
+specified right away (i.e. `(...)`), whereas all optional ones can be [build up][builder-pattern] as desired.
+The `doit()` method performs the actual communication with the server and returns the respective result.
+
+# Usage
+
+## Setting up your Project
+
+To use this library, you would put the following lines into your `Cargo.toml` file:
+
+```toml
+[dependencies]
+google-servicecontrol1 = "*"
+```
+
+## A complete example
+
+```Rust
+extern crate hyper;
+extern crate hyper_rustls;
+extern crate yup_oauth2 as oauth2;
+extern crate google_servicecontrol1 as servicecontrol1;
+use servicecontrol1::CheckRequest;
+use servicecontrol1::{Result, Error};
+use std::default::Default;
+use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+use servicecontrol1::ServiceControl;
+
+// Get an ApplicationSecret instance by some means. It contains the `client_id` and 
+// `client_secret`, among other things.
+let secret: ApplicationSecret = Default::default();
+// Instantiate the authenticator. It will choose a suitable authentication flow for you, 
+// unless you replace  `None` with the desired Flow.
+// Provide your own `AuthenticatorDelegate` to adjust the way it operates and get feedback about 
+// what's going on. You probably want to bring in your own `TokenStorage` to persist tokens and
+// retrieve them from storage.
+let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+                              hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+                              <MemoryStorage as Default>::default(), None);
+let mut hub = ServiceControl::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+// As the method needs a request, you would usually fill it with the desired information
+// into the respective structure. Some of the parts shown here might not be applicable !
+// Values shown here are possibly random and not representative !
+let mut req = CheckRequest::default();
+
+// You can configure optional parameters by calling the respective setters at will, and
+// execute the final call using `doit()`.
+// Values shown here are possibly random and not representative !
+let result = hub.services().check(req, "serviceName")
+             .doit();
+
+match result {
+    Err(e) => match e {
+        // The Error enum provides details about what exactly happened.
+        // You can also just use its `Debug`, `Display` or `Error` traits
+         Error::HttpError(_)
+        |Error::MissingAPIKey
+        |Error::MissingToken(_)
+        |Error::Cancelled
+        |Error::UploadSizeLimitExceeded(_, _)
+        |Error::Failure(_)
+        |Error::BadRequest(_)
+        |Error::FieldClash(_)
+        |Error::JsonDecodeError(_, _) => println!("{}", e),
+    },
+    Ok(res) => println!("Success: {:?}", res),
+}
+
+```
+## Handling Errors
+
+All errors produced by the system are provided either as [Result](https://docs.rs/google-servicecontrol1/1.0.7+20171202/google_servicecontrol1/enum.Result.html) enumeration as return value of 
+the doit() methods, or handed as possibly intermediate results to either the 
+[Hub Delegate](https://docs.rs/google-servicecontrol1/1.0.7+20171202/google_servicecontrol1/trait.Delegate.html), or the [Authenticator Delegate](https://docs.rs/yup-oauth2/*/yup_oauth2/trait.AuthenticatorDelegate.html).
+
+When delegates handle errors or intermediate values, they may have a chance to instruct the system to retry. This 
+makes the system potentially resilient to all kinds of errors.
+
+## Uploads and Downloads
+If a method supports downloads, the response body, which is part of the [Result](https://docs.rs/google-servicecontrol1/1.0.7+20171202/google_servicecontrol1/enum.Result.html), should be
+read by you to obtain the media.
+If such a method also supports a [Response Result](https://docs.rs/google-servicecontrol1/1.0.7+20171202/google_servicecontrol1/trait.ResponseResult.html), it will return that by default.
+You can see it as meta-data for the actual media. To trigger a media download, you will have to set up the builder by making
+this call: `.param("alt", "media")`.
+
+Methods supporting uploads can do so using up to 2 different protocols: 
+*simple* and *resumable*. The distinctiveness of each is represented by customized 
+`doit(...)` methods, which are then named `upload(...)` and `upload_resumable(...)` respectively.
+
+## Customization and Callbacks
+
+You may alter the way an `doit()` method is called by providing a [delegate](https://docs.rs/google-servicecontrol1/1.0.7+20171202/google_servicecontrol1/trait.Delegate.html) to the 
+[Method Builder](https://docs.rs/google-servicecontrol1/1.0.7+20171202/google_servicecontrol1/trait.CallBuilder.html) before making the final `doit()` call. 
+Respective methods will be called to provide progress information, as well as determine whether the system should 
+retry on failure.
+
+The [delegate trait](https://docs.rs/google-servicecontrol1/1.0.7+20171202/google_servicecontrol1/trait.Delegate.html) is default-implemented, allowing you to customize it with minimal effort.
+
+## Optional Parts in Server-Requests
+
+All structures provided by this library are made to be [enocodable](https://docs.rs/google-servicecontrol1/1.0.7+20171202/google_servicecontrol1/trait.RequestValue.html) and 
+[decodable](https://docs.rs/google-servicecontrol1/1.0.7+20171202/google_servicecontrol1/trait.ResponseResult.html) via *json*. Optionals are used to indicate that partial requests are responses 
+are valid.
+Most optionals are are considered [Parts](https://docs.rs/google-servicecontrol1/1.0.7+20171202/google_servicecontrol1/trait.Part.html) which are identifiable by name, which will be sent to 
+the server to indicate either the set parts of the request or the desired parts in the response.
+
+## Builder Arguments
+
+Using [method builders](https://docs.rs/google-servicecontrol1/1.0.7+20171202/google_servicecontrol1/trait.CallBuilder.html), you are able to prepare an action call by repeatedly calling it's methods.
+These will always take a single argument, for which the following statements are true.
+
+* [PODs][wiki-pod] are handed by copy
+* strings are passed as `&str`
+* [request values](https://docs.rs/google-servicecontrol1/1.0.7+20171202/google_servicecontrol1/trait.RequestValue.html) are moved
+
+Arguments will always be copied or cloned into the builder, to make them independent of their original life times.
+
+[wiki-pod]: http://en.wikipedia.org/wiki/Plain_old_data_structure
+[builder-pattern]: http://en.wikipedia.org/wiki/Builder_pattern
+[google-go-api]: https://github.com/google/google-api-go-client
+
+# License
+The **servicecontrol1** library was generated by Sebastian Thiel, and is placed 
+under the *MIT* license.
+You can read the full text at the repository's [license file][repo-license].
+
+[repo-license]: https://github.com/Byron/google-apis-rsblob/master/LICENSE.md

--- a/gen/servicecontrol1/src/cmn.rs
+++ b/gen/servicecontrol1/src/cmn.rs
@@ -1,0 +1,753 @@
+// COPY OF 'src/rust/api/cmn.rs'
+// DO NOT EDIT
+use std::io::{self, Read, Seek, Cursor, Write, SeekFrom};
+use std;
+use std::fmt::{self, Display};
+use std::str::FromStr;
+use std::error;
+use std::thread::sleep;
+use std::time::Duration;
+
+use mime::{Mime, TopLevel, SubLevel, Attr, Value};
+use oauth2::{TokenType, Retry, self};
+use hyper;
+use hyper::header::{ContentType, ContentLength, Headers, UserAgent, Authorization, Header,
+                    HeaderFormat, Bearer};
+use hyper::http::h1::LINE_ENDING;
+use hyper::method::Method;
+use hyper::status::StatusCode;
+
+use serde_json as json;
+
+/// Identifies the Hub. There is only one per library, this trait is supposed
+/// to make intended use more explicit.
+/// The hub allows to access all resource methods more easily.
+pub trait Hub {}
+
+/// Identifies types for building methods of a particular resource type
+pub trait MethodsBuilder {}
+
+/// Identifies types which represent builders for a particular resource method
+pub trait CallBuilder {}
+
+/// Identifies types which can be inserted and deleted.
+/// Types with this trait are most commonly used by clients of this API.
+pub trait Resource {}
+
+/// Identifies types which are used in API responses.
+pub trait ResponseResult {}
+
+/// Identifies types which are used in API requests.
+pub trait RequestValue {}
+
+/// Identifies types which are not actually used by the API
+/// This might be a bug within the google API schema.
+pub trait UnusedType {}
+
+/// Identifies types which are only used as part of other types, which
+/// usually are carrying the `Resource` trait.
+pub trait Part {}
+
+/// Identifies types which are only used by other types internally.
+/// They have no special meaning, this trait just marks them for completeness.
+pub trait NestedType {}
+
+/// A utility to specify reader types which provide seeking capabilities too
+pub trait ReadSeek: Seek + Read {}
+impl<T: Seek + Read> ReadSeek for T {}
+
+/// A trait for all types that can convert themselves into a *parts* string
+pub trait ToParts {
+    fn to_parts(&self) -> String;
+}
+
+/// A utility type which can decode a server response that indicates error
+#[derive(Deserialize)]
+pub struct JsonServerError {
+    pub error: String,
+    pub error_description: Option<String>
+}
+
+/// A utility to represent detailed errors we might see in case there are BadRequests.
+/// The latter happen if the sent parameters or request structures are unsound
+#[derive(Deserialize, Serialize, Debug)]
+pub struct ErrorResponse {
+    error: ServerError,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct ServerError {
+    errors: Vec<ServerMessage>,
+    code: u16,
+    message: String,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct ServerMessage {
+    domain: String,
+    reason: String,
+    message: String,
+    #[serde(rename="locationType")]
+    location_type: Option<String>,
+    location: Option<String>
+}
+
+#[derive(Copy, Clone)]
+pub struct DummyNetworkStream;
+
+impl Read for DummyNetworkStream {
+    fn read(&mut self, _: &mut [u8]) -> io::Result<usize> {
+        Ok(0)
+    }
+}
+
+impl Write for DummyNetworkStream {
+    fn write(&mut self, _: &[u8]) -> io::Result<usize> {
+        Ok(0)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl hyper::net::NetworkStream for DummyNetworkStream {
+    fn peer_addr(&mut self) -> io::Result<std::net::SocketAddr> {
+        Ok("127.0.0.1:1337".parse().unwrap())
+    }
+
+    fn set_read_timeout(&self, _dur: Option<Duration>) -> io::Result<()> {
+        Ok(())
+    }
+
+    fn set_write_timeout(&self, _dur: Option<Duration>) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+
+/// A trait specifying functionality to help controlling any request performed by the API.
+/// The trait has a conservative default implementation.
+///
+/// It contains methods to deal with all common issues, as well with the ones related to
+/// uploading media
+pub trait Delegate {
+
+    /// Called at the beginning of any API request. The delegate should store the method
+    /// information if he is interesting in knowing more context when further calls to it
+    /// are made.
+    /// The matching `finished()` call will always be made, no matter whether or not the API
+    /// request was successful. That way, the delegate may easily maintain a clean state
+    /// between various API calls.
+    fn begin(&mut self, MethodInfo) {}
+
+    /// Called whenever there is an [HttpError](http://hyperium.github.io/hyper/hyper/error/enum.HttpError.html), usually if there are network problems.
+    ///
+    /// If you choose to retry after a duration, the duration should be chosen using the
+    /// [exponential backoff algorithm](http://en.wikipedia.org/wiki/Exponential_backoff).
+    ///
+    /// Return retry information.
+    fn http_error(&mut self, &hyper::Error) -> Retry {
+        Retry::Abort
+    }
+
+    /// Called whenever there is the need for your applications API key after
+    /// the official authenticator implementation didn't provide one, for some reason.
+    /// If this method returns None as well, the underlying operation will fail
+    fn api_key(&mut self) -> Option<String> {
+        None
+    }
+
+    /// Called whenever the Authenticator didn't yield a token. The delegate
+    /// may attempt to provide one, or just take it as a general information about the
+    /// impending failure.
+    /// The given Error provides information about why the token couldn't be acquired in the
+    /// first place
+    fn token(&mut self, err: &error::Error) -> Option<oauth2::Token> {
+        let _ = err;
+        None
+    }
+
+    /// Called during resumable uploads to provide a URL for the impending upload.
+    /// It was saved after a previous call to `store_upload_url(...)`, and if not None,
+    /// will be used instead of asking the server for a new upload URL.
+    /// This is useful in case a previous resumable upload was aborted/canceled, but should now
+    /// be resumed.
+    /// The returned URL will be used exactly once - if it fails again and the delegate allows
+    /// to retry, we will ask the server for a new upload URL.
+    fn upload_url(&mut self) -> Option<String> {
+        None
+    }
+
+    /// Called after we have retrieved a new upload URL for a resumable upload to store it
+    /// in case we fail or cancel. That way, we can attempt to resume the upload later,
+    /// see `upload_url()`.
+    /// It will also be called with None after a successful upload, which allows the delegate
+    /// to forget the URL. That way, we will not attempt to resume an upload that has already
+    /// finished.
+    fn store_upload_url(&mut self, url: Option<&str>) {
+        let _ = url;
+    }
+
+    /// Called whenever a server response could not be decoded from json.
+    /// It's for informational purposes only, the caller will return with an error
+    /// accordingly.
+    ///
+    /// # Arguments
+    ///
+    /// * `json_encoded_value` - The json-encoded value which failed to decode.
+    /// * `json_decode_error`  - The decoder error
+    fn response_json_decode_error(&mut self, json_encoded_value: &str, json_decode_error: &json::Error) {
+        let _ = json_encoded_value;
+        let _ = json_decode_error;
+    }
+
+    /// Called whenever the http request returns with a non-success status code.
+    /// This can involve authentication issues, or anything else that very much
+    /// depends on the used API method.
+    /// The delegate should check the status, header and decoded json error to decide
+    /// whether to retry or not. In the latter case, the underlying call will fail.
+    ///
+    /// If you choose to retry after a duration, the duration should be chosen using the
+    /// [exponential backoff algorithm](http://en.wikipedia.org/wiki/Exponential_backoff).
+    fn http_failure(&mut self, _: &hyper::client::Response, Option<JsonServerError>, _: Option<ServerError>) -> Retry {
+        Retry::Abort
+    }
+
+    /// Called prior to sending the main request of the given method. It can be used to time
+    /// the call or to print progress information.
+    /// It's also useful as you can be sure that a request will definitely be made.
+    fn pre_request(&mut self) { }
+
+    /// Return the size of each chunk of a resumable upload.
+    /// Must be a power of two, with 1<<18 being the smallest allowed chunk size.
+    /// Will be called once before starting any resumable upload.
+    fn chunk_size(&mut self) -> u64 {
+        1 << 23
+    }
+
+    /// Called before the given chunk is uploaded to the server.
+    /// If true is returned, the upload will be interrupted.
+    /// However, it may be resumable if you stored the upload URL in a previous call
+    /// to `store_upload_url()`
+    fn cancel_chunk_upload(&mut self, chunk: &ContentRange) -> bool {
+        let _ = chunk;
+        false
+    }
+
+    /// Called before the API request method returns, in every case. It can be used to clean up
+    /// internal state between calls to the API.
+    /// This call always has a matching call to `begin(...)`.
+    ///
+    /// # Arguments
+    ///
+    /// * `is_success` - a true value indicates the operation was successful. If false, you should
+    ///                  discard all values stored during `store_upload_url`.
+    fn finished(&mut self, is_success: bool) {
+        let _ = is_success;
+    }
+}
+
+/// A delegate with a conservative default implementation, which is used if no other delegate is
+/// set.
+#[derive(Default)]
+pub struct DefaultDelegate;
+
+impl Delegate for DefaultDelegate {}
+
+
+#[derive(Debug)]
+pub enum Error {
+    /// The http connection failed
+    HttpError(hyper::Error),
+
+    /// An attempt was made to upload a resource with size stored in field `.0`
+    /// even though the maximum upload size is what is stored in field `.1`.
+    UploadSizeLimitExceeded(u64, u64),
+
+    /// Represents information about a request that was not understood by the server.
+    /// Details are included.
+    BadRequest(ErrorResponse),
+
+    /// We needed an API key for authentication, but didn't obtain one.
+    /// Neither through the authenticator, nor through the Delegate.
+    MissingAPIKey,
+
+    /// We required a Token, but didn't get one from the Authenticator
+    MissingToken(Box<error::Error>),
+
+    /// The delgate instructed to cancel the operation
+    Cancelled,
+
+    /// An additional, free form field clashed with one of the built-in optional ones
+    FieldClash(&'static str),
+
+    /// Shows that we failed to decode the server response.
+    /// This can happen if the protocol changes in conjunction with strict json decoding.
+    JsonDecodeError(String, json::Error),
+
+    /// Indicates an HTTP repsonse with a non-success status code
+    Failure(hyper::client::Response),
+}
+
+
+impl Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Error::HttpError(ref err) => err.fmt(f),
+            Error::UploadSizeLimitExceeded(ref resource_size, ref max_size) =>
+                writeln!(f, "The media size {} exceeds the maximum allowed upload size of {}"
+                         , resource_size, max_size),
+            Error::MissingAPIKey => {
+                (writeln!(f, "The application's API key was not found in the configuration")).ok();
+                writeln!(f, "It is used as there are no Scopes defined for this method.")
+            },
+            Error::BadRequest(ref err) => {
+                try!(writeln!(f, "Bad Request ({}): {}", err.error.code, err.error.message));
+                for err in err.error.errors.iter() {
+                    try!(writeln!(f, "    {}: {}, {}{}",
+                                            err.domain,
+                                            err.message,
+                                            err.reason,
+                                            match &err.location {
+                                                &Some(ref loc) => format!("@{}", loc),
+                                                &None => String::new(),
+                                            }));
+                }
+                Ok(())
+            },
+            Error::MissingToken(ref err) =>
+                writeln!(f, "Token retrieval failed with error: {}", err),
+            Error::Cancelled =>
+                writeln!(f, "Operation cancelled by delegate"),
+            Error::FieldClash(field) =>
+                writeln!(f, "The custom parameter '{}' is already provided natively by the CallBuilder.", field),
+            Error::JsonDecodeError(ref json_str, ref err)
+                => writeln!(f, "{}: {}", err, json_str),
+            Error::Failure(ref response) =>
+                writeln!(f, "Http status indicates failure: {:?}", response),
+        }
+    }
+}
+
+impl error::Error for Error {
+    fn description(&self) -> &str {
+        match *self {
+            Error::HttpError(ref err) => err.description(),
+            Error::JsonDecodeError(_, ref err) => err.description(),
+            _ => "NO DESCRIPTION POSSIBLE - use `Display.fmt()` instead"
+        }
+    }
+
+    fn cause(&self) -> Option<&error::Error> {
+        match *self {
+            Error::HttpError(ref err) => err.cause(),
+            Error::JsonDecodeError(_, ref err) => err.cause(),
+            _ => None
+        }
+    }
+}
+
+/// A universal result type used as return for all calls.
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Contains information about an API request.
+pub struct MethodInfo {
+    pub id: &'static str,
+    pub http_method: Method,
+}
+
+const BOUNDARY: &'static str = "MDuXWGyeE33QFXGchb2VFWc4Z7945d";
+
+/// Provides a `Read` interface that converts multiple parts into the protocol
+/// identified by [RFC2387](https://tools.ietf.org/html/rfc2387).
+/// **Note**: This implementation is just as rich as it needs to be to perform uploads
+/// to google APIs, and might not be a fully-featured implementation.
+#[derive(Default)]
+pub struct MultiPartReader<'a> {
+    raw_parts: Vec<(Headers, &'a mut Read)>,
+    current_part: Option<(Cursor<Vec<u8>>, &'a mut Read)>,
+    last_part_boundary: Option<Cursor<Vec<u8>>>,
+}
+
+impl<'a> MultiPartReader<'a> {
+
+    /// Reserve memory for exactly the given amount of parts
+    pub fn reserve_exact(&mut self, cap: usize) {
+        self.raw_parts.reserve_exact(cap);
+    }
+
+    /// Add a new part to the queue of parts to be read on the first `read` call.
+    ///
+    /// # Arguments
+    ///
+    /// `headers` - identifying the body of the part. It's similar to the header
+    ///             in an ordinary single-part call, and should thus contain the
+    ///             same information.
+    /// `reader`  - a reader providing the part's body
+    /// `size`    - the amount of bytes provided by the reader. It will be put onto the header as
+    ///             content-size.
+    /// `mime`    - It will be put onto the content type
+    pub fn add_part(&mut self, reader: &'a mut Read, size: u64, mime_type: Mime) -> &mut MultiPartReader<'a> {
+        let mut headers = Headers::new();
+        headers.set(ContentType(mime_type));
+        headers.set(ContentLength(size));
+        self.raw_parts.push((headers, reader));
+        self
+    }
+
+    /// Returns the mime-type representing our multi-part message.
+    /// Use it with the ContentType header.
+    pub fn mime_type(&self) -> Mime {
+        Mime(
+            TopLevel::Multipart,
+            SubLevel::Ext("Related".to_string()),
+            vec![(Attr::Ext("boundary".to_string()), Value::Ext(BOUNDARY.to_string()))],
+        )
+    }
+
+    /// Returns true if we are totally used
+    fn is_depleted(&self) -> bool {
+        self.raw_parts.len() == 0 && self.current_part.is_none() && self.last_part_boundary.is_none()
+    }
+
+    /// Returns true if we are handling our last part
+    fn is_last_part(&self) -> bool {
+        self.raw_parts.len() == 0 && self.current_part.is_some()
+    }
+}
+
+impl<'a> Read for MultiPartReader<'a> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        match (self.raw_parts.len(),
+               self.current_part.is_none(),
+               self.last_part_boundary.is_none()) {
+            (_, _, false) => {
+                let br = self.last_part_boundary.as_mut().unwrap().read(buf).unwrap_or(0);
+                if br < buf.len() {
+                    self.last_part_boundary = None;
+                }
+                return Ok(br)
+            },
+            (0, true, true) => return Ok(0),
+            (n, true, _) if n > 0 => {
+                let (headers, reader) = self.raw_parts.remove(0);
+                let mut c = Cursor::new(Vec::<u8>::new());
+                (write!(&mut c, "{}--{}{}{}{}", LINE_ENDING, BOUNDARY, LINE_ENDING,
+                                                headers, LINE_ENDING)).unwrap();
+                c.seek(SeekFrom::Start(0)).unwrap();
+                self.current_part = Some((c, reader));
+            }
+            _ => {},
+        }
+
+        // read headers as long as possible
+        let (hb, rr) = {
+            let &mut (ref mut c, ref mut reader) = self.current_part.as_mut().unwrap();
+            let b = c.read(buf).unwrap_or(0);
+            (b, reader.read(&mut buf[b..]))
+        };
+
+        match rr {
+            Ok(bytes_read) => {
+                if hb < buf.len() && bytes_read == 0 {
+                    if self.is_last_part() {
+                        // before clearing the last part, we will add the boundary that
+                        // will be written last
+                        self.last_part_boundary = Some(Cursor::new(
+                                                        format!("{}--{}--", LINE_ENDING, BOUNDARY).into_bytes()))
+                    }
+                    // We are depleted - this can trigger the next part to come in
+                    self.current_part = None;
+                }
+                let mut total_bytes_read = hb + bytes_read;
+                while total_bytes_read < buf.len() && !self.is_depleted() {
+                    match self.read(&mut buf[total_bytes_read ..]) {
+                        Ok(br) => total_bytes_read += br,
+                        Err(err) => return Err(err),
+                    }
+                }
+                Ok(total_bytes_read)
+            }
+            Err(err) => {
+                // fail permanently
+                self.current_part = None;
+                self.last_part_boundary = None;
+                self.raw_parts.clear();
+                Err(err)
+            }
+        }
+    }
+}
+
+/// The `X-Upload-Content-Type` header.
+///
+/// Generated via rustc --pretty expanded -Z unstable-options, and manually
+/// processed to be more readable.
+#[derive(PartialEq, Debug, Clone)]
+pub struct XUploadContentType(pub Mime);
+
+impl ::std::ops::Deref for XUploadContentType {
+    type Target = Mime;
+    fn deref<'a>(&'a self) -> &'a Mime { &self.0 }
+}
+impl ::std::ops::DerefMut for XUploadContentType {
+    fn deref_mut<'a>(&'a mut self) -> &'a mut Mime { &mut self.0 }
+}
+impl Header for XUploadContentType {
+    fn header_name() -> &'static str { "X-Upload-Content-Type" }
+    fn parse_header(raw: &[Vec<u8>]) -> hyper::error::Result<Self> {
+        hyper::header::parsing::from_one_raw_str(raw).map(XUploadContentType)
+    }
+}
+impl HeaderFormat for XUploadContentType {
+    fn fmt_header(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        Display::fmt(&**self, f)
+    }
+}
+impl Display for XUploadContentType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(&**self, f)
+    }
+}
+
+#[derive(Clone, PartialEq, Debug)]
+pub struct Chunk {
+    pub first: u64,
+    pub last: u64
+}
+
+impl fmt::Display for Chunk {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        (write!(fmt, "{}-{}", self.first, self.last)).ok();
+        Ok(())
+    }
+}
+
+impl FromStr for Chunk {
+    type Err = &'static str;
+
+    /// NOTE: only implements `%i-%i`, not `*`
+    fn from_str(s: &str) -> std::result::Result<Chunk, &'static str> {
+        let parts: Vec<&str> = s.split('-').collect();
+        if parts.len() != 2 {
+            return Err("Expected two parts: %i-%i")
+        }
+        Ok(
+            Chunk {
+                first: match FromStr::from_str(parts[0]) {
+                    Ok(d) => d,
+                    _ => return Err("Couldn't parse 'first' as digit")
+                },
+                last: match FromStr::from_str(parts[1]) {
+                    Ok(d) => d,
+                    _ => return Err("Couldn't parse 'last' as digit")
+                }
+            }
+        )
+    }
+}
+
+/// Implements the Content-Range header, for serialization only
+#[derive(Clone, PartialEq, Debug)]
+pub struct ContentRange {
+    pub range: Option<Chunk>,
+    pub total_length: u64,
+}
+
+impl Header for ContentRange {
+    fn header_name() -> &'static str {
+        "Content-Range"
+    }
+
+    /// We are not parsable, as parsing is done by the `Range` header
+    fn parse_header(_: &[Vec<u8>]) -> hyper::error::Result<Self> {
+        Err(hyper::error::Error::Method)
+    }
+}
+
+
+impl HeaderFormat for ContentRange {
+    fn fmt_header(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        try!(fmt.write_str("bytes "));
+        match self.range {
+            Some(ref c) => try!(c.fmt(fmt)),
+            None => try!(fmt.write_str("*"))
+        }
+        (write!(fmt, "/{}", self.total_length)).ok();
+        Ok(())
+    }
+}
+
+#[derive(Clone, PartialEq, Debug)]
+pub struct RangeResponseHeader(pub Chunk);
+
+impl Header for RangeResponseHeader {
+    fn header_name() -> &'static str {
+        "Range"
+    }
+
+    fn parse_header(raw: &[Vec<u8>]) -> hyper::error::Result<Self> {
+        if raw.len() > 0 {
+            let v = &raw[0];
+            if let Ok(s) = std::str::from_utf8(v) {
+                const PREFIX: &'static str = "bytes ";
+                if s.starts_with(PREFIX) {
+                    if let Ok(c) = <Chunk as FromStr>::from_str(&s[PREFIX.len()..]) {
+                        return  Ok(RangeResponseHeader(c))
+                    }
+                }
+            }
+        }
+        Err(hyper::error::Error::Method)
+    }
+}
+
+impl HeaderFormat for RangeResponseHeader {
+    /// No implmentation necessary, we just need to parse
+    fn fmt_header(&self, _: &mut fmt::Formatter) -> fmt::Result {
+        Err(fmt::Error)
+    }
+}
+
+/// A utility type to perform a resumable upload from start to end.
+pub struct ResumableUploadHelper<'a, A: 'a> {
+    pub client: &'a mut hyper::client::Client,
+    pub delegate: &'a mut Delegate,
+    pub start_at: Option<u64>,
+    pub auth: &'a mut A,
+    pub user_agent: &'a str,
+    pub auth_header: Authorization<Bearer>,
+    pub url: &'a str,
+    pub reader: &'a mut ReadSeek,
+    pub media_type: Mime,
+    pub content_length: u64
+}
+
+impl<'a, A> ResumableUploadHelper<'a, A>
+    where A: oauth2::GetToken {
+
+    fn query_transfer_status(&mut self) -> std::result::Result<u64, hyper::Result<hyper::client::Response>> {
+        loop {
+            match self.client.post(self.url)
+                .header(UserAgent(self.user_agent.to_string()))
+                .header(ContentRange { range: None, total_length: self.content_length })
+                .header(self.auth_header.clone())
+                .send() {
+                Ok(r) => {
+                    // 308 = resume-incomplete == PermanentRedirect
+                    let headers = r.headers.clone();
+                    let h: &RangeResponseHeader = match headers.get() {
+                        Some(hh) if r.status == StatusCode::PermanentRedirect => hh,
+                        None|Some(_) => {
+                            if let Retry::After(d) = self.delegate.http_failure(&r, None, None) {
+                                sleep(d);
+                                continue;
+                            }
+                            return Err(Ok(r))
+                        }
+                    };
+                    return Ok(h.0.last)
+                }
+                Err(err) => {
+                    if let Retry::After(d) = self.delegate.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    return Err(Err(err))
+                }
+            }
+        }
+    }
+
+    /// returns None if operation was cancelled by delegate, or the HttpResult.
+    /// It can be that we return the result just because we didn't understand the status code -
+    /// caller should check for status himself before assuming it's OK to use
+    pub fn upload(&mut self) -> Option<hyper::Result<hyper::client::Response>> {
+        let mut start = match self.start_at {
+            Some(s) => s,
+            None => match self.query_transfer_status() {
+                Ok(s) => s,
+                Err(result) => return Some(result)
+            }
+        };
+
+        const MIN_CHUNK_SIZE: u64 = 1 << 18;
+        let chunk_size = match self.delegate.chunk_size() {
+            cs if cs > MIN_CHUNK_SIZE => cs,
+            _ => MIN_CHUNK_SIZE
+        };
+
+        self.reader.seek(SeekFrom::Start(start)).unwrap();
+        loop {
+            let request_size = match self.content_length - start {
+                rs if rs > chunk_size => chunk_size,
+                rs => rs
+            };
+
+            let mut section_reader = self.reader.take(request_size);
+            let range_header = ContentRange {
+                range: Some(Chunk {first: start, last: start + request_size - 1}),
+                total_length: self.content_length
+            };
+            start += request_size;
+            if self.delegate.cancel_chunk_upload(&range_header) {
+                return None
+            }
+            let res = self.client.post(self.url)
+                                 .header(range_header)
+                                 .header(ContentType(self.media_type.clone()))
+                                 .header(UserAgent(self.user_agent.to_string()))
+                                 .body(&mut section_reader)
+                                 .send();
+            match res {
+                Ok(mut res) => {
+                    if res.status == StatusCode::PermanentRedirect  {
+                        continue
+                    }
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let Retry::After(d) = self.delegate.http_failure(&res,
+                                                        json::from_str(&json_err).ok(),
+                                                        json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                    }
+                    return Some(Ok(res))
+                },
+                Err(err) => {
+                    if let Retry::After(d) = self.delegate.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    return Some(Err(err))
+                }
+            }
+        }
+    }
+}
+
+// Copy of src/rust/cli/cmn.rs
+// TODO(ST): Allow sharing common code between program types
+pub fn remove_json_null_values(value: &mut json::value::Value) {
+    match *value {
+        json::value::Value::Object(ref mut map) => {
+            let mut for_removal = Vec::new();
+
+            for (key, mut value) in map.iter_mut() {
+                if value.is_null() {
+                    for_removal.push(key.clone());
+                } else {
+                    remove_json_null_values(&mut value);
+                }
+            }
+
+            for key in &for_removal {
+                map.remove(key);
+            }
+        }
+        _ => {}
+    }
+}

--- a/gen/servicecontrol1/src/lib.rs
+++ b/gen/servicecontrol1/src/lib.rs
@@ -1,0 +1,3502 @@
+// DO NOT EDIT !
+// This file was generated automatically from 'src/mako/api/lib.rs.mako'
+// DO NOT EDIT !
+
+//! This documentation was generated from *Service Control* crate version *1.0.7+20171202*, where *20171202* is the exact revision of the *servicecontrol:v1* schema built by the [mako](http://www.makotemplates.org/) code generator *v1.0.7*.
+//! 
+//! Everything else about the *Service Control* *v1* API can be found at the
+//! [official documentation site](https://cloud.google.com/service-control/).
+//! The original source code is [on github](https://github.com/Byron/google-apis-rs/tree/master/gen/servicecontrol1).
+//! # Features
+//! 
+//! Handle the following *Resources* with ease from the central [hub](struct.ServiceControl.html) ... 
+//! 
+//! * services
+//!  * [*allocate quota*](struct.ServiceAllocateQuotaCall.html), [*check*](struct.ServiceCheckCall.html), [*end reconciliation*](struct.ServiceEndReconciliationCall.html), [*release quota*](struct.ServiceReleaseQuotaCall.html), [*report*](struct.ServiceReportCall.html) and [*start reconciliation*](struct.ServiceStartReconciliationCall.html)
+//! 
+//! 
+//! 
+//! 
+//! Not what you are looking for ? Find all other Google APIs in their Rust [documentation index](http://byron.github.io/google-apis-rs).
+//! 
+//! # Structure of this Library
+//! 
+//! The API is structured into the following primary items:
+//! 
+//! * **[Hub](struct.ServiceControl.html)**
+//!     * a central object to maintain state and allow accessing all *Activities*
+//!     * creates [*Method Builders*](trait.MethodsBuilder.html) which in turn
+//!       allow access to individual [*Call Builders*](trait.CallBuilder.html)
+//! * **[Resources](trait.Resource.html)**
+//!     * primary types that you can apply *Activities* to
+//!     * a collection of properties and *Parts*
+//!     * **[Parts](trait.Part.html)**
+//!         * a collection of properties
+//!         * never directly used in *Activities*
+//! * **[Activities](trait.CallBuilder.html)**
+//!     * operations to apply to *Resources*
+//! 
+//! All *structures* are marked with applicable traits to further categorize them and ease browsing.
+//! 
+//! Generally speaking, you can invoke *Activities* like this:
+//! 
+//! ```Rust,ignore
+//! let r = hub.resource().activity(...).doit()
+//! ```
+//! 
+//! Or specifically ...
+//! 
+//! ```ignore
+//! let r = hub.services().check(...).doit()
+//! ```
+//! 
+//! The `resource()` and `activity(...)` calls create [builders][builder-pattern]. The second one dealing with `Activities` 
+//! supports various methods to configure the impending operation (not shown here). It is made such that all required arguments have to be 
+//! specified right away (i.e. `(...)`), whereas all optional ones can be [build up][builder-pattern] as desired.
+//! The `doit()` method performs the actual communication with the server and returns the respective result.
+//! 
+//! # Usage
+//! 
+//! ## Setting up your Project
+//! 
+//! To use this library, you would put the following lines into your `Cargo.toml` file:
+//! 
+//! ```toml
+//! [dependencies]
+//! google-servicecontrol1 = "*"
+//! ```
+//! 
+//! ## A complete example
+//! 
+//! ```test_harness,no_run
+//! extern crate hyper;
+//! extern crate hyper_rustls;
+//! extern crate yup_oauth2 as oauth2;
+//! extern crate google_servicecontrol1 as servicecontrol1;
+//! use servicecontrol1::CheckRequest;
+//! use servicecontrol1::{Result, Error};
+//! # #[test] fn egal() {
+//! use std::default::Default;
+//! use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+//! use servicecontrol1::ServiceControl;
+//! 
+//! // Get an ApplicationSecret instance by some means. It contains the `client_id` and 
+//! // `client_secret`, among other things.
+//! let secret: ApplicationSecret = Default::default();
+//! // Instantiate the authenticator. It will choose a suitable authentication flow for you, 
+//! // unless you replace  `None` with the desired Flow.
+//! // Provide your own `AuthenticatorDelegate` to adjust the way it operates and get feedback about 
+//! // what's going on. You probably want to bring in your own `TokenStorage` to persist tokens and
+//! // retrieve them from storage.
+//! let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+//!                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+//!                               <MemoryStorage as Default>::default(), None);
+//! let mut hub = ServiceControl::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+//! // As the method needs a request, you would usually fill it with the desired information
+//! // into the respective structure. Some of the parts shown here might not be applicable !
+//! // Values shown here are possibly random and not representative !
+//! let mut req = CheckRequest::default();
+//! 
+//! // You can configure optional parameters by calling the respective setters at will, and
+//! // execute the final call using `doit()`.
+//! // Values shown here are possibly random and not representative !
+//! let result = hub.services().check(req, "serviceName")
+//!              .doit();
+//! 
+//! match result {
+//!     Err(e) => match e {
+//!         // The Error enum provides details about what exactly happened.
+//!         // You can also just use its `Debug`, `Display` or `Error` traits
+//!          Error::HttpError(_)
+//!         |Error::MissingAPIKey
+//!         |Error::MissingToken(_)
+//!         |Error::Cancelled
+//!         |Error::UploadSizeLimitExceeded(_, _)
+//!         |Error::Failure(_)
+//!         |Error::BadRequest(_)
+//!         |Error::FieldClash(_)
+//!         |Error::JsonDecodeError(_, _) => println!("{}", e),
+//!     },
+//!     Ok(res) => println!("Success: {:?}", res),
+//! }
+//! # }
+//! ```
+//! ## Handling Errors
+//! 
+//! All errors produced by the system are provided either as [Result](enum.Result.html) enumeration as return value of 
+//! the doit() methods, or handed as possibly intermediate results to either the 
+//! [Hub Delegate](trait.Delegate.html), or the [Authenticator Delegate](https://docs.rs/yup-oauth2/*/yup_oauth2/trait.AuthenticatorDelegate.html).
+//! 
+//! When delegates handle errors or intermediate values, they may have a chance to instruct the system to retry. This 
+//! makes the system potentially resilient to all kinds of errors.
+//! 
+//! ## Uploads and Downloads
+//! If a method supports downloads, the response body, which is part of the [Result](enum.Result.html), should be
+//! read by you to obtain the media.
+//! If such a method also supports a [Response Result](trait.ResponseResult.html), it will return that by default.
+//! You can see it as meta-data for the actual media. To trigger a media download, you will have to set up the builder by making
+//! this call: `.param("alt", "media")`.
+//! 
+//! Methods supporting uploads can do so using up to 2 different protocols: 
+//! *simple* and *resumable*. The distinctiveness of each is represented by customized 
+//! `doit(...)` methods, which are then named `upload(...)` and `upload_resumable(...)` respectively.
+//! 
+//! ## Customization and Callbacks
+//! 
+//! You may alter the way an `doit()` method is called by providing a [delegate](trait.Delegate.html) to the 
+//! [Method Builder](trait.CallBuilder.html) before making the final `doit()` call. 
+//! Respective methods will be called to provide progress information, as well as determine whether the system should 
+//! retry on failure.
+//! 
+//! The [delegate trait](trait.Delegate.html) is default-implemented, allowing you to customize it with minimal effort.
+//! 
+//! ## Optional Parts in Server-Requests
+//! 
+//! All structures provided by this library are made to be [enocodable](trait.RequestValue.html) and 
+//! [decodable](trait.ResponseResult.html) via *json*. Optionals are used to indicate that partial requests are responses 
+//! are valid.
+//! Most optionals are are considered [Parts](trait.Part.html) which are identifiable by name, which will be sent to 
+//! the server to indicate either the set parts of the request or the desired parts in the response.
+//! 
+//! ## Builder Arguments
+//! 
+//! Using [method builders](trait.CallBuilder.html), you are able to prepare an action call by repeatedly calling it's methods.
+//! These will always take a single argument, for which the following statements are true.
+//! 
+//! * [PODs][wiki-pod] are handed by copy
+//! * strings are passed as `&str`
+//! * [request values](trait.RequestValue.html) are moved
+//! 
+//! Arguments will always be copied or cloned into the builder, to make them independent of their original life times.
+//! 
+//! [wiki-pod]: http://en.wikipedia.org/wiki/Plain_old_data_structure
+//! [builder-pattern]: http://en.wikipedia.org/wiki/Builder_pattern
+//! [google-go-api]: https://github.com/google/google-api-go-client
+//! 
+//! 
+
+// Unused attributes happen thanks to defined, but unused structures
+// We don't warn about this, as depending on the API, some data structures or facilities are never used.
+// Instead of pre-determining this, we just disable the lint. It's manually tuned to not have any
+// unused imports in fully featured APIs. Same with unused_mut ... .
+#![allow(unused_imports, unused_mut, dead_code)]
+
+// DO NOT EDIT !
+// This file was generated automatically from 'src/mako/api/lib.rs.mako'
+// DO NOT EDIT !
+
+#[macro_use]
+extern crate serde_derive;
+
+extern crate hyper;
+extern crate serde;
+extern crate serde_json;
+extern crate yup_oauth2 as oauth2;
+extern crate mime;
+extern crate url;
+
+mod cmn;
+
+use std::collections::HashMap;
+use std::cell::RefCell;
+use std::borrow::BorrowMut;
+use std::default::Default;
+use std::collections::BTreeMap;
+use serde_json as json;
+use std::io;
+use std::fs;
+use std::mem;
+use std::thread::sleep;
+use std::time::Duration;
+
+pub use cmn::{MultiPartReader, ToParts, MethodInfo, Result, Error, CallBuilder, Hub, ReadSeek, Part,
+              ResponseResult, RequestValue, NestedType, Delegate, DefaultDelegate, MethodsBuilder,
+              Resource, ErrorResponse, remove_json_null_values};
+
+
+// ##############
+// UTILITIES ###
+// ############
+
+/// Identifies the an OAuth2 authorization scope.
+/// A scope is needed when requesting an
+/// [authorization token](https://developers.google.com/youtube/v3/guides/authentication).
+#[derive(PartialEq, Eq, Hash)]
+pub enum Scope {
+    /// View and manage your data across Google Cloud Platform services
+    CloudPlatform,
+
+    /// Manage your Google Service Control data
+    Full,
+}
+
+impl AsRef<str> for Scope {
+    fn as_ref(&self) -> &str {
+        match *self {
+            Scope::CloudPlatform => "https://www.googleapis.com/auth/cloud-platform",
+            Scope::Full => "https://www.googleapis.com/auth/servicecontrol",
+        }
+    }
+}
+
+impl Default for Scope {
+    fn default() -> Scope {
+        Scope::CloudPlatform
+    }
+}
+
+
+
+// ########
+// HUB ###
+// ######
+
+/// Central instance to access all ServiceControl related resource activities
+///
+/// # Examples
+///
+/// Instantiate a new hub
+///
+/// ```test_harness,no_run
+/// extern crate hyper;
+/// extern crate hyper_rustls;
+/// extern crate yup_oauth2 as oauth2;
+/// extern crate google_servicecontrol1 as servicecontrol1;
+/// use servicecontrol1::CheckRequest;
+/// use servicecontrol1::{Result, Error};
+/// # #[test] fn egal() {
+/// use std::default::Default;
+/// use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// use servicecontrol1::ServiceControl;
+/// 
+/// // Get an ApplicationSecret instance by some means. It contains the `client_id` and 
+/// // `client_secret`, among other things.
+/// let secret: ApplicationSecret = Default::default();
+/// // Instantiate the authenticator. It will choose a suitable authentication flow for you, 
+/// // unless you replace  `None` with the desired Flow.
+/// // Provide your own `AuthenticatorDelegate` to adjust the way it operates and get feedback about 
+/// // what's going on. You probably want to bring in your own `TokenStorage` to persist tokens and
+/// // retrieve them from storage.
+/// let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+///                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+///                               <MemoryStorage as Default>::default(), None);
+/// let mut hub = ServiceControl::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = CheckRequest::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.services().check(req, "serviceName")
+///              .doit();
+/// 
+/// match result {
+///     Err(e) => match e {
+///         // The Error enum provides details about what exactly happened.
+///         // You can also just use its `Debug`, `Display` or `Error` traits
+///          Error::HttpError(_)
+///         |Error::MissingAPIKey
+///         |Error::MissingToken(_)
+///         |Error::Cancelled
+///         |Error::UploadSizeLimitExceeded(_, _)
+///         |Error::Failure(_)
+///         |Error::BadRequest(_)
+///         |Error::FieldClash(_)
+///         |Error::JsonDecodeError(_, _) => println!("{}", e),
+///     },
+///     Ok(res) => println!("Success: {:?}", res),
+/// }
+/// # }
+/// ```
+pub struct ServiceControl<C, A> {
+    client: RefCell<C>,
+    auth: RefCell<A>,
+    _user_agent: String,
+    _base_url: String,
+    _root_url: String,
+}
+
+impl<'a, C, A> Hub for ServiceControl<C, A> {}
+
+impl<'a, C, A> ServiceControl<C, A>
+    where  C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+    pub fn new(client: C, authenticator: A) -> ServiceControl<C, A> {
+        ServiceControl {
+            client: RefCell::new(client),
+            auth: RefCell::new(authenticator),
+            _user_agent: "google-api-rust-client/1.0.7".to_string(),
+            _base_url: "https://servicecontrol.googleapis.com/".to_string(),
+            _root_url: "https://servicecontrol.googleapis.com/".to_string(),
+        }
+    }
+
+    pub fn services(&'a self) -> ServiceMethods<'a, C, A> {
+        ServiceMethods { hub: &self }
+    }
+
+    /// Set the user-agent header field to use in all requests to the server.
+    /// It defaults to `google-api-rust-client/1.0.7`.
+    ///
+    /// Returns the previously set user-agent.
+    pub fn user_agent(&mut self, agent_name: String) -> String {
+        mem::replace(&mut self._user_agent, agent_name)
+    }
+
+    /// Set the base url to use in all requests to the server.
+    /// It defaults to `https://servicecontrol.googleapis.com/`.
+    ///
+    /// Returns the previously set base url.
+    pub fn base_url(&mut self, new_base_url: String) -> String {
+        mem::replace(&mut self._base_url, new_base_url)
+    }
+
+    /// Set the root url to use in all requests to the server.
+    /// It defaults to `https://servicecontrol.googleapis.com/`.
+    ///
+    /// Returns the previously set root url.
+    pub fn root_url(&mut self, new_root_url: String) -> String {
+        mem::replace(&mut self._root_url, new_root_url)
+    }
+}
+
+
+// ############
+// SCHEMAS ###
+// ##########
+/// Defines the errors to be returned in
+/// google.api.servicecontrol.v1.CheckResponse.check_errors.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct CheckError {
+    /// The error code.
+    pub code: Option<String>,
+    /// Free-form text providing details on the error cause of the error.
+    pub detail: Option<String>,
+}
+
+impl Part for CheckError {}
+
+
+/// Represents a single metric value.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct MetricValue {
+    /// A money value.
+    #[serde(rename="moneyValue")]
+    pub money_value: Option<Money>,
+    /// The labels describing the metric value.
+    /// See comments on google.api.servicecontrol.v1.Operation.labels for
+    /// the overriding relationship.
+    pub labels: Option<HashMap<String, String>>,
+    /// A double precision floating point value.
+    #[serde(rename="doubleValue")]
+    pub double_value: Option<f64>,
+    /// A boolean value.
+    #[serde(rename="boolValue")]
+    pub bool_value: Option<bool>,
+    /// The start of the time period over which this metric value's measurement
+    /// applies. The time period has different semantics for different metric
+    /// types (cumulative, delta, and gauge). See the metric definition
+    /// documentation in the service configuration for details.
+    #[serde(rename="startTime")]
+    pub start_time: Option<String>,
+    /// A distribution value.
+    #[serde(rename="distributionValue")]
+    pub distribution_value: Option<Distribution>,
+    /// A text string value.
+    #[serde(rename="stringValue")]
+    pub string_value: Option<String>,
+    /// A signed 64-bit integer value.
+    #[serde(rename="int64Value")]
+    pub int64_value: Option<String>,
+    /// The end of the time period over which this metric value's measurement
+    /// applies.
+    #[serde(rename="endTime")]
+    pub end_time: Option<String>,
+}
+
+impl Part for MetricValue {}
+
+
+/// Response message for QuotaController.StartReconciliation.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [start reconciliation services](struct.ServiceStartReconciliationCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct StartReconciliationResponse {
+    /// ID of the actual config used to process the request.
+    #[serde(rename="serviceConfigId")]
+    pub service_config_id: Option<String>,
+    /// Metric values as tracked by One Platform before the start of
+    /// reconciliation. The following metrics will be included:
+    /// 
+    /// 1. Per quota metric total usage will be specified using the following gauge
+    /// metric:
+    ///   "serviceruntime.googleapis.com/allocation/consumer/quota_used_count"
+    /// 
+    /// 2. Value for each quota limit associated with the metrics will be specified
+    /// using the following gauge metric:
+    ///   "serviceruntime.googleapis.com/quota/limit"
+    #[serde(rename="quotaMetrics")]
+    pub quota_metrics: Option<Vec<MetricValueSet>>,
+    /// Indicates the decision of the reconciliation start.
+    #[serde(rename="reconciliationErrors")]
+    pub reconciliation_errors: Option<Vec<QuotaError>>,
+    /// The same operation_id value used in the StartReconciliationRequest. Used
+    /// for logging and diagnostics purposes.
+    #[serde(rename="operationId")]
+    pub operation_id: Option<String>,
+}
+
+impl ResponseResult for StartReconciliationResponse {}
+
+
+/// Request message for the Report method.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [report services](struct.ServiceReportCall.html) (request)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct ReportRequest {
+    /// Operations to be reported.
+    /// 
+    /// Typically the service should report one operation per request.
+    /// Putting multiple operations into a single request is allowed, but should
+    /// be used only when multiple operations are natually available at the time
+    /// of the report.
+    /// 
+    /// If multiple operations are in a single request, the total request size
+    /// should be no larger than 1MB. See ReportResponse.report_errors for
+    /// partial failure behavior.
+    pub operations: Option<Vec<Operation>>,
+    /// Specifies which version of service config should be used to process the
+    /// request.
+    /// 
+    /// If unspecified or no matching version can be found, the
+    /// latest one will be used.
+    #[serde(rename="serviceConfigId")]
+    pub service_config_id: Option<String>,
+}
+
+impl RequestValue for ReportRequest {}
+
+
+/// Contains the quota information for a quota check response.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct QuotaInfo {
+    /// Map of quota group name to the actual number of tokens consumed. If the
+    /// quota check was not successful, then this will not be populated due to no
+    /// quota consumption.
+    /// 
+    /// We are not merging this field with 'quota_metrics' field because of the
+    /// complexity of scaling in Chemist client code base. For simplicity, we will
+    /// keep this field for Castor (that scales quota usage) and 'quota_metrics'
+    /// for SuperQuota (that doesn't scale quota usage).
+    /// 
+    #[serde(rename="quotaConsumed")]
+    pub quota_consumed: Option<HashMap<String, i32>>,
+    /// Quota metrics to indicate the usage. Depending on the check request, one or
+    /// more of the following metrics will be included:
+    /// 
+    /// 1. For rate quota, per quota group or per quota metric incremental usage
+    /// will be specified using the following delta metric:
+    ///   "serviceruntime.googleapis.com/api/consumer/quota_used_count"
+    /// 
+    /// 2. For allocation quota, per quota metric total usage will be specified
+    /// using the following gauge metric:
+    ///   "serviceruntime.googleapis.com/allocation/consumer/quota_used_count"
+    /// 
+    /// 3. For both rate quota and allocation quota, the quota limit reached
+    /// condition will be specified using the following boolean metric:
+    ///   "serviceruntime.googleapis.com/quota/exceeded"
+    #[serde(rename="quotaMetrics")]
+    pub quota_metrics: Option<Vec<MetricValueSet>>,
+    /// Quota Metrics that have exceeded quota limits.
+    /// For QuotaGroup-based quota, this is QuotaGroup.name
+    /// For QuotaLimit-based quota, this is QuotaLimit.name
+    /// See: google.api.Quota
+    /// Deprecated: Use quota_metrics to get per quota group limit exceeded status.
+    #[serde(rename="limitExceeded")]
+    pub limit_exceeded: Option<Vec<String>>,
+}
+
+impl Part for QuotaInfo {}
+
+
+/// Request message for the ReleaseQuota method.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [release quota services](struct.ServiceReleaseQuotaCall.html) (request)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct ReleaseQuotaRequest {
+    /// Operation that describes the quota release.
+    #[serde(rename="releaseOperation")]
+    pub release_operation: Option<QuotaOperation>,
+    /// Specifies which version of service configuration should be used to process
+    /// the request. If unspecified or no matching version can be found, the latest
+    /// one will be used.
+    #[serde(rename="serviceConfigId")]
+    pub service_config_id: Option<String>,
+}
+
+impl RequestValue for ReleaseQuotaRequest {}
+
+
+/// Distribution represents a frequency distribution of double-valued sample
+/// points. It contains the size of the population of sample points plus
+/// additional optional information:
+/// 
+///   - the arithmetic mean of the samples
+///   - the minimum and maximum of the samples
+///   - the sum-squared-deviation of the samples, used to compute variance
+///   - a histogram of the values of the sample points
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Distribution {
+    /// The total number of samples in the distribution. Must be >= 0.
+    pub count: Option<String>,
+    /// The sum of squared deviations from the mean:
+    ///   Sum[i=1..count]((x_i - mean)^2)
+    /// where each x_i is a sample values. If `count` is zero then this field
+    /// must be zero, otherwise validation of the request fails.
+    #[serde(rename="sumOfSquaredDeviation")]
+    pub sum_of_squared_deviation: Option<f64>,
+    /// The number of samples in each histogram bucket. `bucket_counts` are
+    /// optional. If present, they must sum to the `count` value.
+    /// 
+    /// The buckets are defined below in `bucket_option`. There are N buckets.
+    /// `bucket_counts[0]` is the number of samples in the underflow bucket.
+    /// `bucket_counts[1]` to `bucket_counts[N-1]` are the numbers of samples
+    /// in each of the finite buckets. And `bucket_counts[N] is the number
+    /// of samples in the overflow bucket. See the comments of `bucket_option`
+    /// below for more details.
+    /// 
+    /// Any suffix of trailing zeros may be omitted.
+    #[serde(rename="bucketCounts")]
+    pub bucket_counts: Option<Vec<i64>>,
+    /// Buckets with exponentially growing width.
+    #[serde(rename="exponentialBuckets")]
+    pub exponential_buckets: Option<ExponentialBuckets>,
+    /// The maximum of the population of values. Ignored if `count` is zero.
+    pub maximum: Option<f64>,
+    /// The minimum of the population of values. Ignored if `count` is zero.
+    pub minimum: Option<f64>,
+    /// Buckets with constant width.
+    #[serde(rename="linearBuckets")]
+    pub linear_buckets: Option<LinearBuckets>,
+    /// Buckets with arbitrary user-provided width.
+    #[serde(rename="explicitBuckets")]
+    pub explicit_buckets: Option<ExplicitBuckets>,
+    /// The arithmetic mean of the samples in the distribution. If `count` is
+    /// zero then this field must be zero.
+    pub mean: Option<f64>,
+}
+
+impl Part for Distribution {}
+
+
+/// Describing buckets with arbitrary user-provided width.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct ExplicitBuckets {
+    /// 'bound' is a list of strictly increasing boundaries between
+    /// buckets. Note that a list of length N-1 defines N buckets because
+    /// of fenceposting. See comments on `bucket_options` for details.
+    /// 
+    /// The i'th finite bucket covers the interval
+    ///   [bound[i-1], bound[i])
+    /// where i ranges from 1 to bound_size() - 1. Note that there are no
+    /// finite buckets at all if 'bound' only contains a single element; in
+    /// that special case the single bound defines the boundary between the
+    /// underflow and overflow buckets.
+    /// 
+    /// bucket number                   lower bound    upper bound
+    ///  i == 0 (underflow)              -inf           bound[i]
+    ///  0 < i < bound_size()            bound[i-1]     bound[i]
+    ///  i == bound_size() (overflow)    bound[i-1]     +inf
+    pub bounds: Option<Vec<f64>>,
+}
+
+impl Part for ExplicitBuckets {}
+
+
+/// Represents information regarding a quota operation.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct QuotaOperation {
+    /// Quota mode for this operation.
+    #[serde(rename="quotaMode")]
+    pub quota_mode: Option<String>,
+    /// Identity of the consumer for whom this quota operation is being performed.
+    /// 
+    /// This can be in one of the following formats:
+    ///   project:<project_id>,
+    ///   project_number:<project_number>,
+    ///   api_key:<api_key>.
+    #[serde(rename="consumerId")]
+    pub consumer_id: Option<String>,
+    /// Represents information about this operation. Each MetricValueSet
+    /// corresponds to a metric defined in the service configuration.
+    /// The data type used in the MetricValueSet must agree with
+    /// the data type specified in the metric definition.
+    /// 
+    /// Within a single operation, it is not allowed to have more than one
+    /// MetricValue instances that have the same metric names and identical
+    /// label value combinations. If a request has such duplicated MetricValue
+    /// instances, the entire request is rejected with
+    /// an invalid argument error.
+    /// 
+    /// This field is mutually exclusive with method_name.
+    #[serde(rename="quotaMetrics")]
+    pub quota_metrics: Option<Vec<MetricValueSet>>,
+    /// Fully qualified name of the API method for which this quota operation is
+    /// requested. This name is used for matching quota rules or metric rules and
+    /// billing status rules defined in service configuration.
+    /// 
+    /// This field should not be set if any of the following is true:
+    /// (1) the quota operation is performed on non-API resources.
+    /// (2) quota_metrics is set because the caller is doing quota override.
+    /// 
+    /// Example of an RPC method name:
+    ///     google.example.library.v1.LibraryService.CreateShelf
+    #[serde(rename="methodName")]
+    pub method_name: Option<String>,
+    /// Labels describing the operation.
+    pub labels: Option<HashMap<String, String>>,
+    /// Identity of the operation. This is expected to be unique within the scope
+    /// of the service that generated the operation, and guarantees idempotency in
+    /// case of retries.
+    /// 
+    /// UUID version 4 is recommended, though not required. In scenarios where an
+    /// operation is computed from existing information and an idempotent id is
+    /// desirable for deduplication purpose, UUID version 5 is recommended. See
+    /// RFC 4122 for details.
+    #[serde(rename="operationId")]
+    pub operation_id: Option<String>,
+}
+
+impl Part for QuotaOperation {}
+
+
+/// The `Status` type defines a logical error model that is suitable for different
+/// programming environments, including REST APIs and RPC APIs. It is used by
+/// [gRPC](https://github.com/grpc). The error model is designed to be:
+/// 
+/// - Simple to use and understand for most users
+/// - Flexible enough to meet unexpected needs
+/// 
+/// # Overview
+/// 
+/// The `Status` message contains three pieces of data: error code, error message,
+/// and error details. The error code should be an enum value of
+/// google.rpc.Code, but it may accept additional error codes if needed.  The
+/// error message should be a developer-facing English message that helps
+/// developers *understand* and *resolve* the error. If a localized user-facing
+/// error message is needed, put the localized message in the error details or
+/// localize it in the client. The optional error details may contain arbitrary
+/// information about the error. There is a predefined set of error detail types
+/// in the package `google.rpc` that can be used for common error conditions.
+/// 
+/// # Language mapping
+/// 
+/// The `Status` message is the logical representation of the error model, but it
+/// is not necessarily the actual wire format. When the `Status` message is
+/// exposed in different client libraries and different wire protocols, it can be
+/// mapped differently. For example, it will likely be mapped to some exceptions
+/// in Java, but more likely mapped to some error codes in C.
+/// 
+/// # Other uses
+/// 
+/// The error model and the `Status` message can be used in a variety of
+/// environments, either with or without APIs, to provide a
+/// consistent developer experience across different environments.
+/// 
+/// Example uses of this error model include:
+/// 
+/// - Partial errors. If a service needs to return partial errors to the client,
+///     it may embed the `Status` in the normal response to indicate the partial
+///     errors.
+/// 
+/// - Workflow errors. A typical workflow has multiple steps. Each step may
+///     have a `Status` message for error reporting.
+/// 
+/// - Batch operations. If a client uses batch request and batch response, the
+///     `Status` message should be used directly inside batch response, one for
+///     each error sub-response.
+/// 
+/// - Asynchronous operations. If an API call embeds asynchronous operation
+///     results in its response, the status of those operations should be
+///     represented directly using the `Status` message.
+/// 
+/// - Logging. If some API errors are stored in logs, the message `Status` could
+///     be used directly after any stripping needed for security/privacy reasons.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Status {
+    /// A developer-facing error message, which should be in English. Any
+    /// user-facing error message should be localized and sent in the
+    /// google.rpc.Status.details field, or localized by the client.
+    pub message: Option<String>,
+    /// The status code, which should be an enum value of google.rpc.Code.
+    pub code: Option<i32>,
+    /// A list of messages that carry the error details.  There is a common set of
+    /// message types for APIs to use.
+    pub details: Option<Vec<HashMap<String, String>>>,
+}
+
+impl Part for Status {}
+
+
+/// Response message for the Report method.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [report services](struct.ServiceReportCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct ReportResponse {
+    /// Partial failures, one for each `Operation` in the request that failed
+    /// processing. There are three possible combinations of the RPC status:
+    /// 
+    /// 1. The combination of a successful RPC status and an empty `report_errors`
+    ///    list indicates a complete success where all `Operations` in the
+    ///    request are processed successfully.
+    /// 2. The combination of a successful RPC status and a non-empty
+    ///    `report_errors` list indicates a partial success where some
+    ///    `Operations` in the request succeeded. Each
+    ///    `Operation` that failed processing has a corresponding item
+    ///    in this list.
+    /// 3. A failed RPC status indicates a general non-deterministic failure.
+    ///    When this happens, it's impossible to know which of the
+    ///    'Operations' in the request succeeded or failed.
+    #[serde(rename="reportErrors")]
+    pub report_errors: Option<Vec<ReportError>>,
+    /// Quota usage for each quota release `Operation` request.
+    /// 
+    /// Fully or partially failed quota release request may or may not be present
+    /// in `report_quota_info`. For example, a failed quota release request will
+    /// have the current quota usage info when precise quota library returns the
+    /// info. A deadline exceeded quota request will not have quota usage info.
+    /// 
+    /// If there is no quota release request, report_quota_info will be empty.
+    /// 
+    #[serde(rename="reportInfos")]
+    pub report_infos: Option<Vec<ReportInfo>>,
+    /// The actual config id used to process the request.
+    #[serde(rename="serviceConfigId")]
+    pub service_config_id: Option<String>,
+}
+
+impl ResponseResult for ReportResponse {}
+
+
+/// Response message for the ReleaseQuota method.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [release quota services](struct.ServiceReleaseQuotaCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct ReleaseQuotaResponse {
+    /// The same operation_id value used in the ReleaseQuotaRequest. Used for
+    /// logging and diagnostics purposes.
+    #[serde(rename="operationId")]
+    pub operation_id: Option<String>,
+    /// ID of the actual config used to process the request.
+    #[serde(rename="serviceConfigId")]
+    pub service_config_id: Option<String>,
+    /// Quota metrics to indicate the result of release. Depending on the
+    /// request, one or more of the following metrics will be included:
+    /// 
+    /// 1. For rate quota, per quota group or per quota metric released amount
+    /// will be specified using the following delta metric:
+    ///   "serviceruntime.googleapis.com/api/consumer/quota_refund_count"
+    /// 
+    /// 2. For allocation quota, per quota metric total usage will be specified
+    /// using the following gauge metric:
+    ///   "serviceruntime.googleapis.com/allocation/consumer/quota_used_count"
+    /// 
+    /// 3. For allocation quota, value for each quota limit associated with
+    /// the metrics will be specified using the following gauge metric:
+    ///   "serviceruntime.googleapis.com/quota/limit"
+    #[serde(rename="quotaMetrics")]
+    pub quota_metrics: Option<Vec<MetricValueSet>>,
+    /// Indicates the decision of the release.
+    #[serde(rename="releaseErrors")]
+    pub release_errors: Option<Vec<QuotaError>>,
+}
+
+impl ResponseResult for ReleaseQuotaResponse {}
+
+
+/// Represents a set of metric values in the same metric.
+/// Each metric value in the set should have a unique combination of start time,
+/// end time, and label values.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct MetricValueSet {
+    /// The values in this metric.
+    #[serde(rename="metricValues")]
+    pub metric_values: Option<Vec<MetricValue>>,
+    /// The metric name defined in the service configuration.
+    #[serde(rename="metricName")]
+    pub metric_name: Option<String>,
+}
+
+impl Part for MetricValueSet {}
+
+
+/// Represents error information for QuotaOperation.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct QuotaError {
+    /// Error code.
+    pub code: Option<String>,
+    /// Free-form text that provides details on the cause of the error.
+    pub description: Option<String>,
+    /// Subject to whom this error applies. See the specific enum for more details
+    /// on this field. For example, "clientip:<ip address of client>" or
+    /// "project:<Google developer project id>".
+    pub subject: Option<String>,
+}
+
+impl Part for QuotaError {}
+
+
+/// Response message for QuotaController.EndReconciliation.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [end reconciliation services](struct.ServiceEndReconciliationCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct EndReconciliationResponse {
+    /// ID of the actual config used to process the request.
+    #[serde(rename="serviceConfigId")]
+    pub service_config_id: Option<String>,
+    /// Metric values as tracked by One Platform before the adjustment was made.
+    /// The following metrics will be included:
+    /// 
+    /// 1. Per quota metric total usage will be specified using the following gauge
+    /// metric:
+    ///   "serviceruntime.googleapis.com/allocation/consumer/quota_used_count"
+    /// 
+    /// 2. Value for each quota limit associated with the metrics will be specified
+    /// using the following gauge metric:
+    ///   "serviceruntime.googleapis.com/quota/limit"
+    /// 
+    /// 3. Delta value of the usage after the reconciliation for limits associated
+    /// with the metrics will be specified using the following metric:
+    ///   "serviceruntime.googleapis.com/allocation/reconciliation_delta"
+    /// The delta value is defined as:
+    ///   new_usage_from_client - existing_value_in_spanner.
+    /// This metric is not defined in serviceruntime.yaml or in Cloud Monarch.
+    /// This metric is meant for callers' use only. Since this metric is not
+    /// defined in the monitoring backend, reporting on this metric will result in
+    /// an error.
+    #[serde(rename="quotaMetrics")]
+    pub quota_metrics: Option<Vec<MetricValueSet>>,
+    /// Indicates the decision of the reconciliation end.
+    #[serde(rename="reconciliationErrors")]
+    pub reconciliation_errors: Option<Vec<QuotaError>>,
+    /// The same operation_id value used in the EndReconciliationRequest. Used for
+    /// logging and diagnostics purposes.
+    #[serde(rename="operationId")]
+    pub operation_id: Option<String>,
+}
+
+impl ResponseResult for EndReconciliationResponse {}
+
+
+/// An individual log entry.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct LogEntry {
+    /// The severity of the log entry. The default value is
+    /// `LogSeverity.DEFAULT`.
+    pub severity: Option<String>,
+    /// The log entry payload, represented as a Unicode string (UTF-8).
+    #[serde(rename="textPayload")]
+    pub text_payload: Option<String>,
+    /// The time the event described by the log entry occurred. If
+    /// omitted, defaults to operation start time.
+    pub timestamp: Option<String>,
+    /// A set of user-defined (key, value) data that provides additional
+    /// information about the log entry.
+    pub labels: Option<HashMap<String, String>>,
+    /// The log entry payload, represented as a structure that
+    /// is expressed as a JSON object.
+    #[serde(rename="structPayload")]
+    pub struct_payload: Option<HashMap<String, String>>,
+    /// A unique ID for the log entry used for deduplication. If omitted,
+    /// the implementation will generate one based on operation_id.
+    #[serde(rename="insertId")]
+    pub insert_id: Option<String>,
+    /// The log entry payload, represented as a protocol buffer that is
+    /// expressed as a JSON object. The only accepted type currently is
+    /// AuditLog.
+    #[serde(rename="protoPayload")]
+    pub proto_payload: Option<HashMap<String, String>>,
+    /// Required. The log to which this log entry belongs. Examples: `"syslog"`,
+    /// `"book_log"`.
+    pub name: Option<String>,
+}
+
+impl Part for LogEntry {}
+
+
+/// Describes a resource associated with this operation.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct ResourceInfo {
+    /// The identifier of the parent of this resource instance.
+    /// Must be in one of the following formats:
+    ///     - “projects/<project-id or project-number>”
+    ///     - “folders/<folder-id>”
+    ///     - “organizations/<organization-id>”
+    #[serde(rename="resourceContainer")]
+    pub resource_container: Option<String>,
+    /// Name of the resource. This is used for auditing purposes.
+    #[serde(rename="resourceName")]
+    pub resource_name: Option<String>,
+}
+
+impl Part for ResourceInfo {}
+
+
+/// Request message for the Check method.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [check services](struct.ServiceCheckCall.html) (request)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct CheckRequest {
+    /// Indicates if service activation check should be skipped for this request.
+    /// Default behavior is to perform the check and apply relevant quota.
+    #[serde(rename="skipActivationCheck")]
+    pub skip_activation_check: Option<bool>,
+    /// The operation to be checked.
+    pub operation: Option<Operation>,
+    /// Specifies which version of service configuration should be used to process
+    /// the request.
+    /// 
+    /// If unspecified or no matching version can be found, the
+    /// latest one will be used.
+    #[serde(rename="serviceConfigId")]
+    pub service_config_id: Option<String>,
+    /// Requests the project settings to be returned as part of the check response.
+    #[serde(rename="requestProjectSettings")]
+    pub request_project_settings: Option<bool>,
+}
+
+impl RequestValue for CheckRequest {}
+
+
+/// `ConsumerInfo` provides information about the consumer project.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct ConsumerInfo {
+    /// The Google cloud project number, e.g. 1234567890. A value of 0 indicates
+    /// no project number is found.
+    #[serde(rename="projectNumber")]
+    pub project_number: Option<String>,
+}
+
+impl Part for ConsumerInfo {}
+
+
+/// Response message for the Check method.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [check services](struct.ServiceCheckCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct CheckResponse {
+    /// The same operation_id value used in the CheckRequest.
+    /// Used for logging and diagnostics purposes.
+    #[serde(rename="operationId")]
+    pub operation_id: Option<String>,
+    /// The actual config id used to process the request.
+    #[serde(rename="serviceConfigId")]
+    pub service_config_id: Option<String>,
+    /// Feedback data returned from the server during processing a Check request.
+    #[serde(rename="checkInfo")]
+    pub check_info: Option<CheckInfo>,
+    /// Indicate the decision of the check.
+    /// 
+    /// If no check errors are present, the service should process the operation.
+    /// Otherwise the service should use the list of errors to determine the
+    /// appropriate action.
+    #[serde(rename="checkErrors")]
+    pub check_errors: Option<Vec<CheckError>>,
+    /// Quota information for the check request associated with this response.
+    /// 
+    #[serde(rename="quotaInfo")]
+    pub quota_info: Option<QuotaInfo>,
+}
+
+impl ResponseResult for CheckResponse {}
+
+
+/// Request message for QuotaController.StartReconciliation.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [start reconciliation services](struct.ServiceStartReconciliationCall.html) (request)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct StartReconciliationRequest {
+    /// Specifies which version of service configuration should be used to process
+    /// the request. If unspecified or no matching version can be found, the latest
+    /// one will be used.
+    #[serde(rename="serviceConfigId")]
+    pub service_config_id: Option<String>,
+    /// Operation that describes the quota reconciliation.
+    #[serde(rename="reconciliationOperation")]
+    pub reconciliation_operation: Option<QuotaOperation>,
+}
+
+impl RequestValue for StartReconciliationRequest {}
+
+
+/// Request message for the AllocateQuota method.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [allocate quota services](struct.ServiceAllocateQuotaCall.html) (request)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct AllocateQuotaRequest {
+    /// Specifies which version of service configuration should be used to process
+    /// the request. If unspecified or no matching version can be found, the latest
+    /// one will be used.
+    #[serde(rename="serviceConfigId")]
+    pub service_config_id: Option<String>,
+    /// Operation that describes the quota allocation.
+    #[serde(rename="allocateOperation")]
+    pub allocate_operation: Option<QuotaOperation>,
+}
+
+impl RequestValue for AllocateQuotaRequest {}
+
+
+/// There is no detailed description.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct AllocateInfo {
+    /// A list of label keys that were unused by the server in processing the
+    /// request. Thus, for similar requests repeated in a certain future time
+    /// window, the caller can choose to ignore these labels in the requests
+    /// to achieve better client-side cache hits and quota aggregation.
+    #[serde(rename="unusedArguments")]
+    pub unused_arguments: Option<Vec<String>>,
+}
+
+impl Part for AllocateInfo {}
+
+
+/// Response message for the AllocateQuota method.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [allocate quota services](struct.ServiceAllocateQuotaCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct AllocateQuotaResponse {
+    /// Indicates the decision of the allocate.
+    #[serde(rename="allocateErrors")]
+    pub allocate_errors: Option<Vec<QuotaError>>,
+    /// ID of the actual config used to process the request.
+    #[serde(rename="serviceConfigId")]
+    pub service_config_id: Option<String>,
+    /// Quota metrics to indicate the result of allocation. Depending on the
+    /// request, one or more of the following metrics will be included:
+    /// 
+    /// 1. Per quota group or per quota metric incremental usage will be specified
+    /// using the following delta metric :
+    ///   "serviceruntime.googleapis.com/api/consumer/quota_used_count"
+    /// 
+    /// 2. The quota limit reached condition will be specified using the following
+    /// boolean metric :
+    ///   "serviceruntime.googleapis.com/quota/exceeded"
+    #[serde(rename="quotaMetrics")]
+    pub quota_metrics: Option<Vec<MetricValueSet>>,
+    /// WARNING: DO NOT use this field until this warning message is removed.
+    #[serde(rename="allocateInfo")]
+    pub allocate_info: Option<AllocateInfo>,
+    /// The same operation_id value used in the AllocateQuotaRequest. Used for
+    /// logging and diagnostics purposes.
+    #[serde(rename="operationId")]
+    pub operation_id: Option<String>,
+}
+
+impl ResponseResult for AllocateQuotaResponse {}
+
+
+/// Describing buckets with exponentially growing width.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct ExponentialBuckets {
+    /// The i'th exponential bucket covers the interval
+    ///   [scale * growth_factor^(i-1), scale * growth_factor^i)
+    /// where i ranges from 1 to num_finite_buckets inclusive.
+    /// Must be > 0.
+    pub scale: Option<f64>,
+    /// The i'th exponential bucket covers the interval
+    ///   [scale * growth_factor^(i-1), scale * growth_factor^i)
+    /// where i ranges from 1 to num_finite_buckets inclusive.
+    /// Must be larger than 1.0.
+    #[serde(rename="growthFactor")]
+    pub growth_factor: Option<f64>,
+    /// The number of finite buckets. With the underflow and overflow buckets,
+    /// the total number of buckets is `num_finite_buckets` + 2.
+    /// See comments on `bucket_options` for details.
+    #[serde(rename="numFiniteBuckets")]
+    pub num_finite_buckets: Option<i32>,
+}
+
+impl Part for ExponentialBuckets {}
+
+
+/// Contains additional information about the check operation.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct CheckInfo {
+    /// A list of fields and label keys that are ignored by the server.
+    /// The client doesn't need to send them for following requests to improve
+    /// performance and allow better aggregation.
+    #[serde(rename="unusedArguments")]
+    pub unused_arguments: Option<Vec<String>>,
+    /// Consumer info of this check.
+    #[serde(rename="consumerInfo")]
+    pub consumer_info: Option<ConsumerInfo>,
+}
+
+impl Part for CheckInfo {}
+
+
+/// Represents an amount of money with its currency type.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Money {
+    /// The whole units of the amount.
+    /// For example if `currencyCode` is `"USD"`, then 1 unit is one US dollar.
+    pub units: Option<String>,
+    /// Number of nano (10^-9) units of the amount.
+    /// The value must be between -999,999,999 and +999,999,999 inclusive.
+    /// If `units` is positive, `nanos` must be positive or zero.
+    /// If `units` is zero, `nanos` can be positive, zero, or negative.
+    /// If `units` is negative, `nanos` must be negative or zero.
+    /// For example $-1.75 is represented as `units`=-1 and `nanos`=-750,000,000.
+    pub nanos: Option<i32>,
+    /// The 3-letter currency code defined in ISO 4217.
+    #[serde(rename="currencyCode")]
+    pub currency_code: Option<String>,
+}
+
+impl Part for Money {}
+
+
+/// Request message for QuotaController.EndReconciliation.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [end reconciliation services](struct.ServiceEndReconciliationCall.html) (request)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct EndReconciliationRequest {
+    /// Specifies which version of service configuration should be used to process
+    /// the request. If unspecified or no matching version can be found, the latest
+    /// one will be used.
+    #[serde(rename="serviceConfigId")]
+    pub service_config_id: Option<String>,
+    /// Operation that describes the quota reconciliation.
+    #[serde(rename="reconciliationOperation")]
+    pub reconciliation_operation: Option<QuotaOperation>,
+}
+
+impl RequestValue for EndReconciliationRequest {}
+
+
+/// Contains additional info about the report operation.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct ReportInfo {
+    /// Quota usage info when processing the `Operation`.
+    #[serde(rename="quotaInfo")]
+    pub quota_info: Option<QuotaInfo>,
+    /// The Operation.operation_id value from the request.
+    #[serde(rename="operationId")]
+    pub operation_id: Option<String>,
+}
+
+impl Part for ReportInfo {}
+
+
+/// Represents the processing error of one Operation in the request.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct ReportError {
+    /// Details of the error when processing the Operation.
+    pub status: Option<Status>,
+    /// The Operation.operation_id value from the request.
+    #[serde(rename="operationId")]
+    pub operation_id: Option<String>,
+}
+
+impl Part for ReportError {}
+
+
+/// Represents the properties needed for quota operations.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct QuotaProperties {
+    /// Quota mode for this operation.
+    #[serde(rename="quotaMode")]
+    pub quota_mode: Option<String>,
+}
+
+impl Part for QuotaProperties {}
+
+
+/// Represents information regarding an operation.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Operation {
+    /// Labels describing the operation. Only the following labels are allowed:
+    /// 
+    /// - Labels describing monitored resources as defined in
+    ///   the service configuration.
+    /// - Default labels of metric values. When specified, labels defined in the
+    ///   metric value override these default.
+    /// - The following labels defined by Google Cloud Platform:
+    ///     - `cloud.googleapis.com/location` describing the location where the
+    ///        operation happened,
+    ///     - `servicecontrol.googleapis.com/user_agent` describing the user agent
+    ///        of the API request,
+    ///     - `servicecontrol.googleapis.com/service_agent` describing the service
+    ///        used to handle the API request (e.g. ESP),
+    ///     - `servicecontrol.googleapis.com/platform` describing the platform
+    ///        where the API is served (e.g. GAE, GCE, GKE).
+    pub labels: Option<HashMap<String, String>>,
+    /// Represents information about this operation. Each MetricValueSet
+    /// corresponds to a metric defined in the service configuration.
+    /// The data type used in the MetricValueSet must agree with
+    /// the data type specified in the metric definition.
+    /// 
+    /// Within a single operation, it is not allowed to have more than one
+    /// MetricValue instances that have the same metric names and identical
+    /// label value combinations. If a request has such duplicated MetricValue
+    /// instances, the entire request is rejected with
+    /// an invalid argument error.
+    #[serde(rename="metricValueSets")]
+    pub metric_value_sets: Option<Vec<MetricValueSet>>,
+    /// DO NOT USE. This is an experimental field.
+    pub importance: Option<String>,
+    /// Fully qualified name of the operation. Reserved for future use.
+    #[serde(rename="operationName")]
+    pub operation_name: Option<String>,
+    /// Represents the properties needed for quota check. Applicable only if this
+    /// operation is for a quota check request. If this is not specified, no quota
+    /// check will be performed.
+    #[serde(rename="quotaProperties")]
+    pub quota_properties: Option<QuotaProperties>,
+    /// DO NOT USE. This field is deprecated, use "resources" field instead.
+    /// The resource name of the parent of a resource in the resource hierarchy.
+    /// 
+    /// This can be in one of the following formats:
+    ///     - “projects/<project-id or project-number>”
+    ///     - “folders/<folder-id>”
+    ///     - “organizations/<organization-id>”
+    #[serde(rename="resourceContainer")]
+    pub resource_container: Option<String>,
+    /// User defined labels for the resource that this operation is associated
+    /// with. Only a combination of 1000 user labels per consumer project are
+    /// allowed.
+    #[serde(rename="userLabels")]
+    pub user_labels: Option<HashMap<String, String>>,
+    /// End time of the operation.
+    /// Required when the operation is used in ServiceController.Report,
+    /// but optional when the operation is used in ServiceController.Check.
+    #[serde(rename="endTime")]
+    pub end_time: Option<String>,
+    /// Represents information to be logged.
+    #[serde(rename="logEntries")]
+    pub log_entries: Option<Vec<LogEntry>>,
+    /// Required. Start time of the operation.
+    #[serde(rename="startTime")]
+    pub start_time: Option<String>,
+    /// Identity of the consumer who is using the service.
+    /// This field should be filled in for the operations initiated by a
+    /// consumer, but not for service-initiated operations that are
+    /// not related to a specific consumer.
+    /// 
+    /// This can be in one of the following formats:
+    ///   project:<project_id>,
+    ///   project_number:<project_number>,
+    ///   api_key:<api_key>.
+    #[serde(rename="consumerId")]
+    pub consumer_id: Option<String>,
+    /// The resources that are involved in the operation.
+    pub resources: Option<Vec<ResourceInfo>>,
+    /// Identity of the operation. This must be unique within the scope of the
+    /// service that generated the operation. If the service calls
+    /// Check() and Report() on the same operation, the two calls should carry
+    /// the same id.
+    /// 
+    /// UUID version 4 is recommended, though not required.
+    /// In scenarios where an operation is computed from existing information
+    /// and an idempotent id is desirable for deduplication purpose, UUID version 5
+    /// is recommended. See RFC 4122 for details.
+    #[serde(rename="operationId")]
+    pub operation_id: Option<String>,
+}
+
+impl Part for Operation {}
+
+
+/// Describing buckets with constant width.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct LinearBuckets {
+    /// The i'th linear bucket covers the interval
+    ///   [offset + (i-1) * width, offset + i * width)
+    /// where i ranges from 1 to num_finite_buckets, inclusive.
+    /// Must be strictly positive.
+    pub width: Option<f64>,
+    /// The number of finite buckets. With the underflow and overflow buckets,
+    /// the total number of buckets is `num_finite_buckets` + 2.
+    /// See comments on `bucket_options` for details.
+    #[serde(rename="numFiniteBuckets")]
+    pub num_finite_buckets: Option<i32>,
+    /// The i'th linear bucket covers the interval
+    ///   [offset + (i-1) * width, offset + i * width)
+    /// where i ranges from 1 to num_finite_buckets, inclusive.
+    pub offset: Option<f64>,
+}
+
+impl Part for LinearBuckets {}
+
+
+
+// ###################
+// MethodBuilders ###
+// #################
+
+/// A builder providing access to all methods supported on *service* resources.
+/// It is not used directly, but through the `ServiceControl` hub.
+///
+/// # Example
+///
+/// Instantiate a resource builder
+///
+/// ```test_harness,no_run
+/// extern crate hyper;
+/// extern crate hyper_rustls;
+/// extern crate yup_oauth2 as oauth2;
+/// extern crate google_servicecontrol1 as servicecontrol1;
+/// 
+/// # #[test] fn egal() {
+/// use std::default::Default;
+/// use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// use servicecontrol1::ServiceControl;
+/// 
+/// let secret: ApplicationSecret = Default::default();
+/// let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+///                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+///                               <MemoryStorage as Default>::default(), None);
+/// let mut hub = ServiceControl::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // Usually you wouldn't bind this to a variable, but keep calling *CallBuilders*
+/// // like `allocate_quota(...)`, `check(...)`, `end_reconciliation(...)`, `release_quota(...)`, `report(...)` and `start_reconciliation(...)`
+/// // to build up your call.
+/// let rb = hub.services();
+/// # }
+/// ```
+pub struct ServiceMethods<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a ServiceControl<C, A>,
+}
+
+impl<'a, C, A> MethodsBuilder for ServiceMethods<'a, C, A> {}
+
+impl<'a, C, A> ServiceMethods<'a, C, A> {
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Releases previously allocated quota done through AllocateQuota method.
+    /// 
+    /// This method requires the `servicemanagement.services.quota`
+    /// permission on the specified service. For more information, see
+    /// [Cloud IAM](https://cloud.google.com/iam).
+    /// 
+    /// 
+    /// **NOTE:** The client **must** fail-open on server errors `INTERNAL`,
+    /// `UNKNOWN`, `DEADLINE_EXCEEDED`, and `UNAVAILABLE`. To ensure system
+    /// reliability, the server may inject these errors to prohibit any hard
+    /// dependency on the quota functionality.
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    /// * `serviceName` - Name of the service as specified in the service configuration. For example,
+    ///                   `"pubsub.googleapis.com"`.
+    ///                   See google.api.Service for the definition of a service name.
+    pub fn release_quota(&self, request: ReleaseQuotaRequest, service_name: &str) -> ServiceReleaseQuotaCall<'a, C, A> {
+        ServiceReleaseQuotaCall {
+            hub: self.hub,
+            _request: request,
+            _service_name: service_name.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Checks an operation with Google Service Control to decide whether
+    /// the given operation should proceed. It should be called before the
+    /// operation is executed.
+    /// 
+    /// If feasible, the client should cache the check results and reuse them for
+    /// 60 seconds. In case of server errors, the client can rely on the cached
+    /// results for longer time.
+    /// 
+    /// NOTE: the CheckRequest has the size limit of 64KB.
+    /// 
+    /// This method requires the `servicemanagement.services.check` permission
+    /// on the specified service. For more information, see
+    /// [Google Cloud IAM](https://cloud.google.com/iam).
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    /// * `serviceName` - The service name as specified in its service configuration. For example,
+    ///                   `"pubsub.googleapis.com"`.
+    ///                   See
+    ///                   [google.api.Service](https://cloud.google.com/service-management/reference/rpc/google.api#google.api.Service)
+    ///                   for the definition of a service name.
+    pub fn check(&self, request: CheckRequest, service_name: &str) -> ServiceCheckCall<'a, C, A> {
+        ServiceCheckCall {
+            hub: self.hub,
+            _request: request,
+            _service_name: service_name.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Unlike rate quota, allocation quota does not get refilled periodically.
+    /// So, it is possible that the quota usage as seen by the service differs from
+    /// what the One Platform considers the usage is. This is expected to happen
+    /// only rarely, but over time this can accumulate. Services can invoke
+    /// StartReconciliation and EndReconciliation to correct this usage drift, as
+    /// described below:
+    /// 1. Service sends StartReconciliation with a timestamp in future for each
+    ///    metric that needs to be reconciled. The timestamp being in future allows
+    ///    to account for in-flight AllocateQuota and ReleaseQuota requests for the
+    ///    same metric.
+    /// 2. One Platform records this timestamp and starts tracking subsequent
+    ///    AllocateQuota and ReleaseQuota requests until EndReconciliation is
+    ///    called.
+    /// 3. At or after the time specified in the StartReconciliation, service
+    ///    sends EndReconciliation with the usage that needs to be reconciled to.
+    /// 4. One Platform adjusts its own record of usage for that metric to the
+    ///    value specified in EndReconciliation by taking in to account any
+    ///    allocation or release between StartReconciliation and EndReconciliation.
+    /// 
+    /// Signals the quota controller that the service wants to perform a usage
+    /// reconciliation as specified in the request.
+    /// 
+    /// This method requires the `servicemanagement.services.quota`
+    /// permission on the specified service. For more information, see
+    /// [Google Cloud IAM](https://cloud.google.com/iam).
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    /// * `serviceName` - Name of the service as specified in the service configuration. For example,
+    ///                   `"pubsub.googleapis.com"`.
+    ///                   See google.api.Service for the definition of a service name.
+    pub fn start_reconciliation(&self, request: StartReconciliationRequest, service_name: &str) -> ServiceStartReconciliationCall<'a, C, A> {
+        ServiceStartReconciliationCall {
+            hub: self.hub,
+            _request: request,
+            _service_name: service_name.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Signals the quota controller that service ends the ongoing usage
+    /// reconciliation.
+    /// 
+    /// This method requires the `servicemanagement.services.quota`
+    /// permission on the specified service. For more information, see
+    /// [Google Cloud IAM](https://cloud.google.com/iam).
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    /// * `serviceName` - Name of the service as specified in the service configuration. For example,
+    ///                   `"pubsub.googleapis.com"`.
+    ///                   See google.api.Service for the definition of a service name.
+    pub fn end_reconciliation(&self, request: EndReconciliationRequest, service_name: &str) -> ServiceEndReconciliationCall<'a, C, A> {
+        ServiceEndReconciliationCall {
+            hub: self.hub,
+            _request: request,
+            _service_name: service_name.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Attempts to allocate quota for the specified consumer. It should be called
+    /// before the operation is executed.
+    /// 
+    /// This method requires the `servicemanagement.services.quota`
+    /// permission on the specified service. For more information, see
+    /// [Cloud IAM](https://cloud.google.com/iam).
+    /// 
+    /// **NOTE:** The client **must** fail-open on server errors `INTERNAL`,
+    /// `UNKNOWN`, `DEADLINE_EXCEEDED`, and `UNAVAILABLE`. To ensure system
+    /// reliability, the server may inject these errors to prohibit any hard
+    /// dependency on the quota functionality.
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    /// * `serviceName` - Name of the service as specified in the service configuration. For example,
+    ///                   `"pubsub.googleapis.com"`.
+    ///                   See google.api.Service for the definition of a service name.
+    pub fn allocate_quota(&self, request: AllocateQuotaRequest, service_name: &str) -> ServiceAllocateQuotaCall<'a, C, A> {
+        ServiceAllocateQuotaCall {
+            hub: self.hub,
+            _request: request,
+            _service_name: service_name.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Reports operation results to Google Service Control, such as logs and
+    /// metrics. It should be called after an operation is completed.
+    /// 
+    /// If feasible, the client should aggregate reporting data for up to 5
+    /// seconds to reduce API traffic. Limiting aggregation to 5 seconds is to
+    /// reduce data loss during client crashes. Clients should carefully choose
+    /// the aggregation time window to avoid data loss risk more than 0.01%
+    /// for business and compliance reasons.
+    /// 
+    /// NOTE: the ReportRequest has the size limit of 1MB.
+    /// 
+    /// This method requires the `servicemanagement.services.report` permission
+    /// on the specified service. For more information, see
+    /// [Google Cloud IAM](https://cloud.google.com/iam).
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    /// * `serviceName` - The service name as specified in its service configuration. For example,
+    ///                   `"pubsub.googleapis.com"`.
+    ///                   See
+    ///                   [google.api.Service](https://cloud.google.com/service-management/reference/rpc/google.api#google.api.Service)
+    ///                   for the definition of a service name.
+    pub fn report(&self, request: ReportRequest, service_name: &str) -> ServiceReportCall<'a, C, A> {
+        ServiceReportCall {
+            hub: self.hub,
+            _request: request,
+            _service_name: service_name.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+}
+
+
+
+
+
+// ###################
+// CallBuilders   ###
+// #################
+
+/// Releases previously allocated quota done through AllocateQuota method.
+/// 
+/// This method requires the `servicemanagement.services.quota`
+/// permission on the specified service. For more information, see
+/// [Cloud IAM](https://cloud.google.com/iam).
+/// 
+/// 
+/// **NOTE:** The client **must** fail-open on server errors `INTERNAL`,
+/// `UNKNOWN`, `DEADLINE_EXCEEDED`, and `UNAVAILABLE`. To ensure system
+/// reliability, the server may inject these errors to prohibit any hard
+/// dependency on the quota functionality.
+///
+/// A builder for the *releaseQuota* method supported by a *service* resource.
+/// It is not used directly, but through a `ServiceMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_servicecontrol1 as servicecontrol1;
+/// use servicecontrol1::ReleaseQuotaRequest;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use servicecontrol1::ServiceControl;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = ServiceControl::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = ReleaseQuotaRequest::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.services().release_quota(req, "serviceName")
+///              .doit();
+/// # }
+/// ```
+pub struct ServiceReleaseQuotaCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a ServiceControl<C, A>,
+    _request: ReleaseQuotaRequest,
+    _service_name: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for ServiceReleaseQuotaCall<'a, C, A> {}
+
+impl<'a, C, A> ServiceReleaseQuotaCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, ReleaseQuotaResponse)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "servicecontrol.services.releaseQuota",
+                               http_method: hyper::method::Method::Post });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((4 + self._additional_params.len()));
+        params.push(("serviceName", self._service_name.to_string()));
+        for &field in ["alt", "serviceName"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1/services/{serviceName}:releaseQuota";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{serviceName}", "serviceName")].iter() {
+            let mut replace_with: Option<&str> = None;
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = Some(value);
+                    break;
+                }
+            }
+            url = url.replace(find_this, replace_with.expect("to find substitution value in params"));
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["serviceName"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Post, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: ReleaseQuotaRequest) -> ServiceReleaseQuotaCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// Name of the service as specified in the service configuration. For example,
+    /// `"pubsub.googleapis.com"`.
+    /// 
+    /// See google.api.Service for the definition of a service name.
+    ///
+    /// Sets the *service name* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn service_name(mut self, new_value: &str) -> ServiceReleaseQuotaCall<'a, C, A> {
+        self._service_name = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> ServiceReleaseQuotaCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> ServiceReleaseQuotaCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> ServiceReleaseQuotaCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Checks an operation with Google Service Control to decide whether
+/// the given operation should proceed. It should be called before the
+/// operation is executed.
+/// 
+/// If feasible, the client should cache the check results and reuse them for
+/// 60 seconds. In case of server errors, the client can rely on the cached
+/// results for longer time.
+/// 
+/// NOTE: the CheckRequest has the size limit of 64KB.
+/// 
+/// This method requires the `servicemanagement.services.check` permission
+/// on the specified service. For more information, see
+/// [Google Cloud IAM](https://cloud.google.com/iam).
+///
+/// A builder for the *check* method supported by a *service* resource.
+/// It is not used directly, but through a `ServiceMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_servicecontrol1 as servicecontrol1;
+/// use servicecontrol1::CheckRequest;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use servicecontrol1::ServiceControl;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = ServiceControl::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = CheckRequest::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.services().check(req, "serviceName")
+///              .doit();
+/// # }
+/// ```
+pub struct ServiceCheckCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a ServiceControl<C, A>,
+    _request: CheckRequest,
+    _service_name: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for ServiceCheckCall<'a, C, A> {}
+
+impl<'a, C, A> ServiceCheckCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, CheckResponse)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "servicecontrol.services.check",
+                               http_method: hyper::method::Method::Post });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((4 + self._additional_params.len()));
+        params.push(("serviceName", self._service_name.to_string()));
+        for &field in ["alt", "serviceName"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1/services/{serviceName}:check";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{serviceName}", "serviceName")].iter() {
+            let mut replace_with: Option<&str> = None;
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = Some(value);
+                    break;
+                }
+            }
+            url = url.replace(find_this, replace_with.expect("to find substitution value in params"));
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["serviceName"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Post, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: CheckRequest) -> ServiceCheckCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// The service name as specified in its service configuration. For example,
+    /// `"pubsub.googleapis.com"`.
+    /// 
+    /// See
+    /// [google.api.Service](https://cloud.google.com/service-management/reference/rpc/google.api#google.api.Service)
+    /// for the definition of a service name.
+    ///
+    /// Sets the *service name* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn service_name(mut self, new_value: &str) -> ServiceCheckCall<'a, C, A> {
+        self._service_name = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> ServiceCheckCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> ServiceCheckCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> ServiceCheckCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Unlike rate quota, allocation quota does not get refilled periodically.
+/// So, it is possible that the quota usage as seen by the service differs from
+/// what the One Platform considers the usage is. This is expected to happen
+/// only rarely, but over time this can accumulate. Services can invoke
+/// StartReconciliation and EndReconciliation to correct this usage drift, as
+/// described below:
+/// 1. Service sends StartReconciliation with a timestamp in future for each
+///    metric that needs to be reconciled. The timestamp being in future allows
+///    to account for in-flight AllocateQuota and ReleaseQuota requests for the
+///    same metric.
+/// 2. One Platform records this timestamp and starts tracking subsequent
+///    AllocateQuota and ReleaseQuota requests until EndReconciliation is
+///    called.
+/// 3. At or after the time specified in the StartReconciliation, service
+///    sends EndReconciliation with the usage that needs to be reconciled to.
+/// 4. One Platform adjusts its own record of usage for that metric to the
+///    value specified in EndReconciliation by taking in to account any
+///    allocation or release between StartReconciliation and EndReconciliation.
+/// 
+/// Signals the quota controller that the service wants to perform a usage
+/// reconciliation as specified in the request.
+/// 
+/// This method requires the `servicemanagement.services.quota`
+/// permission on the specified service. For more information, see
+/// [Google Cloud IAM](https://cloud.google.com/iam).
+///
+/// A builder for the *startReconciliation* method supported by a *service* resource.
+/// It is not used directly, but through a `ServiceMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_servicecontrol1 as servicecontrol1;
+/// use servicecontrol1::StartReconciliationRequest;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use servicecontrol1::ServiceControl;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = ServiceControl::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = StartReconciliationRequest::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.services().start_reconciliation(req, "serviceName")
+///              .doit();
+/// # }
+/// ```
+pub struct ServiceStartReconciliationCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a ServiceControl<C, A>,
+    _request: StartReconciliationRequest,
+    _service_name: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for ServiceStartReconciliationCall<'a, C, A> {}
+
+impl<'a, C, A> ServiceStartReconciliationCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, StartReconciliationResponse)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "servicecontrol.services.startReconciliation",
+                               http_method: hyper::method::Method::Post });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((4 + self._additional_params.len()));
+        params.push(("serviceName", self._service_name.to_string()));
+        for &field in ["alt", "serviceName"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1/services/{serviceName}:startReconciliation";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{serviceName}", "serviceName")].iter() {
+            let mut replace_with: Option<&str> = None;
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = Some(value);
+                    break;
+                }
+            }
+            url = url.replace(find_this, replace_with.expect("to find substitution value in params"));
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["serviceName"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Post, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: StartReconciliationRequest) -> ServiceStartReconciliationCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// Name of the service as specified in the service configuration. For example,
+    /// `"pubsub.googleapis.com"`.
+    /// 
+    /// See google.api.Service for the definition of a service name.
+    ///
+    /// Sets the *service name* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn service_name(mut self, new_value: &str) -> ServiceStartReconciliationCall<'a, C, A> {
+        self._service_name = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> ServiceStartReconciliationCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> ServiceStartReconciliationCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> ServiceStartReconciliationCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Signals the quota controller that service ends the ongoing usage
+/// reconciliation.
+/// 
+/// This method requires the `servicemanagement.services.quota`
+/// permission on the specified service. For more information, see
+/// [Google Cloud IAM](https://cloud.google.com/iam).
+///
+/// A builder for the *endReconciliation* method supported by a *service* resource.
+/// It is not used directly, but through a `ServiceMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_servicecontrol1 as servicecontrol1;
+/// use servicecontrol1::EndReconciliationRequest;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use servicecontrol1::ServiceControl;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = ServiceControl::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = EndReconciliationRequest::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.services().end_reconciliation(req, "serviceName")
+///              .doit();
+/// # }
+/// ```
+pub struct ServiceEndReconciliationCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a ServiceControl<C, A>,
+    _request: EndReconciliationRequest,
+    _service_name: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for ServiceEndReconciliationCall<'a, C, A> {}
+
+impl<'a, C, A> ServiceEndReconciliationCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, EndReconciliationResponse)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "servicecontrol.services.endReconciliation",
+                               http_method: hyper::method::Method::Post });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((4 + self._additional_params.len()));
+        params.push(("serviceName", self._service_name.to_string()));
+        for &field in ["alt", "serviceName"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1/services/{serviceName}:endReconciliation";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{serviceName}", "serviceName")].iter() {
+            let mut replace_with: Option<&str> = None;
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = Some(value);
+                    break;
+                }
+            }
+            url = url.replace(find_this, replace_with.expect("to find substitution value in params"));
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["serviceName"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Post, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: EndReconciliationRequest) -> ServiceEndReconciliationCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// Name of the service as specified in the service configuration. For example,
+    /// `"pubsub.googleapis.com"`.
+    /// 
+    /// See google.api.Service for the definition of a service name.
+    ///
+    /// Sets the *service name* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn service_name(mut self, new_value: &str) -> ServiceEndReconciliationCall<'a, C, A> {
+        self._service_name = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> ServiceEndReconciliationCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> ServiceEndReconciliationCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> ServiceEndReconciliationCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Attempts to allocate quota for the specified consumer. It should be called
+/// before the operation is executed.
+/// 
+/// This method requires the `servicemanagement.services.quota`
+/// permission on the specified service. For more information, see
+/// [Cloud IAM](https://cloud.google.com/iam).
+/// 
+/// **NOTE:** The client **must** fail-open on server errors `INTERNAL`,
+/// `UNKNOWN`, `DEADLINE_EXCEEDED`, and `UNAVAILABLE`. To ensure system
+/// reliability, the server may inject these errors to prohibit any hard
+/// dependency on the quota functionality.
+///
+/// A builder for the *allocateQuota* method supported by a *service* resource.
+/// It is not used directly, but through a `ServiceMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_servicecontrol1 as servicecontrol1;
+/// use servicecontrol1::AllocateQuotaRequest;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use servicecontrol1::ServiceControl;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = ServiceControl::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = AllocateQuotaRequest::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.services().allocate_quota(req, "serviceName")
+///              .doit();
+/// # }
+/// ```
+pub struct ServiceAllocateQuotaCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a ServiceControl<C, A>,
+    _request: AllocateQuotaRequest,
+    _service_name: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for ServiceAllocateQuotaCall<'a, C, A> {}
+
+impl<'a, C, A> ServiceAllocateQuotaCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, AllocateQuotaResponse)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "servicecontrol.services.allocateQuota",
+                               http_method: hyper::method::Method::Post });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((4 + self._additional_params.len()));
+        params.push(("serviceName", self._service_name.to_string()));
+        for &field in ["alt", "serviceName"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1/services/{serviceName}:allocateQuota";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{serviceName}", "serviceName")].iter() {
+            let mut replace_with: Option<&str> = None;
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = Some(value);
+                    break;
+                }
+            }
+            url = url.replace(find_this, replace_with.expect("to find substitution value in params"));
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["serviceName"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Post, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: AllocateQuotaRequest) -> ServiceAllocateQuotaCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// Name of the service as specified in the service configuration. For example,
+    /// `"pubsub.googleapis.com"`.
+    /// 
+    /// See google.api.Service for the definition of a service name.
+    ///
+    /// Sets the *service name* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn service_name(mut self, new_value: &str) -> ServiceAllocateQuotaCall<'a, C, A> {
+        self._service_name = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> ServiceAllocateQuotaCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> ServiceAllocateQuotaCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> ServiceAllocateQuotaCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Reports operation results to Google Service Control, such as logs and
+/// metrics. It should be called after an operation is completed.
+/// 
+/// If feasible, the client should aggregate reporting data for up to 5
+/// seconds to reduce API traffic. Limiting aggregation to 5 seconds is to
+/// reduce data loss during client crashes. Clients should carefully choose
+/// the aggregation time window to avoid data loss risk more than 0.01%
+/// for business and compliance reasons.
+/// 
+/// NOTE: the ReportRequest has the size limit of 1MB.
+/// 
+/// This method requires the `servicemanagement.services.report` permission
+/// on the specified service. For more information, see
+/// [Google Cloud IAM](https://cloud.google.com/iam).
+///
+/// A builder for the *report* method supported by a *service* resource.
+/// It is not used directly, but through a `ServiceMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_servicecontrol1 as servicecontrol1;
+/// use servicecontrol1::ReportRequest;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use servicecontrol1::ServiceControl;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = ServiceControl::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = ReportRequest::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.services().report(req, "serviceName")
+///              .doit();
+/// # }
+/// ```
+pub struct ServiceReportCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a ServiceControl<C, A>,
+    _request: ReportRequest,
+    _service_name: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for ServiceReportCall<'a, C, A> {}
+
+impl<'a, C, A> ServiceReportCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, ReportResponse)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "servicecontrol.services.report",
+                               http_method: hyper::method::Method::Post });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((4 + self._additional_params.len()));
+        params.push(("serviceName", self._service_name.to_string()));
+        for &field in ["alt", "serviceName"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1/services/{serviceName}:report";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{serviceName}", "serviceName")].iter() {
+            let mut replace_with: Option<&str> = None;
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = Some(value);
+                    break;
+                }
+            }
+            url = url.replace(find_this, replace_with.expect("to find substitution value in params"));
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["serviceName"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Post, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: ReportRequest) -> ServiceReportCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// The service name as specified in its service configuration. For example,
+    /// `"pubsub.googleapis.com"`.
+    /// 
+    /// See
+    /// [google.api.Service](https://cloud.google.com/service-management/reference/rpc/google.api#google.api.Service)
+    /// for the definition of a service name.
+    ///
+    /// Sets the *service name* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn service_name(mut self, new_value: &str) -> ServiceReportCall<'a, C, A> {
+        self._service_name = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> ServiceReportCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> ServiceReportCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> ServiceReportCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+

--- a/gen/speech1-cli/Cargo.toml
+++ b/gen/speech1-cli/Cargo.toml
@@ -1,0 +1,40 @@
+# DO NOT EDIT !
+# This file was generated automatically from 'src/mako/Cargo.toml.mako'
+# DO NOT EDIT !
+[package]
+
+name = "google-speech1-cli"
+version = "1.0.7+20171205"
+authors = ["Sebastian Thiel <byronimo@gmail.com>"]
+description = "A complete library to interact with Speech (protocol v1)"
+repository = "https://github.com/Byron/google-apis-rs/tree/master/gen/speech1-cli"
+homepage = "https://cloud.google.com/speech/"
+documentation = "http://byron.github.io/google-apis-rs/google_speech1_cli"
+license = "MIT"
+keywords = ["speech", "google", "cli"]
+
+[[bin]]
+name = "speech1"
+
+[dev-dependencies]
+hyper-rustls = "^0.6"
+
+[dependencies]
+hyper = "^ 0.10"
+mime = "^ 0.2.0"
+serde = "^ 1.0"
+serde_json = "^ 1.0"
+serde_derive = "^ 1.0"
+yup-oauth2 = "^ 1.0"
+strsim = "^0.5"
+hyper-rustls = "^0.6"
+yup-hyper-mock = "^2.0"
+clap = "^2.0"
+
+[features]
+
+
+
+[dependencies.google-speech1]
+path = "../speech1"
+version = "1.0.7+20171205"

--- a/gen/speech1-cli/LICENSE.md
+++ b/gen/speech1-cli/LICENSE.md
@@ -1,0 +1,30 @@
+<!---
+DO NOT EDIT !
+This file was generated automatically from 'src/mako/LICENSE.md.mako'
+DO NOT EDIT !
+-->
+The MIT License (MIT)
+=====================
+
+Copyright © `2015-2016` `Sebastian Thiel`
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the “Software”), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.

--- a/gen/speech1-cli/README.md
+++ b/gen/speech1-cli/README.md
@@ -1,0 +1,120 @@
+<!---
+DO NOT EDIT !
+This file was generated automatically from 'src/mako/cli/README.md.mako'
+DO NOT EDIT !
+-->
+The `speech1` command-line interface *(CLI)* allows to use most features of the *Google Speech* service from the comfort of your terminal.
+
+By default all output is printed to standard out, but flags can be set to direct it into a file independent of your shell's
+capabilities. Errors will be printed to standard error, and cause the program's exit code to be non-zero.
+
+If data-structures are requested, these will be returned as pretty-printed JSON, to be useful as input to other tools.
+
+Everything else about the *Speech* API can be found at the
+[official documentation site](https://cloud.google.com/speech/).
+
+# Installation and Source Code
+
+Install the command-line interface with cargo using:
+
+```bash
+cargo install google-speech1-cli
+```
+
+Find the source code [on github](https://github.com/Byron/google-apis-rs/tree/master/gen/speech1-cli).
+
+# Usage
+
+This documentation was generated from the *Speech* API at revision *20171205*. The CLI is at version *1.0.7*.
+
+```bash
+speech1 [options]
+        operations
+                cancel <name> (-r <kv>)... [-p <v>]... [-o <out>]
+                delete <name> [-p <v>]... [-o <out>]
+                get <name> [-p <v>]... [-o <out>]
+                list [-p <v>]... [-o <out>]
+        speech
+                longrunningrecognize (-r <kv>)... [-p <v>]... [-o <out>]
+                recognize (-r <kv>)... [-p <v>]... [-o <out>]
+  speech1 --help
+
+Configuration:
+  [--scope <url>]...
+            Specify the authentication a method should be executed in. Each scope
+            requires the user to grant this application permission to use it.
+            If unset, it defaults to the shortest scope url for a particular method.
+  --config-dir <folder>
+            A directory into which we will store our persistent data. Defaults to
+            a user-writable directory that we will create during the first invocation.
+            [default: ~/.google-service-cli]
+  --debug
+            Output all server communication to standard error. `tx` and `rx` are placed
+            into the same stream.
+  --debug-auth
+            Output all communication related to authentication to standard error. `tx`
+            and `rx` are placed into the same stream.
+
+```
+
+# Configuration
+
+The program will store all persistent data in the `~/.google-service-cli` directory in *JSON* files prefixed with `speech1-`.  You can change the directory used to store configuration with the `--config-dir` flag on a per-invocation basis.
+
+More information about the various kinds of persistent data are given in the following paragraphs.
+
+# Authentication
+
+Most APIs require a user to authenticate any request. If this is the case, the [scope][scopes] determines the 
+set of permissions granted. The granularity of these is usually no more than *read-only* or *full-access*.
+
+If not set, the system will automatically select the smallest feasible scope, e.g. when invoking a
+method that is read-only, it will ask only for a read-only scope. 
+You may use the `--scope` flag to specify a scope directly. 
+All applicable scopes are documented in the respective method's CLI documentation.
+
+The first time a scope is used, the user is asked for permission. Follow the instructions given 
+by the CLI to grant permissions, or to decline.
+
+If a scope was authenticated by the user, the respective information will be stored as *JSON* in the configuration
+directory, e.g. `~/.google-service-cli/speech1-token-<scope-hash>.json`. No manual management of these tokens
+is necessary.
+
+To revoke granted authentication, please refer to the [official documentation][revoke-access].
+
+# Application Secrets
+
+In order to allow any application to use Google services, it will need to be registered using the 
+[Google Developer Console][google-dev-console]. APIs the application may use are then enabled for it
+one by one. Most APIs can be used for free and have a daily quota.
+
+To allow more comfortable usage of the CLI without forcing anyone to register an own application, the CLI
+comes with a default application secret that is configured accordingly. This also means that heavy usage
+all around the world may deplete the daily quota.
+
+You can workaround this limitation by putting your own secrets file at this location: 
+`~/.google-service-cli/speech1-secret.json`, assuming that the required *speech* API 
+was enabled for it. Such a secret file can be downloaded in the *Google Developer Console* at 
+*APIs & auth -> Credentials -> Download JSON* and used as is.
+
+Learn more about how to setup Google projects and enable APIs using the [official documentation][google-project-new].
+
+
+# Debugging
+
+Even though the CLI does its best to provide usable error messages, sometimes it might be desirable to know
+what exactly led to a particular issue. This is done by allowing all client-server communication to be 
+output to standard error *as-is*.
+
+The `--debug` flag will print all client-server communication to standard error, whereas the `--debug-auth` flag
+will cause all communication related to authentication to standard error.
+If the `--debug` flag is set, error-results will be debug-printed, possibly yielding more information about the 
+issue at hand.
+
+You may consider redirecting standard error into a file for ease of use, e.g. `speech1 --debug <resource> <method> [options] 2>debug.txt`.
+
+
+[scopes]: https://developers.google.com/+/api/oauth#scopes
+[revoke-access]: http://webapps.stackexchange.com/a/30849
+[google-dev-console]: https://console.developers.google.com/
+[google-project-new]: https://developers.google.com/console/help/new/

--- a/gen/speech1-cli/mkdocs.yml
+++ b/gen/speech1-cli/mkdocs.yml
@@ -1,0 +1,22 @@
+site_name: Speech v1.0.7+20171205
+site_url: http://byron.github.io/google-apis-rs/google-speech1-cli
+site_description: A complete library to interact with Speech (protocol v1)
+
+repo_url: https://github.com/Byron/google-apis-rs/tree/master/gen/speech1-cli
+
+docs_dir: docs
+site_dir: build_html
+
+pages:
+- ['index.md', 'Home']
+- ['operations_cancel.md', 'Operations', 'Cancel']
+- ['operations_delete.md', 'Operations', 'Delete']
+- ['operations_get.md', 'Operations', 'Get']
+- ['operations_list.md', 'Operations', 'List']
+- ['speech_longrunningrecognize.md', 'Speech', 'Longrunningrecognize']
+- ['speech_recognize.md', 'Speech', 'Recognize']
+
+theme: readthedocs
+
+copyright: Copyright &copy; 2015-2016, `Sebastian Thiel`
+

--- a/gen/speech1-cli/src/cmn.rs
+++ b/gen/speech1-cli/src/cmn.rs
@@ -1,0 +1,799 @@
+// COPY OF 'src/rust/cli/cmn.rs'
+// DO NOT EDIT
+use oauth2::{ApplicationSecret, ConsoleApplicationSecret, TokenStorage, Token};
+use serde_json as json;
+use serde_json::value::Value;
+use mime::Mime;
+use clap::{App, SubCommand};
+use strsim;
+
+use std::fs;
+use std::env;
+use std::io;
+use std::error::Error as StdError;
+use std::fmt;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+use std::string::ToString;
+use std::io::{Write, Read, stdout};
+
+use std::default::Default;
+
+const FIELD_SEP: char = '.';
+
+
+pub enum ComplexType {
+    Pod,
+    Vec,
+    Map,
+}
+
+// Null,
+// Bool(bool),
+// I64(i64),
+// U64(u64),
+// F64(f64),
+// String(String),
+
+pub enum JsonType {
+    Boolean,
+    Int,
+    Uint,
+    Float,
+    String,
+}
+
+pub struct JsonTypeInfo {
+    pub jtype: JsonType,
+    pub ctype: ComplexType,
+}
+
+// Based on @erickt user comment. Thanks for the idea !
+// Remove all keys whose values are null from given value (changed in place)
+pub fn remove_json_null_values(value: &mut Value) {
+    match *value {
+        Value::Object(ref mut map) => {
+            let mut for_removal = Vec::new();
+
+            for (key, mut value) in map.iter_mut() {
+                if value.is_null() {
+                    for_removal.push(key.clone());
+                } else {
+                    remove_json_null_values(&mut value);
+                }
+            }
+
+            for key in &for_removal {
+                map.remove(key);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn did_you_mean<'a>(v: &str, possible_values: &[&'a str]) -> Option<&'a str> {
+
+    let mut candidate: Option<(f64, &str)> = None;
+    for pv in possible_values {
+        let confidence = strsim::jaro_winkler(v, pv);
+        if confidence > 0.8 &&
+           (candidate.is_none() || (candidate.as_ref().unwrap().0 < confidence)) {
+            candidate = Some((confidence, pv));
+        }
+    }
+    match candidate {
+        None => None,
+        Some((_, candidate)) => Some(candidate),
+    }
+}
+
+pub enum CallType {
+    Upload(UploadProtocol),
+    Standard,
+}
+
+arg_enum!{
+    pub enum UploadProtocol {
+        Simple,
+        Resumable
+    }
+}
+
+impl AsRef<str> for UploadProtocol {
+    fn as_ref(&self) -> &str {
+        match *self {
+            UploadProtocol::Simple => "simple",
+            UploadProtocol::Resumable => "resumable",
+        }
+    }
+}
+
+impl AsRef<str> for CallType {
+    fn as_ref(&self) -> &str {
+        match *self {
+            CallType::Upload(ref proto) => proto.as_ref(),
+            CallType::Standard => "standard-request",
+        }
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct FieldCursor(Vec<String>);
+
+impl ToString for  FieldCursor {
+    fn to_string(&self) -> String {
+        self.0.join(".")
+    }
+}
+
+impl From<&'static str> for FieldCursor {
+    fn from(value: &'static str) -> FieldCursor {
+        let mut res = FieldCursor::default();
+        res.set(value).unwrap();
+        res
+    }
+}
+
+fn assure_entry<'a, 'b>(m: &'a mut json::Map<String, Value>, k: &'b String) -> &'a mut Value {
+    if m.contains_key(k) {
+        return m.get_mut(k).expect("value to exist");
+    }
+    m.insert(k.to_owned(), Value::Object(Default::default()));
+    m.get_mut(k).expect("value to exist")
+}
+
+impl FieldCursor {
+    pub fn set(&mut self, value: &str) -> Result<(), CLIError> {
+        if value.len() == 0 {
+            return Err(CLIError::Field(FieldError::Empty));
+        }
+
+        let mut first_is_field_sep = false;
+        let mut char_count: usize = 0;
+        let mut last_c = FIELD_SEP;
+        let mut num_conscutive_field_seps = 0;
+
+        let mut field = String::new();
+        let mut fields = self.0.clone();
+
+        let push_field = |fs: &mut Vec<String>, f: &mut String| {
+            if f.len() > 0 {
+                fs.push(f.clone());
+                f.truncate(0);
+            }
+        };
+
+        for (cid, c) in value.chars().enumerate() {
+            char_count += 1;
+
+            if c == FIELD_SEP {
+                if cid == 0 {
+                    first_is_field_sep = true;
+                }
+                num_conscutive_field_seps += 1;
+                if cid > 0 && last_c == FIELD_SEP {
+                    if fields.pop().is_none() {
+                        return Err(CLIError::Field(FieldError::PopOnEmpty(value.to_string())));
+                    }
+                } else {
+                    push_field(&mut fields, &mut field);
+                }
+            } else {
+                num_conscutive_field_seps = 0;
+                if cid == 1 {
+                    if first_is_field_sep {
+                        fields.truncate(0);
+                    }
+                }
+                field.push(c);
+            }
+
+            last_c = c;
+        }
+
+        push_field(&mut fields, &mut field);
+
+        if char_count == 1 && first_is_field_sep {
+            fields.truncate(0);
+        }
+        if char_count > 1 && num_conscutive_field_seps == 1 {
+            return Err(CLIError::Field(FieldError::TrailingFieldSep(value.to_string())));
+        }
+
+        self.0 = fields;
+        Ok(())
+    }
+
+    pub fn did_you_mean(value: &str, possible_values: &[&str]) -> Option<String> {
+        if value.len() == 0 {
+            return None;
+        }
+
+        let mut last_c = FIELD_SEP;
+
+        let mut field = String::new();
+        let mut output = String::new();
+
+        let push_field = |fs: &mut String, f: &mut String| {
+            if f.len() > 0 {
+                fs.push_str(match did_you_mean(&f, possible_values) {
+                    Some(candidate) => candidate,
+                    None => &f,
+                });
+                f.truncate(0);
+            }
+        };
+
+        for (cid, c) in value.chars().enumerate() {
+            if c == FIELD_SEP {
+                if last_c != FIELD_SEP {
+                    push_field(&mut output, &mut field);
+                }
+                output.push(c);
+            } else {
+                field.push(c);
+            }
+
+            last_c = c;
+        }
+
+        push_field(&mut output, &mut field);
+
+        if &output == value {
+            None
+        } else {
+            Some(output)
+        }
+    }
+
+    pub fn set_json_value(&self,
+                          mut object: &mut Value,
+                          value: &str,
+                          type_info: JsonTypeInfo,
+                          err: &mut InvalidOptionsError,
+                          orig_cursor: &FieldCursor) {
+        assert!(self.0.len() > 0);
+
+        for field in &self.0[..self.0.len() - 1] {
+            let tmp = object;
+            object = match *tmp {
+                Value::Object(ref mut mapping) => {
+                    assure_entry(mapping, &field)
+                }
+                _ => panic!("We don't expect non-object Values here ..."),
+            };
+        }
+
+        match *object {
+            Value::Object(ref mut mapping) => {
+                let field = &self.0[self.0.len() - 1];
+                let to_jval = |value: &str,
+                               jtype: JsonType,
+                               err: &mut InvalidOptionsError|
+                               -> Value {
+                    match jtype {
+                        JsonType::Boolean =>
+                            Value::Bool(arg_from_str(value, err, &field, "boolean")),
+                        JsonType::Int =>
+                            Value::Number(json::Number::from_f64(arg_from_str(value,
+                                                                              err,
+                                                                              &field,
+                                                                              "int"))
+                                              .expect("valid f64")),
+                        JsonType::Uint =>
+                            Value::Number(json::Number::from_f64(arg_from_str(value,
+                                                                              err,
+                                                                              &field,
+                                                                              "uint"))
+                                              .expect("valid f64")),
+                        JsonType::Float =>
+                            Value::Number(json::Number::from_f64(arg_from_str(value,
+                                                                              err,
+                                                                              &field,
+                                                                              "float"))
+                                              .expect("valid f64")),
+                        JsonType::String => Value::String(value.to_owned()),
+                    }
+                };
+
+                match type_info.ctype {
+                    ComplexType::Pod => {
+                        if mapping.insert(field.to_owned(), to_jval(value, type_info.jtype, err))
+                                  .is_some() {
+                            err.issues.push(CLIError::Field(FieldError::Duplicate(orig_cursor.to_string())));
+                        }
+                    }
+                    ComplexType::Vec => {
+                        match *assure_entry(mapping, field) {
+                            Value::Array(ref mut values) =>
+                                values.push(to_jval(value, type_info.jtype, err)),
+                            _ => unreachable!(),
+                        }
+                    }
+                    ComplexType::Map => {
+                        let (key, value) = parse_kv_arg(value, err, true);
+                        let jval = to_jval(value.unwrap_or(""), type_info.jtype, err);
+
+                        match *assure_entry(mapping, &field) {
+
+                            Value::Object(ref mut value_map) => {
+                                if value_map.insert(key.to_owned(), jval).is_some() {
+                                    err.issues.push(CLIError::Field(FieldError::Duplicate(orig_cursor.to_string())));
+                                }
+                            }
+                            _ => unreachable!(),
+                        }
+                    }
+                }
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    pub fn num_fields(&self) -> usize {
+        self.0.len()
+    }
+}
+
+pub fn parse_kv_arg<'a>(kv: &'a str,
+                        err: &mut InvalidOptionsError,
+                        for_hashmap: bool)
+                        -> (&'a str, Option<&'a str>) {
+    let mut add_err = || {
+        err.issues.push(CLIError::InvalidKeyValueSyntax(kv.to_string(), for_hashmap))
+    };
+    match kv.find('=') {
+        None => {
+            add_err();
+            return (kv, None);
+        }
+        Some(pos) => {
+            let key = &kv[..pos];
+            if kv.len() <= pos + 1 {
+                add_err();
+                return (key, Some(""));
+            }
+            (key, Some(&kv[pos + 1..]))
+        }
+    }
+}
+
+pub fn calltype_from_str(name: &str,
+                         valid_protocols: Vec<String>,
+                         err: &mut InvalidOptionsError)
+                         -> CallType {
+    CallType::Upload(match UploadProtocol::from_str(name) {
+        Ok(up) => up,
+        Err(msg) => {
+            err.issues.push(CLIError::InvalidUploadProtocol(name.to_string(), valid_protocols));
+            UploadProtocol::Simple
+        }
+    })
+}
+
+pub fn input_file_from_opts(file_path: &str, err: &mut InvalidOptionsError) -> Option<fs::File> {
+    match fs::File::open(file_path) {
+        Ok(f) => Some(f),
+        Err(io_err) => {
+            err.issues.push(CLIError::Input(InputError::Io((file_path.to_string(), io_err))));
+            None
+        }
+    }
+}
+
+pub fn input_mime_from_opts(mime: &str, err: &mut InvalidOptionsError) -> Option<Mime> {
+    match mime.parse() {
+        Ok(m) => Some(m),
+        Err(_) => {
+            err.issues.push(CLIError::Input(InputError::Mime(mime.to_string())));
+            None
+        }
+    }
+}
+
+pub fn writer_from_opts(arg: Option<&str>) -> Result<Box<Write>, io::Error> {
+    let f = arg.unwrap_or("-");
+    match f {
+        "-" => Ok(Box::new(stdout())),
+        _ => match fs::OpenOptions::new().create(true).write(true).open(f) {
+            Ok(f) => Ok(Box::new(f)),
+            Err(io_err) => Err(io_err),
+        },
+    }
+}
+
+
+pub fn arg_from_str<'a, T>(arg: &str,
+                           err: &mut InvalidOptionsError,
+                           arg_name: &'a str,
+                           arg_type: &'a str)
+                           -> T
+    where T: FromStr + Default,
+          <T as FromStr>::Err: fmt::Display
+{
+    match FromStr::from_str(arg) {
+        Err(perr) => {
+            err.issues.push(CLIError::ParseError(arg_name.to_owned(),
+                                                 arg_type.to_owned(),
+                                                 arg.to_string(),
+                                                 format!("{}", perr)));
+            Default::default()
+        }
+        Ok(v) => v,
+    }
+}
+
+pub struct JsonTokenStorage {
+    pub program_name: &'static str,
+    pub db_dir: String,
+}
+
+impl JsonTokenStorage {
+    fn path(&self, scope_hash: u64) -> PathBuf {
+        Path::new(&self.db_dir).join(&format!("{}-token-{}.json", self.program_name, scope_hash))
+    }
+}
+
+
+#[derive(Debug)]
+pub enum TokenStorageError {
+    Json(json::Error),
+    Io(io::Error),
+}
+
+impl fmt::Display for TokenStorageError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            TokenStorageError::Json(ref err) => writeln!(f, "Could not serialize secrets: {}", err),
+            TokenStorageError::Io(ref err) => writeln!(f, "Failed to write secret token: {}", err),
+        }
+    }
+}
+
+impl StdError for TokenStorageError {
+    fn description(&self) -> &str {
+        "Failure when getting or setting the token storage"
+    }
+}
+
+
+impl TokenStorage for JsonTokenStorage {
+    type Error = TokenStorageError;
+
+    // NOTE: logging might be interesting, currently we swallow all errors
+    fn set(&mut self,
+           scope_hash: u64,
+           _: &Vec<&str>,
+           token: Option<Token>)
+           -> Result<(), TokenStorageError> {
+        match token {
+            None => {
+                match fs::remove_file(self.path(scope_hash)) {
+                    Err(err) => match err.kind() {
+                        io::ErrorKind::NotFound => Ok(()),
+                        _ => Err(TokenStorageError::Io(err)),
+                    },
+                    Ok(_) => Ok(()),
+                }
+            }
+            Some(token) => {
+                match fs::OpenOptions::new().create(true).write(true).open(&self.path(scope_hash)) {
+                    Ok(mut f) => {
+                        match json::to_writer_pretty(&mut f, &token) {
+                            Ok(_) => Ok(()),
+                            Err(serde_err) => Err(TokenStorageError::Json(serde_err)),
+                        }
+                    }
+                    Err(io_err) => Err(TokenStorageError::Io(io_err)),
+                }
+            }
+        }
+    }
+
+    fn get(&self, scope_hash: u64, _: &Vec<&str>) -> Result<Option<Token>, TokenStorageError> {
+        match fs::File::open(&self.path(scope_hash)) {
+            Ok(f) => {
+                match json::de::from_reader(f) {
+                    Ok(token) => Ok(Some(token)),
+                    Err(err) => Err(TokenStorageError::Json(err)),
+                }
+            }
+            Err(io_err) => {
+                match io_err.kind() {
+                    io::ErrorKind::NotFound => Ok(None),
+                    _ => Err(TokenStorageError::Io(io_err)),
+                }
+            }
+        }
+    }
+}
+
+
+#[derive(Debug)]
+pub enum ApplicationSecretError {
+    DecoderError((String, json::Error)),
+    FormatError(String),
+}
+
+impl fmt::Display for ApplicationSecretError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            ApplicationSecretError::DecoderError((ref path, ref err)) =>
+                writeln!(f,
+                         "Could not decode file at '{}' with error: {}.",
+                         path,
+                         err),
+            ApplicationSecretError::FormatError(ref path) =>
+                writeln!(f,
+                         "'installed' field is unset in secret file at '{}'.",
+                         path),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum ConfigurationError {
+    DirectoryCreationFailed((String, io::Error)),
+    DirectoryUnset,
+    HomeExpansionFailed(String),
+    Secret(ApplicationSecretError),
+    Io((String, io::Error)),
+}
+
+impl fmt::Display for ConfigurationError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            ConfigurationError::DirectoryCreationFailed((ref dir, ref err)) =>
+                writeln!(f,
+                         "Directory '{}' could not be created with error: {}.",
+                         dir,
+                         err),
+            ConfigurationError::DirectoryUnset => writeln!(f, "--config-dir was unset or empty."),
+            ConfigurationError::HomeExpansionFailed(ref dir) =>
+                writeln!(f,
+                         "Couldn't find HOME directory of current user, failed to expand '{}'.",
+                         dir),
+            ConfigurationError::Secret(ref err) => writeln!(f, "Secret -> {}", err),
+            ConfigurationError::Io((ref path, ref err)) =>
+                writeln!(f,
+                         "IO operation failed on path '{}' with error: {}.",
+                         path,
+                         err),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum InputError {
+    Io((String, io::Error)),
+    Mime(String),
+}
+
+impl fmt::Display for InputError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            InputError::Io((ref file_path, ref io_err)) =>
+                writeln!(f,
+                         "Failed to open '{}' for reading with error: {}.",
+                         file_path,
+                         io_err),
+            InputError::Mime(ref mime) => writeln!(f, "'{}' is not a known mime-type.", mime),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum FieldError {
+    PopOnEmpty(String),
+    TrailingFieldSep(String),
+    Unknown(String, Option<String>, Option<String>),
+    Duplicate(String),
+    Empty,
+}
+
+
+impl fmt::Display for FieldError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            FieldError::PopOnEmpty(ref field) =>
+                writeln!(f, "'{}': Cannot move up on empty field cursor.", field),
+            FieldError::TrailingFieldSep(ref field) =>
+                writeln!(f,
+                         "'{}': Single field separator may not be last character.",
+                         field),
+            FieldError::Unknown(ref field, ref suggestion, ref value) => {
+                let suffix = match *suggestion {
+                    Some(ref s) => {
+                        let kv = match *value {
+                            Some(ref v) => format!("{}={}", s, v),
+                            None => s.clone(),
+                        };
+                        format!(" Did you mean '{}' ?", kv)
+                    }
+                    None => String::new(),
+                };
+                writeln!(f, "Field '{}' does not exist.{}", field, suffix)
+            }
+            FieldError::Duplicate(ref cursor) =>
+                writeln!(f, "Value at '{}' was already set", cursor),
+            FieldError::Empty => writeln!(f, "Field names must not be empty."),
+        }
+    }
+}
+
+
+#[derive(Debug)]
+pub enum CLIError {
+    Configuration(ConfigurationError),
+    ParseError(String, String, String, String),
+    UnknownParameter(String, Vec<&'static str>),
+    InvalidUploadProtocol(String, Vec<String>),
+    InvalidKeyValueSyntax(String, bool),
+    Input(InputError),
+    Field(FieldError),
+    MissingCommandError,
+    MissingMethodError(String),
+}
+
+impl fmt::Display for CLIError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            CLIError::Configuration(ref err) => write!(f, "Configuration -> {}", err),
+            CLIError::Input(ref err) => write!(f, "Input -> {}", err),
+            CLIError::Field(ref err) => write!(f, "Field -> {}", err),
+            CLIError::InvalidUploadProtocol(ref proto_name, ref valid_names) =>
+                writeln!(f,
+                         "'{}' is not a valid upload protocol. Choose from one of {}.",
+                         proto_name,
+                         valid_names.join(", ")),
+            CLIError::ParseError(ref arg_name, ref type_name, ref value, ref err_desc) =>
+                writeln!(f,
+                         "Failed to parse argument '{}' with value '{}' as {} with error: {}.",
+                         arg_name,
+                         value,
+                         type_name,
+                         err_desc),
+            CLIError::UnknownParameter(ref param_name, ref possible_values) => {
+                let suffix = match did_you_mean(param_name, &possible_values) {
+                    Some(v) => format!(" Did you mean '{}' ?", v),
+                    None => String::new(),
+                };
+                write!(f, "Parameter '{}' is unknown.{}\n", param_name, suffix)
+            }
+            CLIError::InvalidKeyValueSyntax(ref kv, is_hashmap) => {
+                let hashmap_info = if is_hashmap {
+                    "hashmap "
+                } else {
+                    ""
+                };
+                writeln!(f,
+                         "'{}' does not match {}pattern <key>=<value>.",
+                         kv,
+                         hashmap_info)
+            }
+            CLIError::MissingCommandError => writeln!(f, "Please specify the main sub-command."),
+            CLIError::MissingMethodError(ref cmd) =>
+                writeln!(f,
+                         "Please specify the method to call on the '{}' command.",
+                         cmd),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct InvalidOptionsError {
+    pub issues: Vec<CLIError>,
+    pub exit_code: i32,
+}
+
+impl fmt::Display for InvalidOptionsError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        for issue in &self.issues {
+            try!(issue.fmt(f));
+        }
+        Ok(())
+    }
+}
+
+impl InvalidOptionsError {
+    pub fn single(err: CLIError, exit_code: i32) -> InvalidOptionsError {
+        InvalidOptionsError {
+            issues: vec![err],
+            exit_code: exit_code,
+        }
+    }
+
+    pub fn new() -> InvalidOptionsError {
+        InvalidOptionsError {
+            issues: Vec::new(),
+            exit_code: 1,
+        }
+    }
+}
+
+pub fn assure_config_dir_exists(dir: &str) -> Result<String, CLIError> {
+    let trdir = dir.trim();
+    if trdir.len() == 0 {
+        return Err(CLIError::Configuration(ConfigurationError::DirectoryUnset));
+    }
+
+    let expanded_config_dir = if trdir.as_bytes()[0] == b'~' {
+        match env::var("HOME").ok().or(env::var("UserProfile").ok()) {
+            None => return Err(CLIError::Configuration(ConfigurationError::HomeExpansionFailed(trdir.to_string()))),
+            Some(mut user) => {
+                user.push_str(&trdir[1..]);
+                user
+            }
+        }
+    } else {
+        trdir.to_string()
+    };
+
+    if let Err(err) = fs::create_dir(&expanded_config_dir) {
+        if err.kind() != io::ErrorKind::AlreadyExists {
+            return Err(CLIError::Configuration(
+                    ConfigurationError::DirectoryCreationFailed((expanded_config_dir, err))));
+        }
+    }
+
+    Ok(expanded_config_dir)
+}
+
+pub fn application_secret_from_directory(dir: &str,
+                                         secret_basename: &str,
+                                         json_console_secret: &str)
+                                         -> Result<ApplicationSecret, CLIError> {
+    let secret_path = Path::new(dir).join(secret_basename);
+    let secret_str = || secret_path.as_path().to_str().unwrap().to_string();
+    let secret_io_error = |io_err: io::Error| {
+        Err(CLIError::Configuration(ConfigurationError::Io((secret_str(), io_err))))
+    };
+
+    for _ in 0..2 {
+        match fs::File::open(&secret_path) {
+            Err(mut err) => {
+                if err.kind() == io::ErrorKind::NotFound {
+                    // Write our built-in one - user may adjust the written file at will
+
+                    err = match fs::OpenOptions::new()
+                                    .create(true)
+                                    .write(true)
+                                    .open(&secret_path) {
+                        Err(cfe) => cfe,
+                        Ok(mut f) => {
+                            // Assure we convert 'ugly' json string into pretty one
+                            let console_secret: ConsoleApplicationSecret =
+                                json::from_str(json_console_secret).unwrap();
+                            match json::to_writer_pretty(&mut f, &console_secret) {
+                                Err(serde_err) =>
+                                    panic!("Unexpected serde error: {:#?}", serde_err),
+                                Ok(_) => continue,
+                            }
+                        }
+                    };
+                    // fall through to IO error handling
+                }
+                return secret_io_error(err);
+            }
+            Ok(f) => {
+                match json::de::from_reader::<_, ConsoleApplicationSecret>(f) {
+                    Err(json_err) =>
+                        return Err(CLIError::Configuration(
+                            ConfigurationError::Secret(
+                                ApplicationSecretError::DecoderError(
+                                                (secret_str(), json_err)
+                                              )))),
+                    Ok(console_secret) => match console_secret.installed {
+                        Some(secret) => return Ok(secret),
+                        None => return Err(
+                                        CLIError::Configuration(
+                                        ConfigurationError::Secret(
+                                        ApplicationSecretError::FormatError(secret_str())
+                                        ))),
+                    },
+                }
+            }
+        }
+    }
+    unreachable!();
+}

--- a/gen/speech1-cli/src/main.rs
+++ b/gen/speech1-cli/src/main.rs
@@ -1,0 +1,873 @@
+// DO NOT EDIT !
+// This file was generated automatically from 'src/mako/cli/main.rs.mako'
+// DO NOT EDIT !
+#![allow(unused_variables, unused_imports, dead_code, unused_mut)]
+
+#[macro_use]
+extern crate clap;
+extern crate yup_oauth2 as oauth2;
+extern crate yup_hyper_mock as mock;
+extern crate hyper_rustls;
+extern crate serde;
+extern crate serde_json;
+extern crate hyper;
+extern crate mime;
+extern crate strsim;
+extern crate google_speech1 as api;
+
+use std::env;
+use std::io::{self, Write};
+use clap::{App, SubCommand, Arg};
+
+mod cmn;
+
+use cmn::{InvalidOptionsError, CLIError, JsonTokenStorage, arg_from_str, writer_from_opts, parse_kv_arg,
+          input_file_from_opts, input_mime_from_opts, FieldCursor, FieldError, CallType, UploadProtocol,
+          calltype_from_str, remove_json_null_values, ComplexType, JsonType, JsonTypeInfo};
+
+use std::default::Default;
+use std::str::FromStr;
+
+use oauth2::{Authenticator, DefaultAuthenticatorDelegate, FlowType};
+use serde_json as json;
+use clap::ArgMatches;
+
+enum DoitError {
+    IoError(String, io::Error),
+    ApiError(api::Error),
+}
+
+struct Engine<'n> {
+    opt: ArgMatches<'n>,
+    hub: api::Speech<hyper::Client, Authenticator<DefaultAuthenticatorDelegate, JsonTokenStorage, hyper::Client>>,
+    gp: Vec<&'static str>,
+    gpm: Vec<(&'static str, &'static str)>,
+}
+
+
+impl<'n> Engine<'n> {
+    fn _operations_cancel(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec![]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::CancelOperationRequest = json::value::from_value(object).unwrap();
+        let mut call = self.hub.operations().cancel(request, opt.value_of("name").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _operations_delete(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let mut call = self.hub.operations().delete(opt.value_of("name").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _operations_get(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let mut call = self.hub.operations().get(opt.value_of("name").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _operations_list(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let mut call = self.hub.operations().list();
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                "page-token" => {
+                    call = call.page_token(value.unwrap_or(""));
+                },
+                "page-size" => {
+                    call = call.page_size(arg_from_str(value.unwrap_or("-0"), err, "page-size", "integer"));
+                },
+                "name" => {
+                    call = call.name(value.unwrap_or(""));
+                },
+                "filter" => {
+                    call = call.filter(value.unwrap_or(""));
+                },
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v.extend(["filter", "page-token", "name", "page-size"].iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _speech_longrunningrecognize(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    "audio.content" => Some(("audio.content", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "audio.uri" => Some(("audio.uri", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "config.language-code" => Some(("config.languageCode", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "config.encoding" => Some(("config.encoding", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "config.enable-word-time-offsets" => Some(("config.enableWordTimeOffsets", JsonTypeInfo { jtype: JsonType::Boolean, ctype: ComplexType::Pod })),
+                    "config.max-alternatives" => Some(("config.maxAlternatives", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Pod })),
+                    "config.sample-rate-hertz" => Some(("config.sampleRateHertz", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Pod })),
+                    "config.profanity-filter" => Some(("config.profanityFilter", JsonTypeInfo { jtype: JsonType::Boolean, ctype: ComplexType::Pod })),
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec!["audio", "config", "content", "enable-word-time-offsets", "encoding", "language-code", "max-alternatives", "profanity-filter", "sample-rate-hertz", "uri"]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::LongRunningRecognizeRequest = json::value::from_value(object).unwrap();
+        let mut call = self.hub.speech().longrunningrecognize(request);
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _speech_recognize(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    "audio.content" => Some(("audio.content", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "audio.uri" => Some(("audio.uri", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "config.language-code" => Some(("config.languageCode", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "config.encoding" => Some(("config.encoding", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "config.enable-word-time-offsets" => Some(("config.enableWordTimeOffsets", JsonTypeInfo { jtype: JsonType::Boolean, ctype: ComplexType::Pod })),
+                    "config.max-alternatives" => Some(("config.maxAlternatives", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Pod })),
+                    "config.sample-rate-hertz" => Some(("config.sampleRateHertz", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Pod })),
+                    "config.profanity-filter" => Some(("config.profanityFilter", JsonTypeInfo { jtype: JsonType::Boolean, ctype: ComplexType::Pod })),
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec!["audio", "config", "content", "enable-word-time-offsets", "encoding", "language-code", "max-alternatives", "profanity-filter", "sample-rate-hertz", "uri"]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::RecognizeRequest = json::value::from_value(object).unwrap();
+        let mut call = self.hub.speech().recognize(request);
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _doit(&self, dry_run: bool) -> Result<Result<(), DoitError>, Option<InvalidOptionsError>> {
+        let mut err = InvalidOptionsError::new();
+        let mut call_result: Result<(), DoitError> = Ok(());
+        let mut err_opt: Option<InvalidOptionsError> = None;
+        match self.opt.subcommand() {
+            ("operations", Some(opt)) => {
+                match opt.subcommand() {
+                    ("cancel", Some(opt)) => {
+                        call_result = self._operations_cancel(opt, dry_run, &mut err);
+                    },
+                    ("delete", Some(opt)) => {
+                        call_result = self._operations_delete(opt, dry_run, &mut err);
+                    },
+                    ("get", Some(opt)) => {
+                        call_result = self._operations_get(opt, dry_run, &mut err);
+                    },
+                    ("list", Some(opt)) => {
+                        call_result = self._operations_list(opt, dry_run, &mut err);
+                    },
+                    _ => {
+                        err.issues.push(CLIError::MissingMethodError("operations".to_string()));
+                        writeln!(io::stderr(), "{}\n", opt.usage()).ok();
+                    }
+                }
+            },
+            ("speech", Some(opt)) => {
+                match opt.subcommand() {
+                    ("longrunningrecognize", Some(opt)) => {
+                        call_result = self._speech_longrunningrecognize(opt, dry_run, &mut err);
+                    },
+                    ("recognize", Some(opt)) => {
+                        call_result = self._speech_recognize(opt, dry_run, &mut err);
+                    },
+                    _ => {
+                        err.issues.push(CLIError::MissingMethodError("speech".to_string()));
+                        writeln!(io::stderr(), "{}\n", opt.usage()).ok();
+                    }
+                }
+            },
+            _ => {
+                err.issues.push(CLIError::MissingCommandError);
+                writeln!(io::stderr(), "{}\n", self.opt.usage()).ok();
+            }
+        }
+
+        if dry_run {
+            if err.issues.len() > 0 {
+                err_opt = Some(err);
+            }
+            Err(err_opt)
+        } else {
+            Ok(call_result)
+        }
+    }
+
+    // Please note that this call will fail if any part of the opt can't be handled
+    fn new(opt: ArgMatches<'n>) -> Result<Engine<'n>, InvalidOptionsError> {
+        let (config_dir, secret) = {
+            let config_dir = match cmn::assure_config_dir_exists(opt.value_of("folder").unwrap_or("~/.google-service-cli")) {
+                Err(e) => return Err(InvalidOptionsError::single(e, 3)),
+                Ok(p) => p,
+            };
+
+            match cmn::application_secret_from_directory(&config_dir, "speech1-secret.json",
+                                                         "{\"installed\":{\"auth_uri\":\"https://accounts.google.com/o/oauth2/auth\",\"client_secret\":\"hCsslbCUyfehWMmbkG8vTYxG\",\"token_uri\":\"https://accounts.google.com/o/oauth2/token\",\"client_email\":\"\",\"redirect_uris\":[\"urn:ietf:wg:oauth:2.0:oob\",\"oob\"],\"client_x509_cert_url\":\"\",\"client_id\":\"620010449518-9ngf7o4dhs0dka470npqvor6dc5lqb9b.apps.googleusercontent.com\",\"auth_provider_x509_cert_url\":\"https://www.googleapis.com/oauth2/v1/certs\"}}") {
+                Ok(secret) => (config_dir, secret),
+                Err(e) => return Err(InvalidOptionsError::single(e, 4))
+            }
+        };
+
+        let auth = Authenticator::new(  &secret, DefaultAuthenticatorDelegate,
+                                        if opt.is_present("debug-auth") {
+                                            hyper::Client::with_connector(mock::TeeConnector {
+                                                    connector: hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())
+                                                })
+                                        } else {
+                                            hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new()))
+                                        },
+                                        JsonTokenStorage {
+                                          program_name: "speech1",
+                                          db_dir: config_dir.clone(),
+                                        }, Some(FlowType::InstalledRedirect(54324)));
+
+        let client =
+            if opt.is_present("debug") {
+                hyper::Client::with_connector(mock::TeeConnector {
+                        connector: hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())
+                    })
+            } else {
+                hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new()))
+            };
+        let engine = Engine {
+            opt: opt,
+            hub: api::Speech::new(client, auth),
+            gp: vec!["$-xgafv", "access-token", "alt", "bearer-token", "callback", "fields", "key", "oauth-token", "pp", "pretty-print", "quota-user", "upload-type", "upload-protocol"],
+            gpm: vec![
+                    ("$-xgafv", "$.xgafv"),
+                    ("access-token", "access_token"),
+                    ("bearer-token", "bearer_token"),
+                    ("oauth-token", "oauth_token"),
+                    ("pretty-print", "prettyPrint"),
+                    ("quota-user", "quotaUser"),
+                    ("upload-type", "uploadType"),
+                    ("upload-protocol", "upload_protocol"),
+                ]
+        };
+
+        match engine._doit(true) {
+            Err(Some(err)) => Err(err),
+            Err(None)      => Ok(engine),
+            Ok(_)          => unreachable!(),
+        }
+    }
+
+    fn doit(&self) -> Result<(), DoitError> {
+        match self._doit(false) {
+            Ok(res) => res,
+            Err(_) => unreachable!(),
+        }
+    }
+}
+
+fn main() {
+    let mut exit_status = 0i32;
+    let arg_data = [
+        ("operations", "methods: 'cancel', 'delete', 'get' and 'list'", vec![
+            ("cancel",
+                    Some(r##"Starts asynchronous cancellation on a long-running operation.  The server
+        makes a best effort to cancel the operation, but success is not
+        guaranteed.  If the server doesn't support this method, it returns
+        `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
+        Operations.GetOperation or
+        other methods to check whether the cancellation succeeded or whether the
+        operation completed despite cancellation. On successful cancellation,
+        the operation is not deleted; instead, it becomes an operation with
+        an Operation.error value with a google.rpc.Status.code of 1,
+        corresponding to `Code.CANCELLED`."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_speech1_cli/operations_cancel",
+                  vec![
+                    (Some(r##"name"##),
+                     None,
+                     Some(r##"The name of the operation resource to be cancelled."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("delete",
+                    Some(r##"Deletes a long-running operation. This method indicates that the client is
+        no longer interested in the operation result. It does not cancel the
+        operation. If the server doesn't support this method, it returns
+        `google.rpc.Code.UNIMPLEMENTED`."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_speech1_cli/operations_delete",
+                  vec![
+                    (Some(r##"name"##),
+                     None,
+                     Some(r##"The name of the operation resource to be deleted."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("get",
+                    Some(r##"Gets the latest state of a long-running operation.  Clients can use this
+        method to poll the operation result at intervals as recommended by the API
+        service."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_speech1_cli/operations_get",
+                  vec![
+                    (Some(r##"name"##),
+                     None,
+                     Some(r##"The name of the operation resource."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("list",
+                    Some(r##"Lists operations that match the specified filter in the request. If the
+        server doesn't support this method, it returns `UNIMPLEMENTED`.
+        
+        NOTE: the `name` binding allows API services to override the binding
+        to use different resource name schemes, such as `users/*/operations`. To
+        override the binding, API services can add a binding such as
+        `"/v1/{name=users/*}/operations"` to their service configuration.
+        For backwards compatibility, the default name includes the operations
+        collection id, however overriding users must ensure the name binding
+        is the parent resource, without the operations collection id."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_speech1_cli/operations_list",
+                  vec![
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ]),
+        
+        ("speech", "methods: 'longrunningrecognize' and 'recognize'", vec![
+            ("longrunningrecognize",
+                    Some(r##"Performs asynchronous speech recognition: receive results via the
+        google.longrunning.Operations interface. Returns either an
+        `Operation.error` or an `Operation.response` which contains
+        a `LongRunningRecognizeResponse` message."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_speech1_cli/speech_longrunningrecognize",
+                  vec![
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("recognize",
+                    Some(r##"Performs synchronous speech recognition: receive results after all audio
+        has been sent and processed."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_speech1_cli/speech_recognize",
+                  vec![
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ]),
+        
+    ];
+    
+    let mut app = App::new("speech1")
+           .author("Sebastian Thiel <byronimo@gmail.com>")
+           .version("1.0.7+20171205")
+           .about("Converts audio to text by applying powerful neural network models.")
+           .after_help("All documentation details can be found at http://byron.github.io/google-apis-rs/google_speech1_cli")
+           .arg(Arg::with_name("url")
+                   .long("scope")
+                   .help("Specify the authentication a method should be executed in. Each scope requires the user to grant this application permission to use it.If unset, it defaults to the shortest scope url for a particular method.")
+                   .multiple(true)
+                   .takes_value(true))
+           .arg(Arg::with_name("folder")
+                   .long("config-dir")
+                   .help("A directory into which we will store our persistent data. Defaults to a user-writable directory that we will create during the first invocation.[default: ~/.google-service-cli")
+                   .multiple(false)
+                   .takes_value(true))
+           .arg(Arg::with_name("debug")
+                   .long("debug")
+                   .help("Output all server communication to standard error. `tx` and `rx` are placed into the same stream.")
+                   .multiple(false)
+                   .takes_value(false))
+           .arg(Arg::with_name("debug-auth")
+                   .long("debug-auth")
+                   .help("Output all communication related to authentication to standard error. `tx` and `rx` are placed into the same stream.")
+                   .multiple(false)
+                   .takes_value(false));
+           
+           for &(main_command_name, about, ref subcommands) in arg_data.iter() {
+               let mut mcmd = SubCommand::with_name(main_command_name).about(about);
+           
+               for &(sub_command_name, ref desc, url_info, ref args) in subcommands {
+                   let mut scmd = SubCommand::with_name(sub_command_name);
+                   if let &Some(desc) = desc {
+                       scmd = scmd.about(desc);
+                   }
+                   scmd = scmd.after_help(url_info);
+           
+                   for &(ref arg_name, ref flag, ref desc, ref required, ref multi) in args {
+                       let arg_name_str =
+                           match (arg_name, flag) {
+                                   (&Some(an), _       ) => an,
+                                   (_        , &Some(f)) => f,
+                                    _                    => unreachable!(),
+                            };
+                       let mut arg = Arg::with_name(arg_name_str)
+                                         .empty_values(false);
+                       if let &Some(short_flag) = flag {
+                           arg = arg.short(short_flag);
+                       }
+                       if let &Some(desc) = desc {
+                           arg = arg.help(desc);
+                       }
+                       if arg_name.is_some() && flag.is_some() {
+                           arg = arg.takes_value(true);
+                       }
+                       if let &Some(required) = required {
+                           arg = arg.required(required);
+                       }
+                       if let &Some(multi) = multi {
+                           arg = arg.multiple(multi);
+                       }
+                       scmd = scmd.arg(arg);
+                   }
+                   mcmd = mcmd.subcommand(scmd);
+               }
+               app = app.subcommand(mcmd);
+           }
+           
+        let matches = app.get_matches();
+
+    let debug = matches.is_present("debug");
+    match Engine::new(matches) {
+        Err(err) => {
+            exit_status = err.exit_code;
+            writeln!(io::stderr(), "{}", err).ok();
+        },
+        Ok(engine) => {
+            if let Err(doit_err) = engine.doit() {
+                exit_status = 1;
+                match doit_err {
+                    DoitError::IoError(path, err) => {
+                        writeln!(io::stderr(), "Failed to open output file '{}': {}", path, err).ok();
+                    },
+                    DoitError::ApiError(err) => {
+                        if debug {
+                            writeln!(io::stderr(), "{:#?}", err).ok();
+                        } else {
+                            writeln!(io::stderr(), "{}", err).ok();
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    std::process::exit(exit_status);
+}

--- a/gen/speech1/Cargo.toml
+++ b/gen/speech1/Cargo.toml
@@ -1,0 +1,31 @@
+# DO NOT EDIT !
+# This file was generated automatically from 'src/mako/Cargo.toml.mako'
+# DO NOT EDIT !
+[package]
+
+name = "google-speech1"
+version = "1.0.7+20171205"
+authors = ["Sebastian Thiel <byronimo@gmail.com>"]
+description = "A complete library to interact with Speech (protocol v1)"
+repository = "https://github.com/Byron/google-apis-rs/tree/master/gen/speech1"
+homepage = "https://cloud.google.com/speech/"
+documentation = "https://docs.rs/google-speech1/1.0.7+20171205"
+license = "MIT"
+keywords = ["speech", "google", "protocol", "web", "api"]
+
+
+[dev-dependencies]
+hyper-rustls = "^0.6"
+
+[dependencies]
+hyper = "^ 0.10"
+mime = "^ 0.2.0"
+serde = "^ 1.0"
+serde_json = "^ 1.0"
+serde_derive = "^ 1.0"
+yup-oauth2 = "^ 1.0"
+url = "= 0.5"
+
+[features]
+
+

--- a/gen/speech1/LICENSE.md
+++ b/gen/speech1/LICENSE.md
@@ -1,0 +1,30 @@
+<!---
+DO NOT EDIT !
+This file was generated automatically from 'src/mako/LICENSE.md.mako'
+DO NOT EDIT !
+-->
+The MIT License (MIT)
+=====================
+
+Copyright © `2015-2016` `Sebastian Thiel`
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the “Software”), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.

--- a/gen/speech1/README.md
+++ b/gen/speech1/README.md
@@ -1,0 +1,184 @@
+<!---
+DO NOT EDIT !
+This file was generated automatically from 'src/mako/api/README.md.mako'
+DO NOT EDIT !
+-->
+The `google-speech1` library allows access to all features of the *Google Speech* service.
+
+This documentation was generated from *Speech* crate version *1.0.7+20171205*, where *20171205* is the exact revision of the *speech:v1* schema built by the [mako](http://www.makotemplates.org/) code generator *v1.0.7*.
+
+Everything else about the *Speech* *v1* API can be found at the
+[official documentation site](https://cloud.google.com/speech/).
+# Features
+
+Handle the following *Resources* with ease from the central [hub](https://docs.rs/google-speech1/1.0.7+20171205/google_speech1/struct.Speech.html) ... 
+
+* [operations](https://docs.rs/google-speech1/1.0.7+20171205/google_speech1/struct.Operation.html)
+ * [*cancel*](https://docs.rs/google-speech1/1.0.7+20171205/google_speech1/struct.OperationCancelCall.html), [*delete*](https://docs.rs/google-speech1/1.0.7+20171205/google_speech1/struct.OperationDeleteCall.html), [*get*](https://docs.rs/google-speech1/1.0.7+20171205/google_speech1/struct.OperationGetCall.html) and [*list*](https://docs.rs/google-speech1/1.0.7+20171205/google_speech1/struct.OperationListCall.html)
+* speech
+ * [*longrunningrecognize*](https://docs.rs/google-speech1/1.0.7+20171205/google_speech1/struct.SpeechLongrunningrecognizeCall.html) and [*recognize*](https://docs.rs/google-speech1/1.0.7+20171205/google_speech1/struct.SpeechRecognizeCall.html)
+
+
+
+
+# Structure of this Library
+
+The API is structured into the following primary items:
+
+* **[Hub](https://docs.rs/google-speech1/1.0.7+20171205/google_speech1/struct.Speech.html)**
+    * a central object to maintain state and allow accessing all *Activities*
+    * creates [*Method Builders*](https://docs.rs/google-speech1/1.0.7+20171205/google_speech1/trait.MethodsBuilder.html) which in turn
+      allow access to individual [*Call Builders*](https://docs.rs/google-speech1/1.0.7+20171205/google_speech1/trait.CallBuilder.html)
+* **[Resources](https://docs.rs/google-speech1/1.0.7+20171205/google_speech1/trait.Resource.html)**
+    * primary types that you can apply *Activities* to
+    * a collection of properties and *Parts*
+    * **[Parts](https://docs.rs/google-speech1/1.0.7+20171205/google_speech1/trait.Part.html)**
+        * a collection of properties
+        * never directly used in *Activities*
+* **[Activities](https://docs.rs/google-speech1/1.0.7+20171205/google_speech1/trait.CallBuilder.html)**
+    * operations to apply to *Resources*
+
+All *structures* are marked with applicable traits to further categorize them and ease browsing.
+
+Generally speaking, you can invoke *Activities* like this:
+
+```Rust,ignore
+let r = hub.resource().activity(...).doit()
+```
+
+Or specifically ...
+
+```ignore
+let r = hub.operations().get(...).doit()
+let r = hub.speech().longrunningrecognize(...).doit()
+let r = hub.operations().list(...).doit()
+let r = hub.operations().cancel(...).doit()
+let r = hub.operations().delete(...).doit()
+```
+
+The `resource()` and `activity(...)` calls create [builders][builder-pattern]. The second one dealing with `Activities` 
+supports various methods to configure the impending operation (not shown here). It is made such that all required arguments have to be 
+specified right away (i.e. `(...)`), whereas all optional ones can be [build up][builder-pattern] as desired.
+The `doit()` method performs the actual communication with the server and returns the respective result.
+
+# Usage
+
+## Setting up your Project
+
+To use this library, you would put the following lines into your `Cargo.toml` file:
+
+```toml
+[dependencies]
+google-speech1 = "*"
+```
+
+## A complete example
+
+```Rust
+extern crate hyper;
+extern crate hyper_rustls;
+extern crate yup_oauth2 as oauth2;
+extern crate google_speech1 as speech1;
+use speech1::{Result, Error};
+use std::default::Default;
+use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+use speech1::Speech;
+
+// Get an ApplicationSecret instance by some means. It contains the `client_id` and 
+// `client_secret`, among other things.
+let secret: ApplicationSecret = Default::default();
+// Instantiate the authenticator. It will choose a suitable authentication flow for you, 
+// unless you replace  `None` with the desired Flow.
+// Provide your own `AuthenticatorDelegate` to adjust the way it operates and get feedback about 
+// what's going on. You probably want to bring in your own `TokenStorage` to persist tokens and
+// retrieve them from storage.
+let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+                              hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+                              <MemoryStorage as Default>::default(), None);
+let mut hub = Speech::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+// You can configure optional parameters by calling the respective setters at will, and
+// execute the final call using `doit()`.
+// Values shown here are possibly random and not representative !
+let result = hub.operations().list()
+             .page_token("eirmod")
+             .page_size(-48)
+             .name("Stet")
+             .filter("sed")
+             .doit();
+
+match result {
+    Err(e) => match e {
+        // The Error enum provides details about what exactly happened.
+        // You can also just use its `Debug`, `Display` or `Error` traits
+         Error::HttpError(_)
+        |Error::MissingAPIKey
+        |Error::MissingToken(_)
+        |Error::Cancelled
+        |Error::UploadSizeLimitExceeded(_, _)
+        |Error::Failure(_)
+        |Error::BadRequest(_)
+        |Error::FieldClash(_)
+        |Error::JsonDecodeError(_, _) => println!("{}", e),
+    },
+    Ok(res) => println!("Success: {:?}", res),
+}
+
+```
+## Handling Errors
+
+All errors produced by the system are provided either as [Result](https://docs.rs/google-speech1/1.0.7+20171205/google_speech1/enum.Result.html) enumeration as return value of 
+the doit() methods, or handed as possibly intermediate results to either the 
+[Hub Delegate](https://docs.rs/google-speech1/1.0.7+20171205/google_speech1/trait.Delegate.html), or the [Authenticator Delegate](https://docs.rs/yup-oauth2/*/yup_oauth2/trait.AuthenticatorDelegate.html).
+
+When delegates handle errors or intermediate values, they may have a chance to instruct the system to retry. This 
+makes the system potentially resilient to all kinds of errors.
+
+## Uploads and Downloads
+If a method supports downloads, the response body, which is part of the [Result](https://docs.rs/google-speech1/1.0.7+20171205/google_speech1/enum.Result.html), should be
+read by you to obtain the media.
+If such a method also supports a [Response Result](https://docs.rs/google-speech1/1.0.7+20171205/google_speech1/trait.ResponseResult.html), it will return that by default.
+You can see it as meta-data for the actual media. To trigger a media download, you will have to set up the builder by making
+this call: `.param("alt", "media")`.
+
+Methods supporting uploads can do so using up to 2 different protocols: 
+*simple* and *resumable*. The distinctiveness of each is represented by customized 
+`doit(...)` methods, which are then named `upload(...)` and `upload_resumable(...)` respectively.
+
+## Customization and Callbacks
+
+You may alter the way an `doit()` method is called by providing a [delegate](https://docs.rs/google-speech1/1.0.7+20171205/google_speech1/trait.Delegate.html) to the 
+[Method Builder](https://docs.rs/google-speech1/1.0.7+20171205/google_speech1/trait.CallBuilder.html) before making the final `doit()` call. 
+Respective methods will be called to provide progress information, as well as determine whether the system should 
+retry on failure.
+
+The [delegate trait](https://docs.rs/google-speech1/1.0.7+20171205/google_speech1/trait.Delegate.html) is default-implemented, allowing you to customize it with minimal effort.
+
+## Optional Parts in Server-Requests
+
+All structures provided by this library are made to be [enocodable](https://docs.rs/google-speech1/1.0.7+20171205/google_speech1/trait.RequestValue.html) and 
+[decodable](https://docs.rs/google-speech1/1.0.7+20171205/google_speech1/trait.ResponseResult.html) via *json*. Optionals are used to indicate that partial requests are responses 
+are valid.
+Most optionals are are considered [Parts](https://docs.rs/google-speech1/1.0.7+20171205/google_speech1/trait.Part.html) which are identifiable by name, which will be sent to 
+the server to indicate either the set parts of the request or the desired parts in the response.
+
+## Builder Arguments
+
+Using [method builders](https://docs.rs/google-speech1/1.0.7+20171205/google_speech1/trait.CallBuilder.html), you are able to prepare an action call by repeatedly calling it's methods.
+These will always take a single argument, for which the following statements are true.
+
+* [PODs][wiki-pod] are handed by copy
+* strings are passed as `&str`
+* [request values](https://docs.rs/google-speech1/1.0.7+20171205/google_speech1/trait.RequestValue.html) are moved
+
+Arguments will always be copied or cloned into the builder, to make them independent of their original life times.
+
+[wiki-pod]: http://en.wikipedia.org/wiki/Plain_old_data_structure
+[builder-pattern]: http://en.wikipedia.org/wiki/Builder_pattern
+[google-go-api]: https://github.com/google/google-api-go-client
+
+# License
+The **speech1** library was generated by Sebastian Thiel, and is placed 
+under the *MIT* license.
+You can read the full text at the repository's [license file][repo-license].
+
+[repo-license]: https://github.com/Byron/google-apis-rsblob/master/LICENSE.md

--- a/gen/speech1/src/cmn.rs
+++ b/gen/speech1/src/cmn.rs
@@ -1,0 +1,753 @@
+// COPY OF 'src/rust/api/cmn.rs'
+// DO NOT EDIT
+use std::io::{self, Read, Seek, Cursor, Write, SeekFrom};
+use std;
+use std::fmt::{self, Display};
+use std::str::FromStr;
+use std::error;
+use std::thread::sleep;
+use std::time::Duration;
+
+use mime::{Mime, TopLevel, SubLevel, Attr, Value};
+use oauth2::{TokenType, Retry, self};
+use hyper;
+use hyper::header::{ContentType, ContentLength, Headers, UserAgent, Authorization, Header,
+                    HeaderFormat, Bearer};
+use hyper::http::h1::LINE_ENDING;
+use hyper::method::Method;
+use hyper::status::StatusCode;
+
+use serde_json as json;
+
+/// Identifies the Hub. There is only one per library, this trait is supposed
+/// to make intended use more explicit.
+/// The hub allows to access all resource methods more easily.
+pub trait Hub {}
+
+/// Identifies types for building methods of a particular resource type
+pub trait MethodsBuilder {}
+
+/// Identifies types which represent builders for a particular resource method
+pub trait CallBuilder {}
+
+/// Identifies types which can be inserted and deleted.
+/// Types with this trait are most commonly used by clients of this API.
+pub trait Resource {}
+
+/// Identifies types which are used in API responses.
+pub trait ResponseResult {}
+
+/// Identifies types which are used in API requests.
+pub trait RequestValue {}
+
+/// Identifies types which are not actually used by the API
+/// This might be a bug within the google API schema.
+pub trait UnusedType {}
+
+/// Identifies types which are only used as part of other types, which
+/// usually are carrying the `Resource` trait.
+pub trait Part {}
+
+/// Identifies types which are only used by other types internally.
+/// They have no special meaning, this trait just marks them for completeness.
+pub trait NestedType {}
+
+/// A utility to specify reader types which provide seeking capabilities too
+pub trait ReadSeek: Seek + Read {}
+impl<T: Seek + Read> ReadSeek for T {}
+
+/// A trait for all types that can convert themselves into a *parts* string
+pub trait ToParts {
+    fn to_parts(&self) -> String;
+}
+
+/// A utility type which can decode a server response that indicates error
+#[derive(Deserialize)]
+pub struct JsonServerError {
+    pub error: String,
+    pub error_description: Option<String>
+}
+
+/// A utility to represent detailed errors we might see in case there are BadRequests.
+/// The latter happen if the sent parameters or request structures are unsound
+#[derive(Deserialize, Serialize, Debug)]
+pub struct ErrorResponse {
+    error: ServerError,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct ServerError {
+    errors: Vec<ServerMessage>,
+    code: u16,
+    message: String,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct ServerMessage {
+    domain: String,
+    reason: String,
+    message: String,
+    #[serde(rename="locationType")]
+    location_type: Option<String>,
+    location: Option<String>
+}
+
+#[derive(Copy, Clone)]
+pub struct DummyNetworkStream;
+
+impl Read for DummyNetworkStream {
+    fn read(&mut self, _: &mut [u8]) -> io::Result<usize> {
+        Ok(0)
+    }
+}
+
+impl Write for DummyNetworkStream {
+    fn write(&mut self, _: &[u8]) -> io::Result<usize> {
+        Ok(0)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl hyper::net::NetworkStream for DummyNetworkStream {
+    fn peer_addr(&mut self) -> io::Result<std::net::SocketAddr> {
+        Ok("127.0.0.1:1337".parse().unwrap())
+    }
+
+    fn set_read_timeout(&self, _dur: Option<Duration>) -> io::Result<()> {
+        Ok(())
+    }
+
+    fn set_write_timeout(&self, _dur: Option<Duration>) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+
+/// A trait specifying functionality to help controlling any request performed by the API.
+/// The trait has a conservative default implementation.
+///
+/// It contains methods to deal with all common issues, as well with the ones related to
+/// uploading media
+pub trait Delegate {
+
+    /// Called at the beginning of any API request. The delegate should store the method
+    /// information if he is interesting in knowing more context when further calls to it
+    /// are made.
+    /// The matching `finished()` call will always be made, no matter whether or not the API
+    /// request was successful. That way, the delegate may easily maintain a clean state
+    /// between various API calls.
+    fn begin(&mut self, MethodInfo) {}
+
+    /// Called whenever there is an [HttpError](http://hyperium.github.io/hyper/hyper/error/enum.HttpError.html), usually if there are network problems.
+    ///
+    /// If you choose to retry after a duration, the duration should be chosen using the
+    /// [exponential backoff algorithm](http://en.wikipedia.org/wiki/Exponential_backoff).
+    ///
+    /// Return retry information.
+    fn http_error(&mut self, &hyper::Error) -> Retry {
+        Retry::Abort
+    }
+
+    /// Called whenever there is the need for your applications API key after
+    /// the official authenticator implementation didn't provide one, for some reason.
+    /// If this method returns None as well, the underlying operation will fail
+    fn api_key(&mut self) -> Option<String> {
+        None
+    }
+
+    /// Called whenever the Authenticator didn't yield a token. The delegate
+    /// may attempt to provide one, or just take it as a general information about the
+    /// impending failure.
+    /// The given Error provides information about why the token couldn't be acquired in the
+    /// first place
+    fn token(&mut self, err: &error::Error) -> Option<oauth2::Token> {
+        let _ = err;
+        None
+    }
+
+    /// Called during resumable uploads to provide a URL for the impending upload.
+    /// It was saved after a previous call to `store_upload_url(...)`, and if not None,
+    /// will be used instead of asking the server for a new upload URL.
+    /// This is useful in case a previous resumable upload was aborted/canceled, but should now
+    /// be resumed.
+    /// The returned URL will be used exactly once - if it fails again and the delegate allows
+    /// to retry, we will ask the server for a new upload URL.
+    fn upload_url(&mut self) -> Option<String> {
+        None
+    }
+
+    /// Called after we have retrieved a new upload URL for a resumable upload to store it
+    /// in case we fail or cancel. That way, we can attempt to resume the upload later,
+    /// see `upload_url()`.
+    /// It will also be called with None after a successful upload, which allows the delegate
+    /// to forget the URL. That way, we will not attempt to resume an upload that has already
+    /// finished.
+    fn store_upload_url(&mut self, url: Option<&str>) {
+        let _ = url;
+    }
+
+    /// Called whenever a server response could not be decoded from json.
+    /// It's for informational purposes only, the caller will return with an error
+    /// accordingly.
+    ///
+    /// # Arguments
+    ///
+    /// * `json_encoded_value` - The json-encoded value which failed to decode.
+    /// * `json_decode_error`  - The decoder error
+    fn response_json_decode_error(&mut self, json_encoded_value: &str, json_decode_error: &json::Error) {
+        let _ = json_encoded_value;
+        let _ = json_decode_error;
+    }
+
+    /// Called whenever the http request returns with a non-success status code.
+    /// This can involve authentication issues, or anything else that very much
+    /// depends on the used API method.
+    /// The delegate should check the status, header and decoded json error to decide
+    /// whether to retry or not. In the latter case, the underlying call will fail.
+    ///
+    /// If you choose to retry after a duration, the duration should be chosen using the
+    /// [exponential backoff algorithm](http://en.wikipedia.org/wiki/Exponential_backoff).
+    fn http_failure(&mut self, _: &hyper::client::Response, Option<JsonServerError>, _: Option<ServerError>) -> Retry {
+        Retry::Abort
+    }
+
+    /// Called prior to sending the main request of the given method. It can be used to time
+    /// the call or to print progress information.
+    /// It's also useful as you can be sure that a request will definitely be made.
+    fn pre_request(&mut self) { }
+
+    /// Return the size of each chunk of a resumable upload.
+    /// Must be a power of two, with 1<<18 being the smallest allowed chunk size.
+    /// Will be called once before starting any resumable upload.
+    fn chunk_size(&mut self) -> u64 {
+        1 << 23
+    }
+
+    /// Called before the given chunk is uploaded to the server.
+    /// If true is returned, the upload will be interrupted.
+    /// However, it may be resumable if you stored the upload URL in a previous call
+    /// to `store_upload_url()`
+    fn cancel_chunk_upload(&mut self, chunk: &ContentRange) -> bool {
+        let _ = chunk;
+        false
+    }
+
+    /// Called before the API request method returns, in every case. It can be used to clean up
+    /// internal state between calls to the API.
+    /// This call always has a matching call to `begin(...)`.
+    ///
+    /// # Arguments
+    ///
+    /// * `is_success` - a true value indicates the operation was successful. If false, you should
+    ///                  discard all values stored during `store_upload_url`.
+    fn finished(&mut self, is_success: bool) {
+        let _ = is_success;
+    }
+}
+
+/// A delegate with a conservative default implementation, which is used if no other delegate is
+/// set.
+#[derive(Default)]
+pub struct DefaultDelegate;
+
+impl Delegate for DefaultDelegate {}
+
+
+#[derive(Debug)]
+pub enum Error {
+    /// The http connection failed
+    HttpError(hyper::Error),
+
+    /// An attempt was made to upload a resource with size stored in field `.0`
+    /// even though the maximum upload size is what is stored in field `.1`.
+    UploadSizeLimitExceeded(u64, u64),
+
+    /// Represents information about a request that was not understood by the server.
+    /// Details are included.
+    BadRequest(ErrorResponse),
+
+    /// We needed an API key for authentication, but didn't obtain one.
+    /// Neither through the authenticator, nor through the Delegate.
+    MissingAPIKey,
+
+    /// We required a Token, but didn't get one from the Authenticator
+    MissingToken(Box<error::Error>),
+
+    /// The delgate instructed to cancel the operation
+    Cancelled,
+
+    /// An additional, free form field clashed with one of the built-in optional ones
+    FieldClash(&'static str),
+
+    /// Shows that we failed to decode the server response.
+    /// This can happen if the protocol changes in conjunction with strict json decoding.
+    JsonDecodeError(String, json::Error),
+
+    /// Indicates an HTTP repsonse with a non-success status code
+    Failure(hyper::client::Response),
+}
+
+
+impl Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Error::HttpError(ref err) => err.fmt(f),
+            Error::UploadSizeLimitExceeded(ref resource_size, ref max_size) =>
+                writeln!(f, "The media size {} exceeds the maximum allowed upload size of {}"
+                         , resource_size, max_size),
+            Error::MissingAPIKey => {
+                (writeln!(f, "The application's API key was not found in the configuration")).ok();
+                writeln!(f, "It is used as there are no Scopes defined for this method.")
+            },
+            Error::BadRequest(ref err) => {
+                try!(writeln!(f, "Bad Request ({}): {}", err.error.code, err.error.message));
+                for err in err.error.errors.iter() {
+                    try!(writeln!(f, "    {}: {}, {}{}",
+                                            err.domain,
+                                            err.message,
+                                            err.reason,
+                                            match &err.location {
+                                                &Some(ref loc) => format!("@{}", loc),
+                                                &None => String::new(),
+                                            }));
+                }
+                Ok(())
+            },
+            Error::MissingToken(ref err) =>
+                writeln!(f, "Token retrieval failed with error: {}", err),
+            Error::Cancelled =>
+                writeln!(f, "Operation cancelled by delegate"),
+            Error::FieldClash(field) =>
+                writeln!(f, "The custom parameter '{}' is already provided natively by the CallBuilder.", field),
+            Error::JsonDecodeError(ref json_str, ref err)
+                => writeln!(f, "{}: {}", err, json_str),
+            Error::Failure(ref response) =>
+                writeln!(f, "Http status indicates failure: {:?}", response),
+        }
+    }
+}
+
+impl error::Error for Error {
+    fn description(&self) -> &str {
+        match *self {
+            Error::HttpError(ref err) => err.description(),
+            Error::JsonDecodeError(_, ref err) => err.description(),
+            _ => "NO DESCRIPTION POSSIBLE - use `Display.fmt()` instead"
+        }
+    }
+
+    fn cause(&self) -> Option<&error::Error> {
+        match *self {
+            Error::HttpError(ref err) => err.cause(),
+            Error::JsonDecodeError(_, ref err) => err.cause(),
+            _ => None
+        }
+    }
+}
+
+/// A universal result type used as return for all calls.
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Contains information about an API request.
+pub struct MethodInfo {
+    pub id: &'static str,
+    pub http_method: Method,
+}
+
+const BOUNDARY: &'static str = "MDuXWGyeE33QFXGchb2VFWc4Z7945d";
+
+/// Provides a `Read` interface that converts multiple parts into the protocol
+/// identified by [RFC2387](https://tools.ietf.org/html/rfc2387).
+/// **Note**: This implementation is just as rich as it needs to be to perform uploads
+/// to google APIs, and might not be a fully-featured implementation.
+#[derive(Default)]
+pub struct MultiPartReader<'a> {
+    raw_parts: Vec<(Headers, &'a mut Read)>,
+    current_part: Option<(Cursor<Vec<u8>>, &'a mut Read)>,
+    last_part_boundary: Option<Cursor<Vec<u8>>>,
+}
+
+impl<'a> MultiPartReader<'a> {
+
+    /// Reserve memory for exactly the given amount of parts
+    pub fn reserve_exact(&mut self, cap: usize) {
+        self.raw_parts.reserve_exact(cap);
+    }
+
+    /// Add a new part to the queue of parts to be read on the first `read` call.
+    ///
+    /// # Arguments
+    ///
+    /// `headers` - identifying the body of the part. It's similar to the header
+    ///             in an ordinary single-part call, and should thus contain the
+    ///             same information.
+    /// `reader`  - a reader providing the part's body
+    /// `size`    - the amount of bytes provided by the reader. It will be put onto the header as
+    ///             content-size.
+    /// `mime`    - It will be put onto the content type
+    pub fn add_part(&mut self, reader: &'a mut Read, size: u64, mime_type: Mime) -> &mut MultiPartReader<'a> {
+        let mut headers = Headers::new();
+        headers.set(ContentType(mime_type));
+        headers.set(ContentLength(size));
+        self.raw_parts.push((headers, reader));
+        self
+    }
+
+    /// Returns the mime-type representing our multi-part message.
+    /// Use it with the ContentType header.
+    pub fn mime_type(&self) -> Mime {
+        Mime(
+            TopLevel::Multipart,
+            SubLevel::Ext("Related".to_string()),
+            vec![(Attr::Ext("boundary".to_string()), Value::Ext(BOUNDARY.to_string()))],
+        )
+    }
+
+    /// Returns true if we are totally used
+    fn is_depleted(&self) -> bool {
+        self.raw_parts.len() == 0 && self.current_part.is_none() && self.last_part_boundary.is_none()
+    }
+
+    /// Returns true if we are handling our last part
+    fn is_last_part(&self) -> bool {
+        self.raw_parts.len() == 0 && self.current_part.is_some()
+    }
+}
+
+impl<'a> Read for MultiPartReader<'a> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        match (self.raw_parts.len(),
+               self.current_part.is_none(),
+               self.last_part_boundary.is_none()) {
+            (_, _, false) => {
+                let br = self.last_part_boundary.as_mut().unwrap().read(buf).unwrap_or(0);
+                if br < buf.len() {
+                    self.last_part_boundary = None;
+                }
+                return Ok(br)
+            },
+            (0, true, true) => return Ok(0),
+            (n, true, _) if n > 0 => {
+                let (headers, reader) = self.raw_parts.remove(0);
+                let mut c = Cursor::new(Vec::<u8>::new());
+                (write!(&mut c, "{}--{}{}{}{}", LINE_ENDING, BOUNDARY, LINE_ENDING,
+                                                headers, LINE_ENDING)).unwrap();
+                c.seek(SeekFrom::Start(0)).unwrap();
+                self.current_part = Some((c, reader));
+            }
+            _ => {},
+        }
+
+        // read headers as long as possible
+        let (hb, rr) = {
+            let &mut (ref mut c, ref mut reader) = self.current_part.as_mut().unwrap();
+            let b = c.read(buf).unwrap_or(0);
+            (b, reader.read(&mut buf[b..]))
+        };
+
+        match rr {
+            Ok(bytes_read) => {
+                if hb < buf.len() && bytes_read == 0 {
+                    if self.is_last_part() {
+                        // before clearing the last part, we will add the boundary that
+                        // will be written last
+                        self.last_part_boundary = Some(Cursor::new(
+                                                        format!("{}--{}--", LINE_ENDING, BOUNDARY).into_bytes()))
+                    }
+                    // We are depleted - this can trigger the next part to come in
+                    self.current_part = None;
+                }
+                let mut total_bytes_read = hb + bytes_read;
+                while total_bytes_read < buf.len() && !self.is_depleted() {
+                    match self.read(&mut buf[total_bytes_read ..]) {
+                        Ok(br) => total_bytes_read += br,
+                        Err(err) => return Err(err),
+                    }
+                }
+                Ok(total_bytes_read)
+            }
+            Err(err) => {
+                // fail permanently
+                self.current_part = None;
+                self.last_part_boundary = None;
+                self.raw_parts.clear();
+                Err(err)
+            }
+        }
+    }
+}
+
+/// The `X-Upload-Content-Type` header.
+///
+/// Generated via rustc --pretty expanded -Z unstable-options, and manually
+/// processed to be more readable.
+#[derive(PartialEq, Debug, Clone)]
+pub struct XUploadContentType(pub Mime);
+
+impl ::std::ops::Deref for XUploadContentType {
+    type Target = Mime;
+    fn deref<'a>(&'a self) -> &'a Mime { &self.0 }
+}
+impl ::std::ops::DerefMut for XUploadContentType {
+    fn deref_mut<'a>(&'a mut self) -> &'a mut Mime { &mut self.0 }
+}
+impl Header for XUploadContentType {
+    fn header_name() -> &'static str { "X-Upload-Content-Type" }
+    fn parse_header(raw: &[Vec<u8>]) -> hyper::error::Result<Self> {
+        hyper::header::parsing::from_one_raw_str(raw).map(XUploadContentType)
+    }
+}
+impl HeaderFormat for XUploadContentType {
+    fn fmt_header(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        Display::fmt(&**self, f)
+    }
+}
+impl Display for XUploadContentType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(&**self, f)
+    }
+}
+
+#[derive(Clone, PartialEq, Debug)]
+pub struct Chunk {
+    pub first: u64,
+    pub last: u64
+}
+
+impl fmt::Display for Chunk {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        (write!(fmt, "{}-{}", self.first, self.last)).ok();
+        Ok(())
+    }
+}
+
+impl FromStr for Chunk {
+    type Err = &'static str;
+
+    /// NOTE: only implements `%i-%i`, not `*`
+    fn from_str(s: &str) -> std::result::Result<Chunk, &'static str> {
+        let parts: Vec<&str> = s.split('-').collect();
+        if parts.len() != 2 {
+            return Err("Expected two parts: %i-%i")
+        }
+        Ok(
+            Chunk {
+                first: match FromStr::from_str(parts[0]) {
+                    Ok(d) => d,
+                    _ => return Err("Couldn't parse 'first' as digit")
+                },
+                last: match FromStr::from_str(parts[1]) {
+                    Ok(d) => d,
+                    _ => return Err("Couldn't parse 'last' as digit")
+                }
+            }
+        )
+    }
+}
+
+/// Implements the Content-Range header, for serialization only
+#[derive(Clone, PartialEq, Debug)]
+pub struct ContentRange {
+    pub range: Option<Chunk>,
+    pub total_length: u64,
+}
+
+impl Header for ContentRange {
+    fn header_name() -> &'static str {
+        "Content-Range"
+    }
+
+    /// We are not parsable, as parsing is done by the `Range` header
+    fn parse_header(_: &[Vec<u8>]) -> hyper::error::Result<Self> {
+        Err(hyper::error::Error::Method)
+    }
+}
+
+
+impl HeaderFormat for ContentRange {
+    fn fmt_header(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        try!(fmt.write_str("bytes "));
+        match self.range {
+            Some(ref c) => try!(c.fmt(fmt)),
+            None => try!(fmt.write_str("*"))
+        }
+        (write!(fmt, "/{}", self.total_length)).ok();
+        Ok(())
+    }
+}
+
+#[derive(Clone, PartialEq, Debug)]
+pub struct RangeResponseHeader(pub Chunk);
+
+impl Header for RangeResponseHeader {
+    fn header_name() -> &'static str {
+        "Range"
+    }
+
+    fn parse_header(raw: &[Vec<u8>]) -> hyper::error::Result<Self> {
+        if raw.len() > 0 {
+            let v = &raw[0];
+            if let Ok(s) = std::str::from_utf8(v) {
+                const PREFIX: &'static str = "bytes ";
+                if s.starts_with(PREFIX) {
+                    if let Ok(c) = <Chunk as FromStr>::from_str(&s[PREFIX.len()..]) {
+                        return  Ok(RangeResponseHeader(c))
+                    }
+                }
+            }
+        }
+        Err(hyper::error::Error::Method)
+    }
+}
+
+impl HeaderFormat for RangeResponseHeader {
+    /// No implmentation necessary, we just need to parse
+    fn fmt_header(&self, _: &mut fmt::Formatter) -> fmt::Result {
+        Err(fmt::Error)
+    }
+}
+
+/// A utility type to perform a resumable upload from start to end.
+pub struct ResumableUploadHelper<'a, A: 'a> {
+    pub client: &'a mut hyper::client::Client,
+    pub delegate: &'a mut Delegate,
+    pub start_at: Option<u64>,
+    pub auth: &'a mut A,
+    pub user_agent: &'a str,
+    pub auth_header: Authorization<Bearer>,
+    pub url: &'a str,
+    pub reader: &'a mut ReadSeek,
+    pub media_type: Mime,
+    pub content_length: u64
+}
+
+impl<'a, A> ResumableUploadHelper<'a, A>
+    where A: oauth2::GetToken {
+
+    fn query_transfer_status(&mut self) -> std::result::Result<u64, hyper::Result<hyper::client::Response>> {
+        loop {
+            match self.client.post(self.url)
+                .header(UserAgent(self.user_agent.to_string()))
+                .header(ContentRange { range: None, total_length: self.content_length })
+                .header(self.auth_header.clone())
+                .send() {
+                Ok(r) => {
+                    // 308 = resume-incomplete == PermanentRedirect
+                    let headers = r.headers.clone();
+                    let h: &RangeResponseHeader = match headers.get() {
+                        Some(hh) if r.status == StatusCode::PermanentRedirect => hh,
+                        None|Some(_) => {
+                            if let Retry::After(d) = self.delegate.http_failure(&r, None, None) {
+                                sleep(d);
+                                continue;
+                            }
+                            return Err(Ok(r))
+                        }
+                    };
+                    return Ok(h.0.last)
+                }
+                Err(err) => {
+                    if let Retry::After(d) = self.delegate.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    return Err(Err(err))
+                }
+            }
+        }
+    }
+
+    /// returns None if operation was cancelled by delegate, or the HttpResult.
+    /// It can be that we return the result just because we didn't understand the status code -
+    /// caller should check for status himself before assuming it's OK to use
+    pub fn upload(&mut self) -> Option<hyper::Result<hyper::client::Response>> {
+        let mut start = match self.start_at {
+            Some(s) => s,
+            None => match self.query_transfer_status() {
+                Ok(s) => s,
+                Err(result) => return Some(result)
+            }
+        };
+
+        const MIN_CHUNK_SIZE: u64 = 1 << 18;
+        let chunk_size = match self.delegate.chunk_size() {
+            cs if cs > MIN_CHUNK_SIZE => cs,
+            _ => MIN_CHUNK_SIZE
+        };
+
+        self.reader.seek(SeekFrom::Start(start)).unwrap();
+        loop {
+            let request_size = match self.content_length - start {
+                rs if rs > chunk_size => chunk_size,
+                rs => rs
+            };
+
+            let mut section_reader = self.reader.take(request_size);
+            let range_header = ContentRange {
+                range: Some(Chunk {first: start, last: start + request_size - 1}),
+                total_length: self.content_length
+            };
+            start += request_size;
+            if self.delegate.cancel_chunk_upload(&range_header) {
+                return None
+            }
+            let res = self.client.post(self.url)
+                                 .header(range_header)
+                                 .header(ContentType(self.media_type.clone()))
+                                 .header(UserAgent(self.user_agent.to_string()))
+                                 .body(&mut section_reader)
+                                 .send();
+            match res {
+                Ok(mut res) => {
+                    if res.status == StatusCode::PermanentRedirect  {
+                        continue
+                    }
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let Retry::After(d) = self.delegate.http_failure(&res,
+                                                        json::from_str(&json_err).ok(),
+                                                        json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                    }
+                    return Some(Ok(res))
+                },
+                Err(err) => {
+                    if let Retry::After(d) = self.delegate.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    return Some(Err(err))
+                }
+            }
+        }
+    }
+}
+
+// Copy of src/rust/cli/cmn.rs
+// TODO(ST): Allow sharing common code between program types
+pub fn remove_json_null_values(value: &mut json::value::Value) {
+    match *value {
+        json::value::Value::Object(ref mut map) => {
+            let mut for_removal = Vec::new();
+
+            for (key, mut value) in map.iter_mut() {
+                if value.is_null() {
+                    for_removal.push(key.clone());
+                } else {
+                    remove_json_null_values(&mut value);
+                }
+            }
+
+            for key in &for_removal {
+                map.remove(key);
+            }
+        }
+        _ => {}
+    }
+}

--- a/gen/speech1/src/lib.rs
+++ b/gen/speech1/src/lib.rs
@@ -1,0 +1,2584 @@
+// DO NOT EDIT !
+// This file was generated automatically from 'src/mako/api/lib.rs.mako'
+// DO NOT EDIT !
+
+//! This documentation was generated from *Speech* crate version *1.0.7+20171205*, where *20171205* is the exact revision of the *speech:v1* schema built by the [mako](http://www.makotemplates.org/) code generator *v1.0.7*.
+//! 
+//! Everything else about the *Speech* *v1* API can be found at the
+//! [official documentation site](https://cloud.google.com/speech/).
+//! The original source code is [on github](https://github.com/Byron/google-apis-rs/tree/master/gen/speech1).
+//! # Features
+//! 
+//! Handle the following *Resources* with ease from the central [hub](struct.Speech.html) ... 
+//! 
+//! * [operations](struct.Operation.html)
+//!  * [*cancel*](struct.OperationCancelCall.html), [*delete*](struct.OperationDeleteCall.html), [*get*](struct.OperationGetCall.html) and [*list*](struct.OperationListCall.html)
+//! * speech
+//!  * [*longrunningrecognize*](struct.SpeechLongrunningrecognizeCall.html) and [*recognize*](struct.SpeechRecognizeCall.html)
+//! 
+//! 
+//! 
+//! 
+//! Not what you are looking for ? Find all other Google APIs in their Rust [documentation index](http://byron.github.io/google-apis-rs).
+//! 
+//! # Structure of this Library
+//! 
+//! The API is structured into the following primary items:
+//! 
+//! * **[Hub](struct.Speech.html)**
+//!     * a central object to maintain state and allow accessing all *Activities*
+//!     * creates [*Method Builders*](trait.MethodsBuilder.html) which in turn
+//!       allow access to individual [*Call Builders*](trait.CallBuilder.html)
+//! * **[Resources](trait.Resource.html)**
+//!     * primary types that you can apply *Activities* to
+//!     * a collection of properties and *Parts*
+//!     * **[Parts](trait.Part.html)**
+//!         * a collection of properties
+//!         * never directly used in *Activities*
+//! * **[Activities](trait.CallBuilder.html)**
+//!     * operations to apply to *Resources*
+//! 
+//! All *structures* are marked with applicable traits to further categorize them and ease browsing.
+//! 
+//! Generally speaking, you can invoke *Activities* like this:
+//! 
+//! ```Rust,ignore
+//! let r = hub.resource().activity(...).doit()
+//! ```
+//! 
+//! Or specifically ...
+//! 
+//! ```ignore
+//! let r = hub.operations().get(...).doit()
+//! let r = hub.speech().longrunningrecognize(...).doit()
+//! let r = hub.operations().list(...).doit()
+//! let r = hub.operations().cancel(...).doit()
+//! let r = hub.operations().delete(...).doit()
+//! ```
+//! 
+//! The `resource()` and `activity(...)` calls create [builders][builder-pattern]. The second one dealing with `Activities` 
+//! supports various methods to configure the impending operation (not shown here). It is made such that all required arguments have to be 
+//! specified right away (i.e. `(...)`), whereas all optional ones can be [build up][builder-pattern] as desired.
+//! The `doit()` method performs the actual communication with the server and returns the respective result.
+//! 
+//! # Usage
+//! 
+//! ## Setting up your Project
+//! 
+//! To use this library, you would put the following lines into your `Cargo.toml` file:
+//! 
+//! ```toml
+//! [dependencies]
+//! google-speech1 = "*"
+//! ```
+//! 
+//! ## A complete example
+//! 
+//! ```test_harness,no_run
+//! extern crate hyper;
+//! extern crate hyper_rustls;
+//! extern crate yup_oauth2 as oauth2;
+//! extern crate google_speech1 as speech1;
+//! use speech1::{Result, Error};
+//! # #[test] fn egal() {
+//! use std::default::Default;
+//! use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+//! use speech1::Speech;
+//! 
+//! // Get an ApplicationSecret instance by some means. It contains the `client_id` and 
+//! // `client_secret`, among other things.
+//! let secret: ApplicationSecret = Default::default();
+//! // Instantiate the authenticator. It will choose a suitable authentication flow for you, 
+//! // unless you replace  `None` with the desired Flow.
+//! // Provide your own `AuthenticatorDelegate` to adjust the way it operates and get feedback about 
+//! // what's going on. You probably want to bring in your own `TokenStorage` to persist tokens and
+//! // retrieve them from storage.
+//! let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+//!                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+//!                               <MemoryStorage as Default>::default(), None);
+//! let mut hub = Speech::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+//! // You can configure optional parameters by calling the respective setters at will, and
+//! // execute the final call using `doit()`.
+//! // Values shown here are possibly random and not representative !
+//! let result = hub.operations().list()
+//!              .page_token("et")
+//!              .page_size(-18)
+//!              .name("kasd")
+//!              .filter("accusam")
+//!              .doit();
+//! 
+//! match result {
+//!     Err(e) => match e {
+//!         // The Error enum provides details about what exactly happened.
+//!         // You can also just use its `Debug`, `Display` or `Error` traits
+//!          Error::HttpError(_)
+//!         |Error::MissingAPIKey
+//!         |Error::MissingToken(_)
+//!         |Error::Cancelled
+//!         |Error::UploadSizeLimitExceeded(_, _)
+//!         |Error::Failure(_)
+//!         |Error::BadRequest(_)
+//!         |Error::FieldClash(_)
+//!         |Error::JsonDecodeError(_, _) => println!("{}", e),
+//!     },
+//!     Ok(res) => println!("Success: {:?}", res),
+//! }
+//! # }
+//! ```
+//! ## Handling Errors
+//! 
+//! All errors produced by the system are provided either as [Result](enum.Result.html) enumeration as return value of 
+//! the doit() methods, or handed as possibly intermediate results to either the 
+//! [Hub Delegate](trait.Delegate.html), or the [Authenticator Delegate](https://docs.rs/yup-oauth2/*/yup_oauth2/trait.AuthenticatorDelegate.html).
+//! 
+//! When delegates handle errors or intermediate values, they may have a chance to instruct the system to retry. This 
+//! makes the system potentially resilient to all kinds of errors.
+//! 
+//! ## Uploads and Downloads
+//! If a method supports downloads, the response body, which is part of the [Result](enum.Result.html), should be
+//! read by you to obtain the media.
+//! If such a method also supports a [Response Result](trait.ResponseResult.html), it will return that by default.
+//! You can see it as meta-data for the actual media. To trigger a media download, you will have to set up the builder by making
+//! this call: `.param("alt", "media")`.
+//! 
+//! Methods supporting uploads can do so using up to 2 different protocols: 
+//! *simple* and *resumable*. The distinctiveness of each is represented by customized 
+//! `doit(...)` methods, which are then named `upload(...)` and `upload_resumable(...)` respectively.
+//! 
+//! ## Customization and Callbacks
+//! 
+//! You may alter the way an `doit()` method is called by providing a [delegate](trait.Delegate.html) to the 
+//! [Method Builder](trait.CallBuilder.html) before making the final `doit()` call. 
+//! Respective methods will be called to provide progress information, as well as determine whether the system should 
+//! retry on failure.
+//! 
+//! The [delegate trait](trait.Delegate.html) is default-implemented, allowing you to customize it with minimal effort.
+//! 
+//! ## Optional Parts in Server-Requests
+//! 
+//! All structures provided by this library are made to be [enocodable](trait.RequestValue.html) and 
+//! [decodable](trait.ResponseResult.html) via *json*. Optionals are used to indicate that partial requests are responses 
+//! are valid.
+//! Most optionals are are considered [Parts](trait.Part.html) which are identifiable by name, which will be sent to 
+//! the server to indicate either the set parts of the request or the desired parts in the response.
+//! 
+//! ## Builder Arguments
+//! 
+//! Using [method builders](trait.CallBuilder.html), you are able to prepare an action call by repeatedly calling it's methods.
+//! These will always take a single argument, for which the following statements are true.
+//! 
+//! * [PODs][wiki-pod] are handed by copy
+//! * strings are passed as `&str`
+//! * [request values](trait.RequestValue.html) are moved
+//! 
+//! Arguments will always be copied or cloned into the builder, to make them independent of their original life times.
+//! 
+//! [wiki-pod]: http://en.wikipedia.org/wiki/Plain_old_data_structure
+//! [builder-pattern]: http://en.wikipedia.org/wiki/Builder_pattern
+//! [google-go-api]: https://github.com/google/google-api-go-client
+//! 
+//! 
+
+// Unused attributes happen thanks to defined, but unused structures
+// We don't warn about this, as depending on the API, some data structures or facilities are never used.
+// Instead of pre-determining this, we just disable the lint. It's manually tuned to not have any
+// unused imports in fully featured APIs. Same with unused_mut ... .
+#![allow(unused_imports, unused_mut, dead_code)]
+
+// DO NOT EDIT !
+// This file was generated automatically from 'src/mako/api/lib.rs.mako'
+// DO NOT EDIT !
+
+#[macro_use]
+extern crate serde_derive;
+
+extern crate hyper;
+extern crate serde;
+extern crate serde_json;
+extern crate yup_oauth2 as oauth2;
+extern crate mime;
+extern crate url;
+
+mod cmn;
+
+use std::collections::HashMap;
+use std::cell::RefCell;
+use std::borrow::BorrowMut;
+use std::default::Default;
+use std::collections::BTreeMap;
+use serde_json as json;
+use std::io;
+use std::fs;
+use std::mem;
+use std::thread::sleep;
+use std::time::Duration;
+
+pub use cmn::{MultiPartReader, ToParts, MethodInfo, Result, Error, CallBuilder, Hub, ReadSeek, Part,
+              ResponseResult, RequestValue, NestedType, Delegate, DefaultDelegate, MethodsBuilder,
+              Resource, ErrorResponse, remove_json_null_values};
+
+
+// ##############
+// UTILITIES ###
+// ############
+
+/// Identifies the an OAuth2 authorization scope.
+/// A scope is needed when requesting an
+/// [authorization token](https://developers.google.com/youtube/v3/guides/authentication).
+#[derive(PartialEq, Eq, Hash)]
+pub enum Scope {
+    /// View and manage your data across Google Cloud Platform services
+    CloudPlatform,
+
+    /// Convert speech to text using Google speech recognition technology
+    CloudSpeech,
+}
+
+impl AsRef<str> for Scope {
+    fn as_ref(&self) -> &str {
+        match *self {
+            Scope::CloudPlatform => "https://www.googleapis.com/auth/cloud-platform",
+            Scope::CloudSpeech => "https://www.googleapis.com/auth/cloud-speech",
+        }
+    }
+}
+
+impl Default for Scope {
+    fn default() -> Scope {
+        Scope::CloudSpeech
+    }
+}
+
+
+
+// ########
+// HUB ###
+// ######
+
+/// Central instance to access all Speech related resource activities
+///
+/// # Examples
+///
+/// Instantiate a new hub
+///
+/// ```test_harness,no_run
+/// extern crate hyper;
+/// extern crate hyper_rustls;
+/// extern crate yup_oauth2 as oauth2;
+/// extern crate google_speech1 as speech1;
+/// use speech1::{Result, Error};
+/// # #[test] fn egal() {
+/// use std::default::Default;
+/// use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// use speech1::Speech;
+/// 
+/// // Get an ApplicationSecret instance by some means. It contains the `client_id` and 
+/// // `client_secret`, among other things.
+/// let secret: ApplicationSecret = Default::default();
+/// // Instantiate the authenticator. It will choose a suitable authentication flow for you, 
+/// // unless you replace  `None` with the desired Flow.
+/// // Provide your own `AuthenticatorDelegate` to adjust the way it operates and get feedback about 
+/// // what's going on. You probably want to bring in your own `TokenStorage` to persist tokens and
+/// // retrieve them from storage.
+/// let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+///                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+///                               <MemoryStorage as Default>::default(), None);
+/// let mut hub = Speech::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.operations().list()
+///              .page_token("takimata")
+///              .page_size(-70)
+///              .name("amet.")
+///              .filter("erat")
+///              .doit();
+/// 
+/// match result {
+///     Err(e) => match e {
+///         // The Error enum provides details about what exactly happened.
+///         // You can also just use its `Debug`, `Display` or `Error` traits
+///          Error::HttpError(_)
+///         |Error::MissingAPIKey
+///         |Error::MissingToken(_)
+///         |Error::Cancelled
+///         |Error::UploadSizeLimitExceeded(_, _)
+///         |Error::Failure(_)
+///         |Error::BadRequest(_)
+///         |Error::FieldClash(_)
+///         |Error::JsonDecodeError(_, _) => println!("{}", e),
+///     },
+///     Ok(res) => println!("Success: {:?}", res),
+/// }
+/// # }
+/// ```
+pub struct Speech<C, A> {
+    client: RefCell<C>,
+    auth: RefCell<A>,
+    _user_agent: String,
+    _base_url: String,
+    _root_url: String,
+}
+
+impl<'a, C, A> Hub for Speech<C, A> {}
+
+impl<'a, C, A> Speech<C, A>
+    where  C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+    pub fn new(client: C, authenticator: A) -> Speech<C, A> {
+        Speech {
+            client: RefCell::new(client),
+            auth: RefCell::new(authenticator),
+            _user_agent: "google-api-rust-client/1.0.7".to_string(),
+            _base_url: "https://speech.googleapis.com/".to_string(),
+            _root_url: "https://speech.googleapis.com/".to_string(),
+        }
+    }
+
+    pub fn operations(&'a self) -> OperationMethods<'a, C, A> {
+        OperationMethods { hub: &self }
+    }
+    pub fn speech(&'a self) -> SpeechMethods<'a, C, A> {
+        SpeechMethods { hub: &self }
+    }
+
+    /// Set the user-agent header field to use in all requests to the server.
+    /// It defaults to `google-api-rust-client/1.0.7`.
+    ///
+    /// Returns the previously set user-agent.
+    pub fn user_agent(&mut self, agent_name: String) -> String {
+        mem::replace(&mut self._user_agent, agent_name)
+    }
+
+    /// Set the base url to use in all requests to the server.
+    /// It defaults to `https://speech.googleapis.com/`.
+    ///
+    /// Returns the previously set base url.
+    pub fn base_url(&mut self, new_base_url: String) -> String {
+        mem::replace(&mut self._base_url, new_base_url)
+    }
+
+    /// Set the root url to use in all requests to the server.
+    /// It defaults to `https://speech.googleapis.com/`.
+    ///
+    /// Returns the previously set root url.
+    pub fn root_url(&mut self, new_root_url: String) -> String {
+        mem::replace(&mut self._root_url, new_root_url)
+    }
+}
+
+
+// ############
+// SCHEMAS ###
+// ##########
+/// The `Status` type defines a logical error model that is suitable for different
+/// programming environments, including REST APIs and RPC APIs. It is used by
+/// [gRPC](https://github.com/grpc). The error model is designed to be:
+/// 
+/// - Simple to use and understand for most users
+/// - Flexible enough to meet unexpected needs
+/// 
+/// # Overview
+/// 
+/// The `Status` message contains three pieces of data: error code, error message,
+/// and error details. The error code should be an enum value of
+/// google.rpc.Code, but it may accept additional error codes if needed.  The
+/// error message should be a developer-facing English message that helps
+/// developers *understand* and *resolve* the error. If a localized user-facing
+/// error message is needed, put the localized message in the error details or
+/// localize it in the client. The optional error details may contain arbitrary
+/// information about the error. There is a predefined set of error detail types
+/// in the package `google.rpc` that can be used for common error conditions.
+/// 
+/// # Language mapping
+/// 
+/// The `Status` message is the logical representation of the error model, but it
+/// is not necessarily the actual wire format. When the `Status` message is
+/// exposed in different client libraries and different wire protocols, it can be
+/// mapped differently. For example, it will likely be mapped to some exceptions
+/// in Java, but more likely mapped to some error codes in C.
+/// 
+/// # Other uses
+/// 
+/// The error model and the `Status` message can be used in a variety of
+/// environments, either with or without APIs, to provide a
+/// consistent developer experience across different environments.
+/// 
+/// Example uses of this error model include:
+/// 
+/// - Partial errors. If a service needs to return partial errors to the client,
+///     it may embed the `Status` in the normal response to indicate the partial
+///     errors.
+/// 
+/// - Workflow errors. A typical workflow has multiple steps. Each step may
+///     have a `Status` message for error reporting.
+/// 
+/// - Batch operations. If a client uses batch request and batch response, the
+///     `Status` message should be used directly inside batch response, one for
+///     each error sub-response.
+/// 
+/// - Asynchronous operations. If an API call embeds asynchronous operation
+///     results in its response, the status of those operations should be
+///     represented directly using the `Status` message.
+/// 
+/// - Logging. If some API errors are stored in logs, the message `Status` could
+///     be used directly after any stripping needed for security/privacy reasons.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Status {
+    /// A developer-facing error message, which should be in English. Any
+    /// user-facing error message should be localized and sent in the
+    /// google.rpc.Status.details field, or localized by the client.
+    pub message: Option<String>,
+    /// The status code, which should be an enum value of google.rpc.Code.
+    pub code: Option<i32>,
+    /// A list of messages that carry the error details.  There is a common set of
+    /// message types for APIs to use.
+    pub details: Option<Vec<HashMap<String, String>>>,
+}
+
+impl Part for Status {}
+
+
+/// A speech recognition result corresponding to a portion of the audio.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct SpeechRecognitionResult {
+    /// For multi-channel audio, this is the channel number corresponding to the
+    /// recognized result for the audio from that channel.
+    /// For audio_channel_count = N, its output values can range from '0' to 'N-1'.
+    #[serde(rename="channelTag")]
+    pub channel_tag: Option<i32>,
+    /// *Output-only* May contain one or more recognition hypotheses (up to the
+    /// maximum specified in `max_alternatives`).
+    /// These alternatives are ordered in terms of accuracy, with the top (first)
+    /// alternative being the most probable, as ranked by the recognizer.
+    pub alternatives: Option<Vec<SpeechRecognitionAlternative>>,
+}
+
+impl Part for SpeechRecognitionResult {}
+
+
+/// The only message returned to the client by the `Recognize` method. It
+/// contains the result as zero or more sequential `SpeechRecognitionResult`
+/// messages.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [recognize speech](struct.SpeechRecognizeCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct RecognizeResponse {
+    /// *Output-only* Sequential list of transcription results corresponding to
+    /// sequential portions of audio.
+    pub results: Option<Vec<SpeechRecognitionResult>>,
+}
+
+impl ResponseResult for RecognizeResponse {}
+
+
+/// The response message for Operations.ListOperations.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [list operations](struct.OperationListCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct ListOperationsResponse {
+    /// The standard List next-page token.
+    #[serde(rename="nextPageToken")]
+    pub next_page_token: Option<String>,
+    /// A list of operations that matches the specified filter in the request.
+    pub operations: Option<Vec<Operation>>,
+}
+
+impl ResponseResult for ListOperationsResponse {}
+
+
+/// Provides "hints" to the speech recognizer to favor specific words and phrases
+/// in the results.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct SpeechContext {
+    /// *Optional* A list of strings containing words and phrases "hints" so that
+    /// the speech recognition is more likely to recognize them. This can be used
+    /// to improve the accuracy for specific words and phrases, for example, if
+    /// specific commands are typically spoken by the user. This can also be used
+    /// to add additional words to the vocabulary of the recognizer. See
+    /// [usage limits](https://cloud.google.com/speech/limits#content).
+    pub phrases: Option<Vec<String>>,
+}
+
+impl Part for SpeechContext {}
+
+
+/// Contains audio data in the encoding specified in the `RecognitionConfig`.
+/// Either `content` or `uri` must be supplied. Supplying both or neither
+/// returns google.rpc.Code.INVALID_ARGUMENT. See
+/// [audio limits](https://cloud.google.com/speech/limits#content).
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct RecognitionAudio {
+    /// The audio data bytes encoded as specified in
+    /// `RecognitionConfig`. Note: as with all bytes fields, protobuffers use a
+    /// pure binary representation, whereas JSON representations use base64.
+    pub content: Option<String>,
+    /// URI that points to a file that contains audio data bytes as specified in
+    /// `RecognitionConfig`. Currently, only Google Cloud Storage URIs are
+    /// supported, which must be specified in the following format:
+    /// `gs://bucket_name/object_name` (other URI formats return
+    /// google.rpc.Code.INVALID_ARGUMENT). For more information, see
+    /// [Request URIs](https://cloud.google.com/storage/docs/reference-uris).
+    pub uri: Option<String>,
+}
+
+impl Part for RecognitionAudio {}
+
+
+/// Word-specific information for recognized words. Word information is only
+/// included in the response when certain request parameters are set, such
+/// as `enable_word_time_offsets`.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct WordInfo {
+    /// *Output-only* Time offset relative to the beginning of the audio,
+    /// and corresponding to the end of the spoken word.
+    /// This field is only set if `enable_word_time_offsets=true` and only
+    /// in the top hypothesis.
+    /// This is an experimental feature and the accuracy of the time offset can
+    /// vary.
+    #[serde(rename="endTime")]
+    pub end_time: Option<String>,
+    /// *Output-only* The word corresponding to this set of information.
+    pub word: Option<String>,
+    /// *Output-only* Time offset relative to the beginning of the audio,
+    /// and corresponding to the start of the spoken word.
+    /// This field is only set if `enable_word_time_offsets=true` and only
+    /// in the top hypothesis.
+    /// This is an experimental feature and the accuracy of the time offset can
+    /// vary.
+    #[serde(rename="startTime")]
+    pub start_time: Option<String>,
+}
+
+impl Part for WordInfo {}
+
+
+/// The top-level message sent by the client for the `LongRunningRecognize`
+/// method.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [longrunningrecognize speech](struct.SpeechLongrunningrecognizeCall.html) (request)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct LongRunningRecognizeRequest {
+    /// *Required* The audio data to be recognized.
+    pub audio: Option<RecognitionAudio>,
+    /// *Required* Provides information to the recognizer that specifies how to
+    /// process the request.
+    pub config: Option<RecognitionConfig>,
+}
+
+impl RequestValue for LongRunningRecognizeRequest {}
+
+
+/// Provides information to the recognizer that specifies how to process the
+/// request.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct RecognitionConfig {
+    /// *Required* The language of the supplied audio as a
+    /// [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt) language tag.
+    /// Example: "en-US".
+    /// See [Language Support](https://cloud.google.com/speech/docs/languages)
+    /// for a list of the currently supported language codes.
+    #[serde(rename="languageCode")]
+    pub language_code: Option<String>,
+    /// *Required* Sample rate in Hertz of the audio data sent in all
+    /// `RecognitionAudio` messages. Valid values are: 8000-48000.
+    /// 16000 is optimal. For best results, set the sampling rate of the audio
+    /// source to 16000 Hz. If that's not possible, use the native sample rate of
+    /// the audio source (instead of re-sampling).
+    #[serde(rename="sampleRateHertz")]
+    pub sample_rate_hertz: Option<i32>,
+    /// *Required* Encoding of audio data sent in all `RecognitionAudio` messages.
+    pub encoding: Option<String>,
+    /// *Optional* If set to `true`, the server will attempt to filter out
+    /// profanities, replacing all but the initial character in each filtered word
+    /// with asterisks, e.g. "f***". If set to `false` or omitted, profanities
+    /// won't be filtered out.
+    #[serde(rename="profanityFilter")]
+    pub profanity_filter: Option<bool>,
+    /// *Optional* If `true`, the top result includes a list of words and
+    /// the start and end time offsets (timestamps) for those words. If
+    /// `false`, no word-level time offset information is returned. The default is
+    /// `false`.
+    #[serde(rename="enableWordTimeOffsets")]
+    pub enable_word_time_offsets: Option<bool>,
+    /// *Optional* A means to provide context to assist the speech recognition.
+    #[serde(rename="speechContexts")]
+    pub speech_contexts: Option<Vec<SpeechContext>>,
+    /// *Optional* Maximum number of recognition hypotheses to be returned.
+    /// Specifically, the maximum number of `SpeechRecognitionAlternative` messages
+    /// within each `SpeechRecognitionResult`.
+    /// The server may return fewer than `max_alternatives`.
+    /// Valid values are `0`-`30`. A value of `0` or `1` will return a maximum of
+    /// one. If omitted, will return a maximum of one.
+    #[serde(rename="maxAlternatives")]
+    pub max_alternatives: Option<i32>,
+}
+
+impl Part for RecognitionConfig {}
+
+
+/// The request message for Operations.CancelOperation.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [cancel operations](struct.OperationCancelCall.html) (request)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct CancelOperationRequest { _never_set: Option<bool> }
+
+impl RequestValue for CancelOperationRequest {}
+
+
+/// This resource represents a long-running operation that is the result of a
+/// network API call.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [get operations](struct.OperationGetCall.html) (response)
+/// * [longrunningrecognize speech](struct.SpeechLongrunningrecognizeCall.html) (response)
+/// * [list operations](struct.OperationListCall.html) (none)
+/// * [cancel operations](struct.OperationCancelCall.html) (none)
+/// * [delete operations](struct.OperationDeleteCall.html) (none)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Operation {
+    /// The error result of the operation in case of failure or cancellation.
+    pub error: Option<Status>,
+    /// If the value is `false`, it means the operation is still in progress.
+    /// If `true`, the operation is completed, and either `error` or `response` is
+    /// available.
+    pub done: Option<bool>,
+    /// The normal response of the operation in case of success.  If the original
+    /// method returns no data on success, such as `Delete`, the response is
+    /// `google.protobuf.Empty`.  If the original method is standard
+    /// `Get`/`Create`/`Update`, the response should be the resource.  For other
+    /// methods, the response should have the type `XxxResponse`, where `Xxx`
+    /// is the original method name.  For example, if the original method name
+    /// is `TakeSnapshot()`, the inferred response type is
+    /// `TakeSnapshotResponse`.
+    pub response: Option<HashMap<String, String>>,
+    /// The server-assigned name, which is only unique within the same service that
+    /// originally returns it. If you use the default HTTP mapping, the
+    /// `name` should have the format of `operations/some/unique/name`.
+    pub name: Option<String>,
+    /// Service-specific metadata associated with the operation.  It typically
+    /// contains progress information and common metadata such as create time.
+    /// Some services might not provide such metadata.  Any method that returns a
+    /// long-running operation should document the metadata type, if any.
+    pub metadata: Option<HashMap<String, String>>,
+}
+
+impl Resource for Operation {}
+impl ResponseResult for Operation {}
+
+
+/// The top-level message sent by the client for the `Recognize` method.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [recognize speech](struct.SpeechRecognizeCall.html) (request)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct RecognizeRequest {
+    /// *Required* The audio data to be recognized.
+    pub audio: Option<RecognitionAudio>,
+    /// *Required* Provides information to the recognizer that specifies how to
+    /// process the request.
+    pub config: Option<RecognitionConfig>,
+}
+
+impl RequestValue for RecognizeRequest {}
+
+
+/// Alternative hypotheses (a.k.a. n-best list).
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct SpeechRecognitionAlternative {
+    /// *Output-only* The confidence estimate between 0.0 and 1.0. A higher number
+    /// indicates an estimated greater likelihood that the recognized words are
+    /// correct. This field is typically provided only for the top hypothesis, and
+    /// only for `is_final=true` results. Clients should not rely on the
+    /// `confidence` field as it is not guaranteed to be accurate, or even set, in
+    /// any of the results.
+    /// The default of 0.0 is a sentinel value indicating `confidence` was not set.
+    pub confidence: Option<f32>,
+    /// *Output-only* Transcript text representing the words that the user spoke.
+    pub transcript: Option<String>,
+    /// *Output-only* A list of word-specific information for each recognized word.
+    pub words: Option<Vec<WordInfo>>,
+}
+
+impl Part for SpeechRecognitionAlternative {}
+
+
+/// A generic empty message that you can re-use to avoid defining duplicated
+/// empty messages in your APIs. A typical example is to use it as the request
+/// or the response type of an API method. For instance:
+/// 
+///     service Foo {
+///       rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
+///     }
+/// 
+/// The JSON representation for `Empty` is empty JSON object `{}`.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [delete operations](struct.OperationDeleteCall.html) (response)
+/// * [cancel operations](struct.OperationCancelCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Empty { _never_set: Option<bool> }
+
+impl ResponseResult for Empty {}
+
+
+
+// ###################
+// MethodBuilders ###
+// #################
+
+/// A builder providing access to all methods supported on *operation* resources.
+/// It is not used directly, but through the `Speech` hub.
+///
+/// # Example
+///
+/// Instantiate a resource builder
+///
+/// ```test_harness,no_run
+/// extern crate hyper;
+/// extern crate hyper_rustls;
+/// extern crate yup_oauth2 as oauth2;
+/// extern crate google_speech1 as speech1;
+/// 
+/// # #[test] fn egal() {
+/// use std::default::Default;
+/// use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// use speech1::Speech;
+/// 
+/// let secret: ApplicationSecret = Default::default();
+/// let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+///                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+///                               <MemoryStorage as Default>::default(), None);
+/// let mut hub = Speech::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // Usually you wouldn't bind this to a variable, but keep calling *CallBuilders*
+/// // like `cancel(...)`, `delete(...)`, `get(...)` and `list(...)`
+/// // to build up your call.
+/// let rb = hub.operations();
+/// # }
+/// ```
+pub struct OperationMethods<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a Speech<C, A>,
+}
+
+impl<'a, C, A> MethodsBuilder for OperationMethods<'a, C, A> {}
+
+impl<'a, C, A> OperationMethods<'a, C, A> {
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Lists operations that match the specified filter in the request. If the
+    /// server doesn't support this method, it returns `UNIMPLEMENTED`.
+    /// 
+    /// NOTE: the `name` binding allows API services to override the binding
+    /// to use different resource name schemes, such as `users/*/operations`. To
+    /// override the binding, API services can add a binding such as
+    /// `"/v1/{name=users/*}/operations"` to their service configuration.
+    /// For backwards compatibility, the default name includes the operations
+    /// collection id, however overriding users must ensure the name binding
+    /// is the parent resource, without the operations collection id.
+    pub fn list(&self) -> OperationListCall<'a, C, A> {
+        OperationListCall {
+            hub: self.hub,
+            _page_token: Default::default(),
+            _page_size: Default::default(),
+            _name: Default::default(),
+            _filter: Default::default(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Deletes a long-running operation. This method indicates that the client is
+    /// no longer interested in the operation result. It does not cancel the
+    /// operation. If the server doesn't support this method, it returns
+    /// `google.rpc.Code.UNIMPLEMENTED`.
+    /// 
+    /// # Arguments
+    ///
+    /// * `name` - The name of the operation resource to be deleted.
+    pub fn delete(&self, name: &str) -> OperationDeleteCall<'a, C, A> {
+        OperationDeleteCall {
+            hub: self.hub,
+            _name: name.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Gets the latest state of a long-running operation.  Clients can use this
+    /// method to poll the operation result at intervals as recommended by the API
+    /// service.
+    /// 
+    /// # Arguments
+    ///
+    /// * `name` - The name of the operation resource.
+    pub fn get(&self, name: &str) -> OperationGetCall<'a, C, A> {
+        OperationGetCall {
+            hub: self.hub,
+            _name: name.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Starts asynchronous cancellation on a long-running operation.  The server
+    /// makes a best effort to cancel the operation, but success is not
+    /// guaranteed.  If the server doesn't support this method, it returns
+    /// `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
+    /// Operations.GetOperation or
+    /// other methods to check whether the cancellation succeeded or whether the
+    /// operation completed despite cancellation. On successful cancellation,
+    /// the operation is not deleted; instead, it becomes an operation with
+    /// an Operation.error value with a google.rpc.Status.code of 1,
+    /// corresponding to `Code.CANCELLED`.
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    /// * `name` - The name of the operation resource to be cancelled.
+    pub fn cancel(&self, request: CancelOperationRequest, name: &str) -> OperationCancelCall<'a, C, A> {
+        OperationCancelCall {
+            hub: self.hub,
+            _request: request,
+            _name: name.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+}
+
+
+
+/// A builder providing access to all methods supported on *speech* resources.
+/// It is not used directly, but through the `Speech` hub.
+///
+/// # Example
+///
+/// Instantiate a resource builder
+///
+/// ```test_harness,no_run
+/// extern crate hyper;
+/// extern crate hyper_rustls;
+/// extern crate yup_oauth2 as oauth2;
+/// extern crate google_speech1 as speech1;
+/// 
+/// # #[test] fn egal() {
+/// use std::default::Default;
+/// use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// use speech1::Speech;
+/// 
+/// let secret: ApplicationSecret = Default::default();
+/// let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+///                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+///                               <MemoryStorage as Default>::default(), None);
+/// let mut hub = Speech::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // Usually you wouldn't bind this to a variable, but keep calling *CallBuilders*
+/// // like `longrunningrecognize(...)` and `recognize(...)`
+/// // to build up your call.
+/// let rb = hub.speech();
+/// # }
+/// ```
+pub struct SpeechMethods<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a Speech<C, A>,
+}
+
+impl<'a, C, A> MethodsBuilder for SpeechMethods<'a, C, A> {}
+
+impl<'a, C, A> SpeechMethods<'a, C, A> {
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Performs asynchronous speech recognition: receive results via the
+    /// google.longrunning.Operations interface. Returns either an
+    /// `Operation.error` or an `Operation.response` which contains
+    /// a `LongRunningRecognizeResponse` message.
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    pub fn longrunningrecognize(&self, request: LongRunningRecognizeRequest) -> SpeechLongrunningrecognizeCall<'a, C, A> {
+        SpeechLongrunningrecognizeCall {
+            hub: self.hub,
+            _request: request,
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Performs synchronous speech recognition: receive results after all audio
+    /// has been sent and processed.
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    pub fn recognize(&self, request: RecognizeRequest) -> SpeechRecognizeCall<'a, C, A> {
+        SpeechRecognizeCall {
+            hub: self.hub,
+            _request: request,
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+}
+
+
+
+
+
+// ###################
+// CallBuilders   ###
+// #################
+
+/// Lists operations that match the specified filter in the request. If the
+/// server doesn't support this method, it returns `UNIMPLEMENTED`.
+/// 
+/// NOTE: the `name` binding allows API services to override the binding
+/// to use different resource name schemes, such as `users/*/operations`. To
+/// override the binding, API services can add a binding such as
+/// `"/v1/{name=users/*}/operations"` to their service configuration.
+/// For backwards compatibility, the default name includes the operations
+/// collection id, however overriding users must ensure the name binding
+/// is the parent resource, without the operations collection id.
+///
+/// A builder for the *list* method supported by a *operation* resource.
+/// It is not used directly, but through a `OperationMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_speech1 as speech1;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use speech1::Speech;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = Speech::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.operations().list()
+///              .page_token("labore")
+///              .page_size(-9)
+///              .name("nonumy")
+///              .filter("dolores")
+///              .doit();
+/// # }
+/// ```
+pub struct OperationListCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a Speech<C, A>,
+    _page_token: Option<String>,
+    _page_size: Option<i32>,
+    _name: Option<String>,
+    _filter: Option<String>,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for OperationListCall<'a, C, A> {}
+
+impl<'a, C, A> OperationListCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, ListOperationsResponse)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "speech.operations.list",
+                               http_method: hyper::method::Method::Get });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((6 + self._additional_params.len()));
+        if let Some(value) = self._page_token {
+            params.push(("pageToken", value.to_string()));
+        }
+        if let Some(value) = self._page_size {
+            params.push(("pageSize", value.to_string()));
+        }
+        if let Some(value) = self._name {
+            params.push(("name", value.to_string()));
+        }
+        if let Some(value) = self._filter {
+            params.push(("filter", value.to_string()));
+        }
+        for &field in ["alt", "pageToken", "pageSize", "name", "filter"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1/operations";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Get, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    /// The standard list page token.
+    ///
+    /// Sets the *page token* query property to the given value.
+    pub fn page_token(mut self, new_value: &str) -> OperationListCall<'a, C, A> {
+        self._page_token = Some(new_value.to_string());
+        self
+    }
+    /// The standard list page size.
+    ///
+    /// Sets the *page size* query property to the given value.
+    pub fn page_size(mut self, new_value: i32) -> OperationListCall<'a, C, A> {
+        self._page_size = Some(new_value);
+        self
+    }
+    /// The name of the operation's parent resource.
+    ///
+    /// Sets the *name* query property to the given value.
+    pub fn name(mut self, new_value: &str) -> OperationListCall<'a, C, A> {
+        self._name = Some(new_value.to_string());
+        self
+    }
+    /// The standard list filter.
+    ///
+    /// Sets the *filter* query property to the given value.
+    pub fn filter(mut self, new_value: &str) -> OperationListCall<'a, C, A> {
+        self._filter = Some(new_value.to_string());
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> OperationListCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> OperationListCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> OperationListCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Deletes a long-running operation. This method indicates that the client is
+/// no longer interested in the operation result. It does not cancel the
+/// operation. If the server doesn't support this method, it returns
+/// `google.rpc.Code.UNIMPLEMENTED`.
+///
+/// A builder for the *delete* method supported by a *operation* resource.
+/// It is not used directly, but through a `OperationMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_speech1 as speech1;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use speech1::Speech;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = Speech::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.operations().delete("name")
+///              .doit();
+/// # }
+/// ```
+pub struct OperationDeleteCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a Speech<C, A>,
+    _name: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for OperationDeleteCall<'a, C, A> {}
+
+impl<'a, C, A> OperationDeleteCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, Empty)> {
+        use url::percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "speech.operations.delete",
+                               http_method: hyper::method::Method::Delete });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((3 + self._additional_params.len()));
+        params.push(("name", self._name.to_string()));
+        for &field in ["alt", "name"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1/operations/{+name}";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{+name}", "name")].iter() {
+            let mut replace_with = String::new();
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = value.to_string();
+                    break;
+                }
+            }
+            if find_this.as_bytes()[1] == '+' as u8 {
+                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET);
+            }
+            url = url.replace(find_this, &replace_with);
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["name"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Delete, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    /// The name of the operation resource to be deleted.
+    ///
+    /// Sets the *name* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn name(mut self, new_value: &str) -> OperationDeleteCall<'a, C, A> {
+        self._name = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> OperationDeleteCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> OperationDeleteCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> OperationDeleteCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Gets the latest state of a long-running operation.  Clients can use this
+/// method to poll the operation result at intervals as recommended by the API
+/// service.
+///
+/// A builder for the *get* method supported by a *operation* resource.
+/// It is not used directly, but through a `OperationMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_speech1 as speech1;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use speech1::Speech;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = Speech::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.operations().get("name")
+///              .doit();
+/// # }
+/// ```
+pub struct OperationGetCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a Speech<C, A>,
+    _name: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for OperationGetCall<'a, C, A> {}
+
+impl<'a, C, A> OperationGetCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, Operation)> {
+        use url::percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "speech.operations.get",
+                               http_method: hyper::method::Method::Get });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((3 + self._additional_params.len()));
+        params.push(("name", self._name.to_string()));
+        for &field in ["alt", "name"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1/operations/{+name}";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{+name}", "name")].iter() {
+            let mut replace_with = String::new();
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = value.to_string();
+                    break;
+                }
+            }
+            if find_this.as_bytes()[1] == '+' as u8 {
+                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET);
+            }
+            url = url.replace(find_this, &replace_with);
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["name"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Get, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    /// The name of the operation resource.
+    ///
+    /// Sets the *name* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn name(mut self, new_value: &str) -> OperationGetCall<'a, C, A> {
+        self._name = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> OperationGetCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> OperationGetCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> OperationGetCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Starts asynchronous cancellation on a long-running operation.  The server
+/// makes a best effort to cancel the operation, but success is not
+/// guaranteed.  If the server doesn't support this method, it returns
+/// `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
+/// Operations.GetOperation or
+/// other methods to check whether the cancellation succeeded or whether the
+/// operation completed despite cancellation. On successful cancellation,
+/// the operation is not deleted; instead, it becomes an operation with
+/// an Operation.error value with a google.rpc.Status.code of 1,
+/// corresponding to `Code.CANCELLED`.
+///
+/// A builder for the *cancel* method supported by a *operation* resource.
+/// It is not used directly, but through a `OperationMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_speech1 as speech1;
+/// use speech1::CancelOperationRequest;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use speech1::Speech;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = Speech::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = CancelOperationRequest::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.operations().cancel(req, "name")
+///              .doit();
+/// # }
+/// ```
+pub struct OperationCancelCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a Speech<C, A>,
+    _request: CancelOperationRequest,
+    _name: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for OperationCancelCall<'a, C, A> {}
+
+impl<'a, C, A> OperationCancelCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, Empty)> {
+        use url::percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "speech.operations.cancel",
+                               http_method: hyper::method::Method::Post });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((4 + self._additional_params.len()));
+        params.push(("name", self._name.to_string()));
+        for &field in ["alt", "name"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1/operations/{+name}:cancel";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{+name}", "name")].iter() {
+            let mut replace_with = String::new();
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = value.to_string();
+                    break;
+                }
+            }
+            if find_this.as_bytes()[1] == '+' as u8 {
+                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET);
+            }
+            url = url.replace(find_this, &replace_with);
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["name"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Post, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: CancelOperationRequest) -> OperationCancelCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// The name of the operation resource to be cancelled.
+    ///
+    /// Sets the *name* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn name(mut self, new_value: &str) -> OperationCancelCall<'a, C, A> {
+        self._name = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> OperationCancelCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> OperationCancelCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> OperationCancelCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Performs asynchronous speech recognition: receive results via the
+/// google.longrunning.Operations interface. Returns either an
+/// `Operation.error` or an `Operation.response` which contains
+/// a `LongRunningRecognizeResponse` message.
+///
+/// A builder for the *longrunningrecognize* method supported by a *speech* resource.
+/// It is not used directly, but through a `SpeechMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_speech1 as speech1;
+/// use speech1::LongRunningRecognizeRequest;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use speech1::Speech;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = Speech::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = LongRunningRecognizeRequest::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.speech().longrunningrecognize(req)
+///              .doit();
+/// # }
+/// ```
+pub struct SpeechLongrunningrecognizeCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a Speech<C, A>,
+    _request: LongRunningRecognizeRequest,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for SpeechLongrunningrecognizeCall<'a, C, A> {}
+
+impl<'a, C, A> SpeechLongrunningrecognizeCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, Operation)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "speech.speech.longrunningrecognize",
+                               http_method: hyper::method::Method::Post });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((3 + self._additional_params.len()));
+        for &field in ["alt"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1/speech:longrunningrecognize";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Post, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: LongRunningRecognizeRequest) -> SpeechLongrunningrecognizeCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> SpeechLongrunningrecognizeCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> SpeechLongrunningrecognizeCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> SpeechLongrunningrecognizeCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Performs synchronous speech recognition: receive results after all audio
+/// has been sent and processed.
+///
+/// A builder for the *recognize* method supported by a *speech* resource.
+/// It is not used directly, but through a `SpeechMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_speech1 as speech1;
+/// use speech1::RecognizeRequest;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use speech1::Speech;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = Speech::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = RecognizeRequest::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.speech().recognize(req)
+///              .doit();
+/// # }
+/// ```
+pub struct SpeechRecognizeCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a Speech<C, A>,
+    _request: RecognizeRequest,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for SpeechRecognizeCall<'a, C, A> {}
+
+impl<'a, C, A> SpeechRecognizeCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, RecognizeResponse)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "speech.speech.recognize",
+                               http_method: hyper::method::Method::Post });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((3 + self._additional_params.len()));
+        for &field in ["alt"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1/speech:recognize";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Post, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: RecognizeRequest) -> SpeechRecognizeCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> SpeechRecognizeCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> SpeechRecognizeCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> SpeechRecognizeCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+

--- a/gen/speech1_beta1-cli/Cargo.toml
+++ b/gen/speech1_beta1-cli/Cargo.toml
@@ -1,0 +1,40 @@
+# DO NOT EDIT !
+# This file was generated automatically from 'src/mako/Cargo.toml.mako'
+# DO NOT EDIT !
+[package]
+
+name = "google-speech1_beta1-cli"
+version = "1.0.7+20171205"
+authors = ["Sebastian Thiel <byronimo@gmail.com>"]
+description = "A complete library to interact with Speech (protocol v1beta1)"
+repository = "https://github.com/Byron/google-apis-rs/tree/master/gen/speech1_beta1-cli"
+homepage = "https://cloud.google.com/speech/"
+documentation = "http://byron.github.io/google-apis-rs/google_speech1_beta1_cli"
+license = "MIT"
+keywords = ["speech", "google", "cli"]
+
+[[bin]]
+name = "speech1-beta1"
+
+[dev-dependencies]
+hyper-rustls = "^0.6"
+
+[dependencies]
+hyper = "^ 0.10"
+mime = "^ 0.2.0"
+serde = "^ 1.0"
+serde_json = "^ 1.0"
+serde_derive = "^ 1.0"
+yup-oauth2 = "^ 1.0"
+strsim = "^0.5"
+hyper-rustls = "^0.6"
+yup-hyper-mock = "^2.0"
+clap = "^2.0"
+
+[features]
+
+
+
+[dependencies.google-speech1_beta1]
+path = "../speech1_beta1"
+version = "1.0.7+20171205"

--- a/gen/speech1_beta1-cli/LICENSE.md
+++ b/gen/speech1_beta1-cli/LICENSE.md
@@ -1,0 +1,30 @@
+<!---
+DO NOT EDIT !
+This file was generated automatically from 'src/mako/LICENSE.md.mako'
+DO NOT EDIT !
+-->
+The MIT License (MIT)
+=====================
+
+Copyright © `2015-2016` `Sebastian Thiel`
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the “Software”), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.

--- a/gen/speech1_beta1-cli/README.md
+++ b/gen/speech1_beta1-cli/README.md
@@ -1,0 +1,120 @@
+<!---
+DO NOT EDIT !
+This file was generated automatically from 'src/mako/cli/README.md.mako'
+DO NOT EDIT !
+-->
+The `speech1-beta1` command-line interface *(CLI)* allows to use most features of the *Google Speech* service from the comfort of your terminal.
+
+By default all output is printed to standard out, but flags can be set to direct it into a file independent of your shell's
+capabilities. Errors will be printed to standard error, and cause the program's exit code to be non-zero.
+
+If data-structures are requested, these will be returned as pretty-printed JSON, to be useful as input to other tools.
+
+Everything else about the *Speech* API can be found at the
+[official documentation site](https://cloud.google.com/speech/).
+
+# Installation and Source Code
+
+Install the command-line interface with cargo using:
+
+```bash
+cargo install google-speech1_beta1-cli
+```
+
+Find the source code [on github](https://github.com/Byron/google-apis-rs/tree/master/gen/speech1_beta1-cli).
+
+# Usage
+
+This documentation was generated from the *Speech* API at revision *20171205*. The CLI is at version *1.0.7*.
+
+```bash
+speech1-beta1 [options]
+        operations
+                cancel <name> [-p <v>]... [-o <out>]
+                delete <name> [-p <v>]... [-o <out>]
+                get <name> [-p <v>]... [-o <out>]
+                list [-p <v>]... [-o <out>]
+        speech
+                asyncrecognize (-r <kv>)... [-p <v>]... [-o <out>]
+                syncrecognize (-r <kv>)... [-p <v>]... [-o <out>]
+  speech1-beta1 --help
+
+Configuration:
+  [--scope <url>]...
+            Specify the authentication a method should be executed in. Each scope
+            requires the user to grant this application permission to use it.
+            If unset, it defaults to the shortest scope url for a particular method.
+  --config-dir <folder>
+            A directory into which we will store our persistent data. Defaults to
+            a user-writable directory that we will create during the first invocation.
+            [default: ~/.google-service-cli]
+  --debug
+            Output all server communication to standard error. `tx` and `rx` are placed
+            into the same stream.
+  --debug-auth
+            Output all communication related to authentication to standard error. `tx`
+            and `rx` are placed into the same stream.
+
+```
+
+# Configuration
+
+The program will store all persistent data in the `~/.google-service-cli` directory in *JSON* files prefixed with `speech1-beta1-`.  You can change the directory used to store configuration with the `--config-dir` flag on a per-invocation basis.
+
+More information about the various kinds of persistent data are given in the following paragraphs.
+
+# Authentication
+
+Most APIs require a user to authenticate any request. If this is the case, the [scope][scopes] determines the 
+set of permissions granted. The granularity of these is usually no more than *read-only* or *full-access*.
+
+If not set, the system will automatically select the smallest feasible scope, e.g. when invoking a
+method that is read-only, it will ask only for a read-only scope. 
+You may use the `--scope` flag to specify a scope directly. 
+All applicable scopes are documented in the respective method's CLI documentation.
+
+The first time a scope is used, the user is asked for permission. Follow the instructions given 
+by the CLI to grant permissions, or to decline.
+
+If a scope was authenticated by the user, the respective information will be stored as *JSON* in the configuration
+directory, e.g. `~/.google-service-cli/speech1-beta1-token-<scope-hash>.json`. No manual management of these tokens
+is necessary.
+
+To revoke granted authentication, please refer to the [official documentation][revoke-access].
+
+# Application Secrets
+
+In order to allow any application to use Google services, it will need to be registered using the 
+[Google Developer Console][google-dev-console]. APIs the application may use are then enabled for it
+one by one. Most APIs can be used for free and have a daily quota.
+
+To allow more comfortable usage of the CLI without forcing anyone to register an own application, the CLI
+comes with a default application secret that is configured accordingly. This also means that heavy usage
+all around the world may deplete the daily quota.
+
+You can workaround this limitation by putting your own secrets file at this location: 
+`~/.google-service-cli/speech1-beta1-secret.json`, assuming that the required *speech* API 
+was enabled for it. Such a secret file can be downloaded in the *Google Developer Console* at 
+*APIs & auth -> Credentials -> Download JSON* and used as is.
+
+Learn more about how to setup Google projects and enable APIs using the [official documentation][google-project-new].
+
+
+# Debugging
+
+Even though the CLI does its best to provide usable error messages, sometimes it might be desirable to know
+what exactly led to a particular issue. This is done by allowing all client-server communication to be 
+output to standard error *as-is*.
+
+The `--debug` flag will print all client-server communication to standard error, whereas the `--debug-auth` flag
+will cause all communication related to authentication to standard error.
+If the `--debug` flag is set, error-results will be debug-printed, possibly yielding more information about the 
+issue at hand.
+
+You may consider redirecting standard error into a file for ease of use, e.g. `speech1-beta1 --debug <resource> <method> [options] 2>debug.txt`.
+
+
+[scopes]: https://developers.google.com/+/api/oauth#scopes
+[revoke-access]: http://webapps.stackexchange.com/a/30849
+[google-dev-console]: https://console.developers.google.com/
+[google-project-new]: https://developers.google.com/console/help/new/

--- a/gen/speech1_beta1-cli/mkdocs.yml
+++ b/gen/speech1_beta1-cli/mkdocs.yml
@@ -1,0 +1,22 @@
+site_name: Speech v1.0.7+20171205
+site_url: http://byron.github.io/google-apis-rs/google-speech1_beta1-cli
+site_description: A complete library to interact with Speech (protocol v1beta1)
+
+repo_url: https://github.com/Byron/google-apis-rs/tree/master/gen/speech1_beta1-cli
+
+docs_dir: docs
+site_dir: build_html
+
+pages:
+- ['index.md', 'Home']
+- ['operations_cancel.md', 'Operations', 'Cancel']
+- ['operations_delete.md', 'Operations', 'Delete']
+- ['operations_get.md', 'Operations', 'Get']
+- ['operations_list.md', 'Operations', 'List']
+- ['speech_asyncrecognize.md', 'Speech', 'Asyncrecognize']
+- ['speech_syncrecognize.md', 'Speech', 'Syncrecognize']
+
+theme: readthedocs
+
+copyright: Copyright &copy; 2015-2016, `Sebastian Thiel`
+

--- a/gen/speech1_beta1-cli/src/cmn.rs
+++ b/gen/speech1_beta1-cli/src/cmn.rs
@@ -1,0 +1,799 @@
+// COPY OF 'src/rust/cli/cmn.rs'
+// DO NOT EDIT
+use oauth2::{ApplicationSecret, ConsoleApplicationSecret, TokenStorage, Token};
+use serde_json as json;
+use serde_json::value::Value;
+use mime::Mime;
+use clap::{App, SubCommand};
+use strsim;
+
+use std::fs;
+use std::env;
+use std::io;
+use std::error::Error as StdError;
+use std::fmt;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+use std::string::ToString;
+use std::io::{Write, Read, stdout};
+
+use std::default::Default;
+
+const FIELD_SEP: char = '.';
+
+
+pub enum ComplexType {
+    Pod,
+    Vec,
+    Map,
+}
+
+// Null,
+// Bool(bool),
+// I64(i64),
+// U64(u64),
+// F64(f64),
+// String(String),
+
+pub enum JsonType {
+    Boolean,
+    Int,
+    Uint,
+    Float,
+    String,
+}
+
+pub struct JsonTypeInfo {
+    pub jtype: JsonType,
+    pub ctype: ComplexType,
+}
+
+// Based on @erickt user comment. Thanks for the idea !
+// Remove all keys whose values are null from given value (changed in place)
+pub fn remove_json_null_values(value: &mut Value) {
+    match *value {
+        Value::Object(ref mut map) => {
+            let mut for_removal = Vec::new();
+
+            for (key, mut value) in map.iter_mut() {
+                if value.is_null() {
+                    for_removal.push(key.clone());
+                } else {
+                    remove_json_null_values(&mut value);
+                }
+            }
+
+            for key in &for_removal {
+                map.remove(key);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn did_you_mean<'a>(v: &str, possible_values: &[&'a str]) -> Option<&'a str> {
+
+    let mut candidate: Option<(f64, &str)> = None;
+    for pv in possible_values {
+        let confidence = strsim::jaro_winkler(v, pv);
+        if confidence > 0.8 &&
+           (candidate.is_none() || (candidate.as_ref().unwrap().0 < confidence)) {
+            candidate = Some((confidence, pv));
+        }
+    }
+    match candidate {
+        None => None,
+        Some((_, candidate)) => Some(candidate),
+    }
+}
+
+pub enum CallType {
+    Upload(UploadProtocol),
+    Standard,
+}
+
+arg_enum!{
+    pub enum UploadProtocol {
+        Simple,
+        Resumable
+    }
+}
+
+impl AsRef<str> for UploadProtocol {
+    fn as_ref(&self) -> &str {
+        match *self {
+            UploadProtocol::Simple => "simple",
+            UploadProtocol::Resumable => "resumable",
+        }
+    }
+}
+
+impl AsRef<str> for CallType {
+    fn as_ref(&self) -> &str {
+        match *self {
+            CallType::Upload(ref proto) => proto.as_ref(),
+            CallType::Standard => "standard-request",
+        }
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct FieldCursor(Vec<String>);
+
+impl ToString for  FieldCursor {
+    fn to_string(&self) -> String {
+        self.0.join(".")
+    }
+}
+
+impl From<&'static str> for FieldCursor {
+    fn from(value: &'static str) -> FieldCursor {
+        let mut res = FieldCursor::default();
+        res.set(value).unwrap();
+        res
+    }
+}
+
+fn assure_entry<'a, 'b>(m: &'a mut json::Map<String, Value>, k: &'b String) -> &'a mut Value {
+    if m.contains_key(k) {
+        return m.get_mut(k).expect("value to exist");
+    }
+    m.insert(k.to_owned(), Value::Object(Default::default()));
+    m.get_mut(k).expect("value to exist")
+}
+
+impl FieldCursor {
+    pub fn set(&mut self, value: &str) -> Result<(), CLIError> {
+        if value.len() == 0 {
+            return Err(CLIError::Field(FieldError::Empty));
+        }
+
+        let mut first_is_field_sep = false;
+        let mut char_count: usize = 0;
+        let mut last_c = FIELD_SEP;
+        let mut num_conscutive_field_seps = 0;
+
+        let mut field = String::new();
+        let mut fields = self.0.clone();
+
+        let push_field = |fs: &mut Vec<String>, f: &mut String| {
+            if f.len() > 0 {
+                fs.push(f.clone());
+                f.truncate(0);
+            }
+        };
+
+        for (cid, c) in value.chars().enumerate() {
+            char_count += 1;
+
+            if c == FIELD_SEP {
+                if cid == 0 {
+                    first_is_field_sep = true;
+                }
+                num_conscutive_field_seps += 1;
+                if cid > 0 && last_c == FIELD_SEP {
+                    if fields.pop().is_none() {
+                        return Err(CLIError::Field(FieldError::PopOnEmpty(value.to_string())));
+                    }
+                } else {
+                    push_field(&mut fields, &mut field);
+                }
+            } else {
+                num_conscutive_field_seps = 0;
+                if cid == 1 {
+                    if first_is_field_sep {
+                        fields.truncate(0);
+                    }
+                }
+                field.push(c);
+            }
+
+            last_c = c;
+        }
+
+        push_field(&mut fields, &mut field);
+
+        if char_count == 1 && first_is_field_sep {
+            fields.truncate(0);
+        }
+        if char_count > 1 && num_conscutive_field_seps == 1 {
+            return Err(CLIError::Field(FieldError::TrailingFieldSep(value.to_string())));
+        }
+
+        self.0 = fields;
+        Ok(())
+    }
+
+    pub fn did_you_mean(value: &str, possible_values: &[&str]) -> Option<String> {
+        if value.len() == 0 {
+            return None;
+        }
+
+        let mut last_c = FIELD_SEP;
+
+        let mut field = String::new();
+        let mut output = String::new();
+
+        let push_field = |fs: &mut String, f: &mut String| {
+            if f.len() > 0 {
+                fs.push_str(match did_you_mean(&f, possible_values) {
+                    Some(candidate) => candidate,
+                    None => &f,
+                });
+                f.truncate(0);
+            }
+        };
+
+        for (cid, c) in value.chars().enumerate() {
+            if c == FIELD_SEP {
+                if last_c != FIELD_SEP {
+                    push_field(&mut output, &mut field);
+                }
+                output.push(c);
+            } else {
+                field.push(c);
+            }
+
+            last_c = c;
+        }
+
+        push_field(&mut output, &mut field);
+
+        if &output == value {
+            None
+        } else {
+            Some(output)
+        }
+    }
+
+    pub fn set_json_value(&self,
+                          mut object: &mut Value,
+                          value: &str,
+                          type_info: JsonTypeInfo,
+                          err: &mut InvalidOptionsError,
+                          orig_cursor: &FieldCursor) {
+        assert!(self.0.len() > 0);
+
+        for field in &self.0[..self.0.len() - 1] {
+            let tmp = object;
+            object = match *tmp {
+                Value::Object(ref mut mapping) => {
+                    assure_entry(mapping, &field)
+                }
+                _ => panic!("We don't expect non-object Values here ..."),
+            };
+        }
+
+        match *object {
+            Value::Object(ref mut mapping) => {
+                let field = &self.0[self.0.len() - 1];
+                let to_jval = |value: &str,
+                               jtype: JsonType,
+                               err: &mut InvalidOptionsError|
+                               -> Value {
+                    match jtype {
+                        JsonType::Boolean =>
+                            Value::Bool(arg_from_str(value, err, &field, "boolean")),
+                        JsonType::Int =>
+                            Value::Number(json::Number::from_f64(arg_from_str(value,
+                                                                              err,
+                                                                              &field,
+                                                                              "int"))
+                                              .expect("valid f64")),
+                        JsonType::Uint =>
+                            Value::Number(json::Number::from_f64(arg_from_str(value,
+                                                                              err,
+                                                                              &field,
+                                                                              "uint"))
+                                              .expect("valid f64")),
+                        JsonType::Float =>
+                            Value::Number(json::Number::from_f64(arg_from_str(value,
+                                                                              err,
+                                                                              &field,
+                                                                              "float"))
+                                              .expect("valid f64")),
+                        JsonType::String => Value::String(value.to_owned()),
+                    }
+                };
+
+                match type_info.ctype {
+                    ComplexType::Pod => {
+                        if mapping.insert(field.to_owned(), to_jval(value, type_info.jtype, err))
+                                  .is_some() {
+                            err.issues.push(CLIError::Field(FieldError::Duplicate(orig_cursor.to_string())));
+                        }
+                    }
+                    ComplexType::Vec => {
+                        match *assure_entry(mapping, field) {
+                            Value::Array(ref mut values) =>
+                                values.push(to_jval(value, type_info.jtype, err)),
+                            _ => unreachable!(),
+                        }
+                    }
+                    ComplexType::Map => {
+                        let (key, value) = parse_kv_arg(value, err, true);
+                        let jval = to_jval(value.unwrap_or(""), type_info.jtype, err);
+
+                        match *assure_entry(mapping, &field) {
+
+                            Value::Object(ref mut value_map) => {
+                                if value_map.insert(key.to_owned(), jval).is_some() {
+                                    err.issues.push(CLIError::Field(FieldError::Duplicate(orig_cursor.to_string())));
+                                }
+                            }
+                            _ => unreachable!(),
+                        }
+                    }
+                }
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    pub fn num_fields(&self) -> usize {
+        self.0.len()
+    }
+}
+
+pub fn parse_kv_arg<'a>(kv: &'a str,
+                        err: &mut InvalidOptionsError,
+                        for_hashmap: bool)
+                        -> (&'a str, Option<&'a str>) {
+    let mut add_err = || {
+        err.issues.push(CLIError::InvalidKeyValueSyntax(kv.to_string(), for_hashmap))
+    };
+    match kv.find('=') {
+        None => {
+            add_err();
+            return (kv, None);
+        }
+        Some(pos) => {
+            let key = &kv[..pos];
+            if kv.len() <= pos + 1 {
+                add_err();
+                return (key, Some(""));
+            }
+            (key, Some(&kv[pos + 1..]))
+        }
+    }
+}
+
+pub fn calltype_from_str(name: &str,
+                         valid_protocols: Vec<String>,
+                         err: &mut InvalidOptionsError)
+                         -> CallType {
+    CallType::Upload(match UploadProtocol::from_str(name) {
+        Ok(up) => up,
+        Err(msg) => {
+            err.issues.push(CLIError::InvalidUploadProtocol(name.to_string(), valid_protocols));
+            UploadProtocol::Simple
+        }
+    })
+}
+
+pub fn input_file_from_opts(file_path: &str, err: &mut InvalidOptionsError) -> Option<fs::File> {
+    match fs::File::open(file_path) {
+        Ok(f) => Some(f),
+        Err(io_err) => {
+            err.issues.push(CLIError::Input(InputError::Io((file_path.to_string(), io_err))));
+            None
+        }
+    }
+}
+
+pub fn input_mime_from_opts(mime: &str, err: &mut InvalidOptionsError) -> Option<Mime> {
+    match mime.parse() {
+        Ok(m) => Some(m),
+        Err(_) => {
+            err.issues.push(CLIError::Input(InputError::Mime(mime.to_string())));
+            None
+        }
+    }
+}
+
+pub fn writer_from_opts(arg: Option<&str>) -> Result<Box<Write>, io::Error> {
+    let f = arg.unwrap_or("-");
+    match f {
+        "-" => Ok(Box::new(stdout())),
+        _ => match fs::OpenOptions::new().create(true).write(true).open(f) {
+            Ok(f) => Ok(Box::new(f)),
+            Err(io_err) => Err(io_err),
+        },
+    }
+}
+
+
+pub fn arg_from_str<'a, T>(arg: &str,
+                           err: &mut InvalidOptionsError,
+                           arg_name: &'a str,
+                           arg_type: &'a str)
+                           -> T
+    where T: FromStr + Default,
+          <T as FromStr>::Err: fmt::Display
+{
+    match FromStr::from_str(arg) {
+        Err(perr) => {
+            err.issues.push(CLIError::ParseError(arg_name.to_owned(),
+                                                 arg_type.to_owned(),
+                                                 arg.to_string(),
+                                                 format!("{}", perr)));
+            Default::default()
+        }
+        Ok(v) => v,
+    }
+}
+
+pub struct JsonTokenStorage {
+    pub program_name: &'static str,
+    pub db_dir: String,
+}
+
+impl JsonTokenStorage {
+    fn path(&self, scope_hash: u64) -> PathBuf {
+        Path::new(&self.db_dir).join(&format!("{}-token-{}.json", self.program_name, scope_hash))
+    }
+}
+
+
+#[derive(Debug)]
+pub enum TokenStorageError {
+    Json(json::Error),
+    Io(io::Error),
+}
+
+impl fmt::Display for TokenStorageError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            TokenStorageError::Json(ref err) => writeln!(f, "Could not serialize secrets: {}", err),
+            TokenStorageError::Io(ref err) => writeln!(f, "Failed to write secret token: {}", err),
+        }
+    }
+}
+
+impl StdError for TokenStorageError {
+    fn description(&self) -> &str {
+        "Failure when getting or setting the token storage"
+    }
+}
+
+
+impl TokenStorage for JsonTokenStorage {
+    type Error = TokenStorageError;
+
+    // NOTE: logging might be interesting, currently we swallow all errors
+    fn set(&mut self,
+           scope_hash: u64,
+           _: &Vec<&str>,
+           token: Option<Token>)
+           -> Result<(), TokenStorageError> {
+        match token {
+            None => {
+                match fs::remove_file(self.path(scope_hash)) {
+                    Err(err) => match err.kind() {
+                        io::ErrorKind::NotFound => Ok(()),
+                        _ => Err(TokenStorageError::Io(err)),
+                    },
+                    Ok(_) => Ok(()),
+                }
+            }
+            Some(token) => {
+                match fs::OpenOptions::new().create(true).write(true).open(&self.path(scope_hash)) {
+                    Ok(mut f) => {
+                        match json::to_writer_pretty(&mut f, &token) {
+                            Ok(_) => Ok(()),
+                            Err(serde_err) => Err(TokenStorageError::Json(serde_err)),
+                        }
+                    }
+                    Err(io_err) => Err(TokenStorageError::Io(io_err)),
+                }
+            }
+        }
+    }
+
+    fn get(&self, scope_hash: u64, _: &Vec<&str>) -> Result<Option<Token>, TokenStorageError> {
+        match fs::File::open(&self.path(scope_hash)) {
+            Ok(f) => {
+                match json::de::from_reader(f) {
+                    Ok(token) => Ok(Some(token)),
+                    Err(err) => Err(TokenStorageError::Json(err)),
+                }
+            }
+            Err(io_err) => {
+                match io_err.kind() {
+                    io::ErrorKind::NotFound => Ok(None),
+                    _ => Err(TokenStorageError::Io(io_err)),
+                }
+            }
+        }
+    }
+}
+
+
+#[derive(Debug)]
+pub enum ApplicationSecretError {
+    DecoderError((String, json::Error)),
+    FormatError(String),
+}
+
+impl fmt::Display for ApplicationSecretError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            ApplicationSecretError::DecoderError((ref path, ref err)) =>
+                writeln!(f,
+                         "Could not decode file at '{}' with error: {}.",
+                         path,
+                         err),
+            ApplicationSecretError::FormatError(ref path) =>
+                writeln!(f,
+                         "'installed' field is unset in secret file at '{}'.",
+                         path),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum ConfigurationError {
+    DirectoryCreationFailed((String, io::Error)),
+    DirectoryUnset,
+    HomeExpansionFailed(String),
+    Secret(ApplicationSecretError),
+    Io((String, io::Error)),
+}
+
+impl fmt::Display for ConfigurationError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            ConfigurationError::DirectoryCreationFailed((ref dir, ref err)) =>
+                writeln!(f,
+                         "Directory '{}' could not be created with error: {}.",
+                         dir,
+                         err),
+            ConfigurationError::DirectoryUnset => writeln!(f, "--config-dir was unset or empty."),
+            ConfigurationError::HomeExpansionFailed(ref dir) =>
+                writeln!(f,
+                         "Couldn't find HOME directory of current user, failed to expand '{}'.",
+                         dir),
+            ConfigurationError::Secret(ref err) => writeln!(f, "Secret -> {}", err),
+            ConfigurationError::Io((ref path, ref err)) =>
+                writeln!(f,
+                         "IO operation failed on path '{}' with error: {}.",
+                         path,
+                         err),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum InputError {
+    Io((String, io::Error)),
+    Mime(String),
+}
+
+impl fmt::Display for InputError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            InputError::Io((ref file_path, ref io_err)) =>
+                writeln!(f,
+                         "Failed to open '{}' for reading with error: {}.",
+                         file_path,
+                         io_err),
+            InputError::Mime(ref mime) => writeln!(f, "'{}' is not a known mime-type.", mime),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum FieldError {
+    PopOnEmpty(String),
+    TrailingFieldSep(String),
+    Unknown(String, Option<String>, Option<String>),
+    Duplicate(String),
+    Empty,
+}
+
+
+impl fmt::Display for FieldError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            FieldError::PopOnEmpty(ref field) =>
+                writeln!(f, "'{}': Cannot move up on empty field cursor.", field),
+            FieldError::TrailingFieldSep(ref field) =>
+                writeln!(f,
+                         "'{}': Single field separator may not be last character.",
+                         field),
+            FieldError::Unknown(ref field, ref suggestion, ref value) => {
+                let suffix = match *suggestion {
+                    Some(ref s) => {
+                        let kv = match *value {
+                            Some(ref v) => format!("{}={}", s, v),
+                            None => s.clone(),
+                        };
+                        format!(" Did you mean '{}' ?", kv)
+                    }
+                    None => String::new(),
+                };
+                writeln!(f, "Field '{}' does not exist.{}", field, suffix)
+            }
+            FieldError::Duplicate(ref cursor) =>
+                writeln!(f, "Value at '{}' was already set", cursor),
+            FieldError::Empty => writeln!(f, "Field names must not be empty."),
+        }
+    }
+}
+
+
+#[derive(Debug)]
+pub enum CLIError {
+    Configuration(ConfigurationError),
+    ParseError(String, String, String, String),
+    UnknownParameter(String, Vec<&'static str>),
+    InvalidUploadProtocol(String, Vec<String>),
+    InvalidKeyValueSyntax(String, bool),
+    Input(InputError),
+    Field(FieldError),
+    MissingCommandError,
+    MissingMethodError(String),
+}
+
+impl fmt::Display for CLIError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            CLIError::Configuration(ref err) => write!(f, "Configuration -> {}", err),
+            CLIError::Input(ref err) => write!(f, "Input -> {}", err),
+            CLIError::Field(ref err) => write!(f, "Field -> {}", err),
+            CLIError::InvalidUploadProtocol(ref proto_name, ref valid_names) =>
+                writeln!(f,
+                         "'{}' is not a valid upload protocol. Choose from one of {}.",
+                         proto_name,
+                         valid_names.join(", ")),
+            CLIError::ParseError(ref arg_name, ref type_name, ref value, ref err_desc) =>
+                writeln!(f,
+                         "Failed to parse argument '{}' with value '{}' as {} with error: {}.",
+                         arg_name,
+                         value,
+                         type_name,
+                         err_desc),
+            CLIError::UnknownParameter(ref param_name, ref possible_values) => {
+                let suffix = match did_you_mean(param_name, &possible_values) {
+                    Some(v) => format!(" Did you mean '{}' ?", v),
+                    None => String::new(),
+                };
+                write!(f, "Parameter '{}' is unknown.{}\n", param_name, suffix)
+            }
+            CLIError::InvalidKeyValueSyntax(ref kv, is_hashmap) => {
+                let hashmap_info = if is_hashmap {
+                    "hashmap "
+                } else {
+                    ""
+                };
+                writeln!(f,
+                         "'{}' does not match {}pattern <key>=<value>.",
+                         kv,
+                         hashmap_info)
+            }
+            CLIError::MissingCommandError => writeln!(f, "Please specify the main sub-command."),
+            CLIError::MissingMethodError(ref cmd) =>
+                writeln!(f,
+                         "Please specify the method to call on the '{}' command.",
+                         cmd),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct InvalidOptionsError {
+    pub issues: Vec<CLIError>,
+    pub exit_code: i32,
+}
+
+impl fmt::Display for InvalidOptionsError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        for issue in &self.issues {
+            try!(issue.fmt(f));
+        }
+        Ok(())
+    }
+}
+
+impl InvalidOptionsError {
+    pub fn single(err: CLIError, exit_code: i32) -> InvalidOptionsError {
+        InvalidOptionsError {
+            issues: vec![err],
+            exit_code: exit_code,
+        }
+    }
+
+    pub fn new() -> InvalidOptionsError {
+        InvalidOptionsError {
+            issues: Vec::new(),
+            exit_code: 1,
+        }
+    }
+}
+
+pub fn assure_config_dir_exists(dir: &str) -> Result<String, CLIError> {
+    let trdir = dir.trim();
+    if trdir.len() == 0 {
+        return Err(CLIError::Configuration(ConfigurationError::DirectoryUnset));
+    }
+
+    let expanded_config_dir = if trdir.as_bytes()[0] == b'~' {
+        match env::var("HOME").ok().or(env::var("UserProfile").ok()) {
+            None => return Err(CLIError::Configuration(ConfigurationError::HomeExpansionFailed(trdir.to_string()))),
+            Some(mut user) => {
+                user.push_str(&trdir[1..]);
+                user
+            }
+        }
+    } else {
+        trdir.to_string()
+    };
+
+    if let Err(err) = fs::create_dir(&expanded_config_dir) {
+        if err.kind() != io::ErrorKind::AlreadyExists {
+            return Err(CLIError::Configuration(
+                    ConfigurationError::DirectoryCreationFailed((expanded_config_dir, err))));
+        }
+    }
+
+    Ok(expanded_config_dir)
+}
+
+pub fn application_secret_from_directory(dir: &str,
+                                         secret_basename: &str,
+                                         json_console_secret: &str)
+                                         -> Result<ApplicationSecret, CLIError> {
+    let secret_path = Path::new(dir).join(secret_basename);
+    let secret_str = || secret_path.as_path().to_str().unwrap().to_string();
+    let secret_io_error = |io_err: io::Error| {
+        Err(CLIError::Configuration(ConfigurationError::Io((secret_str(), io_err))))
+    };
+
+    for _ in 0..2 {
+        match fs::File::open(&secret_path) {
+            Err(mut err) => {
+                if err.kind() == io::ErrorKind::NotFound {
+                    // Write our built-in one - user may adjust the written file at will
+
+                    err = match fs::OpenOptions::new()
+                                    .create(true)
+                                    .write(true)
+                                    .open(&secret_path) {
+                        Err(cfe) => cfe,
+                        Ok(mut f) => {
+                            // Assure we convert 'ugly' json string into pretty one
+                            let console_secret: ConsoleApplicationSecret =
+                                json::from_str(json_console_secret).unwrap();
+                            match json::to_writer_pretty(&mut f, &console_secret) {
+                                Err(serde_err) =>
+                                    panic!("Unexpected serde error: {:#?}", serde_err),
+                                Ok(_) => continue,
+                            }
+                        }
+                    };
+                    // fall through to IO error handling
+                }
+                return secret_io_error(err);
+            }
+            Ok(f) => {
+                match json::de::from_reader::<_, ConsoleApplicationSecret>(f) {
+                    Err(json_err) =>
+                        return Err(CLIError::Configuration(
+                            ConfigurationError::Secret(
+                                ApplicationSecretError::DecoderError(
+                                                (secret_str(), json_err)
+                                              )))),
+                    Ok(console_secret) => match console_secret.installed {
+                        Some(secret) => return Ok(secret),
+                        None => return Err(
+                                        CLIError::Configuration(
+                                        ConfigurationError::Secret(
+                                        ApplicationSecretError::FormatError(secret_str())
+                                        ))),
+                    },
+                }
+            }
+        }
+    }
+    unreachable!();
+}

--- a/gen/speech1_beta1-cli/src/main.rs
+++ b/gen/speech1_beta1-cli/src/main.rs
@@ -1,0 +1,837 @@
+// DO NOT EDIT !
+// This file was generated automatically from 'src/mako/cli/main.rs.mako'
+// DO NOT EDIT !
+#![allow(unused_variables, unused_imports, dead_code, unused_mut)]
+
+#[macro_use]
+extern crate clap;
+extern crate yup_oauth2 as oauth2;
+extern crate yup_hyper_mock as mock;
+extern crate hyper_rustls;
+extern crate serde;
+extern crate serde_json;
+extern crate hyper;
+extern crate mime;
+extern crate strsim;
+extern crate google_speech1_beta1 as api;
+
+use std::env;
+use std::io::{self, Write};
+use clap::{App, SubCommand, Arg};
+
+mod cmn;
+
+use cmn::{InvalidOptionsError, CLIError, JsonTokenStorage, arg_from_str, writer_from_opts, parse_kv_arg,
+          input_file_from_opts, input_mime_from_opts, FieldCursor, FieldError, CallType, UploadProtocol,
+          calltype_from_str, remove_json_null_values, ComplexType, JsonType, JsonTypeInfo};
+
+use std::default::Default;
+use std::str::FromStr;
+
+use oauth2::{Authenticator, DefaultAuthenticatorDelegate, FlowType};
+use serde_json as json;
+use clap::ArgMatches;
+
+enum DoitError {
+    IoError(String, io::Error),
+    ApiError(api::Error),
+}
+
+struct Engine<'n> {
+    opt: ArgMatches<'n>,
+    hub: api::Speech<hyper::Client, Authenticator<DefaultAuthenticatorDelegate, JsonTokenStorage, hyper::Client>>,
+    gp: Vec<&'static str>,
+    gpm: Vec<(&'static str, &'static str)>,
+}
+
+
+impl<'n> Engine<'n> {
+    fn _operations_cancel(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let mut call = self.hub.operations().cancel(opt.value_of("name").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _operations_delete(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let mut call = self.hub.operations().delete(opt.value_of("name").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _operations_get(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let mut call = self.hub.operations().get(opt.value_of("name").unwrap_or(""));
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _operations_list(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        let mut call = self.hub.operations().list();
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                "page-token" => {
+                    call = call.page_token(value.unwrap_or(""));
+                },
+                "page-size" => {
+                    call = call.page_size(arg_from_str(value.unwrap_or("-0"), err, "page-size", "integer"));
+                },
+                "name" => {
+                    call = call.name(value.unwrap_or(""));
+                },
+                "filter" => {
+                    call = call.filter(value.unwrap_or(""));
+                },
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v.extend(["filter", "page-token", "name", "page-size"].iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _speech_asyncrecognize(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    "audio.content" => Some(("audio.content", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "audio.uri" => Some(("audio.uri", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "config.language-code" => Some(("config.languageCode", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "config.speech-context.phrases" => Some(("config.speechContext.phrases", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Vec })),
+                    "config.encoding" => Some(("config.encoding", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "config.max-alternatives" => Some(("config.maxAlternatives", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Pod })),
+                    "config.profanity-filter" => Some(("config.profanityFilter", JsonTypeInfo { jtype: JsonType::Boolean, ctype: ComplexType::Pod })),
+                    "config.sample-rate" => Some(("config.sampleRate", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Pod })),
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec!["audio", "config", "content", "encoding", "language-code", "max-alternatives", "phrases", "profanity-filter", "sample-rate", "speech-context", "uri"]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::AsyncRecognizeRequest = json::value::from_value(object).unwrap();
+        let mut call = self.hub.speech().asyncrecognize(request);
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _speech_syncrecognize(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    "audio.content" => Some(("audio.content", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "audio.uri" => Some(("audio.uri", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "config.language-code" => Some(("config.languageCode", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "config.speech-context.phrases" => Some(("config.speechContext.phrases", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Vec })),
+                    "config.encoding" => Some(("config.encoding", JsonTypeInfo { jtype: JsonType::String, ctype: ComplexType::Pod })),
+                    "config.max-alternatives" => Some(("config.maxAlternatives", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Pod })),
+                    "config.profanity-filter" => Some(("config.profanityFilter", JsonTypeInfo { jtype: JsonType::Boolean, ctype: ComplexType::Pod })),
+                    "config.sample-rate" => Some(("config.sampleRate", JsonTypeInfo { jtype: JsonType::Int, ctype: ComplexType::Pod })),
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec!["audio", "config", "content", "encoding", "language-code", "max-alternatives", "phrases", "profanity-filter", "sample-rate", "speech-context", "uri"]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::SyncRecognizeRequest = json::value::from_value(object).unwrap();
+        let mut call = self.hub.speech().syncrecognize(request);
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _doit(&self, dry_run: bool) -> Result<Result<(), DoitError>, Option<InvalidOptionsError>> {
+        let mut err = InvalidOptionsError::new();
+        let mut call_result: Result<(), DoitError> = Ok(());
+        let mut err_opt: Option<InvalidOptionsError> = None;
+        match self.opt.subcommand() {
+            ("operations", Some(opt)) => {
+                match opt.subcommand() {
+                    ("cancel", Some(opt)) => {
+                        call_result = self._operations_cancel(opt, dry_run, &mut err);
+                    },
+                    ("delete", Some(opt)) => {
+                        call_result = self._operations_delete(opt, dry_run, &mut err);
+                    },
+                    ("get", Some(opt)) => {
+                        call_result = self._operations_get(opt, dry_run, &mut err);
+                    },
+                    ("list", Some(opt)) => {
+                        call_result = self._operations_list(opt, dry_run, &mut err);
+                    },
+                    _ => {
+                        err.issues.push(CLIError::MissingMethodError("operations".to_string()));
+                        writeln!(io::stderr(), "{}\n", opt.usage()).ok();
+                    }
+                }
+            },
+            ("speech", Some(opt)) => {
+                match opt.subcommand() {
+                    ("asyncrecognize", Some(opt)) => {
+                        call_result = self._speech_asyncrecognize(opt, dry_run, &mut err);
+                    },
+                    ("syncrecognize", Some(opt)) => {
+                        call_result = self._speech_syncrecognize(opt, dry_run, &mut err);
+                    },
+                    _ => {
+                        err.issues.push(CLIError::MissingMethodError("speech".to_string()));
+                        writeln!(io::stderr(), "{}\n", opt.usage()).ok();
+                    }
+                }
+            },
+            _ => {
+                err.issues.push(CLIError::MissingCommandError);
+                writeln!(io::stderr(), "{}\n", self.opt.usage()).ok();
+            }
+        }
+
+        if dry_run {
+            if err.issues.len() > 0 {
+                err_opt = Some(err);
+            }
+            Err(err_opt)
+        } else {
+            Ok(call_result)
+        }
+    }
+
+    // Please note that this call will fail if any part of the opt can't be handled
+    fn new(opt: ArgMatches<'n>) -> Result<Engine<'n>, InvalidOptionsError> {
+        let (config_dir, secret) = {
+            let config_dir = match cmn::assure_config_dir_exists(opt.value_of("folder").unwrap_or("~/.google-service-cli")) {
+                Err(e) => return Err(InvalidOptionsError::single(e, 3)),
+                Ok(p) => p,
+            };
+
+            match cmn::application_secret_from_directory(&config_dir, "speech1-beta1-secret.json",
+                                                         "{\"installed\":{\"auth_uri\":\"https://accounts.google.com/o/oauth2/auth\",\"client_secret\":\"hCsslbCUyfehWMmbkG8vTYxG\",\"token_uri\":\"https://accounts.google.com/o/oauth2/token\",\"client_email\":\"\",\"redirect_uris\":[\"urn:ietf:wg:oauth:2.0:oob\",\"oob\"],\"client_x509_cert_url\":\"\",\"client_id\":\"620010449518-9ngf7o4dhs0dka470npqvor6dc5lqb9b.apps.googleusercontent.com\",\"auth_provider_x509_cert_url\":\"https://www.googleapis.com/oauth2/v1/certs\"}}") {
+                Ok(secret) => (config_dir, secret),
+                Err(e) => return Err(InvalidOptionsError::single(e, 4))
+            }
+        };
+
+        let auth = Authenticator::new(  &secret, DefaultAuthenticatorDelegate,
+                                        if opt.is_present("debug-auth") {
+                                            hyper::Client::with_connector(mock::TeeConnector {
+                                                    connector: hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())
+                                                })
+                                        } else {
+                                            hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new()))
+                                        },
+                                        JsonTokenStorage {
+                                          program_name: "speech1-beta1",
+                                          db_dir: config_dir.clone(),
+                                        }, Some(FlowType::InstalledRedirect(54324)));
+
+        let client =
+            if opt.is_present("debug") {
+                hyper::Client::with_connector(mock::TeeConnector {
+                        connector: hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())
+                    })
+            } else {
+                hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new()))
+            };
+        let engine = Engine {
+            opt: opt,
+            hub: api::Speech::new(client, auth),
+            gp: vec!["$-xgafv", "access-token", "alt", "bearer-token", "callback", "fields", "key", "oauth-token", "pp", "pretty-print", "quota-user", "upload-type", "upload-protocol"],
+            gpm: vec![
+                    ("$-xgafv", "$.xgafv"),
+                    ("access-token", "access_token"),
+                    ("bearer-token", "bearer_token"),
+                    ("oauth-token", "oauth_token"),
+                    ("pretty-print", "prettyPrint"),
+                    ("quota-user", "quotaUser"),
+                    ("upload-type", "uploadType"),
+                    ("upload-protocol", "upload_protocol"),
+                ]
+        };
+
+        match engine._doit(true) {
+            Err(Some(err)) => Err(err),
+            Err(None)      => Ok(engine),
+            Ok(_)          => unreachable!(),
+        }
+    }
+
+    fn doit(&self) -> Result<(), DoitError> {
+        match self._doit(false) {
+            Ok(res) => res,
+            Err(_) => unreachable!(),
+        }
+    }
+}
+
+fn main() {
+    let mut exit_status = 0i32;
+    let arg_data = [
+        ("operations", "methods: 'cancel', 'delete', 'get' and 'list'", vec![
+            ("cancel",
+                    Some(r##"Starts asynchronous cancellation on a long-running operation.  The server
+        makes a best effort to cancel the operation, but success is not
+        guaranteed.  If the server doesn't support this method, it returns
+        `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
+        Operations.GetOperation or
+        other methods to check whether the cancellation succeeded or whether the
+        operation completed despite cancellation. On successful cancellation,
+        the operation is not deleted; instead, it becomes an operation with
+        an Operation.error value with a google.rpc.Status.code of 1,
+        corresponding to `Code.CANCELLED`."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_speech1_beta1_cli/operations_cancel",
+                  vec![
+                    (Some(r##"name"##),
+                     None,
+                     Some(r##"The name of the operation resource to be cancelled."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("delete",
+                    Some(r##"Deletes a long-running operation. This method indicates that the client is
+        no longer interested in the operation result. It does not cancel the
+        operation. If the server doesn't support this method, it returns
+        `google.rpc.Code.UNIMPLEMENTED`."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_speech1_beta1_cli/operations_delete",
+                  vec![
+                    (Some(r##"name"##),
+                     None,
+                     Some(r##"The name of the operation resource to be deleted."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("get",
+                    Some(r##"Gets the latest state of a long-running operation.  Clients can use this
+        method to poll the operation result at intervals as recommended by the API
+        service."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_speech1_beta1_cli/operations_get",
+                  vec![
+                    (Some(r##"name"##),
+                     None,
+                     Some(r##"The name of the operation resource."##),
+                     Some(true),
+                     Some(false)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("list",
+                    Some(r##"Lists operations that match the specified filter in the request. If the
+        server doesn't support this method, it returns `UNIMPLEMENTED`.
+        
+        NOTE: the `name` binding allows API services to override the binding
+        to use different resource name schemes, such as `users/*/operations`. To
+        override the binding, API services can add a binding such as
+        `"/v1/{name=users/*}/operations"` to their service configuration.
+        For backwards compatibility, the default name includes the operations
+        collection id, however overriding users must ensure the name binding
+        is the parent resource, without the operations collection id."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_speech1_beta1_cli/operations_list",
+                  vec![
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ]),
+        
+        ("speech", "methods: 'asyncrecognize' and 'syncrecognize'", vec![
+            ("asyncrecognize",
+                    Some(r##"Performs asynchronous speech recognition: receive results via the
+        [google.longrunning.Operations]
+        (/speech/reference/rest/v1beta1/operations#Operation)
+        interface. Returns either an
+        `Operation.error` or an `Operation.response` which contains
+        an `AsyncRecognizeResponse` message."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_speech1_beta1_cli/speech_asyncrecognize",
+                  vec![
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ("syncrecognize",
+                    Some(r##"Performs synchronous speech recognition: receive results after all audio
+        has been sent and processed."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_speech1_beta1_cli/speech_syncrecognize",
+                  vec![
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ]),
+        
+    ];
+    
+    let mut app = App::new("speech1-beta1")
+           .author("Sebastian Thiel <byronimo@gmail.com>")
+           .version("1.0.7+20171205")
+           .about("Converts audio to text by applying powerful neural network models.")
+           .after_help("All documentation details can be found at http://byron.github.io/google-apis-rs/google_speech1_beta1_cli")
+           .arg(Arg::with_name("url")
+                   .long("scope")
+                   .help("Specify the authentication a method should be executed in. Each scope requires the user to grant this application permission to use it.If unset, it defaults to the shortest scope url for a particular method.")
+                   .multiple(true)
+                   .takes_value(true))
+           .arg(Arg::with_name("folder")
+                   .long("config-dir")
+                   .help("A directory into which we will store our persistent data. Defaults to a user-writable directory that we will create during the first invocation.[default: ~/.google-service-cli")
+                   .multiple(false)
+                   .takes_value(true))
+           .arg(Arg::with_name("debug")
+                   .long("debug")
+                   .help("Output all server communication to standard error. `tx` and `rx` are placed into the same stream.")
+                   .multiple(false)
+                   .takes_value(false))
+           .arg(Arg::with_name("debug-auth")
+                   .long("debug-auth")
+                   .help("Output all communication related to authentication to standard error. `tx` and `rx` are placed into the same stream.")
+                   .multiple(false)
+                   .takes_value(false));
+           
+           for &(main_command_name, about, ref subcommands) in arg_data.iter() {
+               let mut mcmd = SubCommand::with_name(main_command_name).about(about);
+           
+               for &(sub_command_name, ref desc, url_info, ref args) in subcommands {
+                   let mut scmd = SubCommand::with_name(sub_command_name);
+                   if let &Some(desc) = desc {
+                       scmd = scmd.about(desc);
+                   }
+                   scmd = scmd.after_help(url_info);
+           
+                   for &(ref arg_name, ref flag, ref desc, ref required, ref multi) in args {
+                       let arg_name_str =
+                           match (arg_name, flag) {
+                                   (&Some(an), _       ) => an,
+                                   (_        , &Some(f)) => f,
+                                    _                    => unreachable!(),
+                            };
+                       let mut arg = Arg::with_name(arg_name_str)
+                                         .empty_values(false);
+                       if let &Some(short_flag) = flag {
+                           arg = arg.short(short_flag);
+                       }
+                       if let &Some(desc) = desc {
+                           arg = arg.help(desc);
+                       }
+                       if arg_name.is_some() && flag.is_some() {
+                           arg = arg.takes_value(true);
+                       }
+                       if let &Some(required) = required {
+                           arg = arg.required(required);
+                       }
+                       if let &Some(multi) = multi {
+                           arg = arg.multiple(multi);
+                       }
+                       scmd = scmd.arg(arg);
+                   }
+                   mcmd = mcmd.subcommand(scmd);
+               }
+               app = app.subcommand(mcmd);
+           }
+           
+        let matches = app.get_matches();
+
+    let debug = matches.is_present("debug");
+    match Engine::new(matches) {
+        Err(err) => {
+            exit_status = err.exit_code;
+            writeln!(io::stderr(), "{}", err).ok();
+        },
+        Ok(engine) => {
+            if let Err(doit_err) = engine.doit() {
+                exit_status = 1;
+                match doit_err {
+                    DoitError::IoError(path, err) => {
+                        writeln!(io::stderr(), "Failed to open output file '{}': {}", path, err).ok();
+                    },
+                    DoitError::ApiError(err) => {
+                        if debug {
+                            writeln!(io::stderr(), "{:#?}", err).ok();
+                        } else {
+                            writeln!(io::stderr(), "{}", err).ok();
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    std::process::exit(exit_status);
+}

--- a/gen/speech1_beta1/Cargo.toml
+++ b/gen/speech1_beta1/Cargo.toml
@@ -1,0 +1,31 @@
+# DO NOT EDIT !
+# This file was generated automatically from 'src/mako/Cargo.toml.mako'
+# DO NOT EDIT !
+[package]
+
+name = "google-speech1_beta1"
+version = "1.0.7+20171205"
+authors = ["Sebastian Thiel <byronimo@gmail.com>"]
+description = "A complete library to interact with Speech (protocol v1beta1)"
+repository = "https://github.com/Byron/google-apis-rs/tree/master/gen/speech1_beta1"
+homepage = "https://cloud.google.com/speech/"
+documentation = "https://docs.rs/google-speech1_beta1/1.0.7+20171205"
+license = "MIT"
+keywords = ["speech", "google", "protocol", "web", "api"]
+
+
+[dev-dependencies]
+hyper-rustls = "^0.6"
+
+[dependencies]
+hyper = "^ 0.10"
+mime = "^ 0.2.0"
+serde = "^ 1.0"
+serde_json = "^ 1.0"
+serde_derive = "^ 1.0"
+yup-oauth2 = "^ 1.0"
+url = "= 0.5"
+
+[features]
+
+

--- a/gen/speech1_beta1/LICENSE.md
+++ b/gen/speech1_beta1/LICENSE.md
@@ -1,0 +1,30 @@
+<!---
+DO NOT EDIT !
+This file was generated automatically from 'src/mako/LICENSE.md.mako'
+DO NOT EDIT !
+-->
+The MIT License (MIT)
+=====================
+
+Copyright © `2015-2016` `Sebastian Thiel`
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the “Software”), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.

--- a/gen/speech1_beta1/README.md
+++ b/gen/speech1_beta1/README.md
@@ -1,0 +1,184 @@
+<!---
+DO NOT EDIT !
+This file was generated automatically from 'src/mako/api/README.md.mako'
+DO NOT EDIT !
+-->
+The `google-speech1_beta1` library allows access to all features of the *Google Speech* service.
+
+This documentation was generated from *Speech* crate version *1.0.7+20171205*, where *20171205* is the exact revision of the *speech:v1beta1* schema built by the [mako](http://www.makotemplates.org/) code generator *v1.0.7*.
+
+Everything else about the *Speech* *v1_beta1* API can be found at the
+[official documentation site](https://cloud.google.com/speech/).
+# Features
+
+Handle the following *Resources* with ease from the central [hub](https://docs.rs/google-speech1_beta1/1.0.7+20171205/google_speech1_beta1/struct.Speech.html) ... 
+
+* [operations](https://docs.rs/google-speech1_beta1/1.0.7+20171205/google_speech1_beta1/struct.Operation.html)
+ * [*cancel*](https://docs.rs/google-speech1_beta1/1.0.7+20171205/google_speech1_beta1/struct.OperationCancelCall.html), [*delete*](https://docs.rs/google-speech1_beta1/1.0.7+20171205/google_speech1_beta1/struct.OperationDeleteCall.html), [*get*](https://docs.rs/google-speech1_beta1/1.0.7+20171205/google_speech1_beta1/struct.OperationGetCall.html) and [*list*](https://docs.rs/google-speech1_beta1/1.0.7+20171205/google_speech1_beta1/struct.OperationListCall.html)
+* speech
+ * [*asyncrecognize*](https://docs.rs/google-speech1_beta1/1.0.7+20171205/google_speech1_beta1/struct.SpeechAsyncrecognizeCall.html) and [*syncrecognize*](https://docs.rs/google-speech1_beta1/1.0.7+20171205/google_speech1_beta1/struct.SpeechSyncrecognizeCall.html)
+
+
+
+
+# Structure of this Library
+
+The API is structured into the following primary items:
+
+* **[Hub](https://docs.rs/google-speech1_beta1/1.0.7+20171205/google_speech1_beta1/struct.Speech.html)**
+    * a central object to maintain state and allow accessing all *Activities*
+    * creates [*Method Builders*](https://docs.rs/google-speech1_beta1/1.0.7+20171205/google_speech1_beta1/trait.MethodsBuilder.html) which in turn
+      allow access to individual [*Call Builders*](https://docs.rs/google-speech1_beta1/1.0.7+20171205/google_speech1_beta1/trait.CallBuilder.html)
+* **[Resources](https://docs.rs/google-speech1_beta1/1.0.7+20171205/google_speech1_beta1/trait.Resource.html)**
+    * primary types that you can apply *Activities* to
+    * a collection of properties and *Parts*
+    * **[Parts](https://docs.rs/google-speech1_beta1/1.0.7+20171205/google_speech1_beta1/trait.Part.html)**
+        * a collection of properties
+        * never directly used in *Activities*
+* **[Activities](https://docs.rs/google-speech1_beta1/1.0.7+20171205/google_speech1_beta1/trait.CallBuilder.html)**
+    * operations to apply to *Resources*
+
+All *structures* are marked with applicable traits to further categorize them and ease browsing.
+
+Generally speaking, you can invoke *Activities* like this:
+
+```Rust,ignore
+let r = hub.resource().activity(...).doit()
+```
+
+Or specifically ...
+
+```ignore
+let r = hub.speech().asyncrecognize(...).doit()
+let r = hub.operations().delete(...).doit()
+let r = hub.operations().list(...).doit()
+let r = hub.operations().cancel(...).doit()
+let r = hub.operations().get(...).doit()
+```
+
+The `resource()` and `activity(...)` calls create [builders][builder-pattern]. The second one dealing with `Activities` 
+supports various methods to configure the impending operation (not shown here). It is made such that all required arguments have to be 
+specified right away (i.e. `(...)`), whereas all optional ones can be [build up][builder-pattern] as desired.
+The `doit()` method performs the actual communication with the server and returns the respective result.
+
+# Usage
+
+## Setting up your Project
+
+To use this library, you would put the following lines into your `Cargo.toml` file:
+
+```toml
+[dependencies]
+google-speech1_beta1 = "*"
+```
+
+## A complete example
+
+```Rust
+extern crate hyper;
+extern crate hyper_rustls;
+extern crate yup_oauth2 as oauth2;
+extern crate google_speech1_beta1 as speech1_beta1;
+use speech1_beta1::{Result, Error};
+use std::default::Default;
+use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+use speech1_beta1::Speech;
+
+// Get an ApplicationSecret instance by some means. It contains the `client_id` and 
+// `client_secret`, among other things.
+let secret: ApplicationSecret = Default::default();
+// Instantiate the authenticator. It will choose a suitable authentication flow for you, 
+// unless you replace  `None` with the desired Flow.
+// Provide your own `AuthenticatorDelegate` to adjust the way it operates and get feedback about 
+// what's going on. You probably want to bring in your own `TokenStorage` to persist tokens and
+// retrieve them from storage.
+let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+                              hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+                              <MemoryStorage as Default>::default(), None);
+let mut hub = Speech::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+// You can configure optional parameters by calling the respective setters at will, and
+// execute the final call using `doit()`.
+// Values shown here are possibly random and not representative !
+let result = hub.operations().list()
+             .page_token("eirmod")
+             .page_size(-48)
+             .name("Stet")
+             .filter("sed")
+             .doit();
+
+match result {
+    Err(e) => match e {
+        // The Error enum provides details about what exactly happened.
+        // You can also just use its `Debug`, `Display` or `Error` traits
+         Error::HttpError(_)
+        |Error::MissingAPIKey
+        |Error::MissingToken(_)
+        |Error::Cancelled
+        |Error::UploadSizeLimitExceeded(_, _)
+        |Error::Failure(_)
+        |Error::BadRequest(_)
+        |Error::FieldClash(_)
+        |Error::JsonDecodeError(_, _) => println!("{}", e),
+    },
+    Ok(res) => println!("Success: {:?}", res),
+}
+
+```
+## Handling Errors
+
+All errors produced by the system are provided either as [Result](https://docs.rs/google-speech1_beta1/1.0.7+20171205/google_speech1_beta1/enum.Result.html) enumeration as return value of 
+the doit() methods, or handed as possibly intermediate results to either the 
+[Hub Delegate](https://docs.rs/google-speech1_beta1/1.0.7+20171205/google_speech1_beta1/trait.Delegate.html), or the [Authenticator Delegate](https://docs.rs/yup-oauth2/*/yup_oauth2/trait.AuthenticatorDelegate.html).
+
+When delegates handle errors or intermediate values, they may have a chance to instruct the system to retry. This 
+makes the system potentially resilient to all kinds of errors.
+
+## Uploads and Downloads
+If a method supports downloads, the response body, which is part of the [Result](https://docs.rs/google-speech1_beta1/1.0.7+20171205/google_speech1_beta1/enum.Result.html), should be
+read by you to obtain the media.
+If such a method also supports a [Response Result](https://docs.rs/google-speech1_beta1/1.0.7+20171205/google_speech1_beta1/trait.ResponseResult.html), it will return that by default.
+You can see it as meta-data for the actual media. To trigger a media download, you will have to set up the builder by making
+this call: `.param("alt", "media")`.
+
+Methods supporting uploads can do so using up to 2 different protocols: 
+*simple* and *resumable*. The distinctiveness of each is represented by customized 
+`doit(...)` methods, which are then named `upload(...)` and `upload_resumable(...)` respectively.
+
+## Customization and Callbacks
+
+You may alter the way an `doit()` method is called by providing a [delegate](https://docs.rs/google-speech1_beta1/1.0.7+20171205/google_speech1_beta1/trait.Delegate.html) to the 
+[Method Builder](https://docs.rs/google-speech1_beta1/1.0.7+20171205/google_speech1_beta1/trait.CallBuilder.html) before making the final `doit()` call. 
+Respective methods will be called to provide progress information, as well as determine whether the system should 
+retry on failure.
+
+The [delegate trait](https://docs.rs/google-speech1_beta1/1.0.7+20171205/google_speech1_beta1/trait.Delegate.html) is default-implemented, allowing you to customize it with minimal effort.
+
+## Optional Parts in Server-Requests
+
+All structures provided by this library are made to be [enocodable](https://docs.rs/google-speech1_beta1/1.0.7+20171205/google_speech1_beta1/trait.RequestValue.html) and 
+[decodable](https://docs.rs/google-speech1_beta1/1.0.7+20171205/google_speech1_beta1/trait.ResponseResult.html) via *json*. Optionals are used to indicate that partial requests are responses 
+are valid.
+Most optionals are are considered [Parts](https://docs.rs/google-speech1_beta1/1.0.7+20171205/google_speech1_beta1/trait.Part.html) which are identifiable by name, which will be sent to 
+the server to indicate either the set parts of the request or the desired parts in the response.
+
+## Builder Arguments
+
+Using [method builders](https://docs.rs/google-speech1_beta1/1.0.7+20171205/google_speech1_beta1/trait.CallBuilder.html), you are able to prepare an action call by repeatedly calling it's methods.
+These will always take a single argument, for which the following statements are true.
+
+* [PODs][wiki-pod] are handed by copy
+* strings are passed as `&str`
+* [request values](https://docs.rs/google-speech1_beta1/1.0.7+20171205/google_speech1_beta1/trait.RequestValue.html) are moved
+
+Arguments will always be copied or cloned into the builder, to make them independent of their original life times.
+
+[wiki-pod]: http://en.wikipedia.org/wiki/Plain_old_data_structure
+[builder-pattern]: http://en.wikipedia.org/wiki/Builder_pattern
+[google-go-api]: https://github.com/google/google-api-go-client
+
+# License
+The **speech1_beta1** library was generated by Sebastian Thiel, and is placed 
+under the *MIT* license.
+You can read the full text at the repository's [license file][repo-license].
+
+[repo-license]: https://github.com/Byron/google-apis-rsblob/master/LICENSE.md

--- a/gen/speech1_beta1/src/cmn.rs
+++ b/gen/speech1_beta1/src/cmn.rs
@@ -1,0 +1,753 @@
+// COPY OF 'src/rust/api/cmn.rs'
+// DO NOT EDIT
+use std::io::{self, Read, Seek, Cursor, Write, SeekFrom};
+use std;
+use std::fmt::{self, Display};
+use std::str::FromStr;
+use std::error;
+use std::thread::sleep;
+use std::time::Duration;
+
+use mime::{Mime, TopLevel, SubLevel, Attr, Value};
+use oauth2::{TokenType, Retry, self};
+use hyper;
+use hyper::header::{ContentType, ContentLength, Headers, UserAgent, Authorization, Header,
+                    HeaderFormat, Bearer};
+use hyper::http::h1::LINE_ENDING;
+use hyper::method::Method;
+use hyper::status::StatusCode;
+
+use serde_json as json;
+
+/// Identifies the Hub. There is only one per library, this trait is supposed
+/// to make intended use more explicit.
+/// The hub allows to access all resource methods more easily.
+pub trait Hub {}
+
+/// Identifies types for building methods of a particular resource type
+pub trait MethodsBuilder {}
+
+/// Identifies types which represent builders for a particular resource method
+pub trait CallBuilder {}
+
+/// Identifies types which can be inserted and deleted.
+/// Types with this trait are most commonly used by clients of this API.
+pub trait Resource {}
+
+/// Identifies types which are used in API responses.
+pub trait ResponseResult {}
+
+/// Identifies types which are used in API requests.
+pub trait RequestValue {}
+
+/// Identifies types which are not actually used by the API
+/// This might be a bug within the google API schema.
+pub trait UnusedType {}
+
+/// Identifies types which are only used as part of other types, which
+/// usually are carrying the `Resource` trait.
+pub trait Part {}
+
+/// Identifies types which are only used by other types internally.
+/// They have no special meaning, this trait just marks them for completeness.
+pub trait NestedType {}
+
+/// A utility to specify reader types which provide seeking capabilities too
+pub trait ReadSeek: Seek + Read {}
+impl<T: Seek + Read> ReadSeek for T {}
+
+/// A trait for all types that can convert themselves into a *parts* string
+pub trait ToParts {
+    fn to_parts(&self) -> String;
+}
+
+/// A utility type which can decode a server response that indicates error
+#[derive(Deserialize)]
+pub struct JsonServerError {
+    pub error: String,
+    pub error_description: Option<String>
+}
+
+/// A utility to represent detailed errors we might see in case there are BadRequests.
+/// The latter happen if the sent parameters or request structures are unsound
+#[derive(Deserialize, Serialize, Debug)]
+pub struct ErrorResponse {
+    error: ServerError,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct ServerError {
+    errors: Vec<ServerMessage>,
+    code: u16,
+    message: String,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct ServerMessage {
+    domain: String,
+    reason: String,
+    message: String,
+    #[serde(rename="locationType")]
+    location_type: Option<String>,
+    location: Option<String>
+}
+
+#[derive(Copy, Clone)]
+pub struct DummyNetworkStream;
+
+impl Read for DummyNetworkStream {
+    fn read(&mut self, _: &mut [u8]) -> io::Result<usize> {
+        Ok(0)
+    }
+}
+
+impl Write for DummyNetworkStream {
+    fn write(&mut self, _: &[u8]) -> io::Result<usize> {
+        Ok(0)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl hyper::net::NetworkStream for DummyNetworkStream {
+    fn peer_addr(&mut self) -> io::Result<std::net::SocketAddr> {
+        Ok("127.0.0.1:1337".parse().unwrap())
+    }
+
+    fn set_read_timeout(&self, _dur: Option<Duration>) -> io::Result<()> {
+        Ok(())
+    }
+
+    fn set_write_timeout(&self, _dur: Option<Duration>) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+
+/// A trait specifying functionality to help controlling any request performed by the API.
+/// The trait has a conservative default implementation.
+///
+/// It contains methods to deal with all common issues, as well with the ones related to
+/// uploading media
+pub trait Delegate {
+
+    /// Called at the beginning of any API request. The delegate should store the method
+    /// information if he is interesting in knowing more context when further calls to it
+    /// are made.
+    /// The matching `finished()` call will always be made, no matter whether or not the API
+    /// request was successful. That way, the delegate may easily maintain a clean state
+    /// between various API calls.
+    fn begin(&mut self, MethodInfo) {}
+
+    /// Called whenever there is an [HttpError](http://hyperium.github.io/hyper/hyper/error/enum.HttpError.html), usually if there are network problems.
+    ///
+    /// If you choose to retry after a duration, the duration should be chosen using the
+    /// [exponential backoff algorithm](http://en.wikipedia.org/wiki/Exponential_backoff).
+    ///
+    /// Return retry information.
+    fn http_error(&mut self, &hyper::Error) -> Retry {
+        Retry::Abort
+    }
+
+    /// Called whenever there is the need for your applications API key after
+    /// the official authenticator implementation didn't provide one, for some reason.
+    /// If this method returns None as well, the underlying operation will fail
+    fn api_key(&mut self) -> Option<String> {
+        None
+    }
+
+    /// Called whenever the Authenticator didn't yield a token. The delegate
+    /// may attempt to provide one, or just take it as a general information about the
+    /// impending failure.
+    /// The given Error provides information about why the token couldn't be acquired in the
+    /// first place
+    fn token(&mut self, err: &error::Error) -> Option<oauth2::Token> {
+        let _ = err;
+        None
+    }
+
+    /// Called during resumable uploads to provide a URL for the impending upload.
+    /// It was saved after a previous call to `store_upload_url(...)`, and if not None,
+    /// will be used instead of asking the server for a new upload URL.
+    /// This is useful in case a previous resumable upload was aborted/canceled, but should now
+    /// be resumed.
+    /// The returned URL will be used exactly once - if it fails again and the delegate allows
+    /// to retry, we will ask the server for a new upload URL.
+    fn upload_url(&mut self) -> Option<String> {
+        None
+    }
+
+    /// Called after we have retrieved a new upload URL for a resumable upload to store it
+    /// in case we fail or cancel. That way, we can attempt to resume the upload later,
+    /// see `upload_url()`.
+    /// It will also be called with None after a successful upload, which allows the delegate
+    /// to forget the URL. That way, we will not attempt to resume an upload that has already
+    /// finished.
+    fn store_upload_url(&mut self, url: Option<&str>) {
+        let _ = url;
+    }
+
+    /// Called whenever a server response could not be decoded from json.
+    /// It's for informational purposes only, the caller will return with an error
+    /// accordingly.
+    ///
+    /// # Arguments
+    ///
+    /// * `json_encoded_value` - The json-encoded value which failed to decode.
+    /// * `json_decode_error`  - The decoder error
+    fn response_json_decode_error(&mut self, json_encoded_value: &str, json_decode_error: &json::Error) {
+        let _ = json_encoded_value;
+        let _ = json_decode_error;
+    }
+
+    /// Called whenever the http request returns with a non-success status code.
+    /// This can involve authentication issues, or anything else that very much
+    /// depends on the used API method.
+    /// The delegate should check the status, header and decoded json error to decide
+    /// whether to retry or not. In the latter case, the underlying call will fail.
+    ///
+    /// If you choose to retry after a duration, the duration should be chosen using the
+    /// [exponential backoff algorithm](http://en.wikipedia.org/wiki/Exponential_backoff).
+    fn http_failure(&mut self, _: &hyper::client::Response, Option<JsonServerError>, _: Option<ServerError>) -> Retry {
+        Retry::Abort
+    }
+
+    /// Called prior to sending the main request of the given method. It can be used to time
+    /// the call or to print progress information.
+    /// It's also useful as you can be sure that a request will definitely be made.
+    fn pre_request(&mut self) { }
+
+    /// Return the size of each chunk of a resumable upload.
+    /// Must be a power of two, with 1<<18 being the smallest allowed chunk size.
+    /// Will be called once before starting any resumable upload.
+    fn chunk_size(&mut self) -> u64 {
+        1 << 23
+    }
+
+    /// Called before the given chunk is uploaded to the server.
+    /// If true is returned, the upload will be interrupted.
+    /// However, it may be resumable if you stored the upload URL in a previous call
+    /// to `store_upload_url()`
+    fn cancel_chunk_upload(&mut self, chunk: &ContentRange) -> bool {
+        let _ = chunk;
+        false
+    }
+
+    /// Called before the API request method returns, in every case. It can be used to clean up
+    /// internal state between calls to the API.
+    /// This call always has a matching call to `begin(...)`.
+    ///
+    /// # Arguments
+    ///
+    /// * `is_success` - a true value indicates the operation was successful. If false, you should
+    ///                  discard all values stored during `store_upload_url`.
+    fn finished(&mut self, is_success: bool) {
+        let _ = is_success;
+    }
+}
+
+/// A delegate with a conservative default implementation, which is used if no other delegate is
+/// set.
+#[derive(Default)]
+pub struct DefaultDelegate;
+
+impl Delegate for DefaultDelegate {}
+
+
+#[derive(Debug)]
+pub enum Error {
+    /// The http connection failed
+    HttpError(hyper::Error),
+
+    /// An attempt was made to upload a resource with size stored in field `.0`
+    /// even though the maximum upload size is what is stored in field `.1`.
+    UploadSizeLimitExceeded(u64, u64),
+
+    /// Represents information about a request that was not understood by the server.
+    /// Details are included.
+    BadRequest(ErrorResponse),
+
+    /// We needed an API key for authentication, but didn't obtain one.
+    /// Neither through the authenticator, nor through the Delegate.
+    MissingAPIKey,
+
+    /// We required a Token, but didn't get one from the Authenticator
+    MissingToken(Box<error::Error>),
+
+    /// The delgate instructed to cancel the operation
+    Cancelled,
+
+    /// An additional, free form field clashed with one of the built-in optional ones
+    FieldClash(&'static str),
+
+    /// Shows that we failed to decode the server response.
+    /// This can happen if the protocol changes in conjunction with strict json decoding.
+    JsonDecodeError(String, json::Error),
+
+    /// Indicates an HTTP repsonse with a non-success status code
+    Failure(hyper::client::Response),
+}
+
+
+impl Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Error::HttpError(ref err) => err.fmt(f),
+            Error::UploadSizeLimitExceeded(ref resource_size, ref max_size) =>
+                writeln!(f, "The media size {} exceeds the maximum allowed upload size of {}"
+                         , resource_size, max_size),
+            Error::MissingAPIKey => {
+                (writeln!(f, "The application's API key was not found in the configuration")).ok();
+                writeln!(f, "It is used as there are no Scopes defined for this method.")
+            },
+            Error::BadRequest(ref err) => {
+                try!(writeln!(f, "Bad Request ({}): {}", err.error.code, err.error.message));
+                for err in err.error.errors.iter() {
+                    try!(writeln!(f, "    {}: {}, {}{}",
+                                            err.domain,
+                                            err.message,
+                                            err.reason,
+                                            match &err.location {
+                                                &Some(ref loc) => format!("@{}", loc),
+                                                &None => String::new(),
+                                            }));
+                }
+                Ok(())
+            },
+            Error::MissingToken(ref err) =>
+                writeln!(f, "Token retrieval failed with error: {}", err),
+            Error::Cancelled =>
+                writeln!(f, "Operation cancelled by delegate"),
+            Error::FieldClash(field) =>
+                writeln!(f, "The custom parameter '{}' is already provided natively by the CallBuilder.", field),
+            Error::JsonDecodeError(ref json_str, ref err)
+                => writeln!(f, "{}: {}", err, json_str),
+            Error::Failure(ref response) =>
+                writeln!(f, "Http status indicates failure: {:?}", response),
+        }
+    }
+}
+
+impl error::Error for Error {
+    fn description(&self) -> &str {
+        match *self {
+            Error::HttpError(ref err) => err.description(),
+            Error::JsonDecodeError(_, ref err) => err.description(),
+            _ => "NO DESCRIPTION POSSIBLE - use `Display.fmt()` instead"
+        }
+    }
+
+    fn cause(&self) -> Option<&error::Error> {
+        match *self {
+            Error::HttpError(ref err) => err.cause(),
+            Error::JsonDecodeError(_, ref err) => err.cause(),
+            _ => None
+        }
+    }
+}
+
+/// A universal result type used as return for all calls.
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Contains information about an API request.
+pub struct MethodInfo {
+    pub id: &'static str,
+    pub http_method: Method,
+}
+
+const BOUNDARY: &'static str = "MDuXWGyeE33QFXGchb2VFWc4Z7945d";
+
+/// Provides a `Read` interface that converts multiple parts into the protocol
+/// identified by [RFC2387](https://tools.ietf.org/html/rfc2387).
+/// **Note**: This implementation is just as rich as it needs to be to perform uploads
+/// to google APIs, and might not be a fully-featured implementation.
+#[derive(Default)]
+pub struct MultiPartReader<'a> {
+    raw_parts: Vec<(Headers, &'a mut Read)>,
+    current_part: Option<(Cursor<Vec<u8>>, &'a mut Read)>,
+    last_part_boundary: Option<Cursor<Vec<u8>>>,
+}
+
+impl<'a> MultiPartReader<'a> {
+
+    /// Reserve memory for exactly the given amount of parts
+    pub fn reserve_exact(&mut self, cap: usize) {
+        self.raw_parts.reserve_exact(cap);
+    }
+
+    /// Add a new part to the queue of parts to be read on the first `read` call.
+    ///
+    /// # Arguments
+    ///
+    /// `headers` - identifying the body of the part. It's similar to the header
+    ///             in an ordinary single-part call, and should thus contain the
+    ///             same information.
+    /// `reader`  - a reader providing the part's body
+    /// `size`    - the amount of bytes provided by the reader. It will be put onto the header as
+    ///             content-size.
+    /// `mime`    - It will be put onto the content type
+    pub fn add_part(&mut self, reader: &'a mut Read, size: u64, mime_type: Mime) -> &mut MultiPartReader<'a> {
+        let mut headers = Headers::new();
+        headers.set(ContentType(mime_type));
+        headers.set(ContentLength(size));
+        self.raw_parts.push((headers, reader));
+        self
+    }
+
+    /// Returns the mime-type representing our multi-part message.
+    /// Use it with the ContentType header.
+    pub fn mime_type(&self) -> Mime {
+        Mime(
+            TopLevel::Multipart,
+            SubLevel::Ext("Related".to_string()),
+            vec![(Attr::Ext("boundary".to_string()), Value::Ext(BOUNDARY.to_string()))],
+        )
+    }
+
+    /// Returns true if we are totally used
+    fn is_depleted(&self) -> bool {
+        self.raw_parts.len() == 0 && self.current_part.is_none() && self.last_part_boundary.is_none()
+    }
+
+    /// Returns true if we are handling our last part
+    fn is_last_part(&self) -> bool {
+        self.raw_parts.len() == 0 && self.current_part.is_some()
+    }
+}
+
+impl<'a> Read for MultiPartReader<'a> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        match (self.raw_parts.len(),
+               self.current_part.is_none(),
+               self.last_part_boundary.is_none()) {
+            (_, _, false) => {
+                let br = self.last_part_boundary.as_mut().unwrap().read(buf).unwrap_or(0);
+                if br < buf.len() {
+                    self.last_part_boundary = None;
+                }
+                return Ok(br)
+            },
+            (0, true, true) => return Ok(0),
+            (n, true, _) if n > 0 => {
+                let (headers, reader) = self.raw_parts.remove(0);
+                let mut c = Cursor::new(Vec::<u8>::new());
+                (write!(&mut c, "{}--{}{}{}{}", LINE_ENDING, BOUNDARY, LINE_ENDING,
+                                                headers, LINE_ENDING)).unwrap();
+                c.seek(SeekFrom::Start(0)).unwrap();
+                self.current_part = Some((c, reader));
+            }
+            _ => {},
+        }
+
+        // read headers as long as possible
+        let (hb, rr) = {
+            let &mut (ref mut c, ref mut reader) = self.current_part.as_mut().unwrap();
+            let b = c.read(buf).unwrap_or(0);
+            (b, reader.read(&mut buf[b..]))
+        };
+
+        match rr {
+            Ok(bytes_read) => {
+                if hb < buf.len() && bytes_read == 0 {
+                    if self.is_last_part() {
+                        // before clearing the last part, we will add the boundary that
+                        // will be written last
+                        self.last_part_boundary = Some(Cursor::new(
+                                                        format!("{}--{}--", LINE_ENDING, BOUNDARY).into_bytes()))
+                    }
+                    // We are depleted - this can trigger the next part to come in
+                    self.current_part = None;
+                }
+                let mut total_bytes_read = hb + bytes_read;
+                while total_bytes_read < buf.len() && !self.is_depleted() {
+                    match self.read(&mut buf[total_bytes_read ..]) {
+                        Ok(br) => total_bytes_read += br,
+                        Err(err) => return Err(err),
+                    }
+                }
+                Ok(total_bytes_read)
+            }
+            Err(err) => {
+                // fail permanently
+                self.current_part = None;
+                self.last_part_boundary = None;
+                self.raw_parts.clear();
+                Err(err)
+            }
+        }
+    }
+}
+
+/// The `X-Upload-Content-Type` header.
+///
+/// Generated via rustc --pretty expanded -Z unstable-options, and manually
+/// processed to be more readable.
+#[derive(PartialEq, Debug, Clone)]
+pub struct XUploadContentType(pub Mime);
+
+impl ::std::ops::Deref for XUploadContentType {
+    type Target = Mime;
+    fn deref<'a>(&'a self) -> &'a Mime { &self.0 }
+}
+impl ::std::ops::DerefMut for XUploadContentType {
+    fn deref_mut<'a>(&'a mut self) -> &'a mut Mime { &mut self.0 }
+}
+impl Header for XUploadContentType {
+    fn header_name() -> &'static str { "X-Upload-Content-Type" }
+    fn parse_header(raw: &[Vec<u8>]) -> hyper::error::Result<Self> {
+        hyper::header::parsing::from_one_raw_str(raw).map(XUploadContentType)
+    }
+}
+impl HeaderFormat for XUploadContentType {
+    fn fmt_header(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        Display::fmt(&**self, f)
+    }
+}
+impl Display for XUploadContentType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(&**self, f)
+    }
+}
+
+#[derive(Clone, PartialEq, Debug)]
+pub struct Chunk {
+    pub first: u64,
+    pub last: u64
+}
+
+impl fmt::Display for Chunk {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        (write!(fmt, "{}-{}", self.first, self.last)).ok();
+        Ok(())
+    }
+}
+
+impl FromStr for Chunk {
+    type Err = &'static str;
+
+    /// NOTE: only implements `%i-%i`, not `*`
+    fn from_str(s: &str) -> std::result::Result<Chunk, &'static str> {
+        let parts: Vec<&str> = s.split('-').collect();
+        if parts.len() != 2 {
+            return Err("Expected two parts: %i-%i")
+        }
+        Ok(
+            Chunk {
+                first: match FromStr::from_str(parts[0]) {
+                    Ok(d) => d,
+                    _ => return Err("Couldn't parse 'first' as digit")
+                },
+                last: match FromStr::from_str(parts[1]) {
+                    Ok(d) => d,
+                    _ => return Err("Couldn't parse 'last' as digit")
+                }
+            }
+        )
+    }
+}
+
+/// Implements the Content-Range header, for serialization only
+#[derive(Clone, PartialEq, Debug)]
+pub struct ContentRange {
+    pub range: Option<Chunk>,
+    pub total_length: u64,
+}
+
+impl Header for ContentRange {
+    fn header_name() -> &'static str {
+        "Content-Range"
+    }
+
+    /// We are not parsable, as parsing is done by the `Range` header
+    fn parse_header(_: &[Vec<u8>]) -> hyper::error::Result<Self> {
+        Err(hyper::error::Error::Method)
+    }
+}
+
+
+impl HeaderFormat for ContentRange {
+    fn fmt_header(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        try!(fmt.write_str("bytes "));
+        match self.range {
+            Some(ref c) => try!(c.fmt(fmt)),
+            None => try!(fmt.write_str("*"))
+        }
+        (write!(fmt, "/{}", self.total_length)).ok();
+        Ok(())
+    }
+}
+
+#[derive(Clone, PartialEq, Debug)]
+pub struct RangeResponseHeader(pub Chunk);
+
+impl Header for RangeResponseHeader {
+    fn header_name() -> &'static str {
+        "Range"
+    }
+
+    fn parse_header(raw: &[Vec<u8>]) -> hyper::error::Result<Self> {
+        if raw.len() > 0 {
+            let v = &raw[0];
+            if let Ok(s) = std::str::from_utf8(v) {
+                const PREFIX: &'static str = "bytes ";
+                if s.starts_with(PREFIX) {
+                    if let Ok(c) = <Chunk as FromStr>::from_str(&s[PREFIX.len()..]) {
+                        return  Ok(RangeResponseHeader(c))
+                    }
+                }
+            }
+        }
+        Err(hyper::error::Error::Method)
+    }
+}
+
+impl HeaderFormat for RangeResponseHeader {
+    /// No implmentation necessary, we just need to parse
+    fn fmt_header(&self, _: &mut fmt::Formatter) -> fmt::Result {
+        Err(fmt::Error)
+    }
+}
+
+/// A utility type to perform a resumable upload from start to end.
+pub struct ResumableUploadHelper<'a, A: 'a> {
+    pub client: &'a mut hyper::client::Client,
+    pub delegate: &'a mut Delegate,
+    pub start_at: Option<u64>,
+    pub auth: &'a mut A,
+    pub user_agent: &'a str,
+    pub auth_header: Authorization<Bearer>,
+    pub url: &'a str,
+    pub reader: &'a mut ReadSeek,
+    pub media_type: Mime,
+    pub content_length: u64
+}
+
+impl<'a, A> ResumableUploadHelper<'a, A>
+    where A: oauth2::GetToken {
+
+    fn query_transfer_status(&mut self) -> std::result::Result<u64, hyper::Result<hyper::client::Response>> {
+        loop {
+            match self.client.post(self.url)
+                .header(UserAgent(self.user_agent.to_string()))
+                .header(ContentRange { range: None, total_length: self.content_length })
+                .header(self.auth_header.clone())
+                .send() {
+                Ok(r) => {
+                    // 308 = resume-incomplete == PermanentRedirect
+                    let headers = r.headers.clone();
+                    let h: &RangeResponseHeader = match headers.get() {
+                        Some(hh) if r.status == StatusCode::PermanentRedirect => hh,
+                        None|Some(_) => {
+                            if let Retry::After(d) = self.delegate.http_failure(&r, None, None) {
+                                sleep(d);
+                                continue;
+                            }
+                            return Err(Ok(r))
+                        }
+                    };
+                    return Ok(h.0.last)
+                }
+                Err(err) => {
+                    if let Retry::After(d) = self.delegate.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    return Err(Err(err))
+                }
+            }
+        }
+    }
+
+    /// returns None if operation was cancelled by delegate, or the HttpResult.
+    /// It can be that we return the result just because we didn't understand the status code -
+    /// caller should check for status himself before assuming it's OK to use
+    pub fn upload(&mut self) -> Option<hyper::Result<hyper::client::Response>> {
+        let mut start = match self.start_at {
+            Some(s) => s,
+            None => match self.query_transfer_status() {
+                Ok(s) => s,
+                Err(result) => return Some(result)
+            }
+        };
+
+        const MIN_CHUNK_SIZE: u64 = 1 << 18;
+        let chunk_size = match self.delegate.chunk_size() {
+            cs if cs > MIN_CHUNK_SIZE => cs,
+            _ => MIN_CHUNK_SIZE
+        };
+
+        self.reader.seek(SeekFrom::Start(start)).unwrap();
+        loop {
+            let request_size = match self.content_length - start {
+                rs if rs > chunk_size => chunk_size,
+                rs => rs
+            };
+
+            let mut section_reader = self.reader.take(request_size);
+            let range_header = ContentRange {
+                range: Some(Chunk {first: start, last: start + request_size - 1}),
+                total_length: self.content_length
+            };
+            start += request_size;
+            if self.delegate.cancel_chunk_upload(&range_header) {
+                return None
+            }
+            let res = self.client.post(self.url)
+                                 .header(range_header)
+                                 .header(ContentType(self.media_type.clone()))
+                                 .header(UserAgent(self.user_agent.to_string()))
+                                 .body(&mut section_reader)
+                                 .send();
+            match res {
+                Ok(mut res) => {
+                    if res.status == StatusCode::PermanentRedirect  {
+                        continue
+                    }
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let Retry::After(d) = self.delegate.http_failure(&res,
+                                                        json::from_str(&json_err).ok(),
+                                                        json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                    }
+                    return Some(Ok(res))
+                },
+                Err(err) => {
+                    if let Retry::After(d) = self.delegate.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    return Some(Err(err))
+                }
+            }
+        }
+    }
+}
+
+// Copy of src/rust/cli/cmn.rs
+// TODO(ST): Allow sharing common code between program types
+pub fn remove_json_null_values(value: &mut json::value::Value) {
+    match *value {
+        json::value::Value::Object(ref mut map) => {
+            let mut for_removal = Vec::new();
+
+            for (key, mut value) in map.iter_mut() {
+                if value.is_null() {
+                    for_removal.push(key.clone());
+                } else {
+                    remove_json_null_values(&mut value);
+                }
+            }
+
+            for key in &for_removal {
+                map.remove(key);
+            }
+        }
+        _ => {}
+    }
+}

--- a/gen/speech1_beta1/src/lib.rs
+++ b/gen/speech1_beta1/src/lib.rs
@@ -1,0 +1,2493 @@
+// DO NOT EDIT !
+// This file was generated automatically from 'src/mako/api/lib.rs.mako'
+// DO NOT EDIT !
+
+//! This documentation was generated from *Speech* crate version *1.0.7+20171205*, where *20171205* is the exact revision of the *speech:v1beta1* schema built by the [mako](http://www.makotemplates.org/) code generator *v1.0.7*.
+//! 
+//! Everything else about the *Speech* *v1_beta1* API can be found at the
+//! [official documentation site](https://cloud.google.com/speech/).
+//! The original source code is [on github](https://github.com/Byron/google-apis-rs/tree/master/gen/speech1_beta1).
+//! # Features
+//! 
+//! Handle the following *Resources* with ease from the central [hub](struct.Speech.html) ... 
+//! 
+//! * [operations](struct.Operation.html)
+//!  * [*cancel*](struct.OperationCancelCall.html), [*delete*](struct.OperationDeleteCall.html), [*get*](struct.OperationGetCall.html) and [*list*](struct.OperationListCall.html)
+//! * speech
+//!  * [*asyncrecognize*](struct.SpeechAsyncrecognizeCall.html) and [*syncrecognize*](struct.SpeechSyncrecognizeCall.html)
+//! 
+//! 
+//! 
+//! 
+//! Not what you are looking for ? Find all other Google APIs in their Rust [documentation index](http://byron.github.io/google-apis-rs).
+//! 
+//! # Structure of this Library
+//! 
+//! The API is structured into the following primary items:
+//! 
+//! * **[Hub](struct.Speech.html)**
+//!     * a central object to maintain state and allow accessing all *Activities*
+//!     * creates [*Method Builders*](trait.MethodsBuilder.html) which in turn
+//!       allow access to individual [*Call Builders*](trait.CallBuilder.html)
+//! * **[Resources](trait.Resource.html)**
+//!     * primary types that you can apply *Activities* to
+//!     * a collection of properties and *Parts*
+//!     * **[Parts](trait.Part.html)**
+//!         * a collection of properties
+//!         * never directly used in *Activities*
+//! * **[Activities](trait.CallBuilder.html)**
+//!     * operations to apply to *Resources*
+//! 
+//! All *structures* are marked with applicable traits to further categorize them and ease browsing.
+//! 
+//! Generally speaking, you can invoke *Activities* like this:
+//! 
+//! ```Rust,ignore
+//! let r = hub.resource().activity(...).doit()
+//! ```
+//! 
+//! Or specifically ...
+//! 
+//! ```ignore
+//! let r = hub.speech().asyncrecognize(...).doit()
+//! let r = hub.operations().delete(...).doit()
+//! let r = hub.operations().list(...).doit()
+//! let r = hub.operations().cancel(...).doit()
+//! let r = hub.operations().get(...).doit()
+//! ```
+//! 
+//! The `resource()` and `activity(...)` calls create [builders][builder-pattern]. The second one dealing with `Activities` 
+//! supports various methods to configure the impending operation (not shown here). It is made such that all required arguments have to be 
+//! specified right away (i.e. `(...)`), whereas all optional ones can be [build up][builder-pattern] as desired.
+//! The `doit()` method performs the actual communication with the server and returns the respective result.
+//! 
+//! # Usage
+//! 
+//! ## Setting up your Project
+//! 
+//! To use this library, you would put the following lines into your `Cargo.toml` file:
+//! 
+//! ```toml
+//! [dependencies]
+//! google-speech1_beta1 = "*"
+//! ```
+//! 
+//! ## A complete example
+//! 
+//! ```test_harness,no_run
+//! extern crate hyper;
+//! extern crate hyper_rustls;
+//! extern crate yup_oauth2 as oauth2;
+//! extern crate google_speech1_beta1 as speech1_beta1;
+//! use speech1_beta1::{Result, Error};
+//! # #[test] fn egal() {
+//! use std::default::Default;
+//! use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+//! use speech1_beta1::Speech;
+//! 
+//! // Get an ApplicationSecret instance by some means. It contains the `client_id` and 
+//! // `client_secret`, among other things.
+//! let secret: ApplicationSecret = Default::default();
+//! // Instantiate the authenticator. It will choose a suitable authentication flow for you, 
+//! // unless you replace  `None` with the desired Flow.
+//! // Provide your own `AuthenticatorDelegate` to adjust the way it operates and get feedback about 
+//! // what's going on. You probably want to bring in your own `TokenStorage` to persist tokens and
+//! // retrieve them from storage.
+//! let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+//!                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+//!                               <MemoryStorage as Default>::default(), None);
+//! let mut hub = Speech::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+//! // You can configure optional parameters by calling the respective setters at will, and
+//! // execute the final call using `doit()`.
+//! // Values shown here are possibly random and not representative !
+//! let result = hub.operations().list()
+//!              .page_token("et")
+//!              .page_size(-18)
+//!              .name("kasd")
+//!              .filter("accusam")
+//!              .doit();
+//! 
+//! match result {
+//!     Err(e) => match e {
+//!         // The Error enum provides details about what exactly happened.
+//!         // You can also just use its `Debug`, `Display` or `Error` traits
+//!          Error::HttpError(_)
+//!         |Error::MissingAPIKey
+//!         |Error::MissingToken(_)
+//!         |Error::Cancelled
+//!         |Error::UploadSizeLimitExceeded(_, _)
+//!         |Error::Failure(_)
+//!         |Error::BadRequest(_)
+//!         |Error::FieldClash(_)
+//!         |Error::JsonDecodeError(_, _) => println!("{}", e),
+//!     },
+//!     Ok(res) => println!("Success: {:?}", res),
+//! }
+//! # }
+//! ```
+//! ## Handling Errors
+//! 
+//! All errors produced by the system are provided either as [Result](enum.Result.html) enumeration as return value of 
+//! the doit() methods, or handed as possibly intermediate results to either the 
+//! [Hub Delegate](trait.Delegate.html), or the [Authenticator Delegate](https://docs.rs/yup-oauth2/*/yup_oauth2/trait.AuthenticatorDelegate.html).
+//! 
+//! When delegates handle errors or intermediate values, they may have a chance to instruct the system to retry. This 
+//! makes the system potentially resilient to all kinds of errors.
+//! 
+//! ## Uploads and Downloads
+//! If a method supports downloads, the response body, which is part of the [Result](enum.Result.html), should be
+//! read by you to obtain the media.
+//! If such a method also supports a [Response Result](trait.ResponseResult.html), it will return that by default.
+//! You can see it as meta-data for the actual media. To trigger a media download, you will have to set up the builder by making
+//! this call: `.param("alt", "media")`.
+//! 
+//! Methods supporting uploads can do so using up to 2 different protocols: 
+//! *simple* and *resumable*. The distinctiveness of each is represented by customized 
+//! `doit(...)` methods, which are then named `upload(...)` and `upload_resumable(...)` respectively.
+//! 
+//! ## Customization and Callbacks
+//! 
+//! You may alter the way an `doit()` method is called by providing a [delegate](trait.Delegate.html) to the 
+//! [Method Builder](trait.CallBuilder.html) before making the final `doit()` call. 
+//! Respective methods will be called to provide progress information, as well as determine whether the system should 
+//! retry on failure.
+//! 
+//! The [delegate trait](trait.Delegate.html) is default-implemented, allowing you to customize it with minimal effort.
+//! 
+//! ## Optional Parts in Server-Requests
+//! 
+//! All structures provided by this library are made to be [enocodable](trait.RequestValue.html) and 
+//! [decodable](trait.ResponseResult.html) via *json*. Optionals are used to indicate that partial requests are responses 
+//! are valid.
+//! Most optionals are are considered [Parts](trait.Part.html) which are identifiable by name, which will be sent to 
+//! the server to indicate either the set parts of the request or the desired parts in the response.
+//! 
+//! ## Builder Arguments
+//! 
+//! Using [method builders](trait.CallBuilder.html), you are able to prepare an action call by repeatedly calling it's methods.
+//! These will always take a single argument, for which the following statements are true.
+//! 
+//! * [PODs][wiki-pod] are handed by copy
+//! * strings are passed as `&str`
+//! * [request values](trait.RequestValue.html) are moved
+//! 
+//! Arguments will always be copied or cloned into the builder, to make them independent of their original life times.
+//! 
+//! [wiki-pod]: http://en.wikipedia.org/wiki/Plain_old_data_structure
+//! [builder-pattern]: http://en.wikipedia.org/wiki/Builder_pattern
+//! [google-go-api]: https://github.com/google/google-api-go-client
+//! 
+//! 
+
+// Unused attributes happen thanks to defined, but unused structures
+// We don't warn about this, as depending on the API, some data structures or facilities are never used.
+// Instead of pre-determining this, we just disable the lint. It's manually tuned to not have any
+// unused imports in fully featured APIs. Same with unused_mut ... .
+#![allow(unused_imports, unused_mut, dead_code)]
+
+// DO NOT EDIT !
+// This file was generated automatically from 'src/mako/api/lib.rs.mako'
+// DO NOT EDIT !
+
+#[macro_use]
+extern crate serde_derive;
+
+extern crate hyper;
+extern crate serde;
+extern crate serde_json;
+extern crate yup_oauth2 as oauth2;
+extern crate mime;
+extern crate url;
+
+mod cmn;
+
+use std::collections::HashMap;
+use std::cell::RefCell;
+use std::borrow::BorrowMut;
+use std::default::Default;
+use std::collections::BTreeMap;
+use serde_json as json;
+use std::io;
+use std::fs;
+use std::mem;
+use std::thread::sleep;
+use std::time::Duration;
+
+pub use cmn::{MultiPartReader, ToParts, MethodInfo, Result, Error, CallBuilder, Hub, ReadSeek, Part,
+              ResponseResult, RequestValue, NestedType, Delegate, DefaultDelegate, MethodsBuilder,
+              Resource, ErrorResponse, remove_json_null_values};
+
+
+// ##############
+// UTILITIES ###
+// ############
+
+/// Identifies the an OAuth2 authorization scope.
+/// A scope is needed when requesting an
+/// [authorization token](https://developers.google.com/youtube/v3/guides/authentication).
+#[derive(PartialEq, Eq, Hash)]
+pub enum Scope {
+    /// View and manage your data across Google Cloud Platform services
+    CloudPlatform,
+
+    /// Convert speech to text using Google speech recognition technology
+    CloudSpeech,
+}
+
+impl AsRef<str> for Scope {
+    fn as_ref(&self) -> &str {
+        match *self {
+            Scope::CloudPlatform => "https://www.googleapis.com/auth/cloud-platform",
+            Scope::CloudSpeech => "https://www.googleapis.com/auth/cloud-speech",
+        }
+    }
+}
+
+impl Default for Scope {
+    fn default() -> Scope {
+        Scope::CloudSpeech
+    }
+}
+
+
+
+// ########
+// HUB ###
+// ######
+
+/// Central instance to access all Speech related resource activities
+///
+/// # Examples
+///
+/// Instantiate a new hub
+///
+/// ```test_harness,no_run
+/// extern crate hyper;
+/// extern crate hyper_rustls;
+/// extern crate yup_oauth2 as oauth2;
+/// extern crate google_speech1_beta1 as speech1_beta1;
+/// use speech1_beta1::{Result, Error};
+/// # #[test] fn egal() {
+/// use std::default::Default;
+/// use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// use speech1_beta1::Speech;
+/// 
+/// // Get an ApplicationSecret instance by some means. It contains the `client_id` and 
+/// // `client_secret`, among other things.
+/// let secret: ApplicationSecret = Default::default();
+/// // Instantiate the authenticator. It will choose a suitable authentication flow for you, 
+/// // unless you replace  `None` with the desired Flow.
+/// // Provide your own `AuthenticatorDelegate` to adjust the way it operates and get feedback about 
+/// // what's going on. You probably want to bring in your own `TokenStorage` to persist tokens and
+/// // retrieve them from storage.
+/// let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+///                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+///                               <MemoryStorage as Default>::default(), None);
+/// let mut hub = Speech::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.operations().list()
+///              .page_token("takimata")
+///              .page_size(-70)
+///              .name("amet.")
+///              .filter("erat")
+///              .doit();
+/// 
+/// match result {
+///     Err(e) => match e {
+///         // The Error enum provides details about what exactly happened.
+///         // You can also just use its `Debug`, `Display` or `Error` traits
+///          Error::HttpError(_)
+///         |Error::MissingAPIKey
+///         |Error::MissingToken(_)
+///         |Error::Cancelled
+///         |Error::UploadSizeLimitExceeded(_, _)
+///         |Error::Failure(_)
+///         |Error::BadRequest(_)
+///         |Error::FieldClash(_)
+///         |Error::JsonDecodeError(_, _) => println!("{}", e),
+///     },
+///     Ok(res) => println!("Success: {:?}", res),
+/// }
+/// # }
+/// ```
+pub struct Speech<C, A> {
+    client: RefCell<C>,
+    auth: RefCell<A>,
+    _user_agent: String,
+    _base_url: String,
+    _root_url: String,
+}
+
+impl<'a, C, A> Hub for Speech<C, A> {}
+
+impl<'a, C, A> Speech<C, A>
+    where  C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+    pub fn new(client: C, authenticator: A) -> Speech<C, A> {
+        Speech {
+            client: RefCell::new(client),
+            auth: RefCell::new(authenticator),
+            _user_agent: "google-api-rust-client/1.0.7".to_string(),
+            _base_url: "https://speech.googleapis.com/".to_string(),
+            _root_url: "https://speech.googleapis.com/".to_string(),
+        }
+    }
+
+    pub fn operations(&'a self) -> OperationMethods<'a, C, A> {
+        OperationMethods { hub: &self }
+    }
+    pub fn speech(&'a self) -> SpeechMethods<'a, C, A> {
+        SpeechMethods { hub: &self }
+    }
+
+    /// Set the user-agent header field to use in all requests to the server.
+    /// It defaults to `google-api-rust-client/1.0.7`.
+    ///
+    /// Returns the previously set user-agent.
+    pub fn user_agent(&mut self, agent_name: String) -> String {
+        mem::replace(&mut self._user_agent, agent_name)
+    }
+
+    /// Set the base url to use in all requests to the server.
+    /// It defaults to `https://speech.googleapis.com/`.
+    ///
+    /// Returns the previously set base url.
+    pub fn base_url(&mut self, new_base_url: String) -> String {
+        mem::replace(&mut self._base_url, new_base_url)
+    }
+
+    /// Set the root url to use in all requests to the server.
+    /// It defaults to `https://speech.googleapis.com/`.
+    ///
+    /// Returns the previously set root url.
+    pub fn root_url(&mut self, new_root_url: String) -> String {
+        mem::replace(&mut self._root_url, new_root_url)
+    }
+}
+
+
+// ############
+// SCHEMAS ###
+// ##########
+/// The `Status` type defines a logical error model that is suitable for different
+/// programming environments, including REST APIs and RPC APIs. It is used by
+/// [gRPC](https://github.com/grpc). The error model is designed to be:
+/// 
+/// - Simple to use and understand for most users
+/// - Flexible enough to meet unexpected needs
+/// 
+/// # Overview
+/// 
+/// The `Status` message contains three pieces of data: error code, error message,
+/// and error details. The error code should be an enum value of
+/// google.rpc.Code, but it may accept additional error codes if needed.  The
+/// error message should be a developer-facing English message that helps
+/// developers *understand* and *resolve* the error. If a localized user-facing
+/// error message is needed, put the localized message in the error details or
+/// localize it in the client. The optional error details may contain arbitrary
+/// information about the error. There is a predefined set of error detail types
+/// in the package `google.rpc` that can be used for common error conditions.
+/// 
+/// # Language mapping
+/// 
+/// The `Status` message is the logical representation of the error model, but it
+/// is not necessarily the actual wire format. When the `Status` message is
+/// exposed in different client libraries and different wire protocols, it can be
+/// mapped differently. For example, it will likely be mapped to some exceptions
+/// in Java, but more likely mapped to some error codes in C.
+/// 
+/// # Other uses
+/// 
+/// The error model and the `Status` message can be used in a variety of
+/// environments, either with or without APIs, to provide a
+/// consistent developer experience across different environments.
+/// 
+/// Example uses of this error model include:
+/// 
+/// - Partial errors. If a service needs to return partial errors to the client,
+///     it may embed the `Status` in the normal response to indicate the partial
+///     errors.
+/// 
+/// - Workflow errors. A typical workflow has multiple steps. Each step may
+///     have a `Status` message for error reporting.
+/// 
+/// - Batch operations. If a client uses batch request and batch response, the
+///     `Status` message should be used directly inside batch response, one for
+///     each error sub-response.
+/// 
+/// - Asynchronous operations. If an API call embeds asynchronous operation
+///     results in its response, the status of those operations should be
+///     represented directly using the `Status` message.
+/// 
+/// - Logging. If some API errors are stored in logs, the message `Status` could
+///     be used directly after any stripping needed for security/privacy reasons.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Status {
+    /// A developer-facing error message, which should be in English. Any
+    /// user-facing error message should be localized and sent in the
+    /// google.rpc.Status.details field, or localized by the client.
+    pub message: Option<String>,
+    /// The status code, which should be an enum value of google.rpc.Code.
+    pub code: Option<i32>,
+    /// A list of messages that carry the error details.  There is a common set of
+    /// message types for APIs to use.
+    pub details: Option<Vec<HashMap<String, String>>>,
+}
+
+impl Part for Status {}
+
+
+/// A speech recognition result corresponding to a portion of the audio.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct SpeechRecognitionResult {
+    /// *Output-only* May contain one or more recognition hypotheses (up to the
+    /// maximum specified in `max_alternatives`).
+    pub alternatives: Option<Vec<SpeechRecognitionAlternative>>,
+}
+
+impl Part for SpeechRecognitionResult {}
+
+
+/// The response message for Operations.ListOperations.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [list operations](struct.OperationListCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct ListOperationsResponse {
+    /// A list of operations that matches the specified filter in the request.
+    pub operations: Option<Vec<Operation>>,
+    /// The standard List next-page token.
+    #[serde(rename="nextPageToken")]
+    pub next_page_token: Option<String>,
+}
+
+impl ResponseResult for ListOperationsResponse {}
+
+
+/// Provides "hints" to the speech recognizer to favor specific words and phrases
+/// in the results.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct SpeechContext {
+    /// *Optional* A list of strings containing words and phrases "hints" so that
+    /// the speech recognition is more likely to recognize them. This can be used
+    /// to improve the accuracy for specific words and phrases, for example, if
+    /// specific commands are typically spoken by the user. This can also be used
+    /// to add additional words to the vocabulary of the recognizer. See
+    /// [usage limits](https://cloud.google.com/speech/limits#content).
+    pub phrases: Option<Vec<String>>,
+}
+
+impl Part for SpeechContext {}
+
+
+/// Contains audio data in the encoding specified in the `RecognitionConfig`.
+/// Either `content` or `uri` must be supplied. Supplying both or neither
+/// returns google.rpc.Code.INVALID_ARGUMENT. See
+/// [audio limits](https://cloud.google.com/speech/limits#content).
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct RecognitionAudio {
+    /// The audio data bytes encoded as specified in
+    /// `RecognitionConfig`. Note: as with all bytes fields, protobuffers use a
+    /// pure binary representation, whereas JSON representations use base64.
+    pub content: Option<String>,
+    /// URI that points to a file that contains audio data bytes as specified in
+    /// `RecognitionConfig`. Currently, only Google Cloud Storage URIs are
+    /// supported, which must be specified in the following format:
+    /// `gs://bucket_name/object_name` (other URI formats return
+    /// google.rpc.Code.INVALID_ARGUMENT). For more information, see
+    /// [Request URIs](https://cloud.google.com/storage/docs/reference-uris).
+    pub uri: Option<String>,
+}
+
+impl Part for RecognitionAudio {}
+
+
+/// The top-level message sent by the client for the `AsyncRecognize` method.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [asyncrecognize speech](struct.SpeechAsyncrecognizeCall.html) (request)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct AsyncRecognizeRequest {
+    /// *Required* The audio data to be recognized.
+    pub audio: Option<RecognitionAudio>,
+    /// *Required* Provides information to the recognizer that specifies how to
+    /// process the request.
+    pub config: Option<RecognitionConfig>,
+}
+
+impl RequestValue for AsyncRecognizeRequest {}
+
+
+/// The only message returned to the client by `SyncRecognize`. method. It
+/// contains the result as zero or more sequential `SpeechRecognitionResult`
+/// messages.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [syncrecognize speech](struct.SpeechSyncrecognizeCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct SyncRecognizeResponse {
+    /// *Output-only* Sequential list of transcription results corresponding to
+    /// sequential portions of audio.
+    pub results: Option<Vec<SpeechRecognitionResult>>,
+}
+
+impl ResponseResult for SyncRecognizeResponse {}
+
+
+/// The top-level message sent by the client for the `SyncRecognize` method.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [syncrecognize speech](struct.SpeechSyncrecognizeCall.html) (request)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct SyncRecognizeRequest {
+    /// *Required* The audio data to be recognized.
+    pub audio: Option<RecognitionAudio>,
+    /// *Required* Provides information to the recognizer that specifies how to
+    /// process the request.
+    pub config: Option<RecognitionConfig>,
+}
+
+impl RequestValue for SyncRecognizeRequest {}
+
+
+/// A generic empty message that you can re-use to avoid defining duplicated
+/// empty messages in your APIs. A typical example is to use it as the request
+/// or the response type of an API method. For instance:
+/// 
+///     service Foo {
+///       rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
+///     }
+/// 
+/// The JSON representation for `Empty` is empty JSON object `{}`.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [delete operations](struct.OperationDeleteCall.html) (response)
+/// * [cancel operations](struct.OperationCancelCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Empty { _never_set: Option<bool> }
+
+impl ResponseResult for Empty {}
+
+
+/// This resource represents a long-running operation that is the result of a
+/// network API call.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [asyncrecognize speech](struct.SpeechAsyncrecognizeCall.html) (response)
+/// * [delete operations](struct.OperationDeleteCall.html) (none)
+/// * [list operations](struct.OperationListCall.html) (none)
+/// * [cancel operations](struct.OperationCancelCall.html) (none)
+/// * [get operations](struct.OperationGetCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Operation {
+    /// The error result of the operation in case of failure or cancellation.
+    pub error: Option<Status>,
+    /// If the value is `false`, it means the operation is still in progress.
+    /// If `true`, the operation is completed, and either `error` or `response` is
+    /// available.
+    pub done: Option<bool>,
+    /// The normal response of the operation in case of success.  If the original
+    /// method returns no data on success, such as `Delete`, the response is
+    /// `google.protobuf.Empty`.  If the original method is standard
+    /// `Get`/`Create`/`Update`, the response should be the resource.  For other
+    /// methods, the response should have the type `XxxResponse`, where `Xxx`
+    /// is the original method name.  For example, if the original method name
+    /// is `TakeSnapshot()`, the inferred response type is
+    /// `TakeSnapshotResponse`.
+    pub response: Option<HashMap<String, String>>,
+    /// The server-assigned name, which is only unique within the same service that
+    /// originally returns it. If you use the default HTTP mapping, the
+    /// `name` should have the format of `operations/some/unique/name`.
+    pub name: Option<String>,
+    /// Service-specific metadata associated with the operation.  It typically
+    /// contains progress information and common metadata such as create time.
+    /// Some services might not provide such metadata.  Any method that returns a
+    /// long-running operation should document the metadata type, if any.
+    pub metadata: Option<HashMap<String, String>>,
+}
+
+impl Resource for Operation {}
+impl ResponseResult for Operation {}
+
+
+/// Alternative hypotheses (a.k.a. n-best list).
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct SpeechRecognitionAlternative {
+    /// *Output-only* The confidence estimate between 0.0 and 1.0. A higher number
+    /// indicates an estimated greater likelihood that the recognized words are
+    /// correct. This field is typically provided only for the top hypothesis, and
+    /// only for `is_final=true` results. Clients should not rely on the
+    /// `confidence` field as it is not guaranteed to be accurate, or even set, in
+    /// any of the results.
+    /// The default of 0.0 is a sentinel value indicating `confidence` was not set.
+    pub confidence: Option<f32>,
+    /// *Output-only* Transcript text representing the words that the user spoke.
+    pub transcript: Option<String>,
+}
+
+impl Part for SpeechRecognitionAlternative {}
+
+
+/// Provides information to the recognizer that specifies how to process the
+/// request.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct RecognitionConfig {
+    /// *Optional* The language of the supplied audio as a BCP-47 language tag.
+    /// Example: "en-GB"  https://www.rfc-editor.org/rfc/bcp/bcp47.txt
+    /// If omitted, defaults to "en-US". See
+    /// [Language Support](https://cloud.google.com/speech/docs/languages)
+    /// for a list of the currently supported language codes.
+    #[serde(rename="languageCode")]
+    pub language_code: Option<String>,
+    /// *Optional* A means to provide context to assist the speech recognition.
+    #[serde(rename="speechContext")]
+    pub speech_context: Option<SpeechContext>,
+    /// *Required* Encoding of audio data sent in all `RecognitionAudio` messages.
+    pub encoding: Option<String>,
+    /// *Optional* If set to `true`, the server will attempt to filter out
+    /// profanities, replacing all but the initial character in each filtered word
+    /// with asterisks, e.g. "f***". If set to `false` or omitted, profanities
+    /// won't be filtered out.
+    #[serde(rename="profanityFilter")]
+    pub profanity_filter: Option<bool>,
+    /// *Required* Sample rate in Hertz of the audio data sent in all
+    /// `RecognitionAudio` messages. Valid values are: 8000-48000.
+    /// 16000 is optimal. For best results, set the sampling rate of the audio
+    /// source to 16000 Hz. If that's not possible, use the native sample rate of
+    /// the audio source (instead of re-sampling).
+    #[serde(rename="sampleRate")]
+    pub sample_rate: Option<i32>,
+    /// *Optional* Maximum number of recognition hypotheses to be returned.
+    /// Specifically, the maximum number of `SpeechRecognitionAlternative` messages
+    /// within each `SpeechRecognitionResult`.
+    /// The server may return fewer than `max_alternatives`.
+    /// Valid values are `0`-`30`. A value of `0` or `1` will return a maximum of
+    /// one. If omitted, will return a maximum of one.
+    #[serde(rename="maxAlternatives")]
+    pub max_alternatives: Option<i32>,
+}
+
+impl Part for RecognitionConfig {}
+
+
+
+// ###################
+// MethodBuilders ###
+// #################
+
+/// A builder providing access to all methods supported on *operation* resources.
+/// It is not used directly, but through the `Speech` hub.
+///
+/// # Example
+///
+/// Instantiate a resource builder
+///
+/// ```test_harness,no_run
+/// extern crate hyper;
+/// extern crate hyper_rustls;
+/// extern crate yup_oauth2 as oauth2;
+/// extern crate google_speech1_beta1 as speech1_beta1;
+/// 
+/// # #[test] fn egal() {
+/// use std::default::Default;
+/// use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// use speech1_beta1::Speech;
+/// 
+/// let secret: ApplicationSecret = Default::default();
+/// let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+///                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+///                               <MemoryStorage as Default>::default(), None);
+/// let mut hub = Speech::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // Usually you wouldn't bind this to a variable, but keep calling *CallBuilders*
+/// // like `cancel(...)`, `delete(...)`, `get(...)` and `list(...)`
+/// // to build up your call.
+/// let rb = hub.operations();
+/// # }
+/// ```
+pub struct OperationMethods<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a Speech<C, A>,
+}
+
+impl<'a, C, A> MethodsBuilder for OperationMethods<'a, C, A> {}
+
+impl<'a, C, A> OperationMethods<'a, C, A> {
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Lists operations that match the specified filter in the request. If the
+    /// server doesn't support this method, it returns `UNIMPLEMENTED`.
+    /// 
+    /// NOTE: the `name` binding allows API services to override the binding
+    /// to use different resource name schemes, such as `users/*/operations`. To
+    /// override the binding, API services can add a binding such as
+    /// `"/v1/{name=users/*}/operations"` to their service configuration.
+    /// For backwards compatibility, the default name includes the operations
+    /// collection id, however overriding users must ensure the name binding
+    /// is the parent resource, without the operations collection id.
+    pub fn list(&self) -> OperationListCall<'a, C, A> {
+        OperationListCall {
+            hub: self.hub,
+            _page_token: Default::default(),
+            _page_size: Default::default(),
+            _name: Default::default(),
+            _filter: Default::default(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Deletes a long-running operation. This method indicates that the client is
+    /// no longer interested in the operation result. It does not cancel the
+    /// operation. If the server doesn't support this method, it returns
+    /// `google.rpc.Code.UNIMPLEMENTED`.
+    /// 
+    /// # Arguments
+    ///
+    /// * `name` - The name of the operation resource to be deleted.
+    pub fn delete(&self, name: &str) -> OperationDeleteCall<'a, C, A> {
+        OperationDeleteCall {
+            hub: self.hub,
+            _name: name.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Gets the latest state of a long-running operation.  Clients can use this
+    /// method to poll the operation result at intervals as recommended by the API
+    /// service.
+    /// 
+    /// # Arguments
+    ///
+    /// * `name` - The name of the operation resource.
+    pub fn get(&self, name: &str) -> OperationGetCall<'a, C, A> {
+        OperationGetCall {
+            hub: self.hub,
+            _name: name.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Starts asynchronous cancellation on a long-running operation.  The server
+    /// makes a best effort to cancel the operation, but success is not
+    /// guaranteed.  If the server doesn't support this method, it returns
+    /// `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
+    /// Operations.GetOperation or
+    /// other methods to check whether the cancellation succeeded or whether the
+    /// operation completed despite cancellation. On successful cancellation,
+    /// the operation is not deleted; instead, it becomes an operation with
+    /// an Operation.error value with a google.rpc.Status.code of 1,
+    /// corresponding to `Code.CANCELLED`.
+    /// 
+    /// # Arguments
+    ///
+    /// * `name` - The name of the operation resource to be cancelled.
+    pub fn cancel(&self, name: &str) -> OperationCancelCall<'a, C, A> {
+        OperationCancelCall {
+            hub: self.hub,
+            _name: name.to_string(),
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+}
+
+
+
+/// A builder providing access to all methods supported on *speech* resources.
+/// It is not used directly, but through the `Speech` hub.
+///
+/// # Example
+///
+/// Instantiate a resource builder
+///
+/// ```test_harness,no_run
+/// extern crate hyper;
+/// extern crate hyper_rustls;
+/// extern crate yup_oauth2 as oauth2;
+/// extern crate google_speech1_beta1 as speech1_beta1;
+/// 
+/// # #[test] fn egal() {
+/// use std::default::Default;
+/// use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// use speech1_beta1::Speech;
+/// 
+/// let secret: ApplicationSecret = Default::default();
+/// let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+///                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+///                               <MemoryStorage as Default>::default(), None);
+/// let mut hub = Speech::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // Usually you wouldn't bind this to a variable, but keep calling *CallBuilders*
+/// // like `asyncrecognize(...)` and `syncrecognize(...)`
+/// // to build up your call.
+/// let rb = hub.speech();
+/// # }
+/// ```
+pub struct SpeechMethods<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a Speech<C, A>,
+}
+
+impl<'a, C, A> MethodsBuilder for SpeechMethods<'a, C, A> {}
+
+impl<'a, C, A> SpeechMethods<'a, C, A> {
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Performs asynchronous speech recognition: receive results via the
+    /// [google.longrunning.Operations]
+    /// (/speech/reference/rest/v1beta1/operations#Operation)
+    /// interface. Returns either an
+    /// `Operation.error` or an `Operation.response` which contains
+    /// an `AsyncRecognizeResponse` message.
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    pub fn asyncrecognize(&self, request: AsyncRecognizeRequest) -> SpeechAsyncrecognizeCall<'a, C, A> {
+        SpeechAsyncrecognizeCall {
+            hub: self.hub,
+            _request: request,
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Performs synchronous speech recognition: receive results after all audio
+    /// has been sent and processed.
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    pub fn syncrecognize(&self, request: SyncRecognizeRequest) -> SpeechSyncrecognizeCall<'a, C, A> {
+        SpeechSyncrecognizeCall {
+            hub: self.hub,
+            _request: request,
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+}
+
+
+
+
+
+// ###################
+// CallBuilders   ###
+// #################
+
+/// Lists operations that match the specified filter in the request. If the
+/// server doesn't support this method, it returns `UNIMPLEMENTED`.
+/// 
+/// NOTE: the `name` binding allows API services to override the binding
+/// to use different resource name schemes, such as `users/*/operations`. To
+/// override the binding, API services can add a binding such as
+/// `"/v1/{name=users/*}/operations"` to their service configuration.
+/// For backwards compatibility, the default name includes the operations
+/// collection id, however overriding users must ensure the name binding
+/// is the parent resource, without the operations collection id.
+///
+/// A builder for the *list* method supported by a *operation* resource.
+/// It is not used directly, but through a `OperationMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_speech1_beta1 as speech1_beta1;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use speech1_beta1::Speech;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = Speech::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.operations().list()
+///              .page_token("labore")
+///              .page_size(-9)
+///              .name("nonumy")
+///              .filter("dolores")
+///              .doit();
+/// # }
+/// ```
+pub struct OperationListCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a Speech<C, A>,
+    _page_token: Option<String>,
+    _page_size: Option<i32>,
+    _name: Option<String>,
+    _filter: Option<String>,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for OperationListCall<'a, C, A> {}
+
+impl<'a, C, A> OperationListCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, ListOperationsResponse)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "speech.operations.list",
+                               http_method: hyper::method::Method::Get });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((6 + self._additional_params.len()));
+        if let Some(value) = self._page_token {
+            params.push(("pageToken", value.to_string()));
+        }
+        if let Some(value) = self._page_size {
+            params.push(("pageSize", value.to_string()));
+        }
+        if let Some(value) = self._name {
+            params.push(("name", value.to_string()));
+        }
+        if let Some(value) = self._filter {
+            params.push(("filter", value.to_string()));
+        }
+        for &field in ["alt", "pageToken", "pageSize", "name", "filter"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1beta1/operations";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Get, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    /// The standard list page token.
+    ///
+    /// Sets the *page token* query property to the given value.
+    pub fn page_token(mut self, new_value: &str) -> OperationListCall<'a, C, A> {
+        self._page_token = Some(new_value.to_string());
+        self
+    }
+    /// The standard list page size.
+    ///
+    /// Sets the *page size* query property to the given value.
+    pub fn page_size(mut self, new_value: i32) -> OperationListCall<'a, C, A> {
+        self._page_size = Some(new_value);
+        self
+    }
+    /// The name of the operation's parent resource.
+    ///
+    /// Sets the *name* query property to the given value.
+    pub fn name(mut self, new_value: &str) -> OperationListCall<'a, C, A> {
+        self._name = Some(new_value.to_string());
+        self
+    }
+    /// The standard list filter.
+    ///
+    /// Sets the *filter* query property to the given value.
+    pub fn filter(mut self, new_value: &str) -> OperationListCall<'a, C, A> {
+        self._filter = Some(new_value.to_string());
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> OperationListCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> OperationListCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> OperationListCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Deletes a long-running operation. This method indicates that the client is
+/// no longer interested in the operation result. It does not cancel the
+/// operation. If the server doesn't support this method, it returns
+/// `google.rpc.Code.UNIMPLEMENTED`.
+///
+/// A builder for the *delete* method supported by a *operation* resource.
+/// It is not used directly, but through a `OperationMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_speech1_beta1 as speech1_beta1;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use speech1_beta1::Speech;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = Speech::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.operations().delete("name")
+///              .doit();
+/// # }
+/// ```
+pub struct OperationDeleteCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a Speech<C, A>,
+    _name: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for OperationDeleteCall<'a, C, A> {}
+
+impl<'a, C, A> OperationDeleteCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, Empty)> {
+        use url::percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "speech.operations.delete",
+                               http_method: hyper::method::Method::Delete });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((3 + self._additional_params.len()));
+        params.push(("name", self._name.to_string()));
+        for &field in ["alt", "name"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1beta1/operations/{+name}";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{+name}", "name")].iter() {
+            let mut replace_with = String::new();
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = value.to_string();
+                    break;
+                }
+            }
+            if find_this.as_bytes()[1] == '+' as u8 {
+                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET);
+            }
+            url = url.replace(find_this, &replace_with);
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["name"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Delete, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    /// The name of the operation resource to be deleted.
+    ///
+    /// Sets the *name* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn name(mut self, new_value: &str) -> OperationDeleteCall<'a, C, A> {
+        self._name = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> OperationDeleteCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> OperationDeleteCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> OperationDeleteCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Gets the latest state of a long-running operation.  Clients can use this
+/// method to poll the operation result at intervals as recommended by the API
+/// service.
+///
+/// A builder for the *get* method supported by a *operation* resource.
+/// It is not used directly, but through a `OperationMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_speech1_beta1 as speech1_beta1;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use speech1_beta1::Speech;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = Speech::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.operations().get("name")
+///              .doit();
+/// # }
+/// ```
+pub struct OperationGetCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a Speech<C, A>,
+    _name: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for OperationGetCall<'a, C, A> {}
+
+impl<'a, C, A> OperationGetCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, Operation)> {
+        use url::percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "speech.operations.get",
+                               http_method: hyper::method::Method::Get });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((3 + self._additional_params.len()));
+        params.push(("name", self._name.to_string()));
+        for &field in ["alt", "name"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1beta1/operations/{+name}";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{+name}", "name")].iter() {
+            let mut replace_with = String::new();
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = value.to_string();
+                    break;
+                }
+            }
+            if find_this.as_bytes()[1] == '+' as u8 {
+                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET);
+            }
+            url = url.replace(find_this, &replace_with);
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["name"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Get, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    /// The name of the operation resource.
+    ///
+    /// Sets the *name* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn name(mut self, new_value: &str) -> OperationGetCall<'a, C, A> {
+        self._name = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> OperationGetCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> OperationGetCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> OperationGetCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Starts asynchronous cancellation on a long-running operation.  The server
+/// makes a best effort to cancel the operation, but success is not
+/// guaranteed.  If the server doesn't support this method, it returns
+/// `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
+/// Operations.GetOperation or
+/// other methods to check whether the cancellation succeeded or whether the
+/// operation completed despite cancellation. On successful cancellation,
+/// the operation is not deleted; instead, it becomes an operation with
+/// an Operation.error value with a google.rpc.Status.code of 1,
+/// corresponding to `Code.CANCELLED`.
+///
+/// A builder for the *cancel* method supported by a *operation* resource.
+/// It is not used directly, but through a `OperationMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_speech1_beta1 as speech1_beta1;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use speech1_beta1::Speech;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = Speech::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.operations().cancel("name")
+///              .doit();
+/// # }
+/// ```
+pub struct OperationCancelCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a Speech<C, A>,
+    _name: String,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for OperationCancelCall<'a, C, A> {}
+
+impl<'a, C, A> OperationCancelCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, Empty)> {
+        use url::percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "speech.operations.cancel",
+                               http_method: hyper::method::Method::Post });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((3 + self._additional_params.len()));
+        params.push(("name", self._name.to_string()));
+        for &field in ["alt", "name"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1beta1/operations/{+name}:cancel";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+        for &(find_this, param_name) in [("{+name}", "name")].iter() {
+            let mut replace_with = String::new();
+            for &(name, ref value) in params.iter() {
+                if name == param_name {
+                    replace_with = value.to_string();
+                    break;
+                }
+            }
+            if find_this.as_bytes()[1] == '+' as u8 {
+                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET);
+            }
+            url = url.replace(find_this, &replace_with);
+        }
+        {
+            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
+            for param_name in ["name"].iter() {
+                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
+                    indices_for_removal.push(index);
+                }
+            }
+            for &index in indices_for_removal.iter() {
+                params.remove(index);
+            }
+        }
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Post, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone());
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    /// The name of the operation resource to be cancelled.
+    ///
+    /// Sets the *name* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn name(mut self, new_value: &str) -> OperationCancelCall<'a, C, A> {
+        self._name = new_value.to_string();
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> OperationCancelCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> OperationCancelCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> OperationCancelCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Performs asynchronous speech recognition: receive results via the
+/// [google.longrunning.Operations]
+/// (/speech/reference/rest/v1beta1/operations#Operation)
+/// interface. Returns either an
+/// `Operation.error` or an `Operation.response` which contains
+/// an `AsyncRecognizeResponse` message.
+///
+/// A builder for the *asyncrecognize* method supported by a *speech* resource.
+/// It is not used directly, but through a `SpeechMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_speech1_beta1 as speech1_beta1;
+/// use speech1_beta1::AsyncRecognizeRequest;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use speech1_beta1::Speech;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = Speech::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = AsyncRecognizeRequest::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.speech().asyncrecognize(req)
+///              .doit();
+/// # }
+/// ```
+pub struct SpeechAsyncrecognizeCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a Speech<C, A>,
+    _request: AsyncRecognizeRequest,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for SpeechAsyncrecognizeCall<'a, C, A> {}
+
+impl<'a, C, A> SpeechAsyncrecognizeCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, Operation)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "speech.speech.asyncrecognize",
+                               http_method: hyper::method::Method::Post });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((3 + self._additional_params.len()));
+        for &field in ["alt"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1beta1/speech:asyncrecognize";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Post, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: AsyncRecognizeRequest) -> SpeechAsyncrecognizeCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> SpeechAsyncrecognizeCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> SpeechAsyncrecognizeCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> SpeechAsyncrecognizeCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+
+/// Performs synchronous speech recognition: receive results after all audio
+/// has been sent and processed.
+///
+/// A builder for the *syncrecognize* method supported by a *speech* resource.
+/// It is not used directly, but through a `SpeechMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_speech1_beta1 as speech1_beta1;
+/// use speech1_beta1::SyncRecognizeRequest;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use speech1_beta1::Speech;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = Speech::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = SyncRecognizeRequest::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.speech().syncrecognize(req)
+///              .doit();
+/// # }
+/// ```
+pub struct SpeechSyncrecognizeCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a Speech<C, A>,
+    _request: SyncRecognizeRequest,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for SpeechSyncrecognizeCall<'a, C, A> {}
+
+impl<'a, C, A> SpeechSyncrecognizeCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, SyncRecognizeResponse)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "speech.speech.syncrecognize",
+                               http_method: hyper::method::Method::Post });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((3 + self._additional_params.len()));
+        for &field in ["alt"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1beta1/speech:syncrecognize";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Post, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: SyncRecognizeRequest) -> SpeechSyncrecognizeCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> SpeechSyncrecognizeCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> SpeechSyncrecognizeCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> SpeechSyncrecognizeCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+

--- a/gen/vision1-cli/Cargo.toml
+++ b/gen/vision1-cli/Cargo.toml
@@ -1,0 +1,40 @@
+# DO NOT EDIT !
+# This file was generated automatically from 'src/mako/Cargo.toml.mako'
+# DO NOT EDIT !
+[package]
+
+name = "google-vision1-cli"
+version = "1.0.7+20171107"
+authors = ["Sebastian Thiel <byronimo@gmail.com>"]
+description = "A complete library to interact with Vision (protocol v1)"
+repository = "https://github.com/Byron/google-apis-rs/tree/master/gen/vision1-cli"
+homepage = "https://cloud.google.com/vision/"
+documentation = "http://byron.github.io/google-apis-rs/google_vision1_cli"
+license = "MIT"
+keywords = ["vision", "google", "cli"]
+
+[[bin]]
+name = "vision1"
+
+[dev-dependencies]
+hyper-rustls = "^0.6"
+
+[dependencies]
+hyper = "^ 0.10"
+mime = "^ 0.2.0"
+serde = "^ 1.0"
+serde_json = "^ 1.0"
+serde_derive = "^ 1.0"
+yup-oauth2 = "^ 1.0"
+strsim = "^0.5"
+hyper-rustls = "^0.6"
+yup-hyper-mock = "^2.0"
+clap = "^2.0"
+
+[features]
+
+
+
+[dependencies.google-vision1]
+path = "../vision1"
+version = "1.0.7+20171107"

--- a/gen/vision1-cli/LICENSE.md
+++ b/gen/vision1-cli/LICENSE.md
@@ -1,0 +1,30 @@
+<!---
+DO NOT EDIT !
+This file was generated automatically from 'src/mako/LICENSE.md.mako'
+DO NOT EDIT !
+-->
+The MIT License (MIT)
+=====================
+
+Copyright © `2015-2016` `Sebastian Thiel`
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the “Software”), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.

--- a/gen/vision1-cli/README.md
+++ b/gen/vision1-cli/README.md
@@ -1,0 +1,114 @@
+<!---
+DO NOT EDIT !
+This file was generated automatically from 'src/mako/cli/README.md.mako'
+DO NOT EDIT !
+-->
+The `vision1` command-line interface *(CLI)* allows to use most features of the *Google Vision* service from the comfort of your terminal.
+
+By default all output is printed to standard out, but flags can be set to direct it into a file independent of your shell's
+capabilities. Errors will be printed to standard error, and cause the program's exit code to be non-zero.
+
+If data-structures are requested, these will be returned as pretty-printed JSON, to be useful as input to other tools.
+
+Everything else about the *Vision* API can be found at the
+[official documentation site](https://cloud.google.com/vision/).
+
+# Installation and Source Code
+
+Install the command-line interface with cargo using:
+
+```bash
+cargo install google-vision1-cli
+```
+
+Find the source code [on github](https://github.com/Byron/google-apis-rs/tree/master/gen/vision1-cli).
+
+# Usage
+
+This documentation was generated from the *Vision* API at revision *20171107*. The CLI is at version *1.0.7*.
+
+```bash
+vision1 [options]
+        images
+                annotate (-r <kv>)... [-p <v>]... [-o <out>]
+  vision1 --help
+
+Configuration:
+  [--scope <url>]...
+            Specify the authentication a method should be executed in. Each scope
+            requires the user to grant this application permission to use it.
+            If unset, it defaults to the shortest scope url for a particular method.
+  --config-dir <folder>
+            A directory into which we will store our persistent data. Defaults to
+            a user-writable directory that we will create during the first invocation.
+            [default: ~/.google-service-cli]
+  --debug
+            Output all server communication to standard error. `tx` and `rx` are placed
+            into the same stream.
+  --debug-auth
+            Output all communication related to authentication to standard error. `tx`
+            and `rx` are placed into the same stream.
+
+```
+
+# Configuration
+
+The program will store all persistent data in the `~/.google-service-cli` directory in *JSON* files prefixed with `vision1-`.  You can change the directory used to store configuration with the `--config-dir` flag on a per-invocation basis.
+
+More information about the various kinds of persistent data are given in the following paragraphs.
+
+# Authentication
+
+Most APIs require a user to authenticate any request. If this is the case, the [scope][scopes] determines the 
+set of permissions granted. The granularity of these is usually no more than *read-only* or *full-access*.
+
+If not set, the system will automatically select the smallest feasible scope, e.g. when invoking a
+method that is read-only, it will ask only for a read-only scope. 
+You may use the `--scope` flag to specify a scope directly. 
+All applicable scopes are documented in the respective method's CLI documentation.
+
+The first time a scope is used, the user is asked for permission. Follow the instructions given 
+by the CLI to grant permissions, or to decline.
+
+If a scope was authenticated by the user, the respective information will be stored as *JSON* in the configuration
+directory, e.g. `~/.google-service-cli/vision1-token-<scope-hash>.json`. No manual management of these tokens
+is necessary.
+
+To revoke granted authentication, please refer to the [official documentation][revoke-access].
+
+# Application Secrets
+
+In order to allow any application to use Google services, it will need to be registered using the 
+[Google Developer Console][google-dev-console]. APIs the application may use are then enabled for it
+one by one. Most APIs can be used for free and have a daily quota.
+
+To allow more comfortable usage of the CLI without forcing anyone to register an own application, the CLI
+comes with a default application secret that is configured accordingly. This also means that heavy usage
+all around the world may deplete the daily quota.
+
+You can workaround this limitation by putting your own secrets file at this location: 
+`~/.google-service-cli/vision1-secret.json`, assuming that the required *vision* API 
+was enabled for it. Such a secret file can be downloaded in the *Google Developer Console* at 
+*APIs & auth -> Credentials -> Download JSON* and used as is.
+
+Learn more about how to setup Google projects and enable APIs using the [official documentation][google-project-new].
+
+
+# Debugging
+
+Even though the CLI does its best to provide usable error messages, sometimes it might be desirable to know
+what exactly led to a particular issue. This is done by allowing all client-server communication to be 
+output to standard error *as-is*.
+
+The `--debug` flag will print all client-server communication to standard error, whereas the `--debug-auth` flag
+will cause all communication related to authentication to standard error.
+If the `--debug` flag is set, error-results will be debug-printed, possibly yielding more information about the 
+issue at hand.
+
+You may consider redirecting standard error into a file for ease of use, e.g. `vision1 --debug <resource> <method> [options] 2>debug.txt`.
+
+
+[scopes]: https://developers.google.com/+/api/oauth#scopes
+[revoke-access]: http://webapps.stackexchange.com/a/30849
+[google-dev-console]: https://console.developers.google.com/
+[google-project-new]: https://developers.google.com/console/help/new/

--- a/gen/vision1-cli/mkdocs.yml
+++ b/gen/vision1-cli/mkdocs.yml
@@ -1,0 +1,17 @@
+site_name: Vision v1.0.7+20171107
+site_url: http://byron.github.io/google-apis-rs/google-vision1-cli
+site_description: A complete library to interact with Vision (protocol v1)
+
+repo_url: https://github.com/Byron/google-apis-rs/tree/master/gen/vision1-cli
+
+docs_dir: docs
+site_dir: build_html
+
+pages:
+- ['index.md', 'Home']
+- ['images_annotate.md', 'Images', 'Annotate']
+
+theme: readthedocs
+
+copyright: Copyright &copy; 2015-2016, `Sebastian Thiel`
+

--- a/gen/vision1-cli/src/cmn.rs
+++ b/gen/vision1-cli/src/cmn.rs
@@ -1,0 +1,799 @@
+// COPY OF 'src/rust/cli/cmn.rs'
+// DO NOT EDIT
+use oauth2::{ApplicationSecret, ConsoleApplicationSecret, TokenStorage, Token};
+use serde_json as json;
+use serde_json::value::Value;
+use mime::Mime;
+use clap::{App, SubCommand};
+use strsim;
+
+use std::fs;
+use std::env;
+use std::io;
+use std::error::Error as StdError;
+use std::fmt;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+use std::string::ToString;
+use std::io::{Write, Read, stdout};
+
+use std::default::Default;
+
+const FIELD_SEP: char = '.';
+
+
+pub enum ComplexType {
+    Pod,
+    Vec,
+    Map,
+}
+
+// Null,
+// Bool(bool),
+// I64(i64),
+// U64(u64),
+// F64(f64),
+// String(String),
+
+pub enum JsonType {
+    Boolean,
+    Int,
+    Uint,
+    Float,
+    String,
+}
+
+pub struct JsonTypeInfo {
+    pub jtype: JsonType,
+    pub ctype: ComplexType,
+}
+
+// Based on @erickt user comment. Thanks for the idea !
+// Remove all keys whose values are null from given value (changed in place)
+pub fn remove_json_null_values(value: &mut Value) {
+    match *value {
+        Value::Object(ref mut map) => {
+            let mut for_removal = Vec::new();
+
+            for (key, mut value) in map.iter_mut() {
+                if value.is_null() {
+                    for_removal.push(key.clone());
+                } else {
+                    remove_json_null_values(&mut value);
+                }
+            }
+
+            for key in &for_removal {
+                map.remove(key);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn did_you_mean<'a>(v: &str, possible_values: &[&'a str]) -> Option<&'a str> {
+
+    let mut candidate: Option<(f64, &str)> = None;
+    for pv in possible_values {
+        let confidence = strsim::jaro_winkler(v, pv);
+        if confidence > 0.8 &&
+           (candidate.is_none() || (candidate.as_ref().unwrap().0 < confidence)) {
+            candidate = Some((confidence, pv));
+        }
+    }
+    match candidate {
+        None => None,
+        Some((_, candidate)) => Some(candidate),
+    }
+}
+
+pub enum CallType {
+    Upload(UploadProtocol),
+    Standard,
+}
+
+arg_enum!{
+    pub enum UploadProtocol {
+        Simple,
+        Resumable
+    }
+}
+
+impl AsRef<str> for UploadProtocol {
+    fn as_ref(&self) -> &str {
+        match *self {
+            UploadProtocol::Simple => "simple",
+            UploadProtocol::Resumable => "resumable",
+        }
+    }
+}
+
+impl AsRef<str> for CallType {
+    fn as_ref(&self) -> &str {
+        match *self {
+            CallType::Upload(ref proto) => proto.as_ref(),
+            CallType::Standard => "standard-request",
+        }
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct FieldCursor(Vec<String>);
+
+impl ToString for  FieldCursor {
+    fn to_string(&self) -> String {
+        self.0.join(".")
+    }
+}
+
+impl From<&'static str> for FieldCursor {
+    fn from(value: &'static str) -> FieldCursor {
+        let mut res = FieldCursor::default();
+        res.set(value).unwrap();
+        res
+    }
+}
+
+fn assure_entry<'a, 'b>(m: &'a mut json::Map<String, Value>, k: &'b String) -> &'a mut Value {
+    if m.contains_key(k) {
+        return m.get_mut(k).expect("value to exist");
+    }
+    m.insert(k.to_owned(), Value::Object(Default::default()));
+    m.get_mut(k).expect("value to exist")
+}
+
+impl FieldCursor {
+    pub fn set(&mut self, value: &str) -> Result<(), CLIError> {
+        if value.len() == 0 {
+            return Err(CLIError::Field(FieldError::Empty));
+        }
+
+        let mut first_is_field_sep = false;
+        let mut char_count: usize = 0;
+        let mut last_c = FIELD_SEP;
+        let mut num_conscutive_field_seps = 0;
+
+        let mut field = String::new();
+        let mut fields = self.0.clone();
+
+        let push_field = |fs: &mut Vec<String>, f: &mut String| {
+            if f.len() > 0 {
+                fs.push(f.clone());
+                f.truncate(0);
+            }
+        };
+
+        for (cid, c) in value.chars().enumerate() {
+            char_count += 1;
+
+            if c == FIELD_SEP {
+                if cid == 0 {
+                    first_is_field_sep = true;
+                }
+                num_conscutive_field_seps += 1;
+                if cid > 0 && last_c == FIELD_SEP {
+                    if fields.pop().is_none() {
+                        return Err(CLIError::Field(FieldError::PopOnEmpty(value.to_string())));
+                    }
+                } else {
+                    push_field(&mut fields, &mut field);
+                }
+            } else {
+                num_conscutive_field_seps = 0;
+                if cid == 1 {
+                    if first_is_field_sep {
+                        fields.truncate(0);
+                    }
+                }
+                field.push(c);
+            }
+
+            last_c = c;
+        }
+
+        push_field(&mut fields, &mut field);
+
+        if char_count == 1 && first_is_field_sep {
+            fields.truncate(0);
+        }
+        if char_count > 1 && num_conscutive_field_seps == 1 {
+            return Err(CLIError::Field(FieldError::TrailingFieldSep(value.to_string())));
+        }
+
+        self.0 = fields;
+        Ok(())
+    }
+
+    pub fn did_you_mean(value: &str, possible_values: &[&str]) -> Option<String> {
+        if value.len() == 0 {
+            return None;
+        }
+
+        let mut last_c = FIELD_SEP;
+
+        let mut field = String::new();
+        let mut output = String::new();
+
+        let push_field = |fs: &mut String, f: &mut String| {
+            if f.len() > 0 {
+                fs.push_str(match did_you_mean(&f, possible_values) {
+                    Some(candidate) => candidate,
+                    None => &f,
+                });
+                f.truncate(0);
+            }
+        };
+
+        for (cid, c) in value.chars().enumerate() {
+            if c == FIELD_SEP {
+                if last_c != FIELD_SEP {
+                    push_field(&mut output, &mut field);
+                }
+                output.push(c);
+            } else {
+                field.push(c);
+            }
+
+            last_c = c;
+        }
+
+        push_field(&mut output, &mut field);
+
+        if &output == value {
+            None
+        } else {
+            Some(output)
+        }
+    }
+
+    pub fn set_json_value(&self,
+                          mut object: &mut Value,
+                          value: &str,
+                          type_info: JsonTypeInfo,
+                          err: &mut InvalidOptionsError,
+                          orig_cursor: &FieldCursor) {
+        assert!(self.0.len() > 0);
+
+        for field in &self.0[..self.0.len() - 1] {
+            let tmp = object;
+            object = match *tmp {
+                Value::Object(ref mut mapping) => {
+                    assure_entry(mapping, &field)
+                }
+                _ => panic!("We don't expect non-object Values here ..."),
+            };
+        }
+
+        match *object {
+            Value::Object(ref mut mapping) => {
+                let field = &self.0[self.0.len() - 1];
+                let to_jval = |value: &str,
+                               jtype: JsonType,
+                               err: &mut InvalidOptionsError|
+                               -> Value {
+                    match jtype {
+                        JsonType::Boolean =>
+                            Value::Bool(arg_from_str(value, err, &field, "boolean")),
+                        JsonType::Int =>
+                            Value::Number(json::Number::from_f64(arg_from_str(value,
+                                                                              err,
+                                                                              &field,
+                                                                              "int"))
+                                              .expect("valid f64")),
+                        JsonType::Uint =>
+                            Value::Number(json::Number::from_f64(arg_from_str(value,
+                                                                              err,
+                                                                              &field,
+                                                                              "uint"))
+                                              .expect("valid f64")),
+                        JsonType::Float =>
+                            Value::Number(json::Number::from_f64(arg_from_str(value,
+                                                                              err,
+                                                                              &field,
+                                                                              "float"))
+                                              .expect("valid f64")),
+                        JsonType::String => Value::String(value.to_owned()),
+                    }
+                };
+
+                match type_info.ctype {
+                    ComplexType::Pod => {
+                        if mapping.insert(field.to_owned(), to_jval(value, type_info.jtype, err))
+                                  .is_some() {
+                            err.issues.push(CLIError::Field(FieldError::Duplicate(orig_cursor.to_string())));
+                        }
+                    }
+                    ComplexType::Vec => {
+                        match *assure_entry(mapping, field) {
+                            Value::Array(ref mut values) =>
+                                values.push(to_jval(value, type_info.jtype, err)),
+                            _ => unreachable!(),
+                        }
+                    }
+                    ComplexType::Map => {
+                        let (key, value) = parse_kv_arg(value, err, true);
+                        let jval = to_jval(value.unwrap_or(""), type_info.jtype, err);
+
+                        match *assure_entry(mapping, &field) {
+
+                            Value::Object(ref mut value_map) => {
+                                if value_map.insert(key.to_owned(), jval).is_some() {
+                                    err.issues.push(CLIError::Field(FieldError::Duplicate(orig_cursor.to_string())));
+                                }
+                            }
+                            _ => unreachable!(),
+                        }
+                    }
+                }
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    pub fn num_fields(&self) -> usize {
+        self.0.len()
+    }
+}
+
+pub fn parse_kv_arg<'a>(kv: &'a str,
+                        err: &mut InvalidOptionsError,
+                        for_hashmap: bool)
+                        -> (&'a str, Option<&'a str>) {
+    let mut add_err = || {
+        err.issues.push(CLIError::InvalidKeyValueSyntax(kv.to_string(), for_hashmap))
+    };
+    match kv.find('=') {
+        None => {
+            add_err();
+            return (kv, None);
+        }
+        Some(pos) => {
+            let key = &kv[..pos];
+            if kv.len() <= pos + 1 {
+                add_err();
+                return (key, Some(""));
+            }
+            (key, Some(&kv[pos + 1..]))
+        }
+    }
+}
+
+pub fn calltype_from_str(name: &str,
+                         valid_protocols: Vec<String>,
+                         err: &mut InvalidOptionsError)
+                         -> CallType {
+    CallType::Upload(match UploadProtocol::from_str(name) {
+        Ok(up) => up,
+        Err(msg) => {
+            err.issues.push(CLIError::InvalidUploadProtocol(name.to_string(), valid_protocols));
+            UploadProtocol::Simple
+        }
+    })
+}
+
+pub fn input_file_from_opts(file_path: &str, err: &mut InvalidOptionsError) -> Option<fs::File> {
+    match fs::File::open(file_path) {
+        Ok(f) => Some(f),
+        Err(io_err) => {
+            err.issues.push(CLIError::Input(InputError::Io((file_path.to_string(), io_err))));
+            None
+        }
+    }
+}
+
+pub fn input_mime_from_opts(mime: &str, err: &mut InvalidOptionsError) -> Option<Mime> {
+    match mime.parse() {
+        Ok(m) => Some(m),
+        Err(_) => {
+            err.issues.push(CLIError::Input(InputError::Mime(mime.to_string())));
+            None
+        }
+    }
+}
+
+pub fn writer_from_opts(arg: Option<&str>) -> Result<Box<Write>, io::Error> {
+    let f = arg.unwrap_or("-");
+    match f {
+        "-" => Ok(Box::new(stdout())),
+        _ => match fs::OpenOptions::new().create(true).write(true).open(f) {
+            Ok(f) => Ok(Box::new(f)),
+            Err(io_err) => Err(io_err),
+        },
+    }
+}
+
+
+pub fn arg_from_str<'a, T>(arg: &str,
+                           err: &mut InvalidOptionsError,
+                           arg_name: &'a str,
+                           arg_type: &'a str)
+                           -> T
+    where T: FromStr + Default,
+          <T as FromStr>::Err: fmt::Display
+{
+    match FromStr::from_str(arg) {
+        Err(perr) => {
+            err.issues.push(CLIError::ParseError(arg_name.to_owned(),
+                                                 arg_type.to_owned(),
+                                                 arg.to_string(),
+                                                 format!("{}", perr)));
+            Default::default()
+        }
+        Ok(v) => v,
+    }
+}
+
+pub struct JsonTokenStorage {
+    pub program_name: &'static str,
+    pub db_dir: String,
+}
+
+impl JsonTokenStorage {
+    fn path(&self, scope_hash: u64) -> PathBuf {
+        Path::new(&self.db_dir).join(&format!("{}-token-{}.json", self.program_name, scope_hash))
+    }
+}
+
+
+#[derive(Debug)]
+pub enum TokenStorageError {
+    Json(json::Error),
+    Io(io::Error),
+}
+
+impl fmt::Display for TokenStorageError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            TokenStorageError::Json(ref err) => writeln!(f, "Could not serialize secrets: {}", err),
+            TokenStorageError::Io(ref err) => writeln!(f, "Failed to write secret token: {}", err),
+        }
+    }
+}
+
+impl StdError for TokenStorageError {
+    fn description(&self) -> &str {
+        "Failure when getting or setting the token storage"
+    }
+}
+
+
+impl TokenStorage for JsonTokenStorage {
+    type Error = TokenStorageError;
+
+    // NOTE: logging might be interesting, currently we swallow all errors
+    fn set(&mut self,
+           scope_hash: u64,
+           _: &Vec<&str>,
+           token: Option<Token>)
+           -> Result<(), TokenStorageError> {
+        match token {
+            None => {
+                match fs::remove_file(self.path(scope_hash)) {
+                    Err(err) => match err.kind() {
+                        io::ErrorKind::NotFound => Ok(()),
+                        _ => Err(TokenStorageError::Io(err)),
+                    },
+                    Ok(_) => Ok(()),
+                }
+            }
+            Some(token) => {
+                match fs::OpenOptions::new().create(true).write(true).open(&self.path(scope_hash)) {
+                    Ok(mut f) => {
+                        match json::to_writer_pretty(&mut f, &token) {
+                            Ok(_) => Ok(()),
+                            Err(serde_err) => Err(TokenStorageError::Json(serde_err)),
+                        }
+                    }
+                    Err(io_err) => Err(TokenStorageError::Io(io_err)),
+                }
+            }
+        }
+    }
+
+    fn get(&self, scope_hash: u64, _: &Vec<&str>) -> Result<Option<Token>, TokenStorageError> {
+        match fs::File::open(&self.path(scope_hash)) {
+            Ok(f) => {
+                match json::de::from_reader(f) {
+                    Ok(token) => Ok(Some(token)),
+                    Err(err) => Err(TokenStorageError::Json(err)),
+                }
+            }
+            Err(io_err) => {
+                match io_err.kind() {
+                    io::ErrorKind::NotFound => Ok(None),
+                    _ => Err(TokenStorageError::Io(io_err)),
+                }
+            }
+        }
+    }
+}
+
+
+#[derive(Debug)]
+pub enum ApplicationSecretError {
+    DecoderError((String, json::Error)),
+    FormatError(String),
+}
+
+impl fmt::Display for ApplicationSecretError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            ApplicationSecretError::DecoderError((ref path, ref err)) =>
+                writeln!(f,
+                         "Could not decode file at '{}' with error: {}.",
+                         path,
+                         err),
+            ApplicationSecretError::FormatError(ref path) =>
+                writeln!(f,
+                         "'installed' field is unset in secret file at '{}'.",
+                         path),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum ConfigurationError {
+    DirectoryCreationFailed((String, io::Error)),
+    DirectoryUnset,
+    HomeExpansionFailed(String),
+    Secret(ApplicationSecretError),
+    Io((String, io::Error)),
+}
+
+impl fmt::Display for ConfigurationError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            ConfigurationError::DirectoryCreationFailed((ref dir, ref err)) =>
+                writeln!(f,
+                         "Directory '{}' could not be created with error: {}.",
+                         dir,
+                         err),
+            ConfigurationError::DirectoryUnset => writeln!(f, "--config-dir was unset or empty."),
+            ConfigurationError::HomeExpansionFailed(ref dir) =>
+                writeln!(f,
+                         "Couldn't find HOME directory of current user, failed to expand '{}'.",
+                         dir),
+            ConfigurationError::Secret(ref err) => writeln!(f, "Secret -> {}", err),
+            ConfigurationError::Io((ref path, ref err)) =>
+                writeln!(f,
+                         "IO operation failed on path '{}' with error: {}.",
+                         path,
+                         err),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum InputError {
+    Io((String, io::Error)),
+    Mime(String),
+}
+
+impl fmt::Display for InputError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            InputError::Io((ref file_path, ref io_err)) =>
+                writeln!(f,
+                         "Failed to open '{}' for reading with error: {}.",
+                         file_path,
+                         io_err),
+            InputError::Mime(ref mime) => writeln!(f, "'{}' is not a known mime-type.", mime),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum FieldError {
+    PopOnEmpty(String),
+    TrailingFieldSep(String),
+    Unknown(String, Option<String>, Option<String>),
+    Duplicate(String),
+    Empty,
+}
+
+
+impl fmt::Display for FieldError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            FieldError::PopOnEmpty(ref field) =>
+                writeln!(f, "'{}': Cannot move up on empty field cursor.", field),
+            FieldError::TrailingFieldSep(ref field) =>
+                writeln!(f,
+                         "'{}': Single field separator may not be last character.",
+                         field),
+            FieldError::Unknown(ref field, ref suggestion, ref value) => {
+                let suffix = match *suggestion {
+                    Some(ref s) => {
+                        let kv = match *value {
+                            Some(ref v) => format!("{}={}", s, v),
+                            None => s.clone(),
+                        };
+                        format!(" Did you mean '{}' ?", kv)
+                    }
+                    None => String::new(),
+                };
+                writeln!(f, "Field '{}' does not exist.{}", field, suffix)
+            }
+            FieldError::Duplicate(ref cursor) =>
+                writeln!(f, "Value at '{}' was already set", cursor),
+            FieldError::Empty => writeln!(f, "Field names must not be empty."),
+        }
+    }
+}
+
+
+#[derive(Debug)]
+pub enum CLIError {
+    Configuration(ConfigurationError),
+    ParseError(String, String, String, String),
+    UnknownParameter(String, Vec<&'static str>),
+    InvalidUploadProtocol(String, Vec<String>),
+    InvalidKeyValueSyntax(String, bool),
+    Input(InputError),
+    Field(FieldError),
+    MissingCommandError,
+    MissingMethodError(String),
+}
+
+impl fmt::Display for CLIError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            CLIError::Configuration(ref err) => write!(f, "Configuration -> {}", err),
+            CLIError::Input(ref err) => write!(f, "Input -> {}", err),
+            CLIError::Field(ref err) => write!(f, "Field -> {}", err),
+            CLIError::InvalidUploadProtocol(ref proto_name, ref valid_names) =>
+                writeln!(f,
+                         "'{}' is not a valid upload protocol. Choose from one of {}.",
+                         proto_name,
+                         valid_names.join(", ")),
+            CLIError::ParseError(ref arg_name, ref type_name, ref value, ref err_desc) =>
+                writeln!(f,
+                         "Failed to parse argument '{}' with value '{}' as {} with error: {}.",
+                         arg_name,
+                         value,
+                         type_name,
+                         err_desc),
+            CLIError::UnknownParameter(ref param_name, ref possible_values) => {
+                let suffix = match did_you_mean(param_name, &possible_values) {
+                    Some(v) => format!(" Did you mean '{}' ?", v),
+                    None => String::new(),
+                };
+                write!(f, "Parameter '{}' is unknown.{}\n", param_name, suffix)
+            }
+            CLIError::InvalidKeyValueSyntax(ref kv, is_hashmap) => {
+                let hashmap_info = if is_hashmap {
+                    "hashmap "
+                } else {
+                    ""
+                };
+                writeln!(f,
+                         "'{}' does not match {}pattern <key>=<value>.",
+                         kv,
+                         hashmap_info)
+            }
+            CLIError::MissingCommandError => writeln!(f, "Please specify the main sub-command."),
+            CLIError::MissingMethodError(ref cmd) =>
+                writeln!(f,
+                         "Please specify the method to call on the '{}' command.",
+                         cmd),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct InvalidOptionsError {
+    pub issues: Vec<CLIError>,
+    pub exit_code: i32,
+}
+
+impl fmt::Display for InvalidOptionsError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        for issue in &self.issues {
+            try!(issue.fmt(f));
+        }
+        Ok(())
+    }
+}
+
+impl InvalidOptionsError {
+    pub fn single(err: CLIError, exit_code: i32) -> InvalidOptionsError {
+        InvalidOptionsError {
+            issues: vec![err],
+            exit_code: exit_code,
+        }
+    }
+
+    pub fn new() -> InvalidOptionsError {
+        InvalidOptionsError {
+            issues: Vec::new(),
+            exit_code: 1,
+        }
+    }
+}
+
+pub fn assure_config_dir_exists(dir: &str) -> Result<String, CLIError> {
+    let trdir = dir.trim();
+    if trdir.len() == 0 {
+        return Err(CLIError::Configuration(ConfigurationError::DirectoryUnset));
+    }
+
+    let expanded_config_dir = if trdir.as_bytes()[0] == b'~' {
+        match env::var("HOME").ok().or(env::var("UserProfile").ok()) {
+            None => return Err(CLIError::Configuration(ConfigurationError::HomeExpansionFailed(trdir.to_string()))),
+            Some(mut user) => {
+                user.push_str(&trdir[1..]);
+                user
+            }
+        }
+    } else {
+        trdir.to_string()
+    };
+
+    if let Err(err) = fs::create_dir(&expanded_config_dir) {
+        if err.kind() != io::ErrorKind::AlreadyExists {
+            return Err(CLIError::Configuration(
+                    ConfigurationError::DirectoryCreationFailed((expanded_config_dir, err))));
+        }
+    }
+
+    Ok(expanded_config_dir)
+}
+
+pub fn application_secret_from_directory(dir: &str,
+                                         secret_basename: &str,
+                                         json_console_secret: &str)
+                                         -> Result<ApplicationSecret, CLIError> {
+    let secret_path = Path::new(dir).join(secret_basename);
+    let secret_str = || secret_path.as_path().to_str().unwrap().to_string();
+    let secret_io_error = |io_err: io::Error| {
+        Err(CLIError::Configuration(ConfigurationError::Io((secret_str(), io_err))))
+    };
+
+    for _ in 0..2 {
+        match fs::File::open(&secret_path) {
+            Err(mut err) => {
+                if err.kind() == io::ErrorKind::NotFound {
+                    // Write our built-in one - user may adjust the written file at will
+
+                    err = match fs::OpenOptions::new()
+                                    .create(true)
+                                    .write(true)
+                                    .open(&secret_path) {
+                        Err(cfe) => cfe,
+                        Ok(mut f) => {
+                            // Assure we convert 'ugly' json string into pretty one
+                            let console_secret: ConsoleApplicationSecret =
+                                json::from_str(json_console_secret).unwrap();
+                            match json::to_writer_pretty(&mut f, &console_secret) {
+                                Err(serde_err) =>
+                                    panic!("Unexpected serde error: {:#?}", serde_err),
+                                Ok(_) => continue,
+                            }
+                        }
+                    };
+                    // fall through to IO error handling
+                }
+                return secret_io_error(err);
+            }
+            Ok(f) => {
+                match json::de::from_reader::<_, ConsoleApplicationSecret>(f) {
+                    Err(json_err) =>
+                        return Err(CLIError::Configuration(
+                            ConfigurationError::Secret(
+                                ApplicationSecretError::DecoderError(
+                                                (secret_str(), json_err)
+                                              )))),
+                    Ok(console_secret) => match console_secret.installed {
+                        Some(secret) => return Ok(secret),
+                        None => return Err(
+                                        CLIError::Configuration(
+                                        ConfigurationError::Secret(
+                                        ApplicationSecretError::FormatError(secret_str())
+                                        ))),
+                    },
+                }
+            }
+        }
+    }
+    unreachable!();
+}

--- a/gen/vision1-cli/src/main.rs
+++ b/gen/vision1-cli/src/main.rs
@@ -1,0 +1,357 @@
+// DO NOT EDIT !
+// This file was generated automatically from 'src/mako/cli/main.rs.mako'
+// DO NOT EDIT !
+#![allow(unused_variables, unused_imports, dead_code, unused_mut)]
+
+#[macro_use]
+extern crate clap;
+extern crate yup_oauth2 as oauth2;
+extern crate yup_hyper_mock as mock;
+extern crate hyper_rustls;
+extern crate serde;
+extern crate serde_json;
+extern crate hyper;
+extern crate mime;
+extern crate strsim;
+extern crate google_vision1 as api;
+
+use std::env;
+use std::io::{self, Write};
+use clap::{App, SubCommand, Arg};
+
+mod cmn;
+
+use cmn::{InvalidOptionsError, CLIError, JsonTokenStorage, arg_from_str, writer_from_opts, parse_kv_arg,
+          input_file_from_opts, input_mime_from_opts, FieldCursor, FieldError, CallType, UploadProtocol,
+          calltype_from_str, remove_json_null_values, ComplexType, JsonType, JsonTypeInfo};
+
+use std::default::Default;
+use std::str::FromStr;
+
+use oauth2::{Authenticator, DefaultAuthenticatorDelegate, FlowType};
+use serde_json as json;
+use clap::ArgMatches;
+
+enum DoitError {
+    IoError(String, io::Error),
+    ApiError(api::Error),
+}
+
+struct Engine<'n> {
+    opt: ArgMatches<'n>,
+    hub: api::Vision<hyper::Client, Authenticator<DefaultAuthenticatorDelegate, JsonTokenStorage, hyper::Client>>,
+    gp: Vec<&'static str>,
+    gpm: Vec<(&'static str, &'static str)>,
+}
+
+
+impl<'n> Engine<'n> {
+    fn _images_annotate(&self, opt: &ArgMatches<'n>, dry_run: bool, err: &mut InvalidOptionsError)
+                                                    -> Result<(), DoitError> {
+        
+        let mut field_cursor = FieldCursor::default();
+        let mut object = json::value::Value::Object(Default::default());
+        
+        for kvarg in opt.values_of("kv").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let last_errc = err.issues.len();
+            let (key, value) = parse_kv_arg(&*kvarg, err, false);
+            let mut temp_cursor = field_cursor.clone();
+            if let Err(field_err) = temp_cursor.set(&*key) {
+                err.issues.push(field_err);
+            }
+            if value.is_none() {
+                field_cursor = temp_cursor.clone();
+                if err.issues.len() > last_errc {
+                    err.issues.remove(last_errc);
+                }
+                continue;
+            }
+        
+            let type_info: Option<(&'static str, JsonTypeInfo)> =
+                match &temp_cursor.to_string()[..] {
+                    _ => {
+                        let suggestion = FieldCursor::did_you_mean(key, &vec![]);
+                        err.issues.push(CLIError::Field(FieldError::Unknown(temp_cursor.to_string(), suggestion, value.map(|v| v.to_string()))));
+                        None
+                    }
+                };
+            if let Some((field_cursor_str, type_info)) = type_info {
+                FieldCursor::from(field_cursor_str).set_json_value(&mut object, value.unwrap(), type_info, err, &temp_cursor);
+            }
+        }
+        let mut request: api::BatchAnnotateImagesRequest = json::value::from_value(object).unwrap();
+        let mut call = self.hub.images().annotate(request);
+        for parg in opt.values_of("v").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+            let (key, value) = parse_kv_arg(&*parg, err, false);
+            match key {
+                _ => {
+                    let mut found = false;
+                    for param in &self.gp {
+                        if key == *param {
+                            found = true;
+                            call = call.param(self.gpm.iter().find(|t| t.0 == key).unwrap_or(&("", key)).1, value.unwrap_or("unset"));
+                            break;
+                        }
+                    }
+                    if !found {
+                        err.issues.push(CLIError::UnknownParameter(key.to_string(),
+                                                                  {let mut v = Vec::new();
+                                                                           v.extend(self.gp.iter().map(|v|*v));
+                                                                           v } ));
+                    }
+                }
+            }
+        }
+        let protocol = CallType::Standard;
+        if dry_run {
+            Ok(())
+        } else {
+            assert!(err.issues.len() == 0);
+            for scope in self.opt.values_of("url").map(|i|i.collect()).unwrap_or(Vec::new()).iter() {
+                call = call.add_scope(scope);
+            }
+            let mut ostream = match writer_from_opts(opt.value_of("out")) {
+                Ok(mut f) => f,
+                Err(io_err) => return Err(DoitError::IoError(opt.value_of("out").unwrap_or("-").to_string(), io_err)),
+            };
+            match match protocol {
+                CallType::Standard => call.doit(),
+                _ => unreachable!()
+            } {
+                Err(api_err) => Err(DoitError::ApiError(api_err)),
+                Ok((mut response, output_schema)) => {
+                    let mut value = json::value::to_value(&output_schema).expect("serde to work");
+                    remove_json_null_values(&mut value);
+                    json::to_writer_pretty(&mut ostream, &value).unwrap();
+                    ostream.flush().unwrap();
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn _doit(&self, dry_run: bool) -> Result<Result<(), DoitError>, Option<InvalidOptionsError>> {
+        let mut err = InvalidOptionsError::new();
+        let mut call_result: Result<(), DoitError> = Ok(());
+        let mut err_opt: Option<InvalidOptionsError> = None;
+        match self.opt.subcommand() {
+            ("images", Some(opt)) => {
+                match opt.subcommand() {
+                    ("annotate", Some(opt)) => {
+                        call_result = self._images_annotate(opt, dry_run, &mut err);
+                    },
+                    _ => {
+                        err.issues.push(CLIError::MissingMethodError("images".to_string()));
+                        writeln!(io::stderr(), "{}\n", opt.usage()).ok();
+                    }
+                }
+            },
+            _ => {
+                err.issues.push(CLIError::MissingCommandError);
+                writeln!(io::stderr(), "{}\n", self.opt.usage()).ok();
+            }
+        }
+
+        if dry_run {
+            if err.issues.len() > 0 {
+                err_opt = Some(err);
+            }
+            Err(err_opt)
+        } else {
+            Ok(call_result)
+        }
+    }
+
+    // Please note that this call will fail if any part of the opt can't be handled
+    fn new(opt: ArgMatches<'n>) -> Result<Engine<'n>, InvalidOptionsError> {
+        let (config_dir, secret) = {
+            let config_dir = match cmn::assure_config_dir_exists(opt.value_of("folder").unwrap_or("~/.google-service-cli")) {
+                Err(e) => return Err(InvalidOptionsError::single(e, 3)),
+                Ok(p) => p,
+            };
+
+            match cmn::application_secret_from_directory(&config_dir, "vision1-secret.json",
+                                                         "{\"installed\":{\"auth_uri\":\"https://accounts.google.com/o/oauth2/auth\",\"client_secret\":\"hCsslbCUyfehWMmbkG8vTYxG\",\"token_uri\":\"https://accounts.google.com/o/oauth2/token\",\"client_email\":\"\",\"redirect_uris\":[\"urn:ietf:wg:oauth:2.0:oob\",\"oob\"],\"client_x509_cert_url\":\"\",\"client_id\":\"620010449518-9ngf7o4dhs0dka470npqvor6dc5lqb9b.apps.googleusercontent.com\",\"auth_provider_x509_cert_url\":\"https://www.googleapis.com/oauth2/v1/certs\"}}") {
+                Ok(secret) => (config_dir, secret),
+                Err(e) => return Err(InvalidOptionsError::single(e, 4))
+            }
+        };
+
+        let auth = Authenticator::new(  &secret, DefaultAuthenticatorDelegate,
+                                        if opt.is_present("debug-auth") {
+                                            hyper::Client::with_connector(mock::TeeConnector {
+                                                    connector: hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())
+                                                })
+                                        } else {
+                                            hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new()))
+                                        },
+                                        JsonTokenStorage {
+                                          program_name: "vision1",
+                                          db_dir: config_dir.clone(),
+                                        }, Some(FlowType::InstalledRedirect(54324)));
+
+        let client =
+            if opt.is_present("debug") {
+                hyper::Client::with_connector(mock::TeeConnector {
+                        connector: hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())
+                    })
+            } else {
+                hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new()))
+            };
+        let engine = Engine {
+            opt: opt,
+            hub: api::Vision::new(client, auth),
+            gp: vec!["$-xgafv", "access-token", "alt", "bearer-token", "callback", "fields", "key", "oauth-token", "pp", "pretty-print", "quota-user", "upload-type", "upload-protocol"],
+            gpm: vec![
+                    ("$-xgafv", "$.xgafv"),
+                    ("access-token", "access_token"),
+                    ("bearer-token", "bearer_token"),
+                    ("oauth-token", "oauth_token"),
+                    ("pretty-print", "prettyPrint"),
+                    ("quota-user", "quotaUser"),
+                    ("upload-type", "uploadType"),
+                    ("upload-protocol", "upload_protocol"),
+                ]
+        };
+
+        match engine._doit(true) {
+            Err(Some(err)) => Err(err),
+            Err(None)      => Ok(engine),
+            Ok(_)          => unreachable!(),
+        }
+    }
+
+    fn doit(&self) -> Result<(), DoitError> {
+        match self._doit(false) {
+            Ok(res) => res,
+            Err(_) => unreachable!(),
+        }
+    }
+}
+
+fn main() {
+    let mut exit_status = 0i32;
+    let arg_data = [
+        ("images", "methods: 'annotate'", vec![
+            ("annotate",
+                    Some(r##"Run image detection and annotation for a batch of images."##),
+                    "Details at http://byron.github.io/google-apis-rs/google_vision1_cli/images_annotate",
+                  vec![
+                    (Some(r##"kv"##),
+                     Some(r##"r"##),
+                     Some(r##"Set various fields of the request structure, matching the key=value form"##),
+                     Some(true),
+                     Some(true)),
+        
+                    (Some(r##"v"##),
+                     Some(r##"p"##),
+                     Some(r##"Set various optional parameters, matching the key=value form"##),
+                     Some(false),
+                     Some(true)),
+        
+                    (Some(r##"out"##),
+                     Some(r##"o"##),
+                     Some(r##"Specify the file into which to write the program's output"##),
+                     Some(false),
+                     Some(false)),
+                  ]),
+            ]),
+        
+    ];
+    
+    let mut app = App::new("vision1")
+           .author("Sebastian Thiel <byronimo@gmail.com>")
+           .version("1.0.7+20171107")
+           .about("Integrates Google Vision features, including image labeling, face, logo, and landmark detection, optical character recognition (OCR), and detection of explicit content, into applications.")
+           .after_help("All documentation details can be found at http://byron.github.io/google-apis-rs/google_vision1_cli")
+           .arg(Arg::with_name("url")
+                   .long("scope")
+                   .help("Specify the authentication a method should be executed in. Each scope requires the user to grant this application permission to use it.If unset, it defaults to the shortest scope url for a particular method.")
+                   .multiple(true)
+                   .takes_value(true))
+           .arg(Arg::with_name("folder")
+                   .long("config-dir")
+                   .help("A directory into which we will store our persistent data. Defaults to a user-writable directory that we will create during the first invocation.[default: ~/.google-service-cli")
+                   .multiple(false)
+                   .takes_value(true))
+           .arg(Arg::with_name("debug")
+                   .long("debug")
+                   .help("Output all server communication to standard error. `tx` and `rx` are placed into the same stream.")
+                   .multiple(false)
+                   .takes_value(false))
+           .arg(Arg::with_name("debug-auth")
+                   .long("debug-auth")
+                   .help("Output all communication related to authentication to standard error. `tx` and `rx` are placed into the same stream.")
+                   .multiple(false)
+                   .takes_value(false));
+           
+           for &(main_command_name, about, ref subcommands) in arg_data.iter() {
+               let mut mcmd = SubCommand::with_name(main_command_name).about(about);
+           
+               for &(sub_command_name, ref desc, url_info, ref args) in subcommands {
+                   let mut scmd = SubCommand::with_name(sub_command_name);
+                   if let &Some(desc) = desc {
+                       scmd = scmd.about(desc);
+                   }
+                   scmd = scmd.after_help(url_info);
+           
+                   for &(ref arg_name, ref flag, ref desc, ref required, ref multi) in args {
+                       let arg_name_str =
+                           match (arg_name, flag) {
+                                   (&Some(an), _       ) => an,
+                                   (_        , &Some(f)) => f,
+                                    _                    => unreachable!(),
+                            };
+                       let mut arg = Arg::with_name(arg_name_str)
+                                         .empty_values(false);
+                       if let &Some(short_flag) = flag {
+                           arg = arg.short(short_flag);
+                       }
+                       if let &Some(desc) = desc {
+                           arg = arg.help(desc);
+                       }
+                       if arg_name.is_some() && flag.is_some() {
+                           arg = arg.takes_value(true);
+                       }
+                       if let &Some(required) = required {
+                           arg = arg.required(required);
+                       }
+                       if let &Some(multi) = multi {
+                           arg = arg.multiple(multi);
+                       }
+                       scmd = scmd.arg(arg);
+                   }
+                   mcmd = mcmd.subcommand(scmd);
+               }
+               app = app.subcommand(mcmd);
+           }
+           
+        let matches = app.get_matches();
+
+    let debug = matches.is_present("debug");
+    match Engine::new(matches) {
+        Err(err) => {
+            exit_status = err.exit_code;
+            writeln!(io::stderr(), "{}", err).ok();
+        },
+        Ok(engine) => {
+            if let Err(doit_err) = engine.doit() {
+                exit_status = 1;
+                match doit_err {
+                    DoitError::IoError(path, err) => {
+                        writeln!(io::stderr(), "Failed to open output file '{}': {}", path, err).ok();
+                    },
+                    DoitError::ApiError(err) => {
+                        if debug {
+                            writeln!(io::stderr(), "{:#?}", err).ok();
+                        } else {
+                            writeln!(io::stderr(), "{}", err).ok();
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    std::process::exit(exit_status);
+}

--- a/gen/vision1/Cargo.toml
+++ b/gen/vision1/Cargo.toml
@@ -1,0 +1,31 @@
+# DO NOT EDIT !
+# This file was generated automatically from 'src/mako/Cargo.toml.mako'
+# DO NOT EDIT !
+[package]
+
+name = "google-vision1"
+version = "1.0.7+20171107"
+authors = ["Sebastian Thiel <byronimo@gmail.com>"]
+description = "A complete library to interact with Vision (protocol v1)"
+repository = "https://github.com/Byron/google-apis-rs/tree/master/gen/vision1"
+homepage = "https://cloud.google.com/vision/"
+documentation = "https://docs.rs/google-vision1/1.0.7+20171107"
+license = "MIT"
+keywords = ["vision", "google", "protocol", "web", "api"]
+
+
+[dev-dependencies]
+hyper-rustls = "^0.6"
+
+[dependencies]
+hyper = "^ 0.10"
+mime = "^ 0.2.0"
+serde = "^ 1.0"
+serde_json = "^ 1.0"
+serde_derive = "^ 1.0"
+yup-oauth2 = "^ 1.0"
+url = "= 0.5"
+
+[features]
+
+

--- a/gen/vision1/LICENSE.md
+++ b/gen/vision1/LICENSE.md
@@ -1,0 +1,30 @@
+<!---
+DO NOT EDIT !
+This file was generated automatically from 'src/mako/LICENSE.md.mako'
+DO NOT EDIT !
+-->
+The MIT License (MIT)
+=====================
+
+Copyright © `2015-2016` `Sebastian Thiel`
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the “Software”), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.

--- a/gen/vision1/README.md
+++ b/gen/vision1/README.md
@@ -1,0 +1,180 @@
+<!---
+DO NOT EDIT !
+This file was generated automatically from 'src/mako/api/README.md.mako'
+DO NOT EDIT !
+-->
+The `google-vision1` library allows access to all features of the *Google Vision* service.
+
+This documentation was generated from *Vision* crate version *1.0.7+20171107*, where *20171107* is the exact revision of the *vision:v1* schema built by the [mako](http://www.makotemplates.org/) code generator *v1.0.7*.
+
+Everything else about the *Vision* *v1* API can be found at the
+[official documentation site](https://cloud.google.com/vision/).
+# Features
+
+Handle the following *Resources* with ease from the central [hub](https://docs.rs/google-vision1/1.0.7+20171107/google_vision1/struct.Vision.html) ... 
+
+* [images](https://docs.rs/google-vision1/1.0.7+20171107/google_vision1/struct.Image.html)
+ * [*annotate*](https://docs.rs/google-vision1/1.0.7+20171107/google_vision1/struct.ImageAnnotateCall.html)
+
+
+
+
+# Structure of this Library
+
+The API is structured into the following primary items:
+
+* **[Hub](https://docs.rs/google-vision1/1.0.7+20171107/google_vision1/struct.Vision.html)**
+    * a central object to maintain state and allow accessing all *Activities*
+    * creates [*Method Builders*](https://docs.rs/google-vision1/1.0.7+20171107/google_vision1/trait.MethodsBuilder.html) which in turn
+      allow access to individual [*Call Builders*](https://docs.rs/google-vision1/1.0.7+20171107/google_vision1/trait.CallBuilder.html)
+* **[Resources](https://docs.rs/google-vision1/1.0.7+20171107/google_vision1/trait.Resource.html)**
+    * primary types that you can apply *Activities* to
+    * a collection of properties and *Parts*
+    * **[Parts](https://docs.rs/google-vision1/1.0.7+20171107/google_vision1/trait.Part.html)**
+        * a collection of properties
+        * never directly used in *Activities*
+* **[Activities](https://docs.rs/google-vision1/1.0.7+20171107/google_vision1/trait.CallBuilder.html)**
+    * operations to apply to *Resources*
+
+All *structures* are marked with applicable traits to further categorize them and ease browsing.
+
+Generally speaking, you can invoke *Activities* like this:
+
+```Rust,ignore
+let r = hub.resource().activity(...).doit()
+```
+
+Or specifically ...
+
+```ignore
+let r = hub.images().annotate(...).doit()
+```
+
+The `resource()` and `activity(...)` calls create [builders][builder-pattern]. The second one dealing with `Activities` 
+supports various methods to configure the impending operation (not shown here). It is made such that all required arguments have to be 
+specified right away (i.e. `(...)`), whereas all optional ones can be [build up][builder-pattern] as desired.
+The `doit()` method performs the actual communication with the server and returns the respective result.
+
+# Usage
+
+## Setting up your Project
+
+To use this library, you would put the following lines into your `Cargo.toml` file:
+
+```toml
+[dependencies]
+google-vision1 = "*"
+```
+
+## A complete example
+
+```Rust
+extern crate hyper;
+extern crate hyper_rustls;
+extern crate yup_oauth2 as oauth2;
+extern crate google_vision1 as vision1;
+use vision1::BatchAnnotateImagesRequest;
+use vision1::{Result, Error};
+use std::default::Default;
+use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+use vision1::Vision;
+
+// Get an ApplicationSecret instance by some means. It contains the `client_id` and 
+// `client_secret`, among other things.
+let secret: ApplicationSecret = Default::default();
+// Instantiate the authenticator. It will choose a suitable authentication flow for you, 
+// unless you replace  `None` with the desired Flow.
+// Provide your own `AuthenticatorDelegate` to adjust the way it operates and get feedback about 
+// what's going on. You probably want to bring in your own `TokenStorage` to persist tokens and
+// retrieve them from storage.
+let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+                              hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+                              <MemoryStorage as Default>::default(), None);
+let mut hub = Vision::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+// As the method needs a request, you would usually fill it with the desired information
+// into the respective structure. Some of the parts shown here might not be applicable !
+// Values shown here are possibly random and not representative !
+let mut req = BatchAnnotateImagesRequest::default();
+
+// You can configure optional parameters by calling the respective setters at will, and
+// execute the final call using `doit()`.
+// Values shown here are possibly random and not representative !
+let result = hub.images().annotate(req)
+             .doit();
+
+match result {
+    Err(e) => match e {
+        // The Error enum provides details about what exactly happened.
+        // You can also just use its `Debug`, `Display` or `Error` traits
+         Error::HttpError(_)
+        |Error::MissingAPIKey
+        |Error::MissingToken(_)
+        |Error::Cancelled
+        |Error::UploadSizeLimitExceeded(_, _)
+        |Error::Failure(_)
+        |Error::BadRequest(_)
+        |Error::FieldClash(_)
+        |Error::JsonDecodeError(_, _) => println!("{}", e),
+    },
+    Ok(res) => println!("Success: {:?}", res),
+}
+
+```
+## Handling Errors
+
+All errors produced by the system are provided either as [Result](https://docs.rs/google-vision1/1.0.7+20171107/google_vision1/enum.Result.html) enumeration as return value of 
+the doit() methods, or handed as possibly intermediate results to either the 
+[Hub Delegate](https://docs.rs/google-vision1/1.0.7+20171107/google_vision1/trait.Delegate.html), or the [Authenticator Delegate](https://docs.rs/yup-oauth2/*/yup_oauth2/trait.AuthenticatorDelegate.html).
+
+When delegates handle errors or intermediate values, they may have a chance to instruct the system to retry. This 
+makes the system potentially resilient to all kinds of errors.
+
+## Uploads and Downloads
+If a method supports downloads, the response body, which is part of the [Result](https://docs.rs/google-vision1/1.0.7+20171107/google_vision1/enum.Result.html), should be
+read by you to obtain the media.
+If such a method also supports a [Response Result](https://docs.rs/google-vision1/1.0.7+20171107/google_vision1/trait.ResponseResult.html), it will return that by default.
+You can see it as meta-data for the actual media. To trigger a media download, you will have to set up the builder by making
+this call: `.param("alt", "media")`.
+
+Methods supporting uploads can do so using up to 2 different protocols: 
+*simple* and *resumable*. The distinctiveness of each is represented by customized 
+`doit(...)` methods, which are then named `upload(...)` and `upload_resumable(...)` respectively.
+
+## Customization and Callbacks
+
+You may alter the way an `doit()` method is called by providing a [delegate](https://docs.rs/google-vision1/1.0.7+20171107/google_vision1/trait.Delegate.html) to the 
+[Method Builder](https://docs.rs/google-vision1/1.0.7+20171107/google_vision1/trait.CallBuilder.html) before making the final `doit()` call. 
+Respective methods will be called to provide progress information, as well as determine whether the system should 
+retry on failure.
+
+The [delegate trait](https://docs.rs/google-vision1/1.0.7+20171107/google_vision1/trait.Delegate.html) is default-implemented, allowing you to customize it with minimal effort.
+
+## Optional Parts in Server-Requests
+
+All structures provided by this library are made to be [enocodable](https://docs.rs/google-vision1/1.0.7+20171107/google_vision1/trait.RequestValue.html) and 
+[decodable](https://docs.rs/google-vision1/1.0.7+20171107/google_vision1/trait.ResponseResult.html) via *json*. Optionals are used to indicate that partial requests are responses 
+are valid.
+Most optionals are are considered [Parts](https://docs.rs/google-vision1/1.0.7+20171107/google_vision1/trait.Part.html) which are identifiable by name, which will be sent to 
+the server to indicate either the set parts of the request or the desired parts in the response.
+
+## Builder Arguments
+
+Using [method builders](https://docs.rs/google-vision1/1.0.7+20171107/google_vision1/trait.CallBuilder.html), you are able to prepare an action call by repeatedly calling it's methods.
+These will always take a single argument, for which the following statements are true.
+
+* [PODs][wiki-pod] are handed by copy
+* strings are passed as `&str`
+* [request values](https://docs.rs/google-vision1/1.0.7+20171107/google_vision1/trait.RequestValue.html) are moved
+
+Arguments will always be copied or cloned into the builder, to make them independent of their original life times.
+
+[wiki-pod]: http://en.wikipedia.org/wiki/Plain_old_data_structure
+[builder-pattern]: http://en.wikipedia.org/wiki/Builder_pattern
+[google-go-api]: https://github.com/google/google-api-go-client
+
+# License
+The **vision1** library was generated by Sebastian Thiel, and is placed 
+under the *MIT* license.
+You can read the full text at the repository's [license file][repo-license].
+
+[repo-license]: https://github.com/Byron/google-apis-rsblob/master/LICENSE.md

--- a/gen/vision1/src/cmn.rs
+++ b/gen/vision1/src/cmn.rs
@@ -1,0 +1,753 @@
+// COPY OF 'src/rust/api/cmn.rs'
+// DO NOT EDIT
+use std::io::{self, Read, Seek, Cursor, Write, SeekFrom};
+use std;
+use std::fmt::{self, Display};
+use std::str::FromStr;
+use std::error;
+use std::thread::sleep;
+use std::time::Duration;
+
+use mime::{Mime, TopLevel, SubLevel, Attr, Value};
+use oauth2::{TokenType, Retry, self};
+use hyper;
+use hyper::header::{ContentType, ContentLength, Headers, UserAgent, Authorization, Header,
+                    HeaderFormat, Bearer};
+use hyper::http::h1::LINE_ENDING;
+use hyper::method::Method;
+use hyper::status::StatusCode;
+
+use serde_json as json;
+
+/// Identifies the Hub. There is only one per library, this trait is supposed
+/// to make intended use more explicit.
+/// The hub allows to access all resource methods more easily.
+pub trait Hub {}
+
+/// Identifies types for building methods of a particular resource type
+pub trait MethodsBuilder {}
+
+/// Identifies types which represent builders for a particular resource method
+pub trait CallBuilder {}
+
+/// Identifies types which can be inserted and deleted.
+/// Types with this trait are most commonly used by clients of this API.
+pub trait Resource {}
+
+/// Identifies types which are used in API responses.
+pub trait ResponseResult {}
+
+/// Identifies types which are used in API requests.
+pub trait RequestValue {}
+
+/// Identifies types which are not actually used by the API
+/// This might be a bug within the google API schema.
+pub trait UnusedType {}
+
+/// Identifies types which are only used as part of other types, which
+/// usually are carrying the `Resource` trait.
+pub trait Part {}
+
+/// Identifies types which are only used by other types internally.
+/// They have no special meaning, this trait just marks them for completeness.
+pub trait NestedType {}
+
+/// A utility to specify reader types which provide seeking capabilities too
+pub trait ReadSeek: Seek + Read {}
+impl<T: Seek + Read> ReadSeek for T {}
+
+/// A trait for all types that can convert themselves into a *parts* string
+pub trait ToParts {
+    fn to_parts(&self) -> String;
+}
+
+/// A utility type which can decode a server response that indicates error
+#[derive(Deserialize)]
+pub struct JsonServerError {
+    pub error: String,
+    pub error_description: Option<String>
+}
+
+/// A utility to represent detailed errors we might see in case there are BadRequests.
+/// The latter happen if the sent parameters or request structures are unsound
+#[derive(Deserialize, Serialize, Debug)]
+pub struct ErrorResponse {
+    error: ServerError,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct ServerError {
+    errors: Vec<ServerMessage>,
+    code: u16,
+    message: String,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct ServerMessage {
+    domain: String,
+    reason: String,
+    message: String,
+    #[serde(rename="locationType")]
+    location_type: Option<String>,
+    location: Option<String>
+}
+
+#[derive(Copy, Clone)]
+pub struct DummyNetworkStream;
+
+impl Read for DummyNetworkStream {
+    fn read(&mut self, _: &mut [u8]) -> io::Result<usize> {
+        Ok(0)
+    }
+}
+
+impl Write for DummyNetworkStream {
+    fn write(&mut self, _: &[u8]) -> io::Result<usize> {
+        Ok(0)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl hyper::net::NetworkStream for DummyNetworkStream {
+    fn peer_addr(&mut self) -> io::Result<std::net::SocketAddr> {
+        Ok("127.0.0.1:1337".parse().unwrap())
+    }
+
+    fn set_read_timeout(&self, _dur: Option<Duration>) -> io::Result<()> {
+        Ok(())
+    }
+
+    fn set_write_timeout(&self, _dur: Option<Duration>) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+
+/// A trait specifying functionality to help controlling any request performed by the API.
+/// The trait has a conservative default implementation.
+///
+/// It contains methods to deal with all common issues, as well with the ones related to
+/// uploading media
+pub trait Delegate {
+
+    /// Called at the beginning of any API request. The delegate should store the method
+    /// information if he is interesting in knowing more context when further calls to it
+    /// are made.
+    /// The matching `finished()` call will always be made, no matter whether or not the API
+    /// request was successful. That way, the delegate may easily maintain a clean state
+    /// between various API calls.
+    fn begin(&mut self, MethodInfo) {}
+
+    /// Called whenever there is an [HttpError](http://hyperium.github.io/hyper/hyper/error/enum.HttpError.html), usually if there are network problems.
+    ///
+    /// If you choose to retry after a duration, the duration should be chosen using the
+    /// [exponential backoff algorithm](http://en.wikipedia.org/wiki/Exponential_backoff).
+    ///
+    /// Return retry information.
+    fn http_error(&mut self, &hyper::Error) -> Retry {
+        Retry::Abort
+    }
+
+    /// Called whenever there is the need for your applications API key after
+    /// the official authenticator implementation didn't provide one, for some reason.
+    /// If this method returns None as well, the underlying operation will fail
+    fn api_key(&mut self) -> Option<String> {
+        None
+    }
+
+    /// Called whenever the Authenticator didn't yield a token. The delegate
+    /// may attempt to provide one, or just take it as a general information about the
+    /// impending failure.
+    /// The given Error provides information about why the token couldn't be acquired in the
+    /// first place
+    fn token(&mut self, err: &error::Error) -> Option<oauth2::Token> {
+        let _ = err;
+        None
+    }
+
+    /// Called during resumable uploads to provide a URL for the impending upload.
+    /// It was saved after a previous call to `store_upload_url(...)`, and if not None,
+    /// will be used instead of asking the server for a new upload URL.
+    /// This is useful in case a previous resumable upload was aborted/canceled, but should now
+    /// be resumed.
+    /// The returned URL will be used exactly once - if it fails again and the delegate allows
+    /// to retry, we will ask the server for a new upload URL.
+    fn upload_url(&mut self) -> Option<String> {
+        None
+    }
+
+    /// Called after we have retrieved a new upload URL for a resumable upload to store it
+    /// in case we fail or cancel. That way, we can attempt to resume the upload later,
+    /// see `upload_url()`.
+    /// It will also be called with None after a successful upload, which allows the delegate
+    /// to forget the URL. That way, we will not attempt to resume an upload that has already
+    /// finished.
+    fn store_upload_url(&mut self, url: Option<&str>) {
+        let _ = url;
+    }
+
+    /// Called whenever a server response could not be decoded from json.
+    /// It's for informational purposes only, the caller will return with an error
+    /// accordingly.
+    ///
+    /// # Arguments
+    ///
+    /// * `json_encoded_value` - The json-encoded value which failed to decode.
+    /// * `json_decode_error`  - The decoder error
+    fn response_json_decode_error(&mut self, json_encoded_value: &str, json_decode_error: &json::Error) {
+        let _ = json_encoded_value;
+        let _ = json_decode_error;
+    }
+
+    /// Called whenever the http request returns with a non-success status code.
+    /// This can involve authentication issues, or anything else that very much
+    /// depends on the used API method.
+    /// The delegate should check the status, header and decoded json error to decide
+    /// whether to retry or not. In the latter case, the underlying call will fail.
+    ///
+    /// If you choose to retry after a duration, the duration should be chosen using the
+    /// [exponential backoff algorithm](http://en.wikipedia.org/wiki/Exponential_backoff).
+    fn http_failure(&mut self, _: &hyper::client::Response, Option<JsonServerError>, _: Option<ServerError>) -> Retry {
+        Retry::Abort
+    }
+
+    /// Called prior to sending the main request of the given method. It can be used to time
+    /// the call or to print progress information.
+    /// It's also useful as you can be sure that a request will definitely be made.
+    fn pre_request(&mut self) { }
+
+    /// Return the size of each chunk of a resumable upload.
+    /// Must be a power of two, with 1<<18 being the smallest allowed chunk size.
+    /// Will be called once before starting any resumable upload.
+    fn chunk_size(&mut self) -> u64 {
+        1 << 23
+    }
+
+    /// Called before the given chunk is uploaded to the server.
+    /// If true is returned, the upload will be interrupted.
+    /// However, it may be resumable if you stored the upload URL in a previous call
+    /// to `store_upload_url()`
+    fn cancel_chunk_upload(&mut self, chunk: &ContentRange) -> bool {
+        let _ = chunk;
+        false
+    }
+
+    /// Called before the API request method returns, in every case. It can be used to clean up
+    /// internal state between calls to the API.
+    /// This call always has a matching call to `begin(...)`.
+    ///
+    /// # Arguments
+    ///
+    /// * `is_success` - a true value indicates the operation was successful. If false, you should
+    ///                  discard all values stored during `store_upload_url`.
+    fn finished(&mut self, is_success: bool) {
+        let _ = is_success;
+    }
+}
+
+/// A delegate with a conservative default implementation, which is used if no other delegate is
+/// set.
+#[derive(Default)]
+pub struct DefaultDelegate;
+
+impl Delegate for DefaultDelegate {}
+
+
+#[derive(Debug)]
+pub enum Error {
+    /// The http connection failed
+    HttpError(hyper::Error),
+
+    /// An attempt was made to upload a resource with size stored in field `.0`
+    /// even though the maximum upload size is what is stored in field `.1`.
+    UploadSizeLimitExceeded(u64, u64),
+
+    /// Represents information about a request that was not understood by the server.
+    /// Details are included.
+    BadRequest(ErrorResponse),
+
+    /// We needed an API key for authentication, but didn't obtain one.
+    /// Neither through the authenticator, nor through the Delegate.
+    MissingAPIKey,
+
+    /// We required a Token, but didn't get one from the Authenticator
+    MissingToken(Box<error::Error>),
+
+    /// The delgate instructed to cancel the operation
+    Cancelled,
+
+    /// An additional, free form field clashed with one of the built-in optional ones
+    FieldClash(&'static str),
+
+    /// Shows that we failed to decode the server response.
+    /// This can happen if the protocol changes in conjunction with strict json decoding.
+    JsonDecodeError(String, json::Error),
+
+    /// Indicates an HTTP repsonse with a non-success status code
+    Failure(hyper::client::Response),
+}
+
+
+impl Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Error::HttpError(ref err) => err.fmt(f),
+            Error::UploadSizeLimitExceeded(ref resource_size, ref max_size) =>
+                writeln!(f, "The media size {} exceeds the maximum allowed upload size of {}"
+                         , resource_size, max_size),
+            Error::MissingAPIKey => {
+                (writeln!(f, "The application's API key was not found in the configuration")).ok();
+                writeln!(f, "It is used as there are no Scopes defined for this method.")
+            },
+            Error::BadRequest(ref err) => {
+                try!(writeln!(f, "Bad Request ({}): {}", err.error.code, err.error.message));
+                for err in err.error.errors.iter() {
+                    try!(writeln!(f, "    {}: {}, {}{}",
+                                            err.domain,
+                                            err.message,
+                                            err.reason,
+                                            match &err.location {
+                                                &Some(ref loc) => format!("@{}", loc),
+                                                &None => String::new(),
+                                            }));
+                }
+                Ok(())
+            },
+            Error::MissingToken(ref err) =>
+                writeln!(f, "Token retrieval failed with error: {}", err),
+            Error::Cancelled =>
+                writeln!(f, "Operation cancelled by delegate"),
+            Error::FieldClash(field) =>
+                writeln!(f, "The custom parameter '{}' is already provided natively by the CallBuilder.", field),
+            Error::JsonDecodeError(ref json_str, ref err)
+                => writeln!(f, "{}: {}", err, json_str),
+            Error::Failure(ref response) =>
+                writeln!(f, "Http status indicates failure: {:?}", response),
+        }
+    }
+}
+
+impl error::Error for Error {
+    fn description(&self) -> &str {
+        match *self {
+            Error::HttpError(ref err) => err.description(),
+            Error::JsonDecodeError(_, ref err) => err.description(),
+            _ => "NO DESCRIPTION POSSIBLE - use `Display.fmt()` instead"
+        }
+    }
+
+    fn cause(&self) -> Option<&error::Error> {
+        match *self {
+            Error::HttpError(ref err) => err.cause(),
+            Error::JsonDecodeError(_, ref err) => err.cause(),
+            _ => None
+        }
+    }
+}
+
+/// A universal result type used as return for all calls.
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Contains information about an API request.
+pub struct MethodInfo {
+    pub id: &'static str,
+    pub http_method: Method,
+}
+
+const BOUNDARY: &'static str = "MDuXWGyeE33QFXGchb2VFWc4Z7945d";
+
+/// Provides a `Read` interface that converts multiple parts into the protocol
+/// identified by [RFC2387](https://tools.ietf.org/html/rfc2387).
+/// **Note**: This implementation is just as rich as it needs to be to perform uploads
+/// to google APIs, and might not be a fully-featured implementation.
+#[derive(Default)]
+pub struct MultiPartReader<'a> {
+    raw_parts: Vec<(Headers, &'a mut Read)>,
+    current_part: Option<(Cursor<Vec<u8>>, &'a mut Read)>,
+    last_part_boundary: Option<Cursor<Vec<u8>>>,
+}
+
+impl<'a> MultiPartReader<'a> {
+
+    /// Reserve memory for exactly the given amount of parts
+    pub fn reserve_exact(&mut self, cap: usize) {
+        self.raw_parts.reserve_exact(cap);
+    }
+
+    /// Add a new part to the queue of parts to be read on the first `read` call.
+    ///
+    /// # Arguments
+    ///
+    /// `headers` - identifying the body of the part. It's similar to the header
+    ///             in an ordinary single-part call, and should thus contain the
+    ///             same information.
+    /// `reader`  - a reader providing the part's body
+    /// `size`    - the amount of bytes provided by the reader. It will be put onto the header as
+    ///             content-size.
+    /// `mime`    - It will be put onto the content type
+    pub fn add_part(&mut self, reader: &'a mut Read, size: u64, mime_type: Mime) -> &mut MultiPartReader<'a> {
+        let mut headers = Headers::new();
+        headers.set(ContentType(mime_type));
+        headers.set(ContentLength(size));
+        self.raw_parts.push((headers, reader));
+        self
+    }
+
+    /// Returns the mime-type representing our multi-part message.
+    /// Use it with the ContentType header.
+    pub fn mime_type(&self) -> Mime {
+        Mime(
+            TopLevel::Multipart,
+            SubLevel::Ext("Related".to_string()),
+            vec![(Attr::Ext("boundary".to_string()), Value::Ext(BOUNDARY.to_string()))],
+        )
+    }
+
+    /// Returns true if we are totally used
+    fn is_depleted(&self) -> bool {
+        self.raw_parts.len() == 0 && self.current_part.is_none() && self.last_part_boundary.is_none()
+    }
+
+    /// Returns true if we are handling our last part
+    fn is_last_part(&self) -> bool {
+        self.raw_parts.len() == 0 && self.current_part.is_some()
+    }
+}
+
+impl<'a> Read for MultiPartReader<'a> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        match (self.raw_parts.len(),
+               self.current_part.is_none(),
+               self.last_part_boundary.is_none()) {
+            (_, _, false) => {
+                let br = self.last_part_boundary.as_mut().unwrap().read(buf).unwrap_or(0);
+                if br < buf.len() {
+                    self.last_part_boundary = None;
+                }
+                return Ok(br)
+            },
+            (0, true, true) => return Ok(0),
+            (n, true, _) if n > 0 => {
+                let (headers, reader) = self.raw_parts.remove(0);
+                let mut c = Cursor::new(Vec::<u8>::new());
+                (write!(&mut c, "{}--{}{}{}{}", LINE_ENDING, BOUNDARY, LINE_ENDING,
+                                                headers, LINE_ENDING)).unwrap();
+                c.seek(SeekFrom::Start(0)).unwrap();
+                self.current_part = Some((c, reader));
+            }
+            _ => {},
+        }
+
+        // read headers as long as possible
+        let (hb, rr) = {
+            let &mut (ref mut c, ref mut reader) = self.current_part.as_mut().unwrap();
+            let b = c.read(buf).unwrap_or(0);
+            (b, reader.read(&mut buf[b..]))
+        };
+
+        match rr {
+            Ok(bytes_read) => {
+                if hb < buf.len() && bytes_read == 0 {
+                    if self.is_last_part() {
+                        // before clearing the last part, we will add the boundary that
+                        // will be written last
+                        self.last_part_boundary = Some(Cursor::new(
+                                                        format!("{}--{}--", LINE_ENDING, BOUNDARY).into_bytes()))
+                    }
+                    // We are depleted - this can trigger the next part to come in
+                    self.current_part = None;
+                }
+                let mut total_bytes_read = hb + bytes_read;
+                while total_bytes_read < buf.len() && !self.is_depleted() {
+                    match self.read(&mut buf[total_bytes_read ..]) {
+                        Ok(br) => total_bytes_read += br,
+                        Err(err) => return Err(err),
+                    }
+                }
+                Ok(total_bytes_read)
+            }
+            Err(err) => {
+                // fail permanently
+                self.current_part = None;
+                self.last_part_boundary = None;
+                self.raw_parts.clear();
+                Err(err)
+            }
+        }
+    }
+}
+
+/// The `X-Upload-Content-Type` header.
+///
+/// Generated via rustc --pretty expanded -Z unstable-options, and manually
+/// processed to be more readable.
+#[derive(PartialEq, Debug, Clone)]
+pub struct XUploadContentType(pub Mime);
+
+impl ::std::ops::Deref for XUploadContentType {
+    type Target = Mime;
+    fn deref<'a>(&'a self) -> &'a Mime { &self.0 }
+}
+impl ::std::ops::DerefMut for XUploadContentType {
+    fn deref_mut<'a>(&'a mut self) -> &'a mut Mime { &mut self.0 }
+}
+impl Header for XUploadContentType {
+    fn header_name() -> &'static str { "X-Upload-Content-Type" }
+    fn parse_header(raw: &[Vec<u8>]) -> hyper::error::Result<Self> {
+        hyper::header::parsing::from_one_raw_str(raw).map(XUploadContentType)
+    }
+}
+impl HeaderFormat for XUploadContentType {
+    fn fmt_header(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        Display::fmt(&**self, f)
+    }
+}
+impl Display for XUploadContentType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(&**self, f)
+    }
+}
+
+#[derive(Clone, PartialEq, Debug)]
+pub struct Chunk {
+    pub first: u64,
+    pub last: u64
+}
+
+impl fmt::Display for Chunk {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        (write!(fmt, "{}-{}", self.first, self.last)).ok();
+        Ok(())
+    }
+}
+
+impl FromStr for Chunk {
+    type Err = &'static str;
+
+    /// NOTE: only implements `%i-%i`, not `*`
+    fn from_str(s: &str) -> std::result::Result<Chunk, &'static str> {
+        let parts: Vec<&str> = s.split('-').collect();
+        if parts.len() != 2 {
+            return Err("Expected two parts: %i-%i")
+        }
+        Ok(
+            Chunk {
+                first: match FromStr::from_str(parts[0]) {
+                    Ok(d) => d,
+                    _ => return Err("Couldn't parse 'first' as digit")
+                },
+                last: match FromStr::from_str(parts[1]) {
+                    Ok(d) => d,
+                    _ => return Err("Couldn't parse 'last' as digit")
+                }
+            }
+        )
+    }
+}
+
+/// Implements the Content-Range header, for serialization only
+#[derive(Clone, PartialEq, Debug)]
+pub struct ContentRange {
+    pub range: Option<Chunk>,
+    pub total_length: u64,
+}
+
+impl Header for ContentRange {
+    fn header_name() -> &'static str {
+        "Content-Range"
+    }
+
+    /// We are not parsable, as parsing is done by the `Range` header
+    fn parse_header(_: &[Vec<u8>]) -> hyper::error::Result<Self> {
+        Err(hyper::error::Error::Method)
+    }
+}
+
+
+impl HeaderFormat for ContentRange {
+    fn fmt_header(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        try!(fmt.write_str("bytes "));
+        match self.range {
+            Some(ref c) => try!(c.fmt(fmt)),
+            None => try!(fmt.write_str("*"))
+        }
+        (write!(fmt, "/{}", self.total_length)).ok();
+        Ok(())
+    }
+}
+
+#[derive(Clone, PartialEq, Debug)]
+pub struct RangeResponseHeader(pub Chunk);
+
+impl Header for RangeResponseHeader {
+    fn header_name() -> &'static str {
+        "Range"
+    }
+
+    fn parse_header(raw: &[Vec<u8>]) -> hyper::error::Result<Self> {
+        if raw.len() > 0 {
+            let v = &raw[0];
+            if let Ok(s) = std::str::from_utf8(v) {
+                const PREFIX: &'static str = "bytes ";
+                if s.starts_with(PREFIX) {
+                    if let Ok(c) = <Chunk as FromStr>::from_str(&s[PREFIX.len()..]) {
+                        return  Ok(RangeResponseHeader(c))
+                    }
+                }
+            }
+        }
+        Err(hyper::error::Error::Method)
+    }
+}
+
+impl HeaderFormat for RangeResponseHeader {
+    /// No implmentation necessary, we just need to parse
+    fn fmt_header(&self, _: &mut fmt::Formatter) -> fmt::Result {
+        Err(fmt::Error)
+    }
+}
+
+/// A utility type to perform a resumable upload from start to end.
+pub struct ResumableUploadHelper<'a, A: 'a> {
+    pub client: &'a mut hyper::client::Client,
+    pub delegate: &'a mut Delegate,
+    pub start_at: Option<u64>,
+    pub auth: &'a mut A,
+    pub user_agent: &'a str,
+    pub auth_header: Authorization<Bearer>,
+    pub url: &'a str,
+    pub reader: &'a mut ReadSeek,
+    pub media_type: Mime,
+    pub content_length: u64
+}
+
+impl<'a, A> ResumableUploadHelper<'a, A>
+    where A: oauth2::GetToken {
+
+    fn query_transfer_status(&mut self) -> std::result::Result<u64, hyper::Result<hyper::client::Response>> {
+        loop {
+            match self.client.post(self.url)
+                .header(UserAgent(self.user_agent.to_string()))
+                .header(ContentRange { range: None, total_length: self.content_length })
+                .header(self.auth_header.clone())
+                .send() {
+                Ok(r) => {
+                    // 308 = resume-incomplete == PermanentRedirect
+                    let headers = r.headers.clone();
+                    let h: &RangeResponseHeader = match headers.get() {
+                        Some(hh) if r.status == StatusCode::PermanentRedirect => hh,
+                        None|Some(_) => {
+                            if let Retry::After(d) = self.delegate.http_failure(&r, None, None) {
+                                sleep(d);
+                                continue;
+                            }
+                            return Err(Ok(r))
+                        }
+                    };
+                    return Ok(h.0.last)
+                }
+                Err(err) => {
+                    if let Retry::After(d) = self.delegate.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    return Err(Err(err))
+                }
+            }
+        }
+    }
+
+    /// returns None if operation was cancelled by delegate, or the HttpResult.
+    /// It can be that we return the result just because we didn't understand the status code -
+    /// caller should check for status himself before assuming it's OK to use
+    pub fn upload(&mut self) -> Option<hyper::Result<hyper::client::Response>> {
+        let mut start = match self.start_at {
+            Some(s) => s,
+            None => match self.query_transfer_status() {
+                Ok(s) => s,
+                Err(result) => return Some(result)
+            }
+        };
+
+        const MIN_CHUNK_SIZE: u64 = 1 << 18;
+        let chunk_size = match self.delegate.chunk_size() {
+            cs if cs > MIN_CHUNK_SIZE => cs,
+            _ => MIN_CHUNK_SIZE
+        };
+
+        self.reader.seek(SeekFrom::Start(start)).unwrap();
+        loop {
+            let request_size = match self.content_length - start {
+                rs if rs > chunk_size => chunk_size,
+                rs => rs
+            };
+
+            let mut section_reader = self.reader.take(request_size);
+            let range_header = ContentRange {
+                range: Some(Chunk {first: start, last: start + request_size - 1}),
+                total_length: self.content_length
+            };
+            start += request_size;
+            if self.delegate.cancel_chunk_upload(&range_header) {
+                return None
+            }
+            let res = self.client.post(self.url)
+                                 .header(range_header)
+                                 .header(ContentType(self.media_type.clone()))
+                                 .header(UserAgent(self.user_agent.to_string()))
+                                 .body(&mut section_reader)
+                                 .send();
+            match res {
+                Ok(mut res) => {
+                    if res.status == StatusCode::PermanentRedirect  {
+                        continue
+                    }
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let Retry::After(d) = self.delegate.http_failure(&res,
+                                                        json::from_str(&json_err).ok(),
+                                                        json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                    }
+                    return Some(Ok(res))
+                },
+                Err(err) => {
+                    if let Retry::After(d) = self.delegate.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    return Some(Err(err))
+                }
+            }
+        }
+    }
+}
+
+// Copy of src/rust/cli/cmn.rs
+// TODO(ST): Allow sharing common code between program types
+pub fn remove_json_null_values(value: &mut json::value::Value) {
+    match *value {
+        json::value::Value::Object(ref mut map) => {
+            let mut for_removal = Vec::new();
+
+            for (key, mut value) in map.iter_mut() {
+                if value.is_null() {
+                    for_removal.push(key.clone());
+                } else {
+                    remove_json_null_values(&mut value);
+                }
+            }
+
+            for key in &for_removal {
+                map.remove(key);
+            }
+        }
+        _ => {}
+    }
+}

--- a/gen/vision1/src/lib.rs
+++ b/gen/vision1/src/lib.rs
@@ -1,0 +1,1780 @@
+// DO NOT EDIT !
+// This file was generated automatically from 'src/mako/api/lib.rs.mako'
+// DO NOT EDIT !
+
+//! This documentation was generated from *Vision* crate version *1.0.7+20171107*, where *20171107* is the exact revision of the *vision:v1* schema built by the [mako](http://www.makotemplates.org/) code generator *v1.0.7*.
+//! 
+//! Everything else about the *Vision* *v1* API can be found at the
+//! [official documentation site](https://cloud.google.com/vision/).
+//! The original source code is [on github](https://github.com/Byron/google-apis-rs/tree/master/gen/vision1).
+//! # Features
+//! 
+//! Handle the following *Resources* with ease from the central [hub](struct.Vision.html) ... 
+//! 
+//! * [images](struct.Image.html)
+//!  * [*annotate*](struct.ImageAnnotateCall.html)
+//! 
+//! 
+//! 
+//! 
+//! Not what you are looking for ? Find all other Google APIs in their Rust [documentation index](http://byron.github.io/google-apis-rs).
+//! 
+//! # Structure of this Library
+//! 
+//! The API is structured into the following primary items:
+//! 
+//! * **[Hub](struct.Vision.html)**
+//!     * a central object to maintain state and allow accessing all *Activities*
+//!     * creates [*Method Builders*](trait.MethodsBuilder.html) which in turn
+//!       allow access to individual [*Call Builders*](trait.CallBuilder.html)
+//! * **[Resources](trait.Resource.html)**
+//!     * primary types that you can apply *Activities* to
+//!     * a collection of properties and *Parts*
+//!     * **[Parts](trait.Part.html)**
+//!         * a collection of properties
+//!         * never directly used in *Activities*
+//! * **[Activities](trait.CallBuilder.html)**
+//!     * operations to apply to *Resources*
+//! 
+//! All *structures* are marked with applicable traits to further categorize them and ease browsing.
+//! 
+//! Generally speaking, you can invoke *Activities* like this:
+//! 
+//! ```Rust,ignore
+//! let r = hub.resource().activity(...).doit()
+//! ```
+//! 
+//! Or specifically ...
+//! 
+//! ```ignore
+//! let r = hub.images().annotate(...).doit()
+//! ```
+//! 
+//! The `resource()` and `activity(...)` calls create [builders][builder-pattern]. The second one dealing with `Activities` 
+//! supports various methods to configure the impending operation (not shown here). It is made such that all required arguments have to be 
+//! specified right away (i.e. `(...)`), whereas all optional ones can be [build up][builder-pattern] as desired.
+//! The `doit()` method performs the actual communication with the server and returns the respective result.
+//! 
+//! # Usage
+//! 
+//! ## Setting up your Project
+//! 
+//! To use this library, you would put the following lines into your `Cargo.toml` file:
+//! 
+//! ```toml
+//! [dependencies]
+//! google-vision1 = "*"
+//! ```
+//! 
+//! ## A complete example
+//! 
+//! ```test_harness,no_run
+//! extern crate hyper;
+//! extern crate hyper_rustls;
+//! extern crate yup_oauth2 as oauth2;
+//! extern crate google_vision1 as vision1;
+//! use vision1::BatchAnnotateImagesRequest;
+//! use vision1::{Result, Error};
+//! # #[test] fn egal() {
+//! use std::default::Default;
+//! use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+//! use vision1::Vision;
+//! 
+//! // Get an ApplicationSecret instance by some means. It contains the `client_id` and 
+//! // `client_secret`, among other things.
+//! let secret: ApplicationSecret = Default::default();
+//! // Instantiate the authenticator. It will choose a suitable authentication flow for you, 
+//! // unless you replace  `None` with the desired Flow.
+//! // Provide your own `AuthenticatorDelegate` to adjust the way it operates and get feedback about 
+//! // what's going on. You probably want to bring in your own `TokenStorage` to persist tokens and
+//! // retrieve them from storage.
+//! let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+//!                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+//!                               <MemoryStorage as Default>::default(), None);
+//! let mut hub = Vision::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+//! // As the method needs a request, you would usually fill it with the desired information
+//! // into the respective structure. Some of the parts shown here might not be applicable !
+//! // Values shown here are possibly random and not representative !
+//! let mut req = BatchAnnotateImagesRequest::default();
+//! 
+//! // You can configure optional parameters by calling the respective setters at will, and
+//! // execute the final call using `doit()`.
+//! // Values shown here are possibly random and not representative !
+//! let result = hub.images().annotate(req)
+//!              .doit();
+//! 
+//! match result {
+//!     Err(e) => match e {
+//!         // The Error enum provides details about what exactly happened.
+//!         // You can also just use its `Debug`, `Display` or `Error` traits
+//!          Error::HttpError(_)
+//!         |Error::MissingAPIKey
+//!         |Error::MissingToken(_)
+//!         |Error::Cancelled
+//!         |Error::UploadSizeLimitExceeded(_, _)
+//!         |Error::Failure(_)
+//!         |Error::BadRequest(_)
+//!         |Error::FieldClash(_)
+//!         |Error::JsonDecodeError(_, _) => println!("{}", e),
+//!     },
+//!     Ok(res) => println!("Success: {:?}", res),
+//! }
+//! # }
+//! ```
+//! ## Handling Errors
+//! 
+//! All errors produced by the system are provided either as [Result](enum.Result.html) enumeration as return value of 
+//! the doit() methods, or handed as possibly intermediate results to either the 
+//! [Hub Delegate](trait.Delegate.html), or the [Authenticator Delegate](https://docs.rs/yup-oauth2/*/yup_oauth2/trait.AuthenticatorDelegate.html).
+//! 
+//! When delegates handle errors or intermediate values, they may have a chance to instruct the system to retry. This 
+//! makes the system potentially resilient to all kinds of errors.
+//! 
+//! ## Uploads and Downloads
+//! If a method supports downloads, the response body, which is part of the [Result](enum.Result.html), should be
+//! read by you to obtain the media.
+//! If such a method also supports a [Response Result](trait.ResponseResult.html), it will return that by default.
+//! You can see it as meta-data for the actual media. To trigger a media download, you will have to set up the builder by making
+//! this call: `.param("alt", "media")`.
+//! 
+//! Methods supporting uploads can do so using up to 2 different protocols: 
+//! *simple* and *resumable*. The distinctiveness of each is represented by customized 
+//! `doit(...)` methods, which are then named `upload(...)` and `upload_resumable(...)` respectively.
+//! 
+//! ## Customization and Callbacks
+//! 
+//! You may alter the way an `doit()` method is called by providing a [delegate](trait.Delegate.html) to the 
+//! [Method Builder](trait.CallBuilder.html) before making the final `doit()` call. 
+//! Respective methods will be called to provide progress information, as well as determine whether the system should 
+//! retry on failure.
+//! 
+//! The [delegate trait](trait.Delegate.html) is default-implemented, allowing you to customize it with minimal effort.
+//! 
+//! ## Optional Parts in Server-Requests
+//! 
+//! All structures provided by this library are made to be [enocodable](trait.RequestValue.html) and 
+//! [decodable](trait.ResponseResult.html) via *json*. Optionals are used to indicate that partial requests are responses 
+//! are valid.
+//! Most optionals are are considered [Parts](trait.Part.html) which are identifiable by name, which will be sent to 
+//! the server to indicate either the set parts of the request or the desired parts in the response.
+//! 
+//! ## Builder Arguments
+//! 
+//! Using [method builders](trait.CallBuilder.html), you are able to prepare an action call by repeatedly calling it's methods.
+//! These will always take a single argument, for which the following statements are true.
+//! 
+//! * [PODs][wiki-pod] are handed by copy
+//! * strings are passed as `&str`
+//! * [request values](trait.RequestValue.html) are moved
+//! 
+//! Arguments will always be copied or cloned into the builder, to make them independent of their original life times.
+//! 
+//! [wiki-pod]: http://en.wikipedia.org/wiki/Plain_old_data_structure
+//! [builder-pattern]: http://en.wikipedia.org/wiki/Builder_pattern
+//! [google-go-api]: https://github.com/google/google-api-go-client
+//! 
+//! 
+
+// Unused attributes happen thanks to defined, but unused structures
+// We don't warn about this, as depending on the API, some data structures or facilities are never used.
+// Instead of pre-determining this, we just disable the lint. It's manually tuned to not have any
+// unused imports in fully featured APIs. Same with unused_mut ... .
+#![allow(unused_imports, unused_mut, dead_code)]
+
+// DO NOT EDIT !
+// This file was generated automatically from 'src/mako/api/lib.rs.mako'
+// DO NOT EDIT !
+
+#[macro_use]
+extern crate serde_derive;
+
+extern crate hyper;
+extern crate serde;
+extern crate serde_json;
+extern crate yup_oauth2 as oauth2;
+extern crate mime;
+extern crate url;
+
+mod cmn;
+
+use std::collections::HashMap;
+use std::cell::RefCell;
+use std::borrow::BorrowMut;
+use std::default::Default;
+use std::collections::BTreeMap;
+use serde_json as json;
+use std::io;
+use std::fs;
+use std::mem;
+use std::thread::sleep;
+use std::time::Duration;
+
+pub use cmn::{MultiPartReader, ToParts, MethodInfo, Result, Error, CallBuilder, Hub, ReadSeek, Part,
+              ResponseResult, RequestValue, NestedType, Delegate, DefaultDelegate, MethodsBuilder,
+              Resource, ErrorResponse, remove_json_null_values};
+
+
+// ##############
+// UTILITIES ###
+// ############
+
+/// Identifies the an OAuth2 authorization scope.
+/// A scope is needed when requesting an
+/// [authorization token](https://developers.google.com/youtube/v3/guides/authentication).
+#[derive(PartialEq, Eq, Hash)]
+pub enum Scope {
+    /// Apply machine learning models to understand and label images
+    CloudVision,
+
+    /// View and manage your data across Google Cloud Platform services
+    CloudPlatform,
+}
+
+impl AsRef<str> for Scope {
+    fn as_ref(&self) -> &str {
+        match *self {
+            Scope::CloudVision => "https://www.googleapis.com/auth/cloud-vision",
+            Scope::CloudPlatform => "https://www.googleapis.com/auth/cloud-platform",
+        }
+    }
+}
+
+impl Default for Scope {
+    fn default() -> Scope {
+        Scope::CloudVision
+    }
+}
+
+
+
+// ########
+// HUB ###
+// ######
+
+/// Central instance to access all Vision related resource activities
+///
+/// # Examples
+///
+/// Instantiate a new hub
+///
+/// ```test_harness,no_run
+/// extern crate hyper;
+/// extern crate hyper_rustls;
+/// extern crate yup_oauth2 as oauth2;
+/// extern crate google_vision1 as vision1;
+/// use vision1::BatchAnnotateImagesRequest;
+/// use vision1::{Result, Error};
+/// # #[test] fn egal() {
+/// use std::default::Default;
+/// use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// use vision1::Vision;
+/// 
+/// // Get an ApplicationSecret instance by some means. It contains the `client_id` and 
+/// // `client_secret`, among other things.
+/// let secret: ApplicationSecret = Default::default();
+/// // Instantiate the authenticator. It will choose a suitable authentication flow for you, 
+/// // unless you replace  `None` with the desired Flow.
+/// // Provide your own `AuthenticatorDelegate` to adjust the way it operates and get feedback about 
+/// // what's going on. You probably want to bring in your own `TokenStorage` to persist tokens and
+/// // retrieve them from storage.
+/// let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+///                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+///                               <MemoryStorage as Default>::default(), None);
+/// let mut hub = Vision::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = BatchAnnotateImagesRequest::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.images().annotate(req)
+///              .doit();
+/// 
+/// match result {
+///     Err(e) => match e {
+///         // The Error enum provides details about what exactly happened.
+///         // You can also just use its `Debug`, `Display` or `Error` traits
+///          Error::HttpError(_)
+///         |Error::MissingAPIKey
+///         |Error::MissingToken(_)
+///         |Error::Cancelled
+///         |Error::UploadSizeLimitExceeded(_, _)
+///         |Error::Failure(_)
+///         |Error::BadRequest(_)
+///         |Error::FieldClash(_)
+///         |Error::JsonDecodeError(_, _) => println!("{}", e),
+///     },
+///     Ok(res) => println!("Success: {:?}", res),
+/// }
+/// # }
+/// ```
+pub struct Vision<C, A> {
+    client: RefCell<C>,
+    auth: RefCell<A>,
+    _user_agent: String,
+    _base_url: String,
+    _root_url: String,
+}
+
+impl<'a, C, A> Hub for Vision<C, A> {}
+
+impl<'a, C, A> Vision<C, A>
+    where  C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+    pub fn new(client: C, authenticator: A) -> Vision<C, A> {
+        Vision {
+            client: RefCell::new(client),
+            auth: RefCell::new(authenticator),
+            _user_agent: "google-api-rust-client/1.0.7".to_string(),
+            _base_url: "https://vision.googleapis.com/".to_string(),
+            _root_url: "https://vision.googleapis.com/".to_string(),
+        }
+    }
+
+    pub fn images(&'a self) -> ImageMethods<'a, C, A> {
+        ImageMethods { hub: &self }
+    }
+
+    /// Set the user-agent header field to use in all requests to the server.
+    /// It defaults to `google-api-rust-client/1.0.7`.
+    ///
+    /// Returns the previously set user-agent.
+    pub fn user_agent(&mut self, agent_name: String) -> String {
+        mem::replace(&mut self._user_agent, agent_name)
+    }
+
+    /// Set the base url to use in all requests to the server.
+    /// It defaults to `https://vision.googleapis.com/`.
+    ///
+    /// Returns the previously set base url.
+    pub fn base_url(&mut self, new_base_url: String) -> String {
+        mem::replace(&mut self._base_url, new_base_url)
+    }
+
+    /// Set the root url to use in all requests to the server.
+    /// It defaults to `https://vision.googleapis.com/`.
+    ///
+    /// Returns the previously set root url.
+    pub fn root_url(&mut self, new_root_url: String) -> String {
+        mem::replace(&mut self._root_url, new_root_url)
+    }
+}
+
+
+// ############
+// SCHEMAS ###
+// ##########
+/// Request for performing Google Cloud Vision API tasks over a user-provided
+/// image, with user-requested features.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct AnnotateImageRequest {
+    /// Additional context that may accompany the image.
+    #[serde(rename="imageContext")]
+    pub image_context: Option<ImageContext>,
+    /// The image to be processed.
+    pub image: Option<Image>,
+    /// Requested features.
+    pub features: Option<Vec<Feature>>,
+}
+
+impl Part for AnnotateImageRequest {}
+
+
+/// Users describe the type of Google Cloud Vision API tasks to perform over
+/// images by using *Feature*s. Each Feature indicates a type of image
+/// detection task to perform. Features encode the Cloud Vision API
+/// vertical to operate on and the number of top-scoring results to return.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Feature {
+    /// The feature type.
+    #[serde(rename="type")]
+    pub type_: Option<String>,
+    /// Maximum number of results of this type.
+    #[serde(rename="maxResults")]
+    pub max_results: Option<i32>,
+}
+
+impl Part for Feature {}
+
+
+/// An object representing a latitude/longitude pair. This is expressed as a pair
+/// of doubles representing degrees latitude and degrees longitude. Unless
+/// specified otherwise, this must conform to the
+/// <a href="http://www.unoosa.org/pdf/icg/2012/template/WGS_84.pdf">WGS84
+/// standard</a>. Values must be within normalized ranges.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct LatLng {
+    /// The latitude in degrees. It must be in the range [-90.0, +90.0].
+    pub latitude: Option<f64>,
+    /// The longitude in degrees. It must be in the range [-180.0, +180.0].
+    pub longitude: Option<f64>,
+}
+
+impl Part for LatLng {}
+
+
+/// Single crop hint that is used to generate a new crop when serving an image.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct CropHint {
+    /// Confidence of this being a salient region.  Range [0, 1].
+    pub confidence: Option<f32>,
+    /// The bounding polygon for the crop region. The coordinates of the bounding
+    /// box are in the original image's scale, as returned in `ImageParams`.
+    #[serde(rename="boundingPoly")]
+    pub bounding_poly: Option<BoundingPoly>,
+    /// Fraction of importance of this salient region with respect to the original
+    /// image.
+    #[serde(rename="importanceFraction")]
+    pub importance_fraction: Option<f32>,
+}
+
+impl Part for CropHint {}
+
+
+/// Multiple image annotation requests are batched into a single service call.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [annotate images](struct.ImageAnnotateCall.html) (request)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct BatchAnnotateImagesRequest {
+    /// Individual image annotation requests for this batch.
+    pub requests: Option<Vec<AnnotateImageRequest>>,
+}
+
+impl RequestValue for BatchAnnotateImagesRequest {}
+
+
+/// A word representation.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Word {
+    /// The bounding box for the word.
+    /// The vertices are in the order of top-left, top-right, bottom-right,
+    /// bottom-left. When a rotation of the bounding box is detected the rotation
+    /// is represented as around the top-left corner as defined when the text is
+    /// read in the 'natural' orientation.
+    /// For example:
+    ///   * when the text is horizontal it might look like:
+    ///      0----1
+    ///      |    |
+    ///      3----2
+    ///   * when it's rotated 180 degrees around the top-left corner it becomes:
+    ///      2----3
+    ///      |    |
+    ///      1----0
+    ///   and the vertice order will still be (0, 1, 2, 3).
+    #[serde(rename="boundingBox")]
+    pub bounding_box: Option<BoundingPoly>,
+    /// List of symbols in the word.
+    /// The order of the symbols follows the natural reading order.
+    pub symbols: Option<Vec<Symbol>>,
+    /// Additional information detected for the word.
+    pub property: Option<TextProperty>,
+}
+
+impl Part for Word {}
+
+
+/// Set of crop hints that are used to generate new crops when serving images.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct CropHintsAnnotation {
+    /// Crop hint results.
+    #[serde(rename="cropHints")]
+    pub crop_hints: Option<Vec<CropHint>>,
+}
+
+impl Part for CropHintsAnnotation {}
+
+
+/// Set of detected entity features.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct EntityAnnotation {
+    /// The accuracy of the entity detection in an image.
+    /// For example, for an image in which the "Eiffel Tower" entity is detected,
+    /// this field represents the confidence that there is a tower in the query
+    /// image. Range [0, 1].
+    pub confidence: Option<f32>,
+    /// Entity textual description, expressed in its `locale` language.
+    pub description: Option<String>,
+    /// The language code for the locale in which the entity textual
+    /// `description` is expressed.
+    pub locale: Option<String>,
+    /// The relevancy of the ICA (Image Content Annotation) label to the
+    /// image. For example, the relevancy of "tower" is likely higher to an image
+    /// containing the detected "Eiffel Tower" than to an image containing a
+    /// detected distant towering building, even though the confidence that
+    /// there is a tower in each image may be the same. Range [0, 1].
+    pub topicality: Option<f32>,
+    /// Opaque entity ID. Some IDs may be available in
+    /// [Google Knowledge Graph Search
+    /// API](https://developers.google.com/knowledge-graph/).
+    pub mid: Option<String>,
+    /// The location information for the detected entity. Multiple
+    /// `LocationInfo` elements can be present because one location may
+    /// indicate the location of the scene in the image, and another location
+    /// may indicate the location of the place where the image was taken.
+    /// Location information is usually present for landmarks.
+    pub locations: Option<Vec<LocationInfo>>,
+    /// Overall score of the result. Range [0, 1].
+    pub score: Option<f32>,
+    /// Image region to which this entity belongs. Not produced
+    /// for `LABEL_DETECTION` features.
+    #[serde(rename="boundingPoly")]
+    pub bounding_poly: Option<BoundingPoly>,
+    /// Some entities may have optional user-supplied `Property` (name/value)
+    /// fields, such a score or string that qualifies the entity.
+    pub properties: Option<Vec<Property>>,
+}
+
+impl Part for EntityAnnotation {}
+
+
+/// The `Status` type defines a logical error model that is suitable for different
+/// programming environments, including REST APIs and RPC APIs. It is used by
+/// [gRPC](https://github.com/grpc). The error model is designed to be:
+/// 
+/// - Simple to use and understand for most users
+/// - Flexible enough to meet unexpected needs
+/// 
+/// # Overview
+/// 
+/// The `Status` message contains three pieces of data: error code, error message,
+/// and error details. The error code should be an enum value of
+/// google.rpc.Code, but it may accept additional error codes if needed.  The
+/// error message should be a developer-facing English message that helps
+/// developers *understand* and *resolve* the error. If a localized user-facing
+/// error message is needed, put the localized message in the error details or
+/// localize it in the client. The optional error details may contain arbitrary
+/// information about the error. There is a predefined set of error detail types
+/// in the package `google.rpc` that can be used for common error conditions.
+/// 
+/// # Language mapping
+/// 
+/// The `Status` message is the logical representation of the error model, but it
+/// is not necessarily the actual wire format. When the `Status` message is
+/// exposed in different client libraries and different wire protocols, it can be
+/// mapped differently. For example, it will likely be mapped to some exceptions
+/// in Java, but more likely mapped to some error codes in C.
+/// 
+/// # Other uses
+/// 
+/// The error model and the `Status` message can be used in a variety of
+/// environments, either with or without APIs, to provide a
+/// consistent developer experience across different environments.
+/// 
+/// Example uses of this error model include:
+/// 
+/// - Partial errors. If a service needs to return partial errors to the client,
+///     it may embed the `Status` in the normal response to indicate the partial
+///     errors.
+/// 
+/// - Workflow errors. A typical workflow has multiple steps. Each step may
+///     have a `Status` message for error reporting.
+/// 
+/// - Batch operations. If a client uses batch request and batch response, the
+///     `Status` message should be used directly inside batch response, one for
+///     each error sub-response.
+/// 
+/// - Asynchronous operations. If an API call embeds asynchronous operation
+///     results in its response, the status of those operations should be
+///     represented directly using the `Status` message.
+/// 
+/// - Logging. If some API errors are stored in logs, the message `Status` could
+///     be used directly after any stripping needed for security/privacy reasons.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Status {
+    /// A developer-facing error message, which should be in English. Any
+    /// user-facing error message should be localized and sent in the
+    /// google.rpc.Status.details field, or localized by the client.
+    pub message: Option<String>,
+    /// The status code, which should be an enum value of google.rpc.Code.
+    pub code: Option<i32>,
+    /// A list of messages that carry the error details.  There is a common set of
+    /// message types for APIs to use.
+    pub details: Option<Vec<HashMap<String, String>>>,
+}
+
+impl Part for Status {}
+
+
+/// Metadata for online images.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct WebImage {
+    /// The result image URL.
+    pub url: Option<String>,
+    /// (Deprecated) Overall relevancy score for the image.
+    pub score: Option<f32>,
+}
+
+impl Part for WebImage {}
+
+
+/// Stores image properties, such as dominant colors.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct ImageProperties {
+    /// If present, dominant colors completed successfully.
+    #[serde(rename="dominantColors")]
+    pub dominant_colors: Option<DominantColorsAnnotation>,
+}
+
+impl Part for ImageProperties {}
+
+
+/// Color information consists of RGB channels, score, and the fraction of
+/// the image that the color occupies in the image.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct ColorInfo {
+    /// RGB components of the color.
+    pub color: Option<Color>,
+    /// The fraction of pixels the color occupies in the image.
+    /// Value in range [0, 1].
+    #[serde(rename="pixelFraction")]
+    pub pixel_fraction: Option<f32>,
+    /// Image-specific score for this color. Value in range [0, 1].
+    pub score: Option<f32>,
+}
+
+impl Part for ColorInfo {}
+
+
+/// Relevant information for the image from the Internet.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct WebDetection {
+    /// Deduced entities from similar images on the Internet.
+    #[serde(rename="webEntities")]
+    pub web_entities: Option<Vec<WebEntity>>,
+    /// Web pages containing the matching images from the Internet.
+    #[serde(rename="pagesWithMatchingImages")]
+    pub pages_with_matching_images: Option<Vec<WebPage>>,
+    /// The visually similar image results.
+    #[serde(rename="visuallySimilarImages")]
+    pub visually_similar_images: Option<Vec<WebImage>>,
+    /// Partial matching images from the Internet.
+    /// Those images are similar enough to share some key-point features. For
+    /// example an original image will likely have partial matching for its crops.
+    #[serde(rename="partialMatchingImages")]
+    pub partial_matching_images: Option<Vec<WebImage>>,
+    /// Fully matching images from the Internet.
+    /// Can include resized copies of the query image.
+    #[serde(rename="fullMatchingImages")]
+    pub full_matching_images: Option<Vec<WebImage>>,
+}
+
+impl Part for WebDetection {}
+
+
+/// A single symbol representation.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Symbol {
+    /// The bounding box for the symbol.
+    /// The vertices are in the order of top-left, top-right, bottom-right,
+    /// bottom-left. When a rotation of the bounding box is detected the rotation
+    /// is represented as around the top-left corner as defined when the text is
+    /// read in the 'natural' orientation.
+    /// For example:
+    ///   * when the text is horizontal it might look like:
+    ///      0----1
+    ///      |    |
+    ///      3----2
+    ///   * when it's rotated 180 degrees around the top-left corner it becomes:
+    ///      2----3
+    ///      |    |
+    ///      1----0
+    ///   and the vertice order will still be (0, 1, 2, 3).
+    #[serde(rename="boundingBox")]
+    pub bounding_box: Option<BoundingPoly>,
+    /// The actual UTF-8 representation of the symbol.
+    pub text: Option<String>,
+    /// Additional information detected for the symbol.
+    pub property: Option<TextProperty>,
+}
+
+impl Part for Symbol {}
+
+
+/// A vertex represents a 2D point in the image.
+/// NOTE: the vertex coordinates are in the same scale as the original image.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Vertex {
+    /// Y coordinate.
+    pub y: Option<i32>,
+    /// X coordinate.
+    pub x: Option<i32>,
+}
+
+impl Part for Vertex {}
+
+
+/// Additional information detected on the structural component.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct TextProperty {
+    /// Detected start or end of a text segment.
+    #[serde(rename="detectedBreak")]
+    pub detected_break: Option<DetectedBreak>,
+    /// A list of detected languages together with confidence.
+    #[serde(rename="detectedLanguages")]
+    pub detected_languages: Option<Vec<DetectedLanguage>>,
+}
+
+impl Part for TextProperty {}
+
+
+/// Rectangle determined by min and max `LatLng` pairs.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct LatLongRect {
+    /// Min lat/long pair.
+    #[serde(rename="minLatLng")]
+    pub min_lat_lng: Option<LatLng>,
+    /// Max lat/long pair.
+    #[serde(rename="maxLatLng")]
+    pub max_lat_lng: Option<LatLng>,
+}
+
+impl Part for LatLongRect {}
+
+
+/// External image source (Google Cloud Storage image location).
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct ImageSource {
+    /// NOTE: For new code `image_uri` below is preferred.
+    /// Google Cloud Storage image URI, which must be in the following form:
+    /// `gs://bucket_name/object_name` (for details, see
+    /// [Google Cloud Storage Request
+    /// URIs](https://cloud.google.com/storage/docs/reference-uris)).
+    /// NOTE: Cloud Storage object versioning is not supported.
+    #[serde(rename="gcsImageUri")]
+    pub gcs_image_uri: Option<String>,
+    /// Image URI which supports:
+    /// 1) Google Cloud Storage image URI, which must be in the following form:
+    /// `gs://bucket_name/object_name` (for details, see
+    /// [Google Cloud Storage Request
+    /// URIs](https://cloud.google.com/storage/docs/reference-uris)).
+    /// NOTE: Cloud Storage object versioning is not supported.
+    /// 2) Publicly accessible image HTTP/HTTPS URL.
+    /// This is preferred over the legacy `gcs_image_uri` above. When both
+    /// `gcs_image_uri` and `image_uri` are specified, `image_uri` takes
+    /// precedence.
+    #[serde(rename="imageUri")]
+    pub image_uri: Option<String>,
+}
+
+impl Part for ImageSource {}
+
+
+/// Set of features pertaining to the image, computed by computer vision
+/// methods over safe-search verticals (for example, adult, spoof, medical,
+/// violence).
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct SafeSearchAnnotation {
+    /// Likelihood that this is a medical image.
+    pub medical: Option<String>,
+    /// Likelihood that this image contains violent content.
+    pub violence: Option<String>,
+    /// Spoof likelihood. The likelihood that an modification
+    /// was made to the image's canonical version to make it appear
+    /// funny or offensive.
+    pub spoof: Option<String>,
+    /// Represents the adult content likelihood for the image. Adult content may
+    /// contain elements such as nudity, pornographic images or cartoons, or
+    /// sexual activities.
+    pub adult: Option<String>,
+}
+
+impl Part for SafeSearchAnnotation {}
+
+
+/// TextAnnotation contains a structured representation of OCR extracted text.
+/// The hierarchy of an OCR extracted text structure is like this:
+///     TextAnnotation -> Page -> Block -> Paragraph -> Word -> Symbol
+/// Each structural component, starting from Page, may further have their own
+/// properties. Properties describe detected languages, breaks etc.. Please refer
+/// to the TextAnnotation.TextProperty message definition below for more
+/// detail.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct TextAnnotation {
+    /// UTF-8 text detected on the pages.
+    pub text: Option<String>,
+    /// List of pages detected by OCR.
+    pub pages: Option<Vec<Page>>,
+}
+
+impl Part for TextAnnotation {}
+
+
+/// Metadata for web pages.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct WebPage {
+    /// The result web page URL.
+    pub url: Option<String>,
+    /// (Deprecated) Overall relevancy score for the web page.
+    pub score: Option<f32>,
+}
+
+impl Part for WebPage {}
+
+
+/// Detected entity location information.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct LocationInfo {
+    /// lat/long location coordinates.
+    #[serde(rename="latLng")]
+    pub lat_lng: Option<LatLng>,
+}
+
+impl Part for LocationInfo {}
+
+
+/// Structural unit of text representing a number of words in certain order.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Paragraph {
+    /// The bounding box for the paragraph.
+    /// The vertices are in the order of top-left, top-right, bottom-right,
+    /// bottom-left. When a rotation of the bounding box is detected the rotation
+    /// is represented as around the top-left corner as defined when the text is
+    /// read in the 'natural' orientation.
+    /// For example:
+    ///   * when the text is horizontal it might look like:
+    ///      0----1
+    ///      |    |
+    ///      3----2
+    ///   * when it's rotated 180 degrees around the top-left corner it becomes:
+    ///      2----3
+    ///      |    |
+    ///      1----0
+    ///   and the vertice order will still be (0, 1, 2, 3).
+    #[serde(rename="boundingBox")]
+    pub bounding_box: Option<BoundingPoly>,
+    /// Additional information detected for the paragraph.
+    pub property: Option<TextProperty>,
+    /// List of words in this paragraph.
+    pub words: Option<Vec<Word>>,
+}
+
+impl Part for Paragraph {}
+
+
+/// Detected language for a structural component.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct DetectedLanguage {
+    /// The BCP-47 language code, such as "en-US" or "sr-Latn". For more
+    /// information, see
+    /// http://www.unicode.org/reports/tr35/#Unicode_locale_identifier.
+    #[serde(rename="languageCode")]
+    pub language_code: Option<String>,
+    /// Confidence of detected language. Range [0, 1].
+    pub confidence: Option<f32>,
+}
+
+impl Part for DetectedLanguage {}
+
+
+/// Parameters for crop hints annotation request.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct CropHintsParams {
+    /// Aspect ratios in floats, representing the ratio of the width to the height
+    /// of the image. For example, if the desired aspect ratio is 4/3, the
+    /// corresponding float value should be 1.33333.  If not specified, the
+    /// best possible crop is returned. The number of provided aspect ratios is
+    /// limited to a maximum of 16; any aspect ratios provided after the 16th are
+    /// ignored.
+    #[serde(rename="aspectRatios")]
+    pub aspect_ratios: Option<Vec<f32>>,
+}
+
+impl Part for CropHintsParams {}
+
+
+/// A bounding polygon for the detected image annotation.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct BoundingPoly {
+    /// The bounding polygon vertices.
+    pub vertices: Option<Vec<Vertex>>,
+}
+
+impl Part for BoundingPoly {}
+
+
+/// A face-specific landmark (for example, a face feature).
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Landmark {
+    /// Face landmark position.
+    pub position: Option<Position>,
+    /// Face landmark type.
+    #[serde(rename="type")]
+    pub type_: Option<String>,
+}
+
+impl Part for Landmark {}
+
+
+/// A 3D position in the image, used primarily for Face detection landmarks.
+/// A valid Position must have both x and y coordinates.
+/// The position coordinates are in the same scale as the original image.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Position {
+    /// Y coordinate.
+    pub y: Option<f32>,
+    /// X coordinate.
+    pub x: Option<f32>,
+    /// Z coordinate (or depth).
+    pub z: Option<f32>,
+}
+
+impl Part for Position {}
+
+
+/// Detected start or end of a structural component.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct DetectedBreak {
+    /// True if break prepends the element.
+    #[serde(rename="isPrefix")]
+    pub is_prefix: Option<bool>,
+    /// Detected break type.
+    #[serde(rename="type")]
+    pub type_: Option<String>,
+}
+
+impl Part for DetectedBreak {}
+
+
+/// A `Property` consists of a user-supplied name/value pair.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Property {
+    /// Value of numeric properties.
+    #[serde(rename="uint64Value")]
+    pub uint64_value: Option<String>,
+    /// Name of the property.
+    pub name: Option<String>,
+    /// Value of the property.
+    pub value: Option<String>,
+}
+
+impl Part for Property {}
+
+
+/// Detected page from OCR.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Page {
+    /// Page width in pixels.
+    pub width: Option<i32>,
+    /// Additional information detected on the page.
+    pub property: Option<TextProperty>,
+    /// List of blocks of text, images etc on this page.
+    pub blocks: Option<Vec<Block>>,
+    /// Page height in pixels.
+    pub height: Option<i32>,
+}
+
+impl Part for Page {}
+
+
+/// Logical element on the page.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Block {
+    /// The bounding box for the block.
+    /// The vertices are in the order of top-left, top-right, bottom-right,
+    /// bottom-left. When a rotation of the bounding box is detected the rotation
+    /// is represented as around the top-left corner as defined when the text is
+    /// read in the 'natural' orientation.
+    /// For example:
+    ///   * when the text is horizontal it might look like:
+    ///      0----1
+    ///      |    |
+    ///      3----2
+    ///   * when it's rotated 180 degrees around the top-left corner it becomes:
+    ///      2----3
+    ///      |    |
+    ///      1----0
+    ///   and the vertice order will still be (0, 1, 2, 3).
+    #[serde(rename="boundingBox")]
+    pub bounding_box: Option<BoundingPoly>,
+    /// Detected block type (text, image etc) for this block.
+    #[serde(rename="blockType")]
+    pub block_type: Option<String>,
+    /// Additional information detected for the block.
+    pub property: Option<TextProperty>,
+    /// List of paragraphs in this block (if this blocks is of type text).
+    pub paragraphs: Option<Vec<Paragraph>>,
+}
+
+impl Part for Block {}
+
+
+/// Image context and/or feature-specific parameters.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct ImageContext {
+    /// lat/long rectangle that specifies the location of the image.
+    #[serde(rename="latLongRect")]
+    pub lat_long_rect: Option<LatLongRect>,
+    /// List of languages to use for TEXT_DETECTION. In most cases, an empty value
+    /// yields the best results since it enables automatic language detection. For
+    /// languages based on the Latin alphabet, setting `language_hints` is not
+    /// needed. In rare cases, when the language of the text in the image is known,
+    /// setting a hint will help get better results (although it will be a
+    /// significant hindrance if the hint is wrong). Text detection returns an
+    /// error if one or more of the specified languages is not one of the
+    /// [supported languages](/vision/docs/languages).
+    #[serde(rename="languageHints")]
+    pub language_hints: Option<Vec<String>>,
+    /// Parameters for crop hints annotation request.
+    #[serde(rename="cropHintsParams")]
+    pub crop_hints_params: Option<CropHintsParams>,
+}
+
+impl Part for ImageContext {}
+
+
+/// Set of dominant colors and their corresponding scores.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct DominantColorsAnnotation {
+    /// RGB color values with their score and pixel fraction.
+    pub colors: Option<Vec<ColorInfo>>,
+}
+
+impl Part for DominantColorsAnnotation {}
+
+
+/// Represents a color in the RGBA color space. This representation is designed
+/// for simplicity of conversion to/from color representations in various
+/// languages over compactness; for example, the fields of this representation
+/// can be trivially provided to the constructor of "java.awt.Color" in Java; it
+/// can also be trivially provided to UIColor's "+colorWithRed:green:blue:alpha"
+/// method in iOS; and, with just a little work, it can be easily formatted into
+/// a CSS "rgba()" string in JavaScript, as well. Here are some examples:
+/// 
+/// Example (Java):
+/// 
+///      import com.google.type.Color;
+/// 
+///      // ...
+///      public static java.awt.Color fromProto(Color protocolor) {
+///        float alpha = protocolor.hasAlpha()
+///            ? protocolor.getAlpha().getValue()
+///            : 1.0;
+/// 
+///        return new java.awt.Color(
+///            protocolor.getRed(),
+///            protocolor.getGreen(),
+///            protocolor.getBlue(),
+///            alpha);
+///      }
+/// 
+///      public static Color toProto(java.awt.Color color) {
+///        float red = (float) color.getRed();
+///        float green = (float) color.getGreen();
+///        float blue = (float) color.getBlue();
+///        float denominator = 255.0;
+///        Color.Builder resultBuilder =
+///            Color
+///                .newBuilder()
+///                .setRed(red / denominator)
+///                .setGreen(green / denominator)
+///                .setBlue(blue / denominator);
+///        int alpha = color.getAlpha();
+///        if (alpha != 255) {
+///          result.setAlpha(
+///              FloatValue
+///                  .newBuilder()
+///                  .setValue(((float) alpha) / denominator)
+///                  .build());
+///        }
+///        return resultBuilder.build();
+///      }
+///      // ...
+/// 
+/// Example (iOS / Obj-C):
+/// 
+///      // ...
+///      static UIColor* fromProto(Color* protocolor) {
+///         float red = [protocolor red];
+///         float green = [protocolor green];
+///         float blue = [protocolor blue];
+///         FloatValue* alpha_wrapper = [protocolor alpha];
+///         float alpha = 1.0;
+///         if (alpha_wrapper != nil) {
+///           alpha = [alpha_wrapper value];
+///         }
+///         return [UIColor colorWithRed:red green:green blue:blue alpha:alpha];
+///      }
+/// 
+///      static Color* toProto(UIColor* color) {
+///          CGFloat red, green, blue, alpha;
+///          if (![color getRed:&red green:&green blue:&blue alpha:&alpha]) {
+///            return nil;
+///          }
+///          Color* result = [Color alloc] init];
+///          [result setRed:red];
+///          [result setGreen:green];
+///          [result setBlue:blue];
+///          if (alpha <= 0.9999) {
+///            [result setAlpha:floatWrapperWithValue(alpha)];
+///          }
+///          [result autorelease];
+///          return result;
+///     }
+///     // ...
+/// 
+///  Example (JavaScript):
+/// 
+///     // ...
+/// 
+///     var protoToCssColor = function(rgb_color) {
+///        var redFrac = rgb_color.red || 0.0;
+///        var greenFrac = rgb_color.green || 0.0;
+///        var blueFrac = rgb_color.blue || 0.0;
+///        var red = Math.floor(redFrac * 255);
+///        var green = Math.floor(greenFrac * 255);
+///        var blue = Math.floor(blueFrac * 255);
+/// 
+///        if (!('alpha' in rgb_color)) {
+///           return rgbToCssColor_(red, green, blue);
+///        }
+/// 
+///        var alphaFrac = rgb_color.alpha.value || 0.0;
+///        var rgbParams = [red, green, blue].join(',');
+///        return ['rgba(', rgbParams, ',', alphaFrac, ')'].join('');
+///     };
+/// 
+///     var rgbToCssColor_ = function(red, green, blue) {
+///       var rgbNumber = new Number((red << 16) | (green << 8) | blue);
+///       var hexString = rgbNumber.toString(16);
+///       var missingZeros = 6 - hexString.length;
+///       var resultBuilder = ['#'];
+///       for (var i = 0; i < missingZeros; i++) {
+///          resultBuilder.push('0');
+///       }
+///       resultBuilder.push(hexString);
+///       return resultBuilder.join('');
+///     };
+/// 
+///     // ...
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Color {
+    /// The amount of blue in the color as a value in the interval [0, 1].
+    pub blue: Option<f32>,
+    /// The fraction of this color that should be applied to the pixel. That is,
+    /// the final pixel color is defined by the equation:
+    /// 
+    ///   pixel color = alpha * (this color) + (1.0 - alpha) * (background color)
+    /// 
+    /// This means that a value of 1.0 corresponds to a solid color, whereas
+    /// a value of 0.0 corresponds to a completely transparent color. This
+    /// uses a wrapper message rather than a simple float scalar so that it is
+    /// possible to distinguish between a default value and the value being unset.
+    /// If omitted, this color object is to be rendered as a solid color
+    /// (as if the alpha value had been explicitly given with a value of 1.0).
+    pub alpha: Option<f32>,
+    /// The amount of green in the color as a value in the interval [0, 1].
+    pub green: Option<f32>,
+    /// The amount of red in the color as a value in the interval [0, 1].
+    pub red: Option<f32>,
+}
+
+impl Part for Color {}
+
+
+/// Client image to perform Google Cloud Vision API tasks over.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [annotate images](struct.ImageAnnotateCall.html) (none)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct Image {
+    /// Image content, represented as a stream of bytes.
+    /// Note: as with all `bytes` fields, protobuffers use a pure binary
+    /// representation, whereas JSON representations use base64.
+    pub content: Option<String>,
+    /// Google Cloud Storage image location. If both `content` and `source`
+    /// are provided for an image, `content` takes precedence and is
+    /// used to perform the image annotation request.
+    pub source: Option<ImageSource>,
+}
+
+impl Resource for Image {}
+
+
+/// Entity deduced from similar images on the Internet.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct WebEntity {
+    /// Opaque entity ID.
+    #[serde(rename="entityId")]
+    pub entity_id: Option<String>,
+    /// Overall relevancy score for the entity.
+    /// Not normalized and not comparable across different image queries.
+    pub score: Option<f32>,
+    /// Canonical description of the entity, in English.
+    pub description: Option<String>,
+}
+
+impl Part for WebEntity {}
+
+
+/// Response to a batch image annotation request.
+/// 
+/// # Activities
+/// 
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in. 
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+/// 
+/// * [annotate images](struct.ImageAnnotateCall.html) (response)
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct BatchAnnotateImagesResponse {
+    /// Individual responses to image annotation requests within the batch.
+    pub responses: Option<Vec<AnnotateImageResponse>>,
+}
+
+impl ResponseResult for BatchAnnotateImagesResponse {}
+
+
+/// A face annotation object contains the results of face detection.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct FaceAnnotation {
+    /// Sorrow likelihood.
+    #[serde(rename="sorrowLikelihood")]
+    pub sorrow_likelihood: Option<String>,
+    /// Under-exposed likelihood.
+    #[serde(rename="underExposedLikelihood")]
+    pub under_exposed_likelihood: Option<String>,
+    /// Face landmarking confidence. Range [0, 1].
+    #[serde(rename="landmarkingConfidence")]
+    pub landmarking_confidence: Option<f32>,
+    /// Detection confidence. Range [0, 1].
+    #[serde(rename="detectionConfidence")]
+    pub detection_confidence: Option<f32>,
+    /// Joy likelihood.
+    #[serde(rename="joyLikelihood")]
+    pub joy_likelihood: Option<String>,
+    /// Detected face landmarks.
+    pub landmarks: Option<Vec<Landmark>>,
+    /// Surprise likelihood.
+    #[serde(rename="surpriseLikelihood")]
+    pub surprise_likelihood: Option<String>,
+    /// Blurred likelihood.
+    #[serde(rename="blurredLikelihood")]
+    pub blurred_likelihood: Option<String>,
+    /// Pitch angle, which indicates the upwards/downwards angle that the face is
+    /// pointing relative to the image's horizontal plane. Range [-180,180].
+    #[serde(rename="tiltAngle")]
+    pub tilt_angle: Option<f32>,
+    /// Anger likelihood.
+    #[serde(rename="angerLikelihood")]
+    pub anger_likelihood: Option<String>,
+    /// The bounding polygon around the face. The coordinates of the bounding box
+    /// are in the original image's scale, as returned in `ImageParams`.
+    /// The bounding box is computed to "frame" the face in accordance with human
+    /// expectations. It is based on the landmarker results.
+    /// Note that one or more x and/or y coordinates may not be generated in the
+    /// `BoundingPoly` (the polygon will be unbounded) if only a partial face
+    /// appears in the image to be annotated.
+    #[serde(rename="boundingPoly")]
+    pub bounding_poly: Option<BoundingPoly>,
+    /// Roll angle, which indicates the amount of clockwise/anti-clockwise rotation
+    /// of the face relative to the image vertical about the axis perpendicular to
+    /// the face. Range [-180,180].
+    #[serde(rename="rollAngle")]
+    pub roll_angle: Option<f32>,
+    /// Yaw angle, which indicates the leftward/rightward angle that the face is
+    /// pointing relative to the vertical plane perpendicular to the image. Range
+    /// [-180,180].
+    #[serde(rename="panAngle")]
+    pub pan_angle: Option<f32>,
+    /// Headwear likelihood.
+    #[serde(rename="headwearLikelihood")]
+    pub headwear_likelihood: Option<String>,
+    /// The `fd_bounding_poly` bounding polygon is tighter than the
+    /// `boundingPoly`, and encloses only the skin part of the face. Typically, it
+    /// is used to eliminate the face from any image analysis that detects the
+    /// "amount of skin" visible in an image. It is not based on the
+    /// landmarker results, only on the initial face detection, hence
+    /// the <code>fd</code> (face detection) prefix.
+    #[serde(rename="fdBoundingPoly")]
+    pub fd_bounding_poly: Option<BoundingPoly>,
+}
+
+impl Part for FaceAnnotation {}
+
+
+/// Response to an image annotation request.
+/// 
+/// This type is not used in any activity, and only used as *part* of another schema.
+/// 
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct AnnotateImageResponse {
+    /// If present, safe-search annotation has completed successfully.
+    #[serde(rename="safeSearchAnnotation")]
+    pub safe_search_annotation: Option<SafeSearchAnnotation>,
+    /// If present, text (OCR) detection has completed successfully.
+    #[serde(rename="textAnnotations")]
+    pub text_annotations: Option<Vec<EntityAnnotation>>,
+    /// If present, web detection has completed successfully.
+    #[serde(rename="webDetection")]
+    pub web_detection: Option<WebDetection>,
+    /// If present, text (OCR) detection or document (OCR) text detection has
+    /// completed successfully.
+    /// This annotation provides the structural hierarchy for the OCR detected
+    /// text.
+    #[serde(rename="fullTextAnnotation")]
+    pub full_text_annotation: Option<TextAnnotation>,
+    /// If present, label detection has completed successfully.
+    #[serde(rename="labelAnnotations")]
+    pub label_annotations: Option<Vec<EntityAnnotation>>,
+    /// If present, image properties were extracted successfully.
+    #[serde(rename="imagePropertiesAnnotation")]
+    pub image_properties_annotation: Option<ImageProperties>,
+    /// If present, face detection has completed successfully.
+    #[serde(rename="faceAnnotations")]
+    pub face_annotations: Option<Vec<FaceAnnotation>>,
+    /// If present, logo detection has completed successfully.
+    #[serde(rename="logoAnnotations")]
+    pub logo_annotations: Option<Vec<EntityAnnotation>>,
+    /// If present, landmark detection has completed successfully.
+    #[serde(rename="landmarkAnnotations")]
+    pub landmark_annotations: Option<Vec<EntityAnnotation>>,
+    /// If set, represents the error message for the operation.
+    /// Note that filled-in image annotations are guaranteed to be
+    /// correct, even when `error` is set.
+    pub error: Option<Status>,
+    /// If present, crop hints have completed successfully.
+    #[serde(rename="cropHintsAnnotation")]
+    pub crop_hints_annotation: Option<CropHintsAnnotation>,
+}
+
+impl Part for AnnotateImageResponse {}
+
+
+
+// ###################
+// MethodBuilders ###
+// #################
+
+/// A builder providing access to all methods supported on *image* resources.
+/// It is not used directly, but through the `Vision` hub.
+///
+/// # Example
+///
+/// Instantiate a resource builder
+///
+/// ```test_harness,no_run
+/// extern crate hyper;
+/// extern crate hyper_rustls;
+/// extern crate yup_oauth2 as oauth2;
+/// extern crate google_vision1 as vision1;
+/// 
+/// # #[test] fn egal() {
+/// use std::default::Default;
+/// use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// use vision1::Vision;
+/// 
+/// let secret: ApplicationSecret = Default::default();
+/// let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+///                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+///                               <MemoryStorage as Default>::default(), None);
+/// let mut hub = Vision::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // Usually you wouldn't bind this to a variable, but keep calling *CallBuilders*
+/// // like `annotate(...)`
+/// // to build up your call.
+/// let rb = hub.images();
+/// # }
+/// ```
+pub struct ImageMethods<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a Vision<C, A>,
+}
+
+impl<'a, C, A> MethodsBuilder for ImageMethods<'a, C, A> {}
+
+impl<'a, C, A> ImageMethods<'a, C, A> {
+    
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Run image detection and annotation for a batch of images.
+    /// 
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    pub fn annotate(&self, request: BatchAnnotateImagesRequest) -> ImageAnnotateCall<'a, C, A> {
+        ImageAnnotateCall {
+            hub: self.hub,
+            _request: request,
+            _delegate: Default::default(),
+            _scopes: Default::default(),
+            _additional_params: Default::default(),
+        }
+    }
+}
+
+
+
+
+
+// ###################
+// CallBuilders   ###
+// #################
+
+/// Run image detection and annotation for a batch of images.
+///
+/// A builder for the *annotate* method supported by a *image* resource.
+/// It is not used directly, but through a `ImageMethods` instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate yup_oauth2 as oauth2;
+/// # extern crate google_vision1 as vision1;
+/// use vision1::BatchAnnotateImagesRequest;
+/// # #[test] fn egal() {
+/// # use std::default::Default;
+/// # use oauth2::{Authenticator, DefaultAuthenticatorDelegate, ApplicationSecret, MemoryStorage};
+/// # use vision1::Vision;
+/// 
+/// # let secret: ApplicationSecret = Default::default();
+/// # let auth = Authenticator::new(&secret, DefaultAuthenticatorDelegate,
+/// #                               hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())),
+/// #                               <MemoryStorage as Default>::default(), None);
+/// # let mut hub = Vision::new(hyper::Client::with_connector(hyper::net::HttpsConnector::new(hyper_rustls::TlsClient::new())), auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = BatchAnnotateImagesRequest::default();
+/// 
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.images().annotate(req)
+///              .doit();
+/// # }
+/// ```
+pub struct ImageAnnotateCall<'a, C, A>
+    where C: 'a, A: 'a {
+
+    hub: &'a Vision<C, A>,
+    _request: BatchAnnotateImagesRequest,
+    _delegate: Option<&'a mut Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeMap<String, ()>
+}
+
+impl<'a, C, A> CallBuilder for ImageAnnotateCall<'a, C, A> {}
+
+impl<'a, C, A> ImageAnnotateCall<'a, C, A> where C: BorrowMut<hyper::Client>, A: oauth2::GetToken {
+
+
+    /// Perform the operation you have build so far.
+    pub fn doit(mut self) -> Result<(hyper::client::Response, BatchAnnotateImagesResponse)> {
+        use std::io::{Read, Seek};
+        use hyper::header::{ContentType, ContentLength, Authorization, Bearer, UserAgent, Location};
+        let mut dd = DefaultDelegate;
+        let mut dlg: &mut Delegate = match self._delegate {
+            Some(d) => d,
+            None => &mut dd
+        };
+        dlg.begin(MethodInfo { id: "vision.images.annotate",
+                               http_method: hyper::method::Method::Post });
+        let mut params: Vec<(&str, String)> = Vec::with_capacity((3 + self._additional_params.len()));
+        for &field in ["alt"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(Error::FieldClash(field));
+            }
+        }
+        for (name, value) in self._additional_params.iter() {
+            params.push((&name, value.clone()));
+        }
+
+        params.push(("alt", "json".to_string()));
+
+        let mut url = self.hub._base_url.clone() + "v1/images:annotate";
+        if self._scopes.len() == 0 {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        }
+
+
+        if params.len() > 0 {
+            url.push('?');
+            url.push_str(&url::form_urlencoded::serialize(params));
+        }
+
+        let mut json_mime_type = mime::Mime(mime::TopLevel::Application, mime::SubLevel::Json, Default::default());
+        let mut request_value_reader =
+            {
+                let mut value = json::value::to_value(&self._request).expect("serde to work");
+                remove_json_null_values(&mut value);
+                let mut dst = io::Cursor::new(Vec::with_capacity(128));
+                json::to_writer(&mut dst, &value).unwrap();
+                dst
+            };
+        let request_size = request_value_reader.seek(io::SeekFrom::End(0)).unwrap();
+        request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+
+
+        loop {
+            let token = match self.hub.auth.borrow_mut().token(self._scopes.keys()) {
+                Ok(token) => token,
+                Err(err) => {
+                    match  dlg.token(&*err) {
+                        Some(token) => token,
+                        None => {
+                            dlg.finished(false);
+                            return Err(Error::MissingToken(err))
+                        }
+                    }
+                }
+            };
+            let auth_header = Authorization(Bearer { token: token.access_token });
+            request_value_reader.seek(io::SeekFrom::Start(0)).unwrap();
+            let mut req_result = {
+                let mut client = &mut *self.hub.client.borrow_mut();
+                let mut req = client.borrow_mut().request(hyper::method::Method::Post, &url)
+                    .header(UserAgent(self.hub._user_agent.clone()))
+                    .header(auth_header.clone())
+                    .header(ContentType(json_mime_type.clone()))
+                    .header(ContentLength(request_size as u64))
+                    .body(&mut request_value_reader);
+
+                dlg.pre_request();
+                req.send()
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let oauth2::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d);
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(Error::HttpError(err))
+                }
+                Ok(mut res) => {
+                    if !res.status.is_success() {
+                        let mut json_err = String::new();
+                        res.read_to_string(&mut json_err).unwrap();
+                        if let oauth2::Retry::After(d) = dlg.http_failure(&res,
+                                                              json::from_str(&json_err).ok(),
+                                                              json::from_str(&json_err).ok()) {
+                            sleep(d);
+                            continue;
+                        }
+                        dlg.finished(false);
+                        return match json::from_str::<ErrorResponse>(&json_err){
+                            Err(_) => Err(Error::Failure(res)),
+                            Ok(serr) => Err(Error::BadRequest(serr))
+                        }
+                    }
+                    let result_value = {
+                        let mut json_response = String::new();
+                        res.read_to_string(&mut json_response).unwrap();
+                        match json::from_str(&json_response) {
+                            Ok(decoded) => (res, decoded),
+                            Err(err) => {
+                                dlg.response_json_decode_error(&json_response, &err);
+                                return Err(Error::JsonDecodeError(json_response, err));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(result_value)
+                }
+            }
+        }
+    }
+
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: BatchAnnotateImagesRequest) -> ImageAnnotateCall<'a, C, A> {
+        self._request = new_value;
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    /// 
+    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut Delegate) -> ImageAnnotateCall<'a, C, A> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known paramters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *bearer_token* (query-string) - OAuth bearer token.
+    /// * *pp* (query-boolean) - Pretty-print response.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *callback* (query-string) - JSONP
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *$.xgafv* (query-string) - V1 error format.
+    pub fn param<T>(mut self, name: T, value: T) -> ImageAnnotateCall<'a, C, A>
+                                                        where T: AsRef<str> {
+        self._additional_params.insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
+    /// `Scope::CloudPlatform`.
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
+    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
+    /// function for details).
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<T, S>(mut self, scope: T) -> ImageAnnotateCall<'a, C, A>
+                                                        where T: Into<Option<S>>,
+                                                              S: AsRef<str> {
+        match scope.into() {
+          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
+          None => None,
+        };
+        self
+    }
+}
+
+


### PR DESCRIPTION
Removes from the blacklist all of the APIs that successfully build on the latest version of rust (1.23.0) and adds all of the generated files for these APIs.

It looks like some of the tests are failing - but they are failing for some APIs that I have not touched (such as `partners2`) and they are failing on master.