### PR TITLE
Auth refactor

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,6 +19,7 @@ jobs:
           source ~/.profile
           make test-gen
           make gen-all-cli cargo-api ARGS=test
+          make cargo-api ARGS='check --no-default-features'
           make cargo-api ARGS=doc
           make docs-all
           cargo test

--- a/google-apis-common/Cargo.toml
+++ b/google-apis-common/Cargo.toml
@@ -24,11 +24,9 @@ serde_json = "^ 1.0"
 base64 = "0.13.0"
 chrono = { version = "0.4.22", features = ["serde"] }
 
-## TODO: Make yup-oauth2 optional
-## yup-oauth2 = { version = "^ 7.0", optional = true }
-yup-oauth2 = "^ 7.0"
+yup-oauth2 = { version = "^ 7.0", optional = true }
 itertools = "^ 0.10"
-hyper = "^ 0.14"
+hyper = { version = "^ 0.14", features = ["client", "http2"] }
 http = "^0.2"
-tokio = "^1.0"
+tokio = { version = "^1.0", features = ["time"] }
 tower-service = "^0.3.1"

--- a/google-apis-common/src/auth.rs
+++ b/google-apis-common/src/auth.rs
@@ -1,0 +1,96 @@
+use std::future::Future;
+use std::pin::Pin;
+
+// TODO: Simplify this to Option<String>
+type TokenResult = Option<String>;
+
+pub trait GetToken: GetTokenClone + Send + Sync {
+    /// Called whenever there is the need for an oauth token after
+    /// the official authenticator implementation didn't provide one, for some reason.
+    /// If this method returns None as well, the underlying operation will fail
+    fn get_token<'a>(
+        &'a self,
+        _scopes: &'a [&str],
+    ) -> Pin<Box<dyn Future<Output = TokenResult> + Send + 'a>> {
+        Box::pin(async move { None })
+    }
+}
+
+pub trait GetTokenClone {
+    fn clone_box(&self) -> Box<dyn GetToken>;
+}
+
+impl<T> GetTokenClone for T
+where
+    T: 'static + GetToken + Clone,
+{
+    fn clone_box(&self) -> Box<dyn GetToken> {
+        Box::new(self.clone())
+    }
+}
+
+impl Clone for Box<dyn GetToken> {
+    fn clone(&self) -> Box<dyn GetToken> {
+        self.clone_box()
+    }
+}
+
+impl GetToken for String {
+    fn get_token<'a>(
+        &'a self,
+        _scopes: &'a [&str],
+    ) -> Pin<Box<dyn Future<Output = TokenResult> + Send + 'a>> {
+        Box::pin(async move { Some(self.clone()) })
+    }
+}
+
+/// In the event that the API endpoint does not require an oauth2 token, `NoToken` should be provided to the hub to avoid specifying an
+/// authenticator.
+#[derive(Default, Clone)]
+pub struct NoToken;
+
+impl GetToken for NoToken {}
+
+// TODO: Make this optional
+// #[cfg(feature = "yup-oauth2")]
+mod yup_oauth2_impl {
+    use core::future::Future;
+    use core::pin::Pin;
+
+    use super::{GetToken, TokenResult};
+
+    use http::Uri;
+    use hyper::client::connect::Connection;
+    use tokio::io::{AsyncRead, AsyncWrite};
+    use tower_service::Service;
+    use yup_oauth2::authenticator::Authenticator;
+
+    impl<S> GetToken for Authenticator<S>
+    where
+        S: Service<Uri> + Clone + Send + Sync + 'static,
+        S::Response: Connection + AsyncRead + AsyncWrite + Send + Unpin + 'static,
+        S::Future: Send + Unpin + 'static,
+        S::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+    {
+        fn get_token<'a>(
+            &'a self,
+            scopes: &'a [&str],
+        ) -> Pin<Box<dyn Future<Output = TokenResult> + Send + 'a>> {
+            Box::pin(async move { self.token(scopes).await.ok().map(|t| t.as_str().to_owned()) })
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn dyn_get_token_is_send() {
+        fn with_send(_x: impl Send) {}
+
+        let mut gt = String::new();
+        let dgt: &mut dyn GetToken = &mut gt;
+        with_send(dgt);
+    }
+}

--- a/google-apis-common/src/auth.rs
+++ b/google-apis-common/src/auth.rs
@@ -71,7 +71,6 @@
 use std::future::Future;
 use std::pin::Pin;
 
