### PR TITLE
Refactor modification of scopes

### DIFF
--- a/src/generator/lib/util.py
+++ b/src/generator/lib/util.py
@@ -24,35 +24,6 @@ CHRONO_PATH = "client::chrono"
 CHRONO_DATETIME = f"{CHRONO_PATH}::DateTime<{CHRONO_PATH}::offset::Utc>"
 CHRONO_DATE = f"{CHRONO_PATH}::NaiveDate"
 USE_FORMAT = 'use_format_field'
-TYPE_MAP = {
-    'boolean': 'bool',
-    'integer': USE_FORMAT,
-    'number': USE_FORMAT,
-    'uint32': 'u32',
-    'double': 'f64',
-    'float': 'f32',
-    'int32': 'i32',
-    'any': 'String',  # TODO: Figure out how to handle it. It's 'interface' in Go ...
-    'int64': 'i64',
-    'uint64': 'u64',
-    'array': 'Vec',
-    'string': 'String',
-    'object': 'HashMap',
-    # https://github.com/protocolbuffers/protobuf/blob/ec1a70913e5793a7d0a7b5fbf7e0e4f75409dd41/src/google/protobuf/timestamp.proto
-    # In JSON format, the Timestamp type is encoded as a string in the [RFC 3339] format
-    'google-datetime': CHRONO_DATETIME,
-    # Per .json files: RFC 3339 timestamp
-    'date-time': CHRONO_DATETIME,
-    # Per .json files: A date in RFC 3339 format with only the date part
-    # e.g. "2013-01-15"
-    'date': CHRONO_DATE,
-    # https://github.com/protocolbuffers/protobuf/blob/ec1a70913e5793a7d0a7b5fbf7e0e4f75409dd41/src/google/protobuf/duration.proto
-    'google-duration': f"{CHRONO_PATH}::Duration",
-    # guessing bytes is universally url-safe b64
-    "byte": "Vec<u8>",
-    # https://github.com/protocolbuffers/protobuf/blob/ec1a70913e5793a7d0a7b5fbf7e0e4f75409dd41/src/google/protobuf/field_mask.proto
-    "google-fieldmask": "client::FieldMask"
-}
 
 RUST_TYPE_MAP = {
     'boolean': Base("bool"),
@@ -128,7 +99,10 @@ DEL_METHOD = 'delete'
 METHODS_RESOURCE = 'methods'
 
 ADD_PARAM_FN = 'param'
-ADD_SCOPE_FN = 'add_scope'
+ADD_SCOPE_FN = "add_scope"
+ADD_SCOPES_FN = "add_scopes"
+CLEAR_SCOPES_FN = "clear_scopes"
+
 ADD_PARAM_MEDIA_EXAMPLE = "." + ADD_PARAM_FN + '("alt", "media")'
 
 SPACES_PER_TAB = 4

--- a/src/generator/templates/api/lib/mbuild.mako
+++ b/src/generator/templates/api/lib/mbuild.mako
@@ -11,7 +11,8 @@
                       DELEGATE_PROPERTY_NAME, struct_type_bounds_s, scope_url_to_variant,
                       re_find_replacements, ADD_PARAM_FN, ADD_PARAM_MEDIA_EXAMPLE, upload_action_fn, METHODS_RESOURCE,
                       method_name_to_variant, size_to_bytes, method_default_scope,
-                      is_repeated_property, setter_fn_name, ADD_SCOPE_FN, rust_doc_sanitize, items, string_impl)
+                      is_repeated_property, setter_fn_name, ADD_SCOPE_FN, ADD_SCOPES_FN, rust_doc_sanitize,
+                      CLEAR_SCOPES_FN, items, string_impl)
 
     def get_parts(part_prop):
         if not part_prop:
@@ -79,7 +80,7 @@ ${m.description | rust_doc_sanitize, rust_doc_comment}
 % else:
 /// A builder for the *${method}* method supported by a *${singular(resource)}* resource.
 % endif
-/// It is not used directly, but through a `${rb_type(resource)}` instance.
+/// It is not used directly, but through a [`${rb_type(resource)}`] instance.
 ///
 % if part_desc:
 ${part_desc | rust_doc_sanitize, rust_doc_comment}
@@ -173,24 +174,36 @@ ${self._setter_fn(resource, method, m, p, part_prop, ThisType, c)}\
     % if method_default_scope(m):
     /// Identifies the authorization scope for the method you are building.
     ///
-    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
-    /// `${scope_url_to_variant(name, method_default_scope(m), fully_qualified=True)}`.
+    /// Use this method to actively specify which scope should be used, instead the of the default [`Scope`] variant
+    /// [`${scope_url_to_variant(name, method_default_scope(m), fully_qualified=True)}`].
     ///
     /// The `scope` will be added to a set of scopes. This is important as one can maintain access
     /// tokens for more than one scope.
-    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
-    /// In that case, you have to specify your API-key using the `key` parameter (see the `${ADD_PARAM_FN}()`
-    /// function for details).
     ///
     /// Usually there is more than one suitable scope to authorize an operation, some of which may
     /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
     /// sufficient, a read-write scope will do as well.
-    pub fn ${ADD_SCOPE_FN}<T, St>(mut self, scope: T) -> ${ThisType}
-                                                        where T: Into<Option<St>>,
-                                                              St: AsRef<str> {
-        if let Some(scope) = scope.into() {
-          self.${api.properties.scopes}.insert(scope.as_ref().to_string());
-        };
+    pub fn ${ADD_SCOPE_FN}<St>(mut self, scope: St) -> ${ThisType}
+                                                        where St: AsRef<str> {
+        self.${api.properties.scopes}.insert(String::from(scope.as_ref()));
+        self
+    }
+    /// Identifies the authorization scope(s) for the method you are building.
+    ///
+    /// See [`Self::${ADD_SCOPE_FN}()`] for details.
+    pub fn ${ADD_SCOPES_FN}<I, St>(mut self, scopes: I) -> ${ThisType}
+                                                        where I: IntoIterator<Item = St>,
+                                                         St: AsRef<str> {
+        self.${api.properties.scopes}
+            .extend(scopes.into_iter().map(|s| String::from(s.as_ref())));
+        self
+    }
+
+    /// Removes all scopes, and no default scope will be used either.
+    /// In this case, you have to specify your API-key using the `key` parameter (see [`Self::${ADD_PARAM_FN}()`]
+    /// for details).
+    pub fn ${CLEAR_SCOPES_FN}(mut self) -> ${ThisType} {
+        self.${api.properties.scopes}.clear();
         self
     }
     % endif

--- a/src/generator/templates/api/lib/rbuild.mako
+++ b/src/generator/templates/api/lib/rbuild.mako
@@ -25,7 +25,7 @@
 % else:
 /// A builder providing access to all methods supported on *${singular(resource)}* resources.
 % endif
-/// It is not used directly, but through the `${hub_type_name}` hub.
+/// It is not used directly, but through the [`${hub_type_name}`] hub.
 ///
 /// # Example
 ///


### PR DESCRIPTION
- `add_scope` is simplified to simply add scopes, and no longer takes an `Option<_>` item.
- Added `add_scopes` convenience function, which allows adding multiple scopes at once. 
- Added `clear_scopes` function to explicitly allow clearing method scopes.

This also includes small improvements to documentation - primarily by including links to referenced types / methods

Addresses #333 