### PR TITLE
Update outdated docs

### DIFF
--- a/gen/gmail1/src/api.rs
+++ b/gen/gmail1/src/api.rs
@@ -124,7 +124,17 @@ impl Default for Scope {
 ///         secret,
 ///         oauth2::InstalledFlowReturnMethod::HTTPRedirect,
 ///     ).build().await.unwrap();
-/// let mut hub = Gmail::new(hyper::Client::builder().build(hyper_rustls::HttpsConnector::with_native_roots().https_or_http().enable_http1().enable_http2().build()), auth);
+/// let mut hub = Gmail::new(
+///     hyper::Client::builder().build(
+///         hyper_rustls::HttpsConnectorBuilder::new()
+///             .with_native_roots()
+///             .https_or_http()
+///             .enable_http1()
+///             .enable_http2()
+///             .build(),
+///     ),
+///     auth,
+/// );
 /// // As the method needs a request, you would usually fill it with the desired information
 /// // into the respective structure. Some of the parts shown here might not be applicable !
 /// // Values shown here are possibly random and not representative !


### PR DESCRIPTION
The current docs shows a library interaction that is no longer valid. You now need to use `HttpsConnectorBuilder` instead of `HttpsConnector`.