### PR TITLE
 Use generic Authy trait in place of yup_oauth2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ path = "src/rust/lib.rs"
 
 [dependencies]
 clap = "2"
+http = "^0.2"
 hyper = "0.14"
 mime = "0.2"
 rustc-serialize = "*"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 mako==1.2.2
 pyyaml<6
-mkdocs==0.11
+mkdocs==1.3.1
 pytest
 pytest-cov
 codecov

--- a/src/generator/templates/Cargo.toml.mako
+++ b/src/generator/templates/Cargo.toml.mako
@@ -32,7 +32,9 @@ mime = "^ 0.2.0"
 serde = "^ 1.0"
 serde_json = "^ 1.0"
 serde_derive = "^ 1.0"
-yup-oauth2 = { version = "^ 7.0", optional = true }
+## TODO: Make yup-oauth2 optional
+## yup-oauth2 = { version = "^ 7.0", optional = true }
+yup-oauth2 = "^ 7.0"
 itertools = "^ 0.10"
 % for dep in cargo.get('dependencies', list()):
 ${dep}
@@ -54,5 +56,6 @@ path = "../${api_name}"
 version = "${util.crate_version()}"
 % endif
 
-[features]
-default = ["yup-oauth2"]
+## TODO: Make yup-oauth2 optional
+# [features]
+# default = ["yup-oauth2"]

--- a/src/generator/templates/Cargo.toml.mako
+++ b/src/generator/templates/Cargo.toml.mako
@@ -26,6 +26,8 @@ path = "src/main.rs"
 % endif
 
 [dependencies]
+## TODO: temporary, remove when yup-oauth2 is optional
+anyhow = "^ 1.0"
 hyper-rustls = "0.23.0"
 ## Must match the one hyper uses, otherwise there are duplicate similarly named `Mime` structs
 mime = "^ 0.2.0"

--- a/src/generator/templates/Cargo.toml.mako
+++ b/src/generator/templates/Cargo.toml.mako
@@ -32,7 +32,7 @@ mime = "^ 0.2.0"
 serde = "^ 1.0"
 serde_json = "^ 1.0"
 serde_derive = "^ 1.0"
-yup-oauth2 = "^ 7.0"
+yup-oauth2 = { version = "^ 7.0", optional = true }
 itertools = "^ 0.10"
 % for dep in cargo.get('dependencies', list()):
 ${dep}
@@ -41,7 +41,7 @@ ${dep}
 <%
   api_name = util.library_name()
   crate_name_we_depend_on = None
-  
+
   if make.depends_on_suffix is not None:
     crate_name_we_depend_on = library_to_crate_name(api_name, suffix=make.depends_on_suffix)
 %>\
@@ -53,3 +53,6 @@ ${dep}
 path = "../${api_name}"
 version = "${util.crate_version()}"
 % endif
+
+[features]
+default = ["yup-oauth2"]

--- a/src/generator/templates/api/api.rs.mako
+++ b/src/generator/templates/api/api.rs.mako
@@ -30,7 +30,7 @@ use http::Uri;
 use hyper::client::connect;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tower_service;
-use crate::client;
+use crate::{client, client::Authy};
 
 // ##############
 // UTILITIES ###
