### PR TITLE
Allow deserializing into custom responses

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 # This library is just to try out the code that should ultimately go into the code generator !
 
 [workspace]
-members = ["google_field_selector", "google_field_selector_derive", "gen/*"]
+members = ["google_field_selector", "google_field_selector_derive", "gen/*", "src/rust/preproc"]
 
 [package]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,9 @@
 # DO NOT PUBLISH
 # This library is just to try out the code that should ultimately go into the code generator !
+
+[workspace]
+members = ["google_field_selector", "google_field_selector_derive", "gen/*"]
+
 [package]
 
 name = "cmn"

--- a/google_field_selector/Cargo.toml
+++ b/google_field_selector/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "google_field_selector"
+version = "0.1.0"
+authors = ["Sebastian Thiel <byronimo@gmail.com>"]
+edition = "2018"
+
+[dependencies]
+google_field_selector_derive = { version = "0.1.0", path = "../google_field_selector_derive" }
+
+[dev-dependencies]
+chrono = { version = "0.4", features = ["serde"] }
+serde = { version = "1", features = ["derive"] }

--- a/google_field_selector/src/lib.rs
+++ b/google_field_selector/src/lib.rs
@@ -1,0 +1,143 @@
+pub use google_field_selector_derive::FieldSelector;
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, LinkedList, VecDeque};
+/// FieldSelector provides a google api compatible field selector. This value can
+/// be provided in the "fields" attribute of many google api's to request which
+/// subfields to include in a a response. Implementations of FieldSelector will
+/// typically be automatically generated from a procedural macro using
+/// `#[derive(FieldSelector)]`.
+pub trait FieldSelector {
+    fn field_selector() -> String {
+        let mut selector = String::new();
+        Self::field_selector_with_ident("", &mut selector);
+        selector
+    }
+
+    fn field_selector_with_ident(ident: &str, selector: &mut String);
+}
+
+fn append_ident_to_selector(ident: &str, selector: &mut String) {
+    match selector.chars().rev().nth(0) {
+        Some(',') | None => {}
+        _ => selector.push_str(","),
+    }
+    selector.push_str(ident);
+}
+
+// The google api allows specifying attributes of elements within containers
+// enclosing it in parens '()'. FieldSelector is implemented for Vec, HashSet,
+// and BTreeSet to support this functionality.
+fn container_selector<T>(ident: &str, selector: &mut String)
+where
+    T: FieldSelector,
+{
+    append_ident_to_selector(ident, selector);
+    let mut inner_selector = String::new();
+    T::field_selector_with_ident("", &mut inner_selector);
+    if !inner_selector.is_empty() {
+        selector.push_str("(");
+        selector.push_str(&inner_selector);
+        selector.push_str(")");
+    };
+}
+
+macro_rules! leaf_selector_for {
+    ($t:ty) => {
+        impl FieldSelector for $t {
+            fn field_selector_with_ident(ident: &str, selector: &mut String) {
+                append_ident_to_selector(ident, selector);
+            }
+        }
+    };
+}
+
+leaf_selector_for!(bool);
+leaf_selector_for!(char);
+leaf_selector_for!(i8);
+leaf_selector_for!(i16);
+leaf_selector_for!(i32);
+leaf_selector_for!(i64);
+leaf_selector_for!(i128);
+leaf_selector_for!(isize);
+leaf_selector_for!(u8);
+leaf_selector_for!(u16);
+leaf_selector_for!(u32);
+leaf_selector_for!(u64);
+leaf_selector_for!(u128);
+leaf_selector_for!(usize);
+leaf_selector_for!(f32);
+leaf_selector_for!(f64);
+leaf_selector_for!(String);
+
+// For field selection we treat Options as invisible, proxying to the inner type.
+impl<T> FieldSelector for Option<T>
+where
+    T: FieldSelector,
+{
+    fn field_selector_with_ident(ident: &str, selector: &mut String) {
+        T::field_selector_with_ident(ident, selector)
+    }
+}
+
+// implement FieldSelector for std::collections types.
+// Vec, VecDeque, HashSet, BTreeSet, LinkedList, all act as containers of other elements.
+
+impl<T> FieldSelector for Vec<T>
+where
+    T: FieldSelector,
+{
+    fn field_selector_with_ident(ident: &str, selector: &mut String) {
+        container_selector::<T>(ident, selector)
+    }
+}
+
+impl<T> FieldSelector for VecDeque<T>
+where
+    T: FieldSelector,
+{
+    fn field_selector_with_ident(ident: &str, selector: &mut String) {
+        container_selector::<T>(ident, selector)
+    }
+}
+
+impl<T, H> FieldSelector for HashSet<T, H>
+where
+    T: FieldSelector,
+{
+    fn field_selector_with_ident(ident: &str, selector: &mut String) {
+        container_selector::<T>(ident, selector)
+    }
+}
+
+impl<T> FieldSelector for BTreeSet<T>
+where
+    T: FieldSelector,
+{
+    fn field_selector_with_ident(ident: &str, selector: &mut String) {
+        container_selector::<T>(ident, selector)
+    }
+}
+
+impl<T> FieldSelector for LinkedList<T>
+where
+    T: FieldSelector,
+{
+    fn field_selector_with_ident(ident: &str, selector: &mut String) {
+        container_selector::<T>(ident, selector)
+    }
+}
+
+// HashMap and BTreeMap are not considered containers for the purposes of
+// selections. The google api does not provide a mechanism to specify fields of
+// key/value pairs.
+
+impl<K, V, H> FieldSelector for HashMap<K, V, H> {
+    fn field_selector_with_ident(ident: &str, selector: &mut String) {
+        append_ident_to_selector(ident, selector)
+    }
+}
+
+impl<K, V> FieldSelector for BTreeMap<K, V> {
+    fn field_selector_with_ident(ident: &str, selector: &mut String) {
+        append_ident_to_selector(ident, selector)
+    }
+}

--- a/google_field_selector/tests/tests.rs
+++ b/google_field_selector/tests/tests.rs
@@ -1,0 +1,93 @@
+#![allow(dead_code)]
+
+use google_field_selector::FieldSelector;
+use serde::Deserialize;
+use std::collections::HashMap;
+
+#[derive(Deserialize, FieldSelector)]
+#[serde(rename_all = "camelCase")]
+struct File {
+    id: String,
+    mime_type: String,
+    sharing_user: Option<UserInfo>,
+}
+
+#[derive(Deserialize, FieldSelector)]
+#[serde(rename_all = "camelCase")]
+struct UserInfo {
+    me: bool,
+    email_address: String,
+    user_attrs: HashMap<String, String>,
+}
+
+#[test]
+fn basic() {
+    #[derive(Deserialize, FieldSelector)]
+    #[serde(rename_all = "camelCase")]
+    struct Response {
+        next_page_token: String,
+        files: Vec<File>,
+    }
+
+    assert_eq!(
+        Response::field_selector(),
+        "nextPageToken,files(id,mimeType,sharingUser/me,sharingUser/emailAddress,sharingUser/userAttrs)"
+    );
+}
+
+#[test]
+fn generic_with_flatten() {
+    #[derive(Deserialize, FieldSelector)]
+    #[serde(rename_all = "camelCase")]
+    struct Response<T>
+    where
+        T: FieldSelector,
+    {
+        next_page_token: String,
+        #[serde(flatten)]
+        payload: T,
+    }
+
+    #[derive(Deserialize, FieldSelector)]
+    #[serde(rename_all = "camelCase")]
+    struct ListFiles {
+        files: Vec<File>,
+    }
+    assert_eq!(
+        Response::<ListFiles>::field_selector(),
+        "nextPageToken,files(id,mimeType,sharingUser/me,sharingUser/emailAddress,sharingUser/userAttrs)"
+    );
+}
+
+#[test]
+fn external_types() {
+    use chrono::{DateTime, Utc};
+    #[derive(Deserialize)]
+    struct MyCustomVec<T>(Vec<T>);
+
+    #[derive(Deserialize, FieldSelector)]
+    struct File {
+        id: String,
+
+        // Specify that DateTime is a leaf node. Don't treat it as a nested
+        // struct that we can specify subselections of.
+        #[field_selector(leaf)]
+        viewed_by_me_time: DateTime<Utc>,
+    }
+
+    #[derive(Deserialize, FieldSelector)]
+    #[serde(rename_all = "camelCase")]
+    struct Response {
+        next_page_token: String,
+
+        // Specify that MyCustomVec should be treated as a container holding
+        // elements of File.
+        #[field_selector(container_of = "File")]
+        files: MyCustomVec<File>,
+    }
+
+    assert_eq!(
+        Response::field_selector(),
+        "nextPageToken,files(id,viewed_by_me_time)"
+    );
+}

--- a/google_field_selector_derive/Cargo.toml
+++ b/google_field_selector_derive/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "google_field_selector_derive"
+version = "0.1.0"
+authors = ["Sebastian Thiel <byronimo@gmail.com>"]
+edition = "2018"
+
+[lib]
+name = "google_field_selector_derive"
+proc-macro = true
+
+[dependencies]
+serde_derive_internals = "0.24"
+syn = "0.15"
+quote = "0.6"
+proc-macro2 = "0.4"

--- a/google_field_selector_derive/src/lib.rs
+++ b/google_field_selector_derive/src/lib.rs
@@ -1,0 +1,149 @@
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
+use quote::quote;
+use serde_derive_internals as serdei;
+use std::error::Error;
+use syn::{parse_macro_input, DeriveInput};
+
+#[proc_macro_derive(FieldSelector, attributes(field_selector))]
+pub fn derive_field_selector(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    expand_derive_field_selector(&input).unwrap().into()
+}
+
+fn expand_derive_field_selector(input: &DeriveInput) -> Result<TokenStream2, Box<dyn Error>> {
+    let ctx = serdei::Ctxt::new();
+    let cont = serdei::ast::Container::from_ast(&ctx, &input, serdei::Derive::Deserialize);
+    ctx.check()?;
+    let field_output: Vec<proc_macro2::TokenStream> = match cont.data {
+        serdei::ast::Data::Struct(serdei::ast::Style::Struct, fields) => {
+            fields.iter().map(selector_for_field).collect()
+        }
+        _ => return Err("Only able to derive FieldSelector for plain Struct".into()),
+    };
+
+    let ident = cont.ident;
+    let (impl_generics, ty_generics, where_clause) = cont.generics.split_for_impl();
+    let dummy_const = syn::Ident::new(
+        &format!("_IMPL_FIELD_SELECTOR_FOR_{}", ident),
+        proc_macro2::Span::call_site(),
+    );
+    Ok(quote! {
+        const #dummy_const: () = {
+            impl #impl_generics FieldSelector for #ident #ty_generics #where_clause {
+                fn field_selector_with_ident(ident: &str, selector: &mut String) {
+                    match selector.chars().rev().nth(0) {
+                        Some(',') | None => {},
+                        _ => selector.push_str(","),
+                    }
+                    #(#field_output)*
+                }
+            }
+        };
+    })
+}
+
+fn selector_for_field<'a>(field: &serdei::ast::Field<'a>) -> TokenStream2 {
+    enum AttrOverride {
+        ContainerOf(syn::ExprPath),
+        Leaf,
+    }
+    let syn_field = field.original;
+    let attr_override = syn_field.attrs.iter().find_map(|attr| {
+        let metalist = match attr.parse_meta() {
+            Ok(meta @ syn::Meta::List(_)) => meta,
+            _ => return None,
+        };
+        if metalist.name() != "field_selector" {
+            return None;
+        }
+        let nestedlist = match metalist {
+            syn::Meta::List(syn::MetaList { nested, .. }) => nested,
+            _ => return None,
+        };
+        for meta in nestedlist.iter() {
+            match meta {
+                syn::NestedMeta::Meta(syn::Meta::NameValue(syn::MetaNameValue {
+                    ident: name,
+                    lit: syn::Lit::Str(value),
+                    ..
+                })) if name == "container_of" => {
+                    if let Ok(typ_path) = value.parse() {
+                        return Some(AttrOverride::ContainerOf(typ_path));
+                    }
+                }
+                syn::NestedMeta::Meta(syn::Meta::Word(word)) if word == "leaf" => {
+                    return Some(AttrOverride::Leaf);
+                }
+                _ => {}
+            }
+        }
+        None
+    });
+
+    let field_name = field.attrs.name().deserialize_name();
+    match attr_override {
+        Some(AttrOverride::ContainerOf(typ_path)) => {
+            quote! {
+                match selector.chars().rev().nth(0) {
+                    Some(',') | None => {},
+                    _ => selector.push_str(","),
+                }
+                if ident.is_empty() {
+                    selector.push_str(#field_name);
+                } else {
+                    let mut ident = ident.to_owned();
+                    ident.push_str("/");
+                    ident.push_str(#field_name);
+                    selector.push_str(&ident);
+                }
+                let mut inner_selector = String::new();
+                #typ_path::field_selector_with_ident("", &mut inner_selector);
+                if !inner_selector.is_empty() {
+                    selector.push_str("(");
+                    selector.push_str(&inner_selector);
+                    selector.push_str(")");
+                }
+            }
+        }
+        Some(AttrOverride::Leaf) => {
+            quote! {
+                match selector.chars().rev().nth(0) {
+                    Some(',') | None => {},
+                    _ => selector.push_str(","),
+                }
+                if ident.is_empty() {
+                    selector.push_str(#field_name);
+                } else {
+                    let mut ident = ident.to_owned();
+                    ident.push_str("/");
+                    ident.push_str(#field_name);
+                    selector.push_str(&ident);
+                }
+            }
+        }
+        None => {
+            let typ = field.ty;
+            if field.attrs.flatten() {
+                quote! {
+                    <#typ>::field_selector_with_ident(ident, selector);
+                }
+            } else {
+                quote! {
+                    <#typ>::field_selector_with_ident(&{
+                        if ident.is_empty() {
+                            #field_name.to_owned()
+                        } else {
+                            let mut ident = ident.to_owned();
+                            ident.push_str("/");
+                            ident.push_str(#field_name);
+                            ident
+                        }},
+                        selector);
+                }
+            }
+        }
+    }
+}

--- a/src/mako/Cargo.toml.mako
+++ b/src/mako/Cargo.toml.mako
@@ -35,6 +35,7 @@ serde = "^ 1.0"
 serde_json = "^ 1.0"
 serde_derive = "^ 1.0"
 yup-oauth2 = "^ 1.0"
+google_field_selector = { version = "0.1.0", path = "../../google_field_selector" }
 % for dep in cargo.get('dependencies', list()):
 ${dep}
 % endfor

--- a/src/mako/api/lib.rs.mako
+++ b/src/mako/api/lib.rs.mako
@@ -43,6 +43,9 @@ ${lib.docs(c)}
 #[macro_use]
 extern crate serde_derive;
 
+#[macro_use]
+extern crate google_field_selector;
+
 extern crate hyper;
 extern crate serde;
 extern crate serde_json;

--- a/src/mako/api/lib/mbuild.mako
+++ b/src/mako/api/lib/mbuild.mako
@@ -585,7 +585,7 @@ match result {
         if !params.iter().any(|&(ref k, ref _v)| *k == "fields") {
 	    let fields = T::field_selector();
 	    if !fields.is_empty() {
-	        params.push(("fields", T::field_selector()));
+	        params.push(("fields", fields));
 	    }
         }
         % endif ## fields in parameters

--- a/src/mako/api/lib/mbuild.mako
+++ b/src/mako/api/lib/mbuild.mako
@@ -414,7 +414,7 @@ match result {
     if response_schema:
         if not supports_download:
             reserved_params = ['alt']
-        into_types['T'].extend(['Default', 'serde::de::DeserializeOwned'])
+        into_types['T'].extend(['Default', 'serde::de::DeserializeOwned', 'FieldSelector'])
         rtype = 'Result<(hyper::client::Response, %s)>' % (unique_type_name(response_schema.id))
 
     mtype_param = 'RS'
@@ -581,6 +581,14 @@ match result {
         }
 
         % if response_schema:
+        % if "fields" in parameters:
+        if !params.iter().any(|&(ref k, ref _v)| *k == "fields") {
+	    let fields = T::field_selector();
+	    if !fields.is_empty() {
+	        params.push(("fields", T::field_selector()));
+	    }
+        }
+        % endif ## fields in parameters
         % if supports_download:
         let (json_field_missing, enable_resource_parsing) = {
             let mut enable = true;

--- a/src/mako/api/lib/schema.mako
+++ b/src/mako/api/lib/schema.mako
@@ -127,6 +127,11 @@ impl ${TO_PARTS_MARKER} for ${s_type} {
     }
 }
 % endif
+
+impl FieldSelector for ${s_type} {
+    // The default types specify an empty field selector.
+    fn field_selector_with_ident(_ident: &str, _selector: &mut String) {}
+}
 </%def>
 
 #########################################################################################################

--- a/src/mako/lib/util.py
+++ b/src/mako/lib/util.py
@@ -1056,6 +1056,12 @@ def size_to_bytes(size):
         raise ValueError("Invalid unit: '%s'" % unit)
     # end handle errors gracefully
 
+class FnArg(object):
+    def __init__(self, binding, name, typ):
+        self.binding = binding
+        self.name = name
+        self.typ = typ
+
 
 if __name__ == '__main__':
     raise AssertionError('For import only')

--- a/src/rust/api/cmn.rs
+++ b/src/rust/api/cmn.rs
@@ -17,6 +17,8 @@ use hyper::status::StatusCode;
 
 use serde_json as json;
 
+pub use google_field_selector::FieldSelector;
+
 /// Identifies the Hub. There is only one per library, this trait is supposed
 /// to make intended use more explicit.
 /// The hub allows to access all resource methods more easily.


### PR DESCRIPTION
This is a pretty quick implementation that allows deserializing into custom structs as outlined in issue #225.

This does the simplest and most straightforward thing. Wherever there is a `doit` method there is now an accompanying `doit_into` that has a generic return type that needs to implement DeserializeOwned + Default + FieldSelector.

All the existing custom types have been updated to implement FieldSelector so they can be used with the `doit_into` methods and the `doit` methods are implemented as calls to `doit_into`.

I think there remain some rough edges, but in general I think this works pretty well. I didn't want to publish any new crates until after the PR has been reviewed so the dependencies are currently specified with path specifications. These will need to be removed and updated to proper crate names when publishing. The documentation also needs to get updated, but I wanted to send this for review before polishing up those details.