### PR TITLE
Bug-fix for the upload error: Failed at uploading 'client requires absolute-form URIs

### DIFF
--- a/etc/bin/mako-render
+++ b/etc/bin/mako-render
@@ -233,7 +233,7 @@ def load_data(datafiles):
             if not imported_yaml:
                 import yaml
                 imported_yaml = True
-            data = yaml.load_all(open(filename, 'r'))
+            data = yaml.load_all(open(filename, 'r'), Loader=yaml.loader.FullLoader)
             data = list(data)[0]
         else:
             raise ValueError("Invalid data-file '%s', must be .json, .yaml or .yml" % filename)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-mako==1.1.3
+mako==1.1.4
 pyyaml
-mkdocs==0.11
+mkdocs==1.1.2
 pytest
 pytest-cov
 importlib_resources

--- a/src/mako/api/lib/mbuild.mako
+++ b/src/mako/api/lib/mbuild.mako
@@ -721,7 +721,6 @@ else {
                 if should_ask_dlg_for_url && (upload_url = dlg.upload_url()) == () && upload_url.is_some() {
                     should_ask_dlg_for_url = false;
                     upload_url_from_server = false;
-                    let url = upload_url.as_ref().and_then(|s| Some(url::Url::parse(s).unwrap())).unwrap();
                     Ok(hyper::Response::builder()
                         .status(hyper::StatusCode::OK)
                         .header("Localtion", upload_url.as_ref().unwrap().clone())

--- a/src/rust/api/client.rs
+++ b/src/rust/api/client.rs
@@ -719,6 +719,7 @@ impl<'a, A> ResumableUploadHelper<'a, A> {
                 .client
                 .request(
                     hyper::Request::builder()
+                        .uri(self.url)
                         .method(hyper::Method::POST)
                         .header("Content-Range", range_header.header_value())
                         .header(CONTENT_TYPE, format!("{}", self.media_type))


### PR DESCRIPTION
I found a bug in the code preventing be from uploading to Google Drive, the fix was pretty simple, one just need to add the `url` to the request, from some reason that was missing.

I assume that this bug also exist for all the other APIs there has an upload feature, because the code is the same for all of them.

**Bonus/Note:**
- Bumped the python lib used to generate everything to the newest version, I was unable to install the old ones any more. It seems to have caused by a deprecation of a library.
- Found some unused code, which I removed  
  `let url = upload_url.as_ref().and_then(|s| Some(url::Url::parse(s).unwrap())).unwrap();`