@@ -55,7 +55,7 @@ ${lib.hub_usage_example(c)}\
 #[derive(Clone)]
 pub struct ${hub_type}${ht_params} {
     pub client: hyper::Client<S, hyper::body::Body>,
-    pub auth: oauth2::authenticator::Authenticator<S>,
+    pub auth: Box<dyn client::Authy>,
     _user_agent: String,
     _base_url: String,
     _root_url: String,
@@ -65,10 +65,10 @@ impl<'a, ${', '.join(HUB_TYPE_PARAMETERS)}> client::Hub for ${hub_type}${ht_para
 
 impl<'a, ${', '.join(HUB_TYPE_PARAMETERS)}> ${hub_type}${ht_params} {
 
-    pub fn new(client: hyper::Client<S, hyper::body::Body>, authenticator: oauth2::authenticator::Authenticator<S>) -> ${hub_type}${ht_params} {
+    pub fn new<A: 'static + client::Authy>(client: hyper::Client<S, hyper::body::Body>, auth: A) -> ${hub_type}${ht_params} {
         ${hub_type} {
             client,
-            auth: authenticator,
+            auth: Box::new(auth),
             _user_agent: "${default_user_agent}".to_string(),
             _base_url: "${baseUrl}".to_string(),
             _root_url: "${rootUrl}".to_string(),

--- a/src/generator/templates/api/api.rs.mako
+++ b/src/generator/templates/api/api.rs.mako
@@ -30,7 +30,7 @@ use http::Uri;
 use hyper::client::connect;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tower_service;
-use crate::{client, client::Authy};
+use crate::{client, client::GetToken};
 
 // ##############
 // UTILITIES ###
@@ -55,7 +55,7 @@ ${lib.hub_usage_example(c)}\
 #[derive(Clone)]
 pub struct ${hub_type}${ht_params} {
     pub client: hyper::Client<S, hyper::body::Body>,
-    pub auth: Box<dyn client::Authy>,
+    pub auth: Box<dyn client::GetToken>,
     _user_agent: String,
     _base_url: String,
     _root_url: String,
@@ -65,7 +65,7 @@ impl<'a, ${', '.join(HUB_TYPE_PARAMETERS)}> client::Hub for ${hub_type}${ht_para
 
 impl<'a, ${', '.join(HUB_TYPE_PARAMETERS)}> ${hub_type}${ht_params} {
 
-    pub fn new<A: 'static + client::Authy>(client: hyper::Client<S, hyper::body::Body>, auth: A) -> ${hub_type}${ht_params} {
+    pub fn new<A: 'static + client::GetToken>(client: hyper::Client<S, hyper::body::Body>, auth: A) -> ${hub_type}${ht_params} {
         ${hub_type} {
             client,
             auth: Box::new(auth),

--- a/src/generator/templates/api/lib/mbuild.mako
+++ b/src/generator/templates/api/lib/mbuild.mako
@@ -387,7 +387,7 @@ match result {
          Error::HttpError(_)
         |Error::Io(_)
         |Error::MissingAPIKey
-        |Error::MissingToken
+        |Error::MissingToken(_)
         |Error::Cancelled
         |Error::UploadSizeLimitExceeded(_, _)
         |Error::Failure(_)
@@ -710,7 +710,7 @@ else {
                 // TODO: remove Ok / Err branches
                 Ok(Some(token)) => token.clone(),
                 Ok(None) => {
-                    let err = oauth2::OtherError("unknown error occurred while generating oauth2 token".into());
+                    let err = oauth2::Error::OtherError(anyhow::Error::msg("unknown error occurred while generating oauth2 token"));
                     match dlg.token(&err) {
                         Some(token) => token,
                         None => {

--- a/src/generator/templates/api/lib/mbuild.mako
+++ b/src/generator/templates/api/lib/mbuild.mako
@@ -387,7 +387,7 @@ match result {
          Error::HttpError(_)
         |Error::Io(_)
         |Error::MissingAPIKey
-        |Error::MissingToken(_)
+        |Error::MissingToken
         |Error::Cancelled
         |Error::UploadSizeLimitExceeded(_, _)
         |Error::Failure(_)
@@ -706,14 +706,14 @@ else {
 
         loop {
             % if default_scope:
-            let token = match ${auth_call}.token(&self.${api.properties.scopes}.keys().collect::<Vec<_>>()[..]).await {
-                Ok(token) => token.clone(),
-                Err(err) => {
-                    match  dlg.token(&err) {
+            let token = match ${auth_call}.get_token(&self.${api.properties.scopes}.keys().map(String::as_str).collect::<Vec<_>>()[..]).await {
+                Some(token) => token.clone(),
+                None => {
+                    match dlg.token() {
                         Some(token) => token,
                         None => {
                             ${delegate_finish}(false);
-                            return Err(client::Error::MissingToken(err))
+                            return Err(client::Error::MissingToken)
                         }
                     }
                 }

--- a/src/generator/templates/cli/mkdocs.yml.mako
+++ b/src/generator/templates/cli/mkdocs.yml.mako
@@ -17,8 +17,9 @@ site_dir: ${mkdocs.site_dir}
 nav:
 - Home: 'index.md'
 % for resource in sorted(c.rta_map.keys()):
+- '${pretty(resource)}':
 % for method in sorted(c.rta_map[resource]):
-- '${subcommand_md_filename(resource, method)}': '${pretty(resource)}', '${pretty(method)}'
+    - '${pretty(method)}': '${subcommand_md_filename(resource, method)}'
 % endfor # each method
 % endfor # each resource
 

--- a/src/generator/templates/cli/mkdocs.yml.mako
+++ b/src/generator/templates/cli/mkdocs.yml.mako
@@ -15,10 +15,10 @@ docs_dir: ${mkdocs.docs_dir}
 site_dir: ${mkdocs.site_dir}
 
 nav:
-- ['index.md', 'Home']
+- Home: 'index.md'
 % for resource in sorted(c.rta_map.keys()):
 % for method in sorted(c.rta_map[resource]):
-- ['${subcommand_md_filename(resource, method)}', '${pretty(resource)}', '${pretty(method)}']
+- '${subcommand_md_filename(resource, method)}': '${pretty(resource)}', '${pretty(method)}'
 % endfor # each method
 % endfor # each resource
 

--- a/src/generator/templates/cli/mkdocs.yml.mako
+++ b/src/generator/templates/cli/mkdocs.yml.mako
@@ -14,7 +14,7 @@ repo_url: ${util.github_source_root_url()}
 docs_dir: ${mkdocs.docs_dir}
 site_dir: ${mkdocs.site_dir}
 
-pages:
+nav:
 - ['index.md', 'Home']
 % for resource in sorted(c.rta_map.keys()):
 % for method in sorted(c.rta_map[resource]):

--- a/src/rust/api/client.rs
+++ b/src/rust/api/client.rs
@@ -795,7 +795,7 @@ pub async fn get_body_as_string(res_body: &mut hyper::Body) -> String {
 type TokenResult = std::result::Result<Option<String>, oauth2::Error>;
 
 pub trait GetToken: GetTokenClone {
-    /// Called whenever there is the need for your applications API key after
+    /// Called whenever there is the need for an oauth token after
     /// the official authenticator implementation didn't provide one, for some reason.
     /// If this method returns None as well, the underlying operation will fail
     fn get_token<'a>(&'a self, _scopes: &'a [&str]) -> Pin<Box<dyn Future<Output=TokenResult> + 'a>> {
@@ -828,7 +828,12 @@ impl GetToken for String {
     }
 }
 
-impl GetToken for () {}
+/// In the event that the API endpoint does not require an oauth2 token, `NoToken` should be provided to the hub to avoid specifying an
+/// authenticator.
+#[derive(Default, Clone)]
+pub struct NoToken;
+
+impl GetToken for NoToken {}
 
 // TODO: Make this optional
 // #[cfg(feature = "yup-oauth2")]


### PR DESCRIPTION
Note: New PR without generated API files.

I decided to give the "decouple" approach a try, as it fits my needs better.

I took the approach of creating an `Authenticator` trait which allows tokens to be generated asynchronously (as approached to the delegate, which requires sync). I believe the crates should still work as before for anyone not using a custom `Delegate` trait, as `Hub::new` accepts an instance of `Authenticator`, which is implemented for `yup_oauth2::authenticator::Authenticator`.

`yup-oauth2` is no longer a required dependency, and can be disabled if a user should choose to do so by using `default-features = false`. 

The only breaking change introduced is `err` parameter from the `Delegate::token` method. Given that the `Authenticator` implementation can handle any `yup-oauth2` errors internally, it doesn't seem necessary for `Delegate::token` to also handle this.

There's a default implementation of `Authenticator` for `String` (user-provided oauth tokens) and `()` (no token at all - this seems like a good idea for APIs which do not use need oauth2)