### PR TITLE
Update yup-oauth2 to 8.0.0

### DIFF
--- a/google-apis-common/Cargo.toml
+++ b/google-apis-common/Cargo.toml
@@ -25,7 +25,7 @@ base64 = "0.13.0"
 chrono = { version = "0.4.22", features = ["serde"] }
 url = "= 1.7"
 
-yup-oauth2 = { version = "^ 7.0", optional = true }
+yup-oauth2 = { version = "^ 8.0", optional = true }
 itertools = "^ 0.10"
 hyper = { version = "^ 0.14", features = ["client", "http2"] }
 http = "^0.2"

--- a/google-apis-common/src/auth.rs
+++ b/google-apis-common/src/auth.rs
@@ -57,7 +57,7 @@
 //!             for _ in 0..=self.retries {
 //!                 match self.auth.token(scopes).await {
 //!                     Ok(token) => {
-//!                         auth_token = Ok(Some(token.as_str().to_owned()));
+//!                         auth_token = Ok(token.token().map(|t| t.to_owned()));
 //!                         break;
 //!                     },
 //!                     Err(e) => auth_token = Err(e.into()),
@@ -146,7 +146,7 @@ mod yup_oauth2_impl {
             Box::pin(async move {
                 self.token(scopes)
                     .await
-                    .map(|t| Some(t.as_str().to_owned()))
+                    .map(|t| t.token().map(|t| t.to_owned()))
                     .map_err(|e| e.into())
             })
         }

--- a/google-clis-common/Cargo.toml
+++ b/google-clis-common/Cargo.toml
@@ -17,7 +17,7 @@ doctest = false
 
 [dependencies]
 mime = "^ 0.3"
-yup-oauth2 = "^ 7.0"
+yup-oauth2 = "^ 8.0"
 serde = "1"
 serde_json = "1"
 strsim = "0.10.0"


### PR DESCRIPTION
yup-oauth2 supports impersonating service accounts in 8.0, which is a very useful feature.
Here's an attempt to bump the dep in google-apis-common.