### PR TITLE
Fix resumable uploads

### DIFF
--- a/src/rust/api/client.rs
+++ b/src/rust/api/client.rs
@@ -694,8 +694,9 @@ impl<'a, A> ResumableUploadHelper<'a, A> {
             _ => MIN_CHUNK_SIZE,
         };
 
-        self.reader.seek(SeekFrom::Start(start)).unwrap();
         loop {
+            self.reader.seek(SeekFrom::Start(start)).unwrap();
+
             let request_size = match self.content_length - start {
                 rs if rs > chunk_size => chunk_size,
                 rs => rs,
@@ -711,7 +712,6 @@ impl<'a, A> ResumableUploadHelper<'a, A> {
                 }),
                 total_length: self.content_length,
             };
-            start += request_size;
             if self.delegate.cancel_chunk_upload(&range_header) {
                 return None;
             }
@@ -730,6 +730,8 @@ impl<'a, A> ResumableUploadHelper<'a, A> {
                 .await;
             match res {
                 Ok(res) => {
+                    start += request_size;
+
                     if res.status() == StatusCode::PERMANENT_REDIRECT {
                         continue;
                     }


### PR DESCRIPTION
The retry logic of the resumable uploads would continue to the next chunk even if the previous chunk was not successfully uploaded. This would cause the api to return a 503 error.
I noticed the issue when logging out chunk and http_error with a custom delegate, it shows that the start position increments even if there is an error: 

```
chunk: ContentRange { range: Some(Chunk { first: 0, last: 8388607 }), total_length: 639445126 }
chunk: ContentRange { range: Some(Chunk { first: 8388608, last: 16777215 }), total_length: 639445126 }
chunk: ContentRange { range: Some(Chunk { first: 16777216, last: 25165823 }), total_length: 639445126 }
chunk: ContentRange { range: Some(Chunk { first: 25165824, last: 33554431 }), total_length: 639445126 }
chunk: ContentRange { range: Some(Chunk { first: 33554432, last: 41943039 }), total_length: 639445126 }
chunk: ContentRange { range: Some(Chunk { first: 41943040, last: 50331647 }), total_length: 639445126 }
chunk: ContentRange { range: Some(Chunk { first: 50331648, last: 58720255 }), total_length: 639445126 }
chunk: ContentRange { range: Some(Chunk { first: 58720256, last: 67108863 }), total_length: 639445126 }
chunk: ContentRange { range: Some(Chunk { first: 67108864, last: 75497471 }), total_length: 639445126 }

http_error: hyper::Error(Io, Kind(BrokenPipe))

chunk: ContentRange { range: Some(Chunk { first: 75497472, last: 83886079 }), total_length: 639445126 }

http_failure: Response { status: 503, version: HTTP/2.0, headers: {...}, body: Body(Full(b"Invalid request.  According to the Content-Range header, the upload offset is 75497472 byte(s), which exceeds already uploaded size of 72613888 byte(s).")) }

chunk: ContentRange { range: Some(Chunk { first: 83886080, last: 92274687 }), total_length: 639445126 }

http_failure: Response { status: 503, version: HTTP/2.0, headers: {...}, body: Body(Full(b"Invalid request.  According to the Content-Range header, the upload offset is 83886080 byte(s), which exceeds already uploaded size of 72613888 byte(s).")) }
```

My fix only increments the start position if the chunk upload was successful. Fix is tested ok with the Drive lib.