### PR TITLE
Improve handling of plurals in generator.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ codecov
 ghp-import
 pyright
 types-PyYAML
+inflect

--- a/src/generator/lib/util.py
+++ b/src/generator/lib/util.py
@@ -2,6 +2,7 @@ import os
 import re
 import subprocess
 
+import inflect
 from dataclasses import dataclass
 from typing import Any, Dict, List, Mapping, Tuple
 from copy import deepcopy
@@ -93,6 +94,10 @@ data_unit_multipliers = {
     'pb': 1024 ** 5,
     '%': 1,
 }
+
+
+inflection = inflect.engine()
+
 
 HUB_TYPE_PARAMETERS = ('S',)
 
@@ -284,11 +289,15 @@ def md_italic(l):
 
 
 def singular(s):
-    if s.endswith('ies'):
-        return s[:-3] + 'y'
-    if s[-1] == 's':
-        return s[:-1]
-    return s
+    if s.lower().endswith('data'):
+        return s
+
+    single_noun = inflection.singular_noun(s)
+
+    if single_noun is False:
+        return s
+    else:
+        return single_noun
 
 
 def split_camelcase_s(s):


### PR DESCRIPTION
The generator tries to turn plural into singular nouns. However, some words turn out badly, including:
 - Addresse (from Addresses)
 - Prefixe (from Prefixes)
 - Bookshelve (from Bookshelves)
 - Sery (from Series)

By using a library, we can get a slightly better outcome. I've added an exception for "Data", because seeing that turned into "Datum" is a bit jarring.

For the above, the resulting generated word:
- Address
- Prefix
- Bookshelf
- Series