### PR TITLE
Fix #307 by reexporting publicly hyper and hyper_rustls

### DIFF
--- a/src/mako/api/lib.rs.mako
+++ b/src/mako/api/lib.rs.mako
@@ -43,7 +43,9 @@ ${lib.docs(c)}
 #[macro_use]
 extern crate serde_derive;
 
-extern crate hyper;
+// Re-export the hyper and hyper_rustls crate, they are required to build the hub
+pub extern crate hyper;
+pub extern crate hyper_rustls;
 extern crate serde;
 extern crate serde_json;
 // Re-export the yup_oauth2 crate, that is required to call some methods of the hub and the client

--- a/src/mako/api/lib/lib.mako
+++ b/src/mako/api/lib/lib.mako
@@ -176,8 +176,6 @@ To use this library, you would put the following lines into your `Cargo.toml` fi
 ```toml
 [dependencies]
 ${util.crate_name()} = "*"
-hyper = "^0.14"
-hyper-rustls = "^0.22"
 serde = "^1.0"
 serde_json = "^1.0"
 ```
@@ -245,7 +243,7 @@ Arguments will always be copied or cloned into the builder, to make them indepen
 ###############################################################################################
 <%def name="test_hub(hub_type, comments=True)">\
 use std::default::Default;
-use ${util.library_name()}::{${hub_type}, oauth2};
+use ${util.library_name()}::{${hub_type}, oauth2, hyper, hyper_rustls};
 
 % if comments:
 // Get an ApplicationSecret instance by some means. It contains the `client_id` and 


### PR DESCRIPTION
Fix #307

This PR can be tested by:
- generating the new rust code by running  `make drive3-cli-cargo ARGS=check` inside the google-apis-rs folder
- Creating an empty project and specifying a dependency to the new code

```toml
[dependencies]
google-drive3 = {path = "../google-apis-rs/gen/drive3"} # path to generated gdrive api
```

- Writing a minimal example inside this new project:
```rust
fn main() {
    let hub = google_drive3::DriveHub::new(
        google_drive3::hyper::Client::builder().build(
            google_drive3::hyper_rustls::HttpsConnector::with_native_roots()
        ),
        todo!()
    );
}
```

- Checking this new project: `cargo check`