### PR TITLE
Update mime

### DIFF
--- a/google-apis-common/Cargo.toml
+++ b/google-apis-common/Cargo.toml
@@ -16,7 +16,7 @@ doctest = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-mime = "^ 0.2.0"
+mime = "^ 0.3"
 serde = { version = "^ 1.0", features = ["derive"] }
 serde_with = "2.0.1"
 serde_json = "^ 1.0"

--- a/google-apis-common/src/lib.rs
+++ b/google-apis-common/src/lib.rs
@@ -17,7 +17,7 @@ use hyper::header::{HeaderMap, AUTHORIZATION, CONTENT_LENGTH, CONTENT_TYPE, USER
 use hyper::Method;
 use hyper::StatusCode;
 
-use mime::{Attr, Mime, SubLevel, TopLevel, Value};
+use mime::Mime;
 
 use serde_json as json;
 
@@ -358,7 +358,7 @@ impl<'a> MultiPartReader<'a> {
         let mut headers = HeaderMap::new();
         headers.insert(
             CONTENT_TYPE,
-            hyper::header::HeaderValue::from_str(&format!("{}", mime_type)).unwrap(),
+            hyper::header::HeaderValue::from_str(&mime_type.to_string()).unwrap(),
         );
         headers.insert(CONTENT_LENGTH, size.into());
         self.raw_parts.push((headers, reader));
@@ -368,14 +368,8 @@ impl<'a> MultiPartReader<'a> {
     /// Returns the mime-type representing our multi-part message.
     /// Use it with the ContentType header.
     pub fn mime_type(&self) -> Mime {
-        Mime(
-            TopLevel::Multipart,
-            SubLevel::Ext("related".to_string()),
-            vec![(
-                Attr::Ext("boundary".to_string()),
-                Value::Ext(BOUNDARY.to_string()),
-            )],
-        )
+        Mime::from_str(&format!("multipart/related;boundary={}", BOUNDARY))
+            .expect("valid mimetype")
     }
 
     /// Returns true if we are totally used

--- a/src/generator/templates/Cargo.toml.mako
+++ b/src/generator/templates/Cargo.toml.mako
@@ -26,11 +26,10 @@ path = "src/main.rs"
 % endif
 
 [dependencies]
-## TODO: temporary, remove when yup-oauth2 is optional
 anyhow = "^ 1.0"
 hyper-rustls = "0.23.0"
 ## Must match the one hyper uses, otherwise there are duplicate similarly named `Mime` structs
-mime = "^ 0.2.0"
+mime = "^ 0.3.0"
 serde = { version = "^ 1.0", features = ["derive"] }
 serde_json = "^ 1.0"
 itertools = "^ 0.10"

--- a/src/generator/templates/api/lib/mbuild.mako
+++ b/src/generator/templates/api/lib/mbuild.mako
@@ -747,10 +747,9 @@ else {
                         ${READER_SEEK | indent_all_but_first_by(5)}
                         mp_reader.add_part(&mut request_value_reader, request_size, json_mime_type.clone())
                                  .add_part(&mut reader, size, reader_mime_type.clone());
-                        let mime_type = mp_reader.mime_type();
-                        (&mut mp_reader as &mut (dyn io::Read + Send), (CONTENT_TYPE, mime_type.to_string()))
+                        (&mut mp_reader as &mut (dyn io::Read + Send), client::MultiPartReader::mime_type())
                     },
-                    _ => (&mut request_value_reader as &mut (dyn io::Read + Send), (CONTENT_TYPE, json_mime_type.to_string())),
+                    _ => (&mut request_value_reader as &mut (dyn io::Read + Send), json_mime_type.clone()),
                 };
             % endif
                 let client = &self.hub.client;
@@ -774,15 +773,15 @@ else {
                 % if request_value:
                     % if not simple_media_param:
                         let request = req_builder
-                        .header(CONTENT_TYPE, format!("{}", json_mime_type.to_string()))
+                        .header(CONTENT_TYPE, json_mime_type.to_string())
                         .header(CONTENT_LENGTH, request_size as u64)
                         .body(hyper::body::Body::from(request_value_reader.get_ref().clone()))\
                     % else:
                         let mut body_reader_bytes = vec![];
                         body_reader.read_to_end(&mut body_reader_bytes).unwrap();
                         let request = req_builder
-                        .header(content_type.0, content_type.1.to_string())
-                        .body(hyper::body::Body::from(body_reader_bytes))\
+                            .header(CONTENT_TYPE, content_type.to_string())
+                            .body(hyper::body::Body::from(body_reader_bytes))\
                     % endif ## not simple_media_param
                 % else:
                     % if simple_media_param:

--- a/src/generator/templates/api/lib/mbuild.mako
+++ b/src/generator/templates/api/lib/mbuild.mako
@@ -689,7 +689,7 @@ else {
         let url = url::Url::parse_with_params(&url, params).unwrap();
 
         % if request_value:
-        let mut json_mime_type: mime::Mime = "application/json".parse().unwrap();
+        let mut json_mime_type = mime::APPLICATION_JSON;
         let mut request_value_reader =
             {
                 let mut value = json::value::to_value(&self.${property(REQUEST_VALUE_PROPERTY_NAME)}).expect("serde to work");


### PR DESCRIPTION
I noticed that the `mime` dependency is very old, and every crate the apis use which use `mime` use a more recent version.

However, this is a breaking change, going from `mime v0.2.6.0` to `mime v 0.3.16.0`.