-// TODO: Simplify this to Option<String>
 type TokenResult = Option<String>;
 
 pub trait GetToken: GetTokenClone + Send + Sync {
@@ -121,8 +120,7 @@ pub struct NoToken;
 
 impl GetToken for NoToken {}
 
-// TODO: Make this optional
-// #[cfg(feature = "yup-oauth2")]
+#[cfg(feature = "yup-oauth2")]
 mod yup_oauth2_impl {
     use core::future::Future;
     use core::pin::Pin;

--- a/google-apis-common/src/auth.rs
+++ b/google-apis-common/src/auth.rs
@@ -54,7 +54,7 @@
 //!     ) -> Pin<Box<dyn Future<Output = Result<Option<String>, Box<dyn std::error::Error + Send + Sync>>> + Send + 'a>> {
 //!         Box::pin(async move {
 //!             let mut auth_token = Ok(None);
-//!             for _ in 0..self.retries {
+//!             for _ in 0..=self.retries {
 //!                 match self.auth.token(scopes).await {
 //!                     Ok(token) => {
 //!                         auth_token = Ok(Some(token.as_str().to_owned()));

--- a/google-apis-common/src/auth.rs
+++ b/google-apis-common/src/auth.rs
@@ -74,9 +74,8 @@ use std::pin::Pin;
 type TokenResult = Option<String>;
 
 pub trait GetToken: GetTokenClone + Send + Sync {
-    /// Called whenever there is the need for an oauth token after
-    /// the official authenticator implementation didn't provide one, for some reason.
-    /// If this method returns None as well, the underlying operation will fail
+    /// Called whenever an API call require authentication via an oauth2 token.
+    /// Returns `None` if a token can not be generated for the provided scopes.
     fn get_token<'a>(
         &'a self,
         _scopes: &'a [&str],

--- a/google-apis-common/src/lib.rs
+++ b/google-apis-common/src/lib.rs
@@ -29,6 +29,7 @@ pub use auth::{GetToken, NoToken};
 pub use chrono;
 pub use field_mask::FieldMask;
 pub use serde_with;
+#[cfg(feature = "yup-oauth2")]
 pub use yup_oauth2 as oauth2;
 
 const LINE_ENDING: &str = "\r\n";

--- a/src/generator/templates/Cargo.toml.mako
+++ b/src/generator/templates/Cargo.toml.mako
@@ -58,6 +58,8 @@ path = "../${api_name}"
 version = "${util.crate_version()}"
 % endif
 
-## TODO: Make yup-oauth2 optional
-# [features]
-# default = ["yup-oauth2"]
+% if not cargo.get("is_executable", False):
+[features]
+yup-oauth2 = ["google-apis-common/yup-oauth2"]
+default = ["yup-oauth2"]
+% endif

--- a/src/generator/templates/api/api.rs.mako
+++ b/src/generator/templates/api/api.rs.mako
@@ -31,7 +31,7 @@ use tokio::time::sleep;
 use tower_service;
 use serde::{Serialize, Deserialize};
 
-use crate::{client, client::GetToken, client::oauth2, client::serde_with};
+use crate::{client, client::GetToken, client::serde_with};
 
 // ##############
 // UTILITIES ###

--- a/src/generator/templates/api/lib.rs.mako
+++ b/src/generator/templates/api/lib.rs.mako
@@ -49,5 +49,8 @@ pub mod api;
 
 // Re-export the hub type and some basic client structs
 pub use api::${hub_type};
+pub use client::{Result, Error, Delegate, FieldMask};
+
 // Re-export the yup_oauth2 crate, that is required to call some methods of the hub and the client
-pub use client::{Result, Error, Delegate, oauth2, FieldMask};
+#[cfg(feature = "yup-oauth2")]
+pub use client::oauth2;

--- a/src/generator/templates/api/lib/mbuild.mako
+++ b/src/generator/templates/api/lib/mbuild.mako
@@ -711,24 +711,13 @@ else {
         loop {
             % if default_scope:
             let token = match ${auth_call}.get_token(&self.${api.properties.scopes}.iter().map(String::as_str).collect::<Vec<_>>()[..]).await {
-                // TODO: remove Ok / Err branches
-                Ok(Some(token)) => token.clone(),
-                Ok(None) => {
-                    let err = oauth2::Error::OtherError(anyhow::Error::msg("unknown error occurred while generating oauth2 token"));
-                    match dlg.token(&err) {
+                Some(token) => token.clone(),
+                None => {
+                    match dlg.token() {
                         Some(token) => token,
                         None => {
                             ${delegate_finish}(false);
-                            return Err(client::Error::MissingToken(err))
-                        }
-                    }
-                }
-                Err(err) => {
-                    match dlg.token(&err) {
-                        Some(token) => token,
-                        None => {
-                            ${delegate_finish}(false);
-                            return Err(client::Error::MissingToken(err))
+                            return Err(client::Error::MissingToken);
                         }
                     }
                 }

--- a/src/generator/templates/api/lib/mbuild.mako
+++ b/src/generator/templates/api/lib/mbuild.mako
@@ -856,7 +856,8 @@ else {
                                 start_at: if upload_url_from_server { Some(0) } else { None },
                                 auth: &${auth_call},
                                 user_agent: &self.hub._user_agent,
-                                auth_header: format!("Bearer {}", token.expect("resumable upload requires token").as_str()),
+                                // TODO: Check this assumption
+                                auth_header: format!("Bearer {}", token.ok_or_else(|| client::Error::MissingToken("resumable upload requires token".into()))?.as_str()),
                                 url: url_str,
                                 reader: &mut reader,
                                 media_type: reader_mime_type.clone(),

--- a/src/generator/templates/api/lib/mbuild.mako
+++ b/src/generator/templates/api/lib/mbuild.mako
@@ -399,7 +399,7 @@ match result {
          Error::HttpError(_)
         |Error::Io(_)
         |Error::MissingAPIKey
-        |Error::MissingToken(_)
+        |Error::MissingToken
         |Error::Cancelled
         |Error::UploadSizeLimitExceeded(_, _)
         |Error::Failure(_)


### PR DESCRIPTION
Since we're moving on to the next API version, I'm revisiting this change as well.

PR includes:
- Documentation on how to use authentication, and how to implement custom authenticators as needed
- More flexible authentication error types
- Optional `yup-oauth2` (included by default)
- Optional token for APIs which optionally require token.

I'd also like to see about entirely removing the `yup-oauth2` dependency for (and `auth` argument in Hub constructor) for unauthenticated APIs