### PR TITLE
Refactor params into google-apis-common

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,6 +7,14 @@ on:
     branches: [main]
 
 jobs:
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: Swatinem/rust-cache@v2
+      - name: Run clippy
+        run: |
+          cargo clippy -- -D warnings
   build-and-test:
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,9 +25,11 @@ jobs:
       - name: Run tests
         run: |
           source ~/.profile
+          cargo test
           make test-gen
           make gen-all-cli cargo-api ARGS=test
           make cargo-api ARGS='check --no-default-features'
+          make cargo-api ARGS=check
           make cargo-api ARGS=doc
+          make cargo-cli ARGS=check
           make docs-all
-          cargo test

--- a/google-apis-common/Cargo.toml
+++ b/google-apis-common/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "^ 1.0"
 
 base64 = "0.13.0"
 chrono = { version = "0.4.22", features = ["serde"] }
+url = "= 1.7"
 
 yup-oauth2 = { version = "^ 7.0", optional = true }
 itertools = "^ 0.10"

--- a/google-apis-common/src/field_mask.rs
+++ b/google-apis-common/src/field_mask.rs
@@ -1,3 +1,4 @@
+use std::fmt::{Display, Formatter};
 use std::str::FromStr;
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -73,15 +74,15 @@ impl FromStr for FieldMask {
     }
 }
 
