### PR TITLE
Made doit() in FileInsertCall public

### DIFF
--- a/gen/drive2/src/api.rs
+++ b/gen/drive2/src/api.rs
@@ -13556,7 +13556,7 @@ where
 
 
     /// Perform the operation you have build so far.
-    async fn doit<RS>(mut self, mut reader: RS, reader_mime_type: mime::Mime, protocol: &'static str) -> client::Result<(hyper::Response<hyper::body::Body>, File)>
+    pub async fn doit<RS>(mut self, mut reader: RS, reader_mime_type: mime::Mime, protocol: &'static str) -> client::Result<(hyper::Response<hyper::body::Body>, File)>
 		where RS: client::ReadSeek {
         use std::io::{Read, Seek};
         use hyper::header::{CONTENT_TYPE, CONTENT_LENGTH, AUTHORIZATION, USER_AGENT, LOCATION};


### PR DESCRIPTION
The function doit() in FileInsertCall  is a private method and inaccessible. This PR fixes that.