### PR TITLE
Refactor client functions

### DIFF
--- a/google-apis-common/src/lib.rs
+++ b/google-apis-common/src/lib.rs
@@ -752,32 +752,14 @@ where
 
 // TODO(ST): Allow sharing common code between program types
 pub fn remove_json_null_values(value: &mut json::value::Value) {
-    match *value {
-        json::value::Value::Object(ref mut map) => {
-            let mut for_removal = Vec::new();
-
-            for (key, mut value) in map.iter_mut() {
-                if value.is_null() {
-                    for_removal.push(key.clone());
-                } else {
-                    remove_json_null_values(&mut value);
-                }
-            }
-
-            for key in &for_removal {
-                map.remove(key);
-            }
+    match value {
+        json::value::Value::Object(map) => {
+            map.retain(|_, value| !value.is_null());
+            map.values_mut().for_each(remove_json_null_values);
         }
-        json::value::Value::Array(ref mut arr) => {
-            let mut i = 0;
-            while i < arr.len() {
-                if arr[i].is_null() {
-                    arr.remove(i);
-                } else {
-                    remove_json_null_values(&mut arr[i]);
-                    i += 1;
-                }
-            }
+        json::value::Value::Array(arr) => {
+            arr.retain(|value| !value.is_null());
+            arr.iter_mut().for_each(remove_json_null_values);
         }
         _ => {}
     }

--- a/src/generator/templates/api/api.rs.mako
+++ b/src/generator/templates/api/api.rs.mako
@@ -24,11 +24,11 @@ use serde_json as json;
 use std::io;
 use std::fs;
 use std::mem;
-use std::thread::sleep;
 
 use http::Uri;
 use hyper::client::connect;
 use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::time::sleep;
 use tower_service;
 use serde::{Serialize, Deserialize};
 

--- a/src/generator/templates/api/lib/mbuild.mako
+++ b/src/generator/templates/api/lib/mbuild.mako
@@ -819,7 +819,7 @@ else {
             match req_result {
                 Err(err) => {
                     if let client::Retry::After(d) = dlg.http_error(&err) {
-                        sleep(d);
+                        sleep(d).await;
                         continue;
                     }
                     ${delegate_finish}(false);
@@ -835,7 +835,7 @@ else {
                         let server_response = json::from_str::<serde_json::Value>(&res_body_string).ok();
 
                         if let client::Retry::After(d) = dlg.http_failure(&restored_response, server_response.clone()) {
-                            sleep(d);
+                            sleep(d).await;
                             continue;
                         }
 


### PR DESCRIPTION
I'm not sure whether these changes should be included in the previous PR - but given that it's non-essential, I've decided to keep them separate. 

The first change is refactoring `remove_json_null_values` to run in linear time (the `arr.remove()` call takes `O(n)` time and may be  called `n` times, which could accidentally lead to quadratic run times) - this incidentally makes the code a lot cleaner.

The second change is using `tokio::time::sleep` in place of `std::thread::sleep` in the upload functions (for both `google-apis-common` and `api.rs`). `std::thread::sleep` is blocking per https://doc.rust-lang.org/stable/std/thread/fn.sleep.html, and should not be used in async functions. 