-impl FieldMask {
-    pub fn to_string(&self) -> String {
+impl Display for FieldMask {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let mut repr = String::new();
         for path in &self.0 {
             titlecase(path, &mut repr);
             repr.push(',');
         }
         repr.pop();
-        repr
+        f.write_str(&repr)
     }
 }
 

--- a/google-apis-common/src/field_mask.rs
+++ b/google-apis-common/src/field_mask.rs
@@ -30,7 +30,7 @@ fn snakecase(source: &str) -> String {
 }
 
 /// A `FieldMask` as defined in `https://github.com/protocolbuffers/protobuf/blob/ec1a70913e5793a7d0a7b5fbf7e0e4f75409dd41/src/google/protobuf/field_mask.proto#L180`
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct FieldMask(Vec<String>);
 
 impl Serialize for FieldMask {

--- a/google-apis-common/src/field_mask.rs
+++ b/google-apis-common/src/field_mask.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 fn titlecase(source: &str, dest: &mut String) {
@@ -46,12 +48,13 @@ impl<'de> Deserialize<'de> for FieldMask {
         D: Deserializer<'de>,
     {
         let s: &str = Deserialize::deserialize(deserializer)?;
-        Ok(FieldMask::from_str(s))
+        Ok(FieldMask::from_str(s).unwrap())
     }
 }
 
-impl FieldMask {
-    fn from_str(s: &str) -> FieldMask {
+impl FromStr for FieldMask {
+    type Err = std::convert::Infallible;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
         let mut in_quotes = false;
         let mut prev_ind = 0;
         let mut paths = Vec::new();
@@ -66,9 +69,11 @@ impl FieldMask {
             }
         }
         paths.push(snakecase(&s[prev_ind..]));
-        FieldMask(paths)
+        Ok(FieldMask(paths))
     }
+}
 
+impl FieldMask {
     pub fn to_string(&self) -> String {
         let mut repr = String::new();
         for path in &self.0 {

--- a/google-apis-common/src/lib.rs
+++ b/google-apis-common/src/lib.rs
@@ -25,7 +25,6 @@ use serde_json as json;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::time::sleep;
 
-
 pub use auth::{GetToken, NoToken};
 pub use chrono;
 pub use field_mask::FieldMask;
@@ -778,7 +777,7 @@ mod test_api {
     use std::str::FromStr;
 
     use ::serde::{Deserialize, Serialize};
-    
+
     use serde_json as json;
 
     #[test]

--- a/google-apis-common/src/lib.rs
+++ b/google-apis-common/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod auth;
 pub mod field_mask;
 pub mod serde;
+pub mod url;
 
 use std::error;
 use std::error::Error as StdError;

--- a/google-apis-common/src/lib.rs
+++ b/google-apis-common/src/lib.rs
@@ -41,6 +41,12 @@ pub enum Retry {
     After(Duration),
 }
 
+#[derive(PartialEq, Eq)]
+pub enum UploadProtocol {
+    Simple,
+    Resumable,
+}
+
 /// Identifies the Hub. There is only one per library, this trait is supposed
 /// to make intended use more explicit.
 /// The hub allows to access all resource methods more easily.

--- a/google-apis-common/src/lib.rs
+++ b/google-apis-common/src/lib.rs
@@ -24,7 +24,7 @@ use serde_json as json;
 
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::time::sleep;
-use tower_service;
+
 
 pub use auth::{GetToken, NoToken};
 pub use chrono;
@@ -372,7 +372,7 @@ impl<'a> MultiPartReader<'a> {
         let mut headers = HeaderMap::new();
         headers.insert(
             CONTENT_TYPE,
-            hyper::header::HeaderValue::from_str(&mime_type.to_string()).unwrap(),
+            hyper::header::HeaderValue::from_str(mime_type.as_ref()).unwrap(),
         );
         headers.insert(CONTENT_LENGTH, size.into());
         self.raw_parts.push((headers, reader));
@@ -481,7 +481,7 @@ impl<'a> Read for MultiPartReader<'a> {
 ///
 /// Generated via rustc --pretty expanded -Z unstable-options, and manually
 /// processed to be more readable.
-#[derive(PartialEq, Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct XUploadContentType(pub Mime);
 
 impl ::std::ops::Deref for XUploadContentType {
@@ -501,7 +501,7 @@ impl Display for XUploadContentType {
     }
 }
 
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub struct Chunk {
     pub first: u64,
     pub last: u64,
@@ -537,7 +537,7 @@ impl FromStr for Chunk {
 }
 
 /// Implements the Content-Range header, for serialization only
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub struct ContentRange {
     pub range: Option<Chunk>,
     pub total_length: u64,
@@ -556,7 +556,7 @@ impl ContentRange {
     }
 }
 
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub struct RangeResponseHeader(pub Chunk);
 
 impl RangeResponseHeader {
@@ -565,7 +565,7 @@ impl RangeResponseHeader {
             if let Ok(s) = std::str::from_utf8(raw) {
                 const PREFIX: &str = "bytes ";
                 if let Some(stripped) = s.strip_prefix(PREFIX) {
-                    if let Ok(c) = <Chunk as FromStr>::from_str(&stripped) {
+                    if let Ok(c) = <Chunk as FromStr>::from_str(stripped) {
                         return RangeResponseHeader(c);
                     }
                 }
@@ -778,7 +778,7 @@ mod test_api {
     use std::str::FromStr;
 
     use ::serde::{Deserialize, Serialize};
-    use mime;
+    
     use serde_json as json;
 
     #[test]
@@ -809,7 +809,7 @@ mod test_api {
         json::to_string(&<Bar as Default>::default()).unwrap();
 
         let j = "{\"snooSnoo\":\"foo\"}";
-        let b: Bar = json::from_str(&j).unwrap();
+        let b: Bar = json::from_str(j).unwrap();
         assert_eq!(b.snoo_snoo, "foo");
 
         // We can't have unknown fields with structs.

--- a/google-apis-common/src/serde.rs
+++ b/google-apis-common/src/serde.rs
@@ -61,9 +61,9 @@ pub mod duration {
         };
 
         let (seconds, nanoseconds) = if let Some((seconds, nanos)) = value.split_once('.') {
-            let is_neg = seconds.starts_with("-");
+            let is_neg = seconds.starts_with('-');
             let seconds = i64::from_str(seconds)?;
-            let nano_magnitude = nanos.chars().filter(|c| c.is_digit(10)).count() as u32;
+            let nano_magnitude = nanos.chars().filter(|c| c.is_ascii_digit()).count() as u32;
             if nano_magnitude > 9 {
                 // not enough precision to model the remaining digits
                 return Err(ParseDurationError::NanosTooSmall);
@@ -263,7 +263,7 @@ mod test {
             serde_json::from_str(r#"{"bytes": "aGVsbG8gd29ybGQ="}"#).unwrap();
         assert_eq!(
             Some(b"hello world".as_slice()),
-            wrapper.bytes.as_ref().map(Vec::as_slice)
+            wrapper.bytes.as_deref()
         );
     }
 

--- a/google-apis-common/src/serde.rs
+++ b/google-apis-common/src/serde.rs
@@ -261,10 +261,7 @@ mod test {
     fn urlsafe_base64_de_success_cases() {
         let wrapper: Base64Wrapper =
             serde_json::from_str(r#"{"bytes": "aGVsbG8gd29ybGQ="}"#).unwrap();
-        assert_eq!(
-            Some(b"hello world".as_slice()),
-            wrapper.bytes.as_deref()
-        );
+        assert_eq!(Some(b"hello world".as_slice()), wrapper.bytes.as_deref());
     }
 
     #[test]

--- a/google-apis-common/src/url.rs
+++ b/google-apis-common/src/url.rs
@@ -42,7 +42,7 @@ impl<'a> Params<'a> {
     ) -> String {
         if url_encode {
             let mut replace_with: Cow<str> = self.get(param).unwrap_or("").into();
-            if from.as_bytes()[1] == '+' as u8 {
+            if from.as_bytes()[1] == b'+' {
                 replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET)
                     .to_string()
                     .into();
@@ -66,6 +66,6 @@ impl<'a> Params<'a> {
     }
 
     pub fn parse_with_url(&self, url: &str) -> Url {
-        Url::parse_with_params(&url, &self.params).unwrap()
+        Url::parse_with_params(url, &self.params).unwrap()
     }
 }

--- a/google-apis-common/src/url.rs
+++ b/google-apis-common/src/url.rs
@@ -1,0 +1,71 @@
+use std::borrow::Cow;
+
+use ::url::percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
+use ::url::Url;
+
+pub struct Params<'a> {
+    params: Vec<(&'a str, Cow<'a, str>)>,
+}
+
+impl<'a> Params<'a> {
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            params: Vec::with_capacity(capacity),
+        }
+    }
+
+    pub fn push<I: Into<Cow<'a, str>>>(&mut self, param: &'a str, value: I) {
+        self.params.push((param, value.into()))
+    }
+
+    pub fn extend<I: Iterator<Item = (&'a String, IC)>, IC: Into<Cow<'a, str>>>(
+        &mut self,
+        params: I,
+    ) {
+        self.params
+            .extend(params.map(|(k, v)| (k.as_str(), v.into())))
+    }
+
+    pub fn get(&self, param_name: &str) -> Option<&str> {
+        self.params
+            .iter()
+            .find(|(name, _)| name == &param_name)
+            .map(|(_, param)| param.as_ref())
+    }
+
+    pub fn uri_replacement(
+        &self,
+        url: String,
+        param: &str,
+        from: &str,
+        url_encode: bool,
+    ) -> String {
+        if url_encode {
+            let mut replace_with: Cow<str> = self.get(param).unwrap_or("").into();
+            if from.as_bytes()[1] == '+' as u8 {
+                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET)
+                    .to_string()
+                    .into();
+            }
+            url.replace(from, &replace_with)
+        } else {
+            let replace_with = self
+                .get(param)
+                .expect("to find substitution value in params");
+
+            url.replace(from, replace_with)
+        }
+    }
+
+    pub fn remove_params(&mut self, to_remove: &[&str]) {
+        self.params.retain(|(n, _)| !to_remove.contains(n))
+    }
+
+    pub fn inner_mut(&mut self) -> &mut Vec<(&'a str, Cow<'a, str>)> {
+        self.params.as_mut()
+    }
+
+    pub fn parse_with_url(&self, url: &str) -> Url {
+        Url::parse_with_params(&url, &self.params).unwrap()
+    }
+}

--- a/google-apis-common/src/url.rs
+++ b/google-apis-common/src/url.rs
@@ -41,7 +41,7 @@ impl<'a> Params<'a> {
         url_encode: bool,
     ) -> String {
         if url_encode {
-            let mut replace_with: Cow<str> = self.get(param).unwrap_or("").into();
+            let mut replace_with: Cow<str> = self.get(param).unwrap_or_default().into();
             if from.as_bytes()[1] == b'+' {
                 replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET)
                     .to_string()

--- a/google-clis-common/Cargo.toml
+++ b/google-clis-common/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2021"
 doctest = false
 
 [dependencies]
-mime = "0.2"
+mime = "^ 0.3"
 yup-oauth2 = "^ 7.0"
 serde = "1"
 serde_json = "1"

--- a/google-clis-common/src/lib.rs
+++ b/google-clis-common/src/lib.rs
@@ -620,6 +620,15 @@ pub struct InvalidOptionsError {
     pub exit_code: i32,
 }
 
+impl Default for InvalidOptionsError {
+    fn default() -> Self {
+        InvalidOptionsError {
+            issues: Vec::new(),
+            exit_code: 1,
+        }
+    }
+}
+
 impl fmt::Display for InvalidOptionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         for issue in &self.issues {
@@ -638,10 +647,7 @@ impl InvalidOptionsError {
     }
 
     pub fn new() -> InvalidOptionsError {
-        InvalidOptionsError {
-            issues: Vec::new(),
-            exit_code: 1,
-        }
+        Default::default()
     }
 }
 

--- a/src/generator/lib/cli.py
+++ b/src/generator/lib/cli.py
@@ -6,6 +6,8 @@ import collections
 from copy import deepcopy
 from random import (randint, random, choice)
 
+from generator.lib import types
+
 SPLIT_START = '>>>>>>>'
 SPLIT_END = '<<<<<<<'
 
@@ -56,7 +58,7 @@ JSON_TYPE_RND_MAP = {'boolean': lambda: str(bool(randint(0, 1))).lower(),
                      'number' : lambda: random(),
                      'int32' : lambda: randint(-101, -1),
                      'int64' : lambda: randint(-101, -1),
-                     'string': lambda: '%s' % choice(util.words).lower()}
+                     'string': lambda: '%s' % choice(types.WORDS).lower()}
 
 JSON_TYPE_TO_ENUM_MAP = {'boolean' : 'Boolean',
                          'integer' : 'Int',
@@ -73,17 +75,6 @@ JSON_TYPE_TO_ENUM_MAP = {'boolean' : 'Boolean',
 CTYPE_TO_ENUM_MAP = {CTYPE_POD:   'Pod',
                      CTYPE_ARRAY: 'Vec',
                      CTYPE_MAP:   'Map'}
-
-JSON_TYPE_VALUE_MAP = {'boolean': 'false',
-                       'integer' : '-0',
-                       'uint32' : '0',
-                       'uint64' : '0',
-                       'float' : '0.0',
-                       'double' : '0.0',
-                       'number' : '0.0',
-                       'int32' : '-0',
-                       'int64' : '-0',
-                       'string': ''}
 
 assert len(set(JSON_TYPE_RND_MAP.keys()) ^ POD_TYPES) == 0
 

--- a/src/generator/lib/types.py
+++ b/src/generator/lib/types.py
@@ -1,0 +1,97 @@
+from .rust_type import Base, HashMap, Vec
+from random import randint, random, choice, seed
+
+seed(1337)
+
+WORDS = [
+    w.strip(',') for w in
+    "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.".split(
+        ' ')]
+
+
+def chrono_date(y=None, m=None, d=None):
+    y = randint(1, 9999) if y is None else y
+    m = randint(1, 12) if m is None else m
+    d = randint(1, 31) if d is None else d
+    return f"chrono::NaiveDate::from_ymd({y}, {m}, {d})"
+
+
+CHRONO_PATH = "client::chrono"
+CHRONO_DATETIME = f"{CHRONO_PATH}::DateTime<{CHRONO_PATH}::offset::Utc>"
+CHRONO_DATE = f"{CHRONO_PATH}::NaiveDate"
+USE_FORMAT = 'use_format_field'
+CHRONO_UTC_NOW = "chrono::Utc::now()"
+
+RUST_TYPE_MAP = {
+    'boolean': Base("bool"),
+    'integer': USE_FORMAT,
+    'number': USE_FORMAT,
+    'uint32': Base("u32"),
+    'double': Base("f64"),
+    'float': Base("f32"),
+    'int32': Base("i32"),
+    'any': Base("String"),  # TODO: Figure out how to handle it. It's 'interface' in Go ...
+    'int64': Base("i64"),
+    'uint64': Base("u64"),
+    'array': Vec(None),
+    'string': Base("String"),
+    'object': HashMap(None, None),
+    # https://github.com/protocolbuffers/protobuf/blob/ec1a70913e5793a7d0a7b5fbf7e0e4f75409dd41/src/google/protobuf/timestamp.proto
+    # In JSON format, the Timestamp type is encoded as a string in the [RFC 3339] format
+    'google-datetime': Base(CHRONO_DATETIME),
+    # Per .json files: RFC 3339 timestamp
+    'date-time': Base(CHRONO_DATETIME),
+    # Per .json files: A date in RFC 3339 format with only the date part
+    # e.g. "2013-01-15"
+    'date': Base(CHRONO_DATE),
+    # https://github.com/protocolbuffers/protobuf/blob/ec1a70913e5793a7d0a7b5fbf7e0e4f75409dd41/src/google/protobuf/duration.proto
+    'google-duration': Base(f"{CHRONO_PATH}::Duration"),
+    # guessing bytes is universally url-safe b64
+    "byte": Vec(Base("u8")),
+    # https://github.com/protocolbuffers/protobuf/blob/ec1a70913e5793a7d0a7b5fbf7e0e4f75409dd41/src/google/protobuf/field_mask.proto
+    "google-fieldmask": Base("client::FieldMask")
+}
+
+RUST_TYPE_RND_MAP = {
+    'bool': lambda: str(bool(randint(0, 1))).lower(),
+    'u32': lambda: randint(0, 100),
+    'u64': lambda: randint(0, 100),
+    'f64': lambda: random(),
+    'f32': lambda: random(),
+    'i32': lambda: randint(-101, -1),
+    'i64': lambda: randint(-101, -1),
+    'String': lambda: '"%s"' % choice(WORDS),
+    '&str': lambda: '"%s"' % choice(WORDS),
+    '&Vec<String>': lambda: '&vec!["%s".into()]' % choice(WORDS),
+    "Vec<u8>": lambda: f"vec![0, 1, 2, 3]",
+    # why a reference to Vec? Because it works. Should be slice, but who knows how typing works here.
+    "&Vec<u8>": lambda: f"&vec![0, 1, 2, 3]",
+    # TODO: styling this
+    f"{CHRONO_PATH}::Duration": lambda: f"chrono::Duration::seconds({randint(0, 9999999)})",
+    CHRONO_DATE: chrono_date,
+    CHRONO_DATETIME: lambda: CHRONO_UTC_NOW,
+    "FieldMask": lambda: f"FieldMask(vec![{choice(WORDS)}])",
+}
+
+JSON_TO_RUST_DEFAULT = {
+    'boolean': 'false',
+    'uint32': '0',
+    'uint64': '0',
+    'int32': "-0",
+    'int64': "-0",
+    'float': '0.0',
+    'double': '0.0',
+    'string': "\"\"",
+    'google-datetime': CHRONO_UTC_NOW,
+    'date-time': CHRONO_UTC_NOW,
+    'date': chrono_date(2000, 1, 1),
+    # https://github.com/protocolbuffers/protobuf/blob/ec1a70913e5793a7d0a7b5fbf7e0e4f75409dd41/src/google/protobuf/duration.proto
+    'google-duration': "chrono::Duration::seconds(0)",
+    # guessing bytes is universally url-safe b64
+    "byte": "b\"hello world\"",
+    # https://github.com/protocolbuffers/protobuf/blob/ec1a70913e5793a7d0a7b5fbf7e0e4f75409dd41/src/google/protobuf/field_mask.proto
+    "google-fieldmask": "FieldMask::default()"
+}
+
+
+assert set(JSON_TO_RUST_DEFAULT.keys()).issubset(set(RUST_TYPE_MAP.keys()))

--- a/src/generator/lib/util.py
+++ b/src/generator/lib/util.py
@@ -1222,8 +1222,9 @@ def string_impl(p):
         "byte": lambda x: f"::client::serde::urlsafe_base64::to_string(&{x})",
         "google-datetime": lambda x: f"::client::serde::datetime_to_string(&{x})",
         "date-time": lambda x: f"::client::serde::datetime_to_string(&{x})",
-        "google-fieldmask": lambda x: f"{x}.to_string()"
-    }.get(p.get("format"), lambda x: f"{x}.to_string()")
+        "google-fieldmask": lambda x: f"{x}.to_string()",
+        "string": lambda x: x
+    }.get(p.get("format", p["type"]), lambda x: f"{x}.to_string()")
 
 
 if __name__ == '__main__':

--- a/src/generator/templates/api/lib/mbuild.mako
+++ b/src/generator/templates/api/lib/mbuild.mako
@@ -14,9 +14,11 @@
                       is_repeated_property, setter_fn_name, ADD_SCOPE_FN, ADD_SCOPES_FN, rust_doc_sanitize,
                       CLEAR_SCOPES_FN, items, string_impl)
 
+    SIMPLE = "simple"
+    RESUMABLE = "resumable"
     PROTOCOL_TYPE_MAP = {
-        "simple": "client::UploadProtocol::Simple",
-        "resumable": "client::UploadProtocol::Resumable"
+        SIMPLE: "client::UploadProtocol::Simple",
+        RESUMABLE: "client::UploadProtocol::Resumable"
     }
 
     def get_parts(part_prop):
@@ -457,9 +459,9 @@ match result {
         where = '\n\t\twhere ' + mtype_param + ': client::ReadSeek'
         add_args = (', mut reader: %s, reader_mime_type: mime::Mime' % mtype_param) + ", protocol: client::UploadProtocol"
         for p in media_params:
-            if p.protocol == 'simple':
+            if p.protocol == SIMPLE:
                 simple_media_param = p
-            elif p.protocol == 'resumable':
+            elif p.protocol == RESUMABLE:
                 resumable_media_param = p
     # end handle media params
 
@@ -541,7 +543,7 @@ match result {
     if media_params and 'mediaUpload' in m:
         upload_type_map = dict()
         for mp in media_params:
-            if mp.protocol == 'simple':
+            if mp.protocol == SIMPLE:
                 upload_type_map[mp.protocol] = m.mediaUpload.protocols.simple.multipart and 'multipart' or 'media'
                 break
         # for each media param

--- a/src/generator/templates/api/lib/mbuild.mako
+++ b/src/generator/templates/api/lib/mbuild.mako
@@ -658,21 +658,18 @@ else {
     replace_assign = 'Some(value)'
     url_replace_arg = 'replace_with.expect("to find substitution value in params")'
     if URL_ENCODE in special_cases:
-        replace_init = ' = String::new()'
-        replace_assign = 'value.to_string()'
+        replace_init = ': Cow<str> = "".into()'
+        replace_assign = 'Cow::from(value.as_ref())'
         url_replace_arg = '&replace_with'
     # end handle url encoding
 %>\
             let mut replace_with${replace_init};
-            for &(name, ref value) in params.iter() {
-                if name == param_name {
-                    replace_with = ${replace_assign};
-                    break;
-                }
+            if let Some((_, value)) = params.iter().find(|(name, _)| name == &param_name) {
+                replace_with = ${replace_assign};
             }
             % if URL_ENCODE in special_cases:
             if find_this.as_bytes()[1] == '+' as u8 {
-                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET).to_string();
+                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET).to_string().into();
             }
             % endif
             url = url.replace(find_this, ${url_replace_arg});

--- a/src/generator/templates/api/lib/mbuild.mako
+++ b/src/generator/templates/api/lib/mbuild.mako
@@ -715,7 +715,7 @@ else {
             % if request_value and simple_media_param:
                 let mut mp_reader: client::MultiPartReader = Default::default();
                 let (mut body_reader, content_type) = match protocol {
-                    "${simple_media_param.protocol}" => {
+                    ${PROTOCOL_TYPE_MAP[simple_media_param.protocol]} => {
                         mp_reader.reserve_exact(2);
                         ${READER_SEEK | indent_all_but_first_by(5)}
                         mp_reader.add_part(&mut request_value_reader, request_size, json_mime_type.clone())

--- a/src/generator/templates/api/lib/mbuild.mako
+++ b/src/generator/templates/api/lib/mbuild.mako
@@ -592,19 +592,14 @@ match result {
 
         % if response_schema:
         % if supports_download:
-        let (json_field_missing, enable_resource_parsing) = {
-            let mut enable = true;
-            let mut field_missing = true;
-            for &(name, ref value) in params.iter() {
-                if name == "alt" {
-                    field_missing = false;
-                    enable = value == "json";
-                    break;
-                }
+        let (alt_field_missing, enable_resource_parsing) = {
+            if let Some((_, value)) = params.iter().find(|(name, _)| name == &"alt") {
+                (false, value == "json")
+            } else {
+                (true, true)
             }
-            (field_missing, enable)
         };
-        if json_field_missing {
+        if alt_field_missing {
             params.push(("alt", "json".into()));
         }
         % else:

--- a/src/generator/templates/cli/lib/engine.mako
+++ b/src/generator/templates/cli/lib/engine.mako
@@ -5,12 +5,12 @@
                       ADD_SCOPE_FN, TREF, enclose_in)
     from generator.lib.cli import (mangle_subcommand, new_method_context, PARAM_FLAG, STRUCT_FLAG, OUTPUT_FLAG, VALUE_ARG,
                      CONFIG_DIR, SCOPE_FLAG, is_request_value_property, FIELD_SEP, docopt_mode, FILE_ARG, MIME_ARG, OUT_ARG,
-                     call_method_ident, POD_TYPES, opt_value, ident, JSON_TYPE_VALUE_MAP,
+                     call_method_ident, POD_TYPES, opt_value, ident,
                      KEY_VALUE_ARG, to_cli_schema, SchemaEntry, CTYPE_POD, actual_json_type, CTYPE_MAP, CTYPE_ARRAY,
                      application_secret_path, CONFIG_DIR_FLAG, req_value, MODE_ARG,
                      opt_values, SCOPE_ARG, CONFIG_DIR_ARG, DEFAULT_MIME, field_vec, comma_sep_fields, JSON_TYPE_TO_ENUM_MAP,
                      CTYPE_TO_ENUM_MAP)
-
+    from generator.lib.types import JSON_TO_RUST_DEFAULT
     v_arg = '<%s>' % VALUE_ARG
     SOPT = 'self.opt'
 
@@ -226,8 +226,9 @@ for parg in ${opt_values(VALUE_ARG)} {
     match key {
 % for p in optional_props:
 <%
-    ptype = actual_json_type(p.name, p.type)
-    value_unwrap = 'value.unwrap_or("%s")' % JSON_TYPE_VALUE_MAP[ptype]
+    ptype = actual_json_type(p.name, p.get("format", p.type))
+    default_value = JSON_TO_RUST_DEFAULT[ptype]
+    value_unwrap = f"value.unwrap_or({default_value})"
 %>\
         "${mangle_subcommand(p.name)}" => {
         % if p.name == 'alt':
@@ -237,7 +238,7 @@ for parg in ${opt_values(VALUE_ARG)} {
         % endif
             call = call.${mangle_ident(setter_fn_name(p))}(\
         % if ptype != 'string':
-arg_from_str(${value_unwrap}, err, "${mangle_subcommand(p.name)}", "${ptype}")\
+        value.map(|v| arg_from_str(v, err, "${mangle_subcommand(p.name)}", "${ptype}")).unwrap_or(${default_value})\
         % else:
 ${value_unwrap}\
         % endif # handle conversion

--- a/src/generator/templates/cli/main.rs.mako
+++ b/src/generator/templates/cli/main.rs.mako
@@ -21,7 +21,8 @@ use std::env;
 use std::io::{self, Write};
 use clap::{App, SubCommand, Arg};
 
-use ${to_extern_crate_name(library_to_crate_name(library_name(name, version), make.depends_on_suffix))}::{api, Error, oauth2};
+use ${to_extern_crate_name(library_to_crate_name(library_name(name, version), make.depends_on_suffix))}::{api, Error, oauth2, client::chrono, FieldMask};
+
 
 use google_clis_common as client;
 

--- a/src/rust/preproc/src/main.rs
+++ b/src/rust/preproc/src/main.rs
@@ -31,5 +31,5 @@ fn main() {
         None,
     )
     .unwrap();
-    io::stdout().write_all(&output.as_bytes()).unwrap();
+    io::stdout().write_all(output.as_bytes()).unwrap();
 }


### PR DESCRIPTION
This refactors the shared url parameter functionality into `google-apis-common`. 

This is good for testing, and reduces the amount of mako-specific code-gen, which is nice. This also reduces the size of the generated `compute1` library by 2.4%, from 168MB to 164MB (and compile times from 43s to 35s, though I don't know if this is due to other effects).

Additionally, I noticed that the `url` crate is very out of date - however, I have no idea where to update this dependency, as my initial grep failed to find anything.