### PR TITLE
docs: add lang attribute to docs index

### DIFF
--- a/src/mako/index.html.mako
+++ b/src/mako/index.html.mako
@@ -25,7 +25,7 @@ DO NOT EDIT !
 This file was generated automatically by '${self.uri}'
 DO NOT EDIT !
 -->
-<html>
+<html lang="en">
 <head>
   <link rel="stylesheet" 
     href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" 


### PR DESCRIPTION
Use the W3 standard "lang" attribute on the "html" tag to provide context for browsers and screen
readers.

Context: Chrome has a language heuristic that determines the page is in Portuguese. It displays the "Translate this page" dialog. Adding the "lang" attribute context should prevent this dialog.

Reference: https://www.w3.org/International/questions/qa-html-language-declarations