### PR TITLE
Add missing trait bounds for proper async to GetToken

### DIFF
--- a/google-apis-common/src/lib.rs
+++ b/google-apis-common/src/lib.rs
@@ -793,7 +793,7 @@ pub async fn get_body_as_string(res_body: &mut hyper::Body) -> String {
 // TODO: Simplify this to Option<String>
 type TokenResult = std::result::Result<Option<String>, oauth2::Error>;
 
-pub trait GetToken: GetTokenClone {
+pub trait GetToken: GetTokenClone + Send {
     /// Called whenever there is the need for an oauth token after
     /// the official authenticator implementation didn't provide one, for some reason.
     /// If this method returns None as well, the underlying operation will fail
@@ -927,5 +927,14 @@ mod test_api {
         let mut dd = DefaultDelegate::default();
         let dlg: &mut dyn Delegate = &mut dd;
         with_send(dlg);
+    }
+    
+    #[test]
+    fn dyn_get_token_is_send() {
+        fn with_send(_x: impl Send) {}
+
+        let mut gt = String::new();
+        let dgt: &mut dyn GetToken = &mut dd;
+        with_send(dgt);
     }
 }

--- a/google-apis-common/src/lib.rs
+++ b/google-apis-common/src/lib.rs
@@ -934,7 +934,7 @@ mod test_api {
         fn with_send(_x: impl Send) {}
 
         let mut gt = String::new();
-        let dgt: &mut dyn GetToken = &mut dd;
+        let dgt: &mut dyn GetToken = &mut gt;
         with_send(dgt);
     }
 }

--- a/google-apis-common/src/lib.rs
+++ b/google-apis-common/src/lib.rs
@@ -793,11 +793,11 @@ pub async fn get_body_as_string(res_body: &mut hyper::Body) -> String {
 // TODO: Simplify this to Option<String>
 type TokenResult = std::result::Result<Option<String>, oauth2::Error>;
 
-pub trait GetToken: GetTokenClone + Send {
+pub trait GetToken: GetTokenClone + Send + Sync {
     /// Called whenever there is the need for an oauth token after
     /// the official authenticator implementation didn't provide one, for some reason.
     /// If this method returns None as well, the underlying operation will fail
-    fn get_token<'a>(&'a self, _scopes: &'a [&str]) -> Pin<Box<dyn Future<Output=TokenResult> + 'a>> {
+    fn get_token<'a>(&'a self, _scopes: &'a [&str]) -> Pin<Box<dyn Future<Output=TokenResult> + Send + 'a>> {
         Box::pin(async move { Ok(None) })
     }
 }
@@ -822,7 +822,7 @@ impl Clone for Box<dyn GetToken> {
 }
 
 impl GetToken for String {
-    fn get_token<'a>(&'a self, _scopes: &'a [&str]) -> Pin<Box<dyn Future<Output=TokenResult> + 'a>> {
+    fn get_token<'a>(&'a self, _scopes: &'a [&str]) -> Pin<Box<dyn Future<Output=TokenResult> + Send + 'a>> {
         Box::pin(async move { Ok(Some(self.clone())) })
     }
 }
@@ -854,7 +854,7 @@ mod yup_oauth2_impl {
         S::Response: Connection + AsyncRead + AsyncWrite + Send + Unpin + 'static,
         S::Future: Send + Unpin + 'static,
         S::Error: Into<Box<dyn std::error::Error + Send + Sync>> {
-        fn get_token<'a>(&'a self, scopes: &'a [&str]) -> Pin<Box<dyn Future<Output=TokenResult> + 'a>> {
+        fn get_token<'a>(&'a self, scopes: &'a [&str]) -> Pin<Box<dyn Future<Output=TokenResult> + Send + 'a>> {
             Box::pin(async move {
                 self.token(scopes).await.map(|t| Some(t.as_str().to_owned()))
             })


### PR DESCRIPTION
I apparently missed a few necessary trait bounds while implementing `GetToken`, which I discovered while using the crate in my project. I've added the necessary bound plus a test to ensure that it remains correct in the future.

Unfortunately, I think this might necessitate yanking the previous versions of google-apis-common (as they will likely fail to compile).