### PR TITLE
fix(rust): teach remove_json_null_values about arrays

### DIFF
--- a/src/rust/api/cmn.rs
+++ b/src/rust/api/cmn.rs
@@ -746,6 +746,17 @@ pub fn remove_json_null_values(value: &mut json::value::Value) {
                 map.remove(key);
             }
         }
+        json::value::Value::Array(ref mut arr) => {
+            let mut i = 0;
+            while i < arr.len() {
+                if arr[i].is_null() {
+                    arr.remove(i);
+                } else {
+                    remove_json_null_values(&mut arr[i]);
+                    i += 1;
+                }
+            }
+        }
         _ => {}
     }
 }

--- a/src/rust/cli/cmn.rs
+++ b/src/rust/cli/cmn.rs
@@ -65,6 +65,17 @@ pub fn remove_json_null_values(value: &mut Value) {
                 map.remove(key);
             }
         }
+        json::value::Value::Array(ref mut arr) => {
+            let mut i = 0;
+            while i < arr.len() {
+                if arr[i].is_null() {
+                    arr.remove(i);
+                } else {
+                    remove_json_null_values(&mut arr[i]);
+                    i += 1;
+                }
+            }
+        }
         _ => {}
     }
 }


### PR DESCRIPTION
change `remove_json_null_values()` to properly remove nulls from and recurse into arrays google_firestore1_beta1's `CommitRequest` contains an array of `Write` objects which can ultimately contain `Value` members that need to have nulls removed to avoid sending multiple types of values which generates a 400 response

fixes calls to google_firestore1_beta1's `hub.projects().databases_documents_commit()`