### PR TITLE
Fix '-force' target generation for JSON schemata.

### DIFF
--- a/src/mako/deps.mako
+++ b/src/mako/deps.mako
@@ -7,6 +7,7 @@
 	import urllib2
 	import json
 
+	apis = {}
 	api_info = []
 	doc_root = directories.output + '/' + directories.doc_subdir
 	doc_index = doc_root + '/index.html'
@@ -184,7 +185,7 @@ help${agsuffix}:
 % if global_targets:
 .PHONY += update-json
 
-% for info in ('apis' in globals() and apis.get('items') or []):
+% for info in (apis.get('items') or []):
 <%
 	import util
 	import os


### PR DESCRIPTION
In some environments, a variable-existence test in a template was
yielding a false negative which resulted in the template not generating
'-force' targets for API JSON files, even when the `FETCH_APIS`
environment variable was set during template rendering.

This commit adjusts the way the test for the variable presence is done
such that the '-force' targets now render when they should.