### PR TITLE
Remove old time dependency from API.

### DIFF
--- a/google-apis-common/Cargo.toml
+++ b/google-apis-common/Cargo.toml
@@ -22,7 +22,7 @@ serde_with = "2.0.1"
 serde_json = "^ 1.0"
 
 base64 = "0.13.0"
-chrono = { version = "0.4.22", features = ["serde"] }
+chrono = { version = "0.4.22", default-features = false, features = ["clock", "serde"] }
 url = "= 1.7"
 
 yup-oauth2 = { version = "^ 7.0", optional = true }


### PR DESCRIPTION
Chrono currently depends on an old version of time with a reported vulnerability: https://rustsec.org/advisories/RUSTSEC-2020-0159

While it does not use any vulnerable code, the dependency may show up in code vulnerability scans, etc.

This removes the "oldtime" feature from chrono, to remove that. Also removes the "std" feature because it doesn't seem to be in use in this code.
