### PR TITLE
core(ci): Fix version of Python used on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+dist: trusty
+sudo: false
+
 language: rust
 os:
   - linux
@@ -8,10 +11,26 @@ rust:
 matrix:
   allow_failures:
     - rust: nightly
+
+before_install:
+  - curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash
+  - pyenv versions
+  - pyenv install --skip-existing "${PYENV_VERSION}"
+  - pyenv versions
+  - pyenv global "${PYENV_VERSION}"
+  - pyenv version
 script:
   - make gen-all-cli cargo-api ARGS=test
   - make cargo-api ARGS=doc
   - "if [[ $TRAVIS_RUST_VERSION = nightly ]]; then cargo test; fi"
+
 env:
   global:
-    secure: Plj5DqAQX/4+KPM+nOAZ2sCbGIsoSrHo1YggfesQnU7paR734XO/4IayWnsNO/3q6bDi4GIcn56RUZAD3xBJJBNLia2CYIickIIYORRqLWbLdbzQaxBbD670ahtzEuUSFJTRKURPwFteAnsWYgNMNzwXOVNwLS5IUBqWTcS+N0g=
+    - PYENV_VERSION: 2.7.14
+    - secure: Plj5DqAQX/4+KPM+nOAZ2sCbGIsoSrHo1YggfesQnU7paR734XO/4IayWnsNO/3q6bDi4GIcn56RUZAD3xBJJBNLia2CYIickIIYORRqLWbLdbzQaxBbD670ahtzEuUSFJTRKURPwFteAnsWYgNMNzwXOVNwLS5IUBqWTcS+N0g=
+
+cache:
+  - cargo
+  - pip
+  directories:
+    - $HOME/.pyenv_cache

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .PHONY: help deps regen-apis license clean
 .SUFFIXES:
 
+VIRTUALENV_VERSION = 16.0.0
 VENV = .virtualenv/virtualenv.py
 VENV_DIR := .pyenv-$(shell uname)
 PYTHON := $(VENV_DIR)/bin/python
@@ -50,8 +51,8 @@ help:
 	$(info help           -   print this help)
 
 $(VENV):
-	wget -nv https://pypi.python.org/packages/source/v/virtualenv/virtualenv-12.0.7.tar.gz -O virtualenv-12.0.7.tar.gz
-	tar -xzf virtualenv-12.0.7.tar.gz && mv virtualenv-12.0.7 ./.virtualenv && rm -f virtualenv-12.0.7.tar.gz
+	wget -nv https://pypi.python.org/packages/source/v/virtualenv/virtualenv-$(VIRTUALENV_VERSION).tar.gz -O virtualenv-$(VIRTUALENV_VERSION).tar.gz
+	tar -xzf virtualenv-$(VIRTUALENV_VERSION).tar.gz && mv virtualenv-$(VIRTUALENV_VERSION) ./.virtualenv && rm -f virtualenv-$(VIRTUALENV_VERSION).tar.gz
 	chmod +x $@
 
 $(PYTHON): $(VENV)


### PR DESCRIPTION
mkdocs depends on tornado that fails to compile on Python before 2.7.9.
When running in Travis not using the Python language a very old version
of Python is used.

This commit adds pyenv and uses it to ensure Travis Python is viable and
stable. This also updates virtualenv to the latest version.

This fixes #203 