### PR TITLE
docs(LIB): Add dependencies to README

### DIFF
--- a/src/mako/api/lib/lib.mako
+++ b/src/mako/api/lib/lib.mako
@@ -177,6 +177,14 @@ To use this library, you would put the following lines into your `Cargo.toml` fi
 ```toml
 [dependencies]
 ${util.crate_name()} = "*"
+# This project intentionally uses an old version of Hyper. See
+# https://github.com/Byron/google-apis-rs/issues/173 for more
+# information.
+hyper = "^0.10"
+hyper-rustls = "^0.6"
+serde = "^1.0"
+serde_json = "^1.0"
+yup-oauth2 = "^1.0"
 ```
 
 ${'##'} A complete example


### PR DESCRIPTION
In the section that describes setting up the Cargo.toml, add the
required dependencies, and note that `hyper` and `hyper-rustls` are not
the latest versions. This helps new users get started quicker and
easier.

Related to #173