### PR TITLE
Map 'any' JSON Schema type to json::Value instead of String

### DIFF
--- a/gen/fcm1/Cargo.toml
+++ b/gen/fcm1/Cargo.toml
@@ -4,12 +4,12 @@
 [package]
 
 name = "google-fcm1"
-version = "4.0.1+20220228"
+version = "5.0.2-beta-1+20220228"
 authors = ["Sebastian Thiel <byronimo@gmail.com>"]
 description = "A complete library to interact with Firebase Cloud Messaging (protocol v1)"
 repository = "https://github.com/Byron/google-apis-rs/tree/main/gen/fcm1"
 homepage = "https://firebase.google.com/docs/cloud-messaging"
-documentation = "https://docs.rs/google-fcm1/4.0.1+20220228"
+documentation = "https://docs.rs/google-fcm1/5.0.2-beta-1+20220228"
 license = "MIT"
 keywords = ["fcm", "google", "protocol", "web", "api"]
 autobins = false
@@ -17,13 +17,13 @@ edition = "2018"
 
 
 [dependencies]
+anyhow = "^ 1.0"
 hyper-rustls = "0.23.0"
-mime = "^ 0.2.0"
-serde = "^ 1.0"
+mime = "^ 0.3.0"
+serde = { version = "^ 1.0", features = ["derive"] }
 serde_json = "^ 1.0"
-serde_derive = "^ 1.0"
-yup-oauth2 = "^ 7.0"
 itertools = "^ 0.10"
+google-apis-common = { path = "../../google-apis-common", version = "5.0.1" }
 hyper = "^ 0.14"
 http = "^0.2"
 tokio = "^1.0"
@@ -32,3 +32,6 @@ url = "= 1.7"
 
 
 
+[features]
+yup-oauth2 = ["google-apis-common/yup-oauth2"]
+default = ["yup-oauth2"]

--- a/gen/fcm1/README.md
+++ b/gen/fcm1/README.md
@@ -5,16 +5,16 @@ DO NOT EDIT !
 -->
 The `google-fcm1` library allows access to all features of the *Google Firebase Cloud Messaging* service.
 
-This documentation was generated from *Firebase Cloud Messaging* crate version *4.0.1+20220228*, where *20220228* is the exact revision of the *fcm:v1* schema built by the [mako](http://www.makotemplates.org/) code generator *v4.0.1*.
+This documentation was generated from *Firebase Cloud Messaging* crate version *5.0.2-beta-1+20220228*, where *20220228* is the exact revision of the *fcm:v1* schema built by the [mako](http://www.makotemplates.org/) code generator *v5.0.2-beta-1*.
 
 Everything else about the *Firebase Cloud Messaging* *v1* API can be found at the
 [official documentation site](https://firebase.google.com/docs/cloud-messaging).
 # Features
 
-Handle the following *Resources* with ease from the central [hub](https://docs.rs/google-fcm1/4.0.1+20220228/google_fcm1/FirebaseCloudMessaging) ... 
+Handle the following *Resources* with ease from the central [hub](https://docs.rs/google-fcm1/5.0.2-beta-1+20220228/google_fcm1/FirebaseCloudMessaging) ... 
 
 * projects
- * [*messages send*](https://docs.rs/google-fcm1/4.0.1+20220228/google_fcm1/api::ProjectMessageSendCall)
+ * [*messages send*](https://docs.rs/google-fcm1/5.0.2-beta-1+20220228/google_fcm1/api::ProjectMessageSendCall)
 
 
 
@@ -23,17 +23,17 @@ Handle the following *Resources* with ease from the central [hub](https://docs.r
 
 The API is structured into the following primary items:
 
-* **[Hub](https://docs.rs/google-fcm1/4.0.1+20220228/google_fcm1/FirebaseCloudMessaging)**
+* **[Hub](https://docs.rs/google-fcm1/5.0.2-beta-1+20220228/google_fcm1/FirebaseCloudMessaging)**
     * a central object to maintain state and allow accessing all *Activities*
-    * creates [*Method Builders*](https://docs.rs/google-fcm1/4.0.1+20220228/google_fcm1/client::MethodsBuilder) which in turn
-      allow access to individual [*Call Builders*](https://docs.rs/google-fcm1/4.0.1+20220228/google_fcm1/client::CallBuilder)
-* **[Resources](https://docs.rs/google-fcm1/4.0.1+20220228/google_fcm1/client::Resource)**
+    * creates [*Method Builders*](https://docs.rs/google-fcm1/5.0.2-beta-1+20220228/google_fcm1/client::MethodsBuilder) which in turn
+      allow access to individual [*Call Builders*](https://docs.rs/google-fcm1/5.0.2-beta-1+20220228/google_fcm1/client::CallBuilder)
+* **[Resources](https://docs.rs/google-fcm1/5.0.2-beta-1+20220228/google_fcm1/client::Resource)**
     * primary types that you can apply *Activities* to
     * a collection of properties and *Parts*
-    * **[Parts](https://docs.rs/google-fcm1/4.0.1+20220228/google_fcm1/client::Part)**
+    * **[Parts](https://docs.rs/google-fcm1/5.0.2-beta-1+20220228/google_fcm1/client::Part)**
         * a collection of properties
         * never directly used in *Activities*
-* **[Activities](https://docs.rs/google-fcm1/4.0.1+20220228/google_fcm1/client::CallBuilder)**
+* **[Activities](https://docs.rs/google-fcm1/5.0.2-beta-1+20220228/google_fcm1/client::CallBuilder)**
     * operations to apply to *Resources*
 
 All *structures* are marked with applicable traits to further categorize them and ease browsing.
@@ -77,7 +77,7 @@ extern crate google_fcm1 as fcm1;
 use fcm1::api::SendMessageRequest;
 use fcm1::{Result, Error};
 use std::default::Default;
-use fcm1::{FirebaseCloudMessaging, oauth2, hyper, hyper_rustls};
+use fcm1::{FirebaseCloudMessaging, oauth2, hyper, hyper_rustls, chrono, FieldMask};
 
 // Get an ApplicationSecret instance by some means. It contains the `client_id` and 
 // `client_secret`, among other things.
@@ -124,17 +124,17 @@ match result {
 ```
 ## Handling Errors
 
-All errors produced by the system are provided either as [Result](https://docs.rs/google-fcm1/4.0.1+20220228/google_fcm1/client::Result) enumeration as return value of
+All errors produced by the system are provided either as [Result](https://docs.rs/google-fcm1/5.0.2-beta-1+20220228/google_fcm1/client::Result) enumeration as return value of
 the doit() methods, or handed as possibly intermediate results to either the 
-[Hub Delegate](https://docs.rs/google-fcm1/4.0.1+20220228/google_fcm1/client::Delegate), or the [Authenticator Delegate](https://docs.rs/yup-oauth2/*/yup_oauth2/trait.AuthenticatorDelegate.html).
+[Hub Delegate](https://docs.rs/google-fcm1/5.0.2-beta-1+20220228/google_fcm1/client::Delegate), or the [Authenticator Delegate](https://docs.rs/yup-oauth2/*/yup_oauth2/trait.AuthenticatorDelegate.html).
 
 When delegates handle errors or intermediate values, they may have a chance to instruct the system to retry. This 
 makes the system potentially resilient to all kinds of errors.
 
 ## Uploads and Downloads
-If a method supports downloads, the response body, which is part of the [Result](https://docs.rs/google-fcm1/4.0.1+20220228/google_fcm1/client::Result), should be
+If a method supports downloads, the response body, which is part of the [Result](https://docs.rs/google-fcm1/5.0.2-beta-1+20220228/google_fcm1/client::Result), should be
 read by you to obtain the media.
-If such a method also supports a [Response Result](https://docs.rs/google-fcm1/4.0.1+20220228/google_fcm1/client::ResponseResult), it will return that by default.
+If such a method also supports a [Response Result](https://docs.rs/google-fcm1/5.0.2-beta-1+20220228/google_fcm1/client::ResponseResult), it will return that by default.
 You can see it as meta-data for the actual media. To trigger a media download, you will have to set up the builder by making
 this call: `.param("alt", "media")`.
 
@@ -144,29 +144,29 @@ Methods supporting uploads can do so using up to 2 different protocols:
 
 ## Customization and Callbacks
 
-You may alter the way an `doit()` method is called by providing a [delegate](https://docs.rs/google-fcm1/4.0.1+20220228/google_fcm1/client::Delegate) to the 
-[Method Builder](https://docs.rs/google-fcm1/4.0.1+20220228/google_fcm1/client::CallBuilder) before making the final `doit()` call. 
+You may alter the way an `doit()` method is called by providing a [delegate](https://docs.rs/google-fcm1/5.0.2-beta-1+20220228/google_fcm1/client::Delegate) to the 
+[Method Builder](https://docs.rs/google-fcm1/5.0.2-beta-1+20220228/google_fcm1/client::CallBuilder) before making the final `doit()` call. 
 Respective methods will be called to provide progress information, as well as determine whether the system should 
 retry on failure.
 
-The [delegate trait](https://docs.rs/google-fcm1/4.0.1+20220228/google_fcm1/client::Delegate) is default-implemented, allowing you to customize it with minimal effort.
+The [delegate trait](https://docs.rs/google-fcm1/5.0.2-beta-1+20220228/google_fcm1/client::Delegate) is default-implemented, allowing you to customize it with minimal effort.
 
 ## Optional Parts in Server-Requests
 
-All structures provided by this library are made to be [encodable](https://docs.rs/google-fcm1/4.0.1+20220228/google_fcm1/client::RequestValue) and 
-[decodable](https://docs.rs/google-fcm1/4.0.1+20220228/google_fcm1/client::ResponseResult) via *json*. Optionals are used to indicate that partial requests are responses 
+All structures provided by this library are made to be [encodable](https://docs.rs/google-fcm1/5.0.2-beta-1+20220228/google_fcm1/client::RequestValue) and 
+[decodable](https://docs.rs/google-fcm1/5.0.2-beta-1+20220228/google_fcm1/client::ResponseResult) via *json*. Optionals are used to indicate that partial requests are responses 
 are valid.
-Most optionals are are considered [Parts](https://docs.rs/google-fcm1/4.0.1+20220228/google_fcm1/client::Part) which are identifiable by name, which will be sent to 
+Most optionals are are considered [Parts](https://docs.rs/google-fcm1/5.0.2-beta-1+20220228/google_fcm1/client::Part) which are identifiable by name, which will be sent to 
 the server to indicate either the set parts of the request or the desired parts in the response.
 
 ## Builder Arguments
 
-Using [method builders](https://docs.rs/google-fcm1/4.0.1+20220228/google_fcm1/client::CallBuilder), you are able to prepare an action call by repeatedly calling it's methods.
+Using [method builders](https://docs.rs/google-fcm1/5.0.2-beta-1+20220228/google_fcm1/client::CallBuilder), you are able to prepare an action call by repeatedly calling it's methods.
 These will always take a single argument, for which the following statements are true.
 
 * [PODs][wiki-pod] are handed by copy
 * strings are passed as `&str`
-* [request values](https://docs.rs/google-fcm1/4.0.1+20220228/google_fcm1/client::RequestValue) are moved
+* [request values](https://docs.rs/google-fcm1/5.0.2-beta-1+20220228/google_fcm1/client::RequestValue) are moved
 
 Arguments will always be copied or cloned into the builder, to make them independent of their original life times.
 

--- a/gen/fcm1/src/api.rs
+++ b/gen/fcm1/src/api.rs
@@ -1,19 +1,20 @@
 use std::collections::HashMap;
 use std::cell::RefCell;
 use std::default::Default;
-use std::collections::BTreeMap;
+use std::collections::BTreeSet;
 use std::error::Error as StdError;
 use serde_json as json;
 use std::io;
 use std::fs;
 use std::mem;
-use std::thread::sleep;
 
-use http::Uri;
 use hyper::client::connect;
 use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::time::sleep;
 use tower_service;
-use crate::client;
+use serde::{Serialize, Deserialize};
+
+use crate::{client, client::GetToken, client::serde_with};
 
 // ##############
 // UTILITIES ###
@@ -66,7 +67,7 @@ impl Default for Scope {
 /// use fcm1::{Result, Error};
 /// # async fn dox() {
 /// use std::default::Default;
-/// use fcm1::{FirebaseCloudMessaging, oauth2, hyper, hyper_rustls};
+/// use fcm1::{FirebaseCloudMessaging, oauth2, hyper, hyper_rustls, chrono, FieldMask};
 /// 
 /// // Get an ApplicationSecret instance by some means. It contains the `client_id` and 
 /// // `client_secret`, among other things.
@@ -114,7 +115,7 @@ impl Default for Scope {
 #[derive(Clone)]
 pub struct FirebaseCloudMessaging<S> {
     pub client: hyper::Client<S, hyper::body::Body>,
-    pub auth: oauth2::authenticator::Authenticator<S>,
+    pub auth: Box<dyn client::GetToken>,
     _user_agent: String,
     _base_url: String,
     _root_url: String,
@@ -124,11 +125,11 @@ impl<'a, S> client::Hub for FirebaseCloudMessaging<S> {}
 
 impl<'a, S> FirebaseCloudMessaging<S> {
 
-    pub fn new(client: hyper::Client<S, hyper::body::Body>, authenticator: oauth2::authenticator::Authenticator<S>) -> FirebaseCloudMessaging<S> {
+    pub fn new<A: 'static + client::GetToken>(client: hyper::Client<S, hyper::body::Body>, auth: A) -> FirebaseCloudMessaging<S> {
         FirebaseCloudMessaging {
             client,
-            auth: authenticator,
-            _user_agent: "google-api-rust-client/4.0.1".to_string(),
+            auth: Box::new(auth),
+            _user_agent: "google-api-rust-client/5.0.2-beta-1".to_string(),
             _base_url: "https://fcm.googleapis.com/".to_string(),
             _root_url: "https://fcm.googleapis.com/".to_string(),
         }
@@ -139,7 +140,7 @@ impl<'a, S> FirebaseCloudMessaging<S> {
     }
 
     /// Set the user-agent header field to use in all requests to the server.
-    /// It defaults to `google-api-rust-client/4.0.1`.
+    /// It defaults to `google-api-rust-client/5.0.2-beta-1`.
     ///
     /// Returns the previously set user-agent.
     pub fn user_agent(&mut self, agent_name: String) -> String {
@@ -171,28 +172,38 @@ impl<'a, S> FirebaseCloudMessaging<S> {
 /// 
 /// This type is not used in any activity, and only used as *part* of another schema.
 /// 
+#[serde_with::serde_as(crate = "::client::serde_with")]
 #[derive(Default, Clone, Debug, Serialize, Deserialize)]
 pub struct AndroidConfig {
     /// An identifier of a group of messages that can be collapsed, so that only the last message gets sent when delivery can be resumed. A maximum of 4 different collapse keys is allowed at any given time.
     #[serde(rename="collapseKey")]
+    
     pub collapse_key: Option<String>,
     /// Arbitrary key/value payload. If present, it will override google.firebase.fcm.v1.Message.data.
+    
     pub data: Option<HashMap<String, String>>,
     /// If set to true, messages will be allowed to be delivered to the app while the device is in direct boot mode. See [Support Direct Boot mode](https://developer.android.com/training/articles/direct-boot).
     #[serde(rename="directBootOk")]
+    
     pub direct_boot_ok: Option<bool>,
     /// Options for features provided by the FCM SDK for Android.
     #[serde(rename="fcmOptions")]
+    
     pub fcm_options: Option<AndroidFcmOptions>,
     /// Notification to send to android devices.
+    
     pub notification: Option<AndroidNotification>,
     /// Message priority. Can take "normal" and "high" values. For more information, see [Setting the priority of a message](https://goo.gl/GjONJv).
+    
     pub priority: Option<String>,
     /// Package name of the application where the registration token must match in order to receive the message.
     #[serde(rename="restrictedPackageName")]
+    
     pub restricted_package_name: Option<String>,
     /// How long (in seconds) the message should be kept in FCM storage if the device is offline. The maximum time to live supported is 4 weeks, and the default value is 4 weeks if not set. Set it to 0 if want to send the message immediately. In JSON format, the Duration type is encoded as a string rather than an object, where the string ends in the suffix "s" (indicating seconds) and is preceded by the number of seconds, with nanoseconds expressed as fractional seconds. For example, 3 seconds with 0 nanoseconds should be encoded in JSON format as "3s", while 3 seconds and 1 nanosecond should be expressed in JSON format as "3.000000001s". The ttl will be rounded down to the nearest second.
-    pub ttl: Option<String>,
+    
+    #[serde_as(as = "Option<::client::serde::duration::Wrapper>")]
+    pub ttl: Option<client::chrono::Duration>,
 }
 
 impl client::Part for AndroidConfig {}
@@ -202,10 +213,12 @@ impl client::Part for AndroidConfig {}
 /// 
 /// This type is not used in any activity, and only used as *part* of another schema.
 /// 
+#[serde_with::serde_as(crate = "::client::serde_with")]
 #[derive(Default, Clone, Debug, Serialize, Deserialize)]
 pub struct AndroidFcmOptions {
     /// Label associated with the message's analytics data.
     #[serde(rename="analyticsLabel")]
+    
     pub analytics_label: Option<String>,
 }
 
@@ -216,72 +229,99 @@ impl client::Part for AndroidFcmOptions {}
 /// 
 /// This type is not used in any activity, and only used as *part* of another schema.
 /// 
+#[serde_with::serde_as(crate = "::client::serde_with")]
 #[derive(Default, Clone, Debug, Serialize, Deserialize)]
 pub struct AndroidNotification {
     /// The notification's body text. If present, it will override google.firebase.fcm.v1.Notification.body.
+    
     pub body: Option<String>,
     /// Variable string values to be used in place of the format specifiers in body_loc_key to use to localize the body text to the user's current localization. See [Formatting and Styling](https://goo.gl/MalYE3) for more information.
     #[serde(rename="bodyLocArgs")]
+    
     pub body_loc_args: Option<Vec<String>>,
     /// The key to the body string in the app's string resources to use to localize the body text to the user's current localization. See [String Resources](https://goo.gl/NdFZGI) for more information.
     #[serde(rename="bodyLocKey")]
+    
     pub body_loc_key: Option<String>,
     /// The [notification's channel id](https://developer.android.com/guide/topics/ui/notifiers/notifications#ManageChannels) (new in Android O). The app must create a channel with this channel ID before any notification with this channel ID is received. If you don't send this channel ID in the request, or if the channel ID provided has not yet been created by the app, FCM uses the channel ID specified in the app manifest.
     #[serde(rename="channelId")]
+    
     pub channel_id: Option<String>,
     /// The action associated with a user click on the notification. If specified, an activity with a matching intent filter is launched when a user clicks on the notification.
     #[serde(rename="clickAction")]
+    
     pub click_action: Option<String>,
     /// The notification's icon color, expressed in #rrggbb format.
+    
     pub color: Option<String>,
     /// If set to true, use the Android framework's default LED light settings for the notification. Default values are specified in [config.xml](https://android.googlesource.com/platform/frameworks/base/+/master/core/res/res/values/config.xml). If `default_light_settings` is set to true and `light_settings` is also set, the user-specified `light_settings` is used instead of the default value.
     #[serde(rename="defaultLightSettings")]
+    
     pub default_light_settings: Option<bool>,
     /// If set to true, use the Android framework's default sound for the notification. Default values are specified in [config.xml](https://android.googlesource.com/platform/frameworks/base/+/master/core/res/res/values/config.xml).
     #[serde(rename="defaultSound")]
+    
     pub default_sound: Option<bool>,
     /// If set to true, use the Android framework's default vibrate pattern for the notification. Default values are specified in [config.xml](https://android.googlesource.com/platform/frameworks/base/+/master/core/res/res/values/config.xml). If `default_vibrate_timings` is set to true and `vibrate_timings` is also set, the default value is used instead of the user-specified `vibrate_timings`.
     #[serde(rename="defaultVibrateTimings")]
+    
     pub default_vibrate_timings: Option<bool>,
     /// Set the time that the event in the notification occurred. Notifications in the panel are sorted by this time. A point in time is represented using [protobuf.Timestamp](https://developers.google.com/protocol-buffers/docs/reference/java/com/google/protobuf/Timestamp).
     #[serde(rename="eventTime")]
-    pub event_time: Option<String>,
+    
+    pub event_time: Option<client::chrono::DateTime<client::chrono::offset::Utc>>,
     /// The notification's icon. Sets the notification icon to myicon for drawable resource myicon. If you don't send this key in the request, FCM displays the launcher icon specified in your app manifest.
+    
     pub icon: Option<String>,
     /// Contains the URL of an image that is going to be displayed in a notification. If present, it will override google.firebase.fcm.v1.Notification.image.
+    
     pub image: Option<String>,
     /// Settings to control the notification's LED blinking rate and color if LED is available on the device. The total blinking time is controlled by the OS.
     #[serde(rename="lightSettings")]
+    
     pub light_settings: Option<LightSettings>,
     /// Set whether or not this notification is relevant only to the current device. Some notifications can be bridged to other devices for remote display, such as a Wear OS watch. This hint can be set to recommend this notification not be bridged. See [Wear OS guides](https://developer.android.com/training/wearables/notifications/bridger#existing-method-of-preventing-bridging)
     #[serde(rename="localOnly")]
+    
     pub local_only: Option<bool>,
     /// Sets the number of items this notification represents. May be displayed as a badge count for launchers that support badging.See [Notification Badge](https://developer.android.com/training/notify-user/badges). For example, this might be useful if you're using just one notification to represent multiple new messages but you want the count here to represent the number of total new messages. If zero or unspecified, systems that support badging use the default, which is to increment a number displayed on the long-press menu each time a new notification arrives.
     #[serde(rename="notificationCount")]
+    
     pub notification_count: Option<i32>,
     /// Set the relative priority for this notification. Priority is an indication of how much of the user's attention should be consumed by this notification. Low-priority notifications may be hidden from the user in certain situations, while the user might be interrupted for a higher-priority notification. The effect of setting the same priorities may differ slightly on different platforms. Note this priority differs from `AndroidMessagePriority`. This priority is processed by the client after the message has been delivered, whereas [AndroidMessagePriority](https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages#androidmessagepriority) is an FCM concept that controls when the message is delivered.
     #[serde(rename="notificationPriority")]
+    
     pub notification_priority: Option<String>,
     /// The sound to play when the device receives the notification. Supports "default" or the filename of a sound resource bundled in the app. Sound files must reside in /res/raw/.
+    
     pub sound: Option<String>,
     /// When set to false or unset, the notification is automatically dismissed when the user clicks it in the panel. When set to true, the notification persists even when the user clicks it.
+    
     pub sticky: Option<bool>,
     /// Identifier used to replace existing notifications in the notification drawer. If not specified, each request creates a new notification. If specified and a notification with the same tag is already being shown, the new notification replaces the existing one in the notification drawer.
+    
     pub tag: Option<String>,
     /// Sets the "ticker" text, which is sent to accessibility services. Prior to API level 21 (`Lollipop`), sets the text that is displayed in the status bar when the notification first arrives.
+    
     pub ticker: Option<String>,
     /// The notification's title. If present, it will override google.firebase.fcm.v1.Notification.title.
+    
     pub title: Option<String>,
     /// Variable string values to be used in place of the format specifiers in title_loc_key to use to localize the title text to the user's current localization. See [Formatting and Styling](https://goo.gl/MalYE3) for more information.
     #[serde(rename="titleLocArgs")]
+    
     pub title_loc_args: Option<Vec<String>>,
     /// The key to the title string in the app's string resources to use to localize the title text to the user's current localization. See [String Resources](https://goo.gl/NdFZGI) for more information.
     #[serde(rename="titleLocKey")]
+    
     pub title_loc_key: Option<String>,
     /// Set the vibration pattern to use. Pass in an array of [protobuf.Duration](https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Duration) to turn on or off the vibrator. The first value indicates the `Duration` to wait before turning the vibrator on. The next value indicates the `Duration` to keep the vibrator on. Subsequent values alternate between `Duration` to turn the vibrator off and to turn the vibrator on. If `vibrate_timings` is set and `default_vibrate_timings` is set to `true`, the default value is used instead of the user-specified `vibrate_timings`.
     #[serde(rename="vibrateTimings")]
-    pub vibrate_timings: Option<Vec<String>>,
+    
+    #[serde_as(as = "Option<Vec<::client::serde::duration::Wrapper>>")]
+    pub vibrate_timings: Option<Vec<client::chrono::Duration>>,
     /// Set the [Notification.visibility](https://developer.android.com/reference/android/app/Notification.html#visibility) of the notification.
+    
     pub visibility: Option<String>,
 }
 
@@ -292,15 +332,19 @@ impl client::Part for AndroidNotification {}
 /// 
 /// This type is not used in any activity, and only used as *part* of another schema.
 /// 
+#[serde_with::serde_as(crate = "::client::serde_with")]
 #[derive(Default, Clone, Debug, Serialize, Deserialize)]
 pub struct ApnsConfig {
     /// Options for features provided by the FCM SDK for iOS.
     #[serde(rename="fcmOptions")]
+    
     pub fcm_options: Option<ApnsFcmOptions>,
     /// HTTP request headers defined in Apple Push Notification Service. Refer to [APNs request headers](https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/sending_notification_requests_to_apns) for supported headers such as `apns-expiration` and `apns-priority`.
+    
     pub headers: Option<HashMap<String, String>>,
     /// APNs payload as a JSON object, including both `aps` dictionary and custom payload. See [Payload Key Reference](https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/generating_a_remote_notification). If present, it overrides google.firebase.fcm.v1.Notification.title and google.firebase.fcm.v1.Notification.body. The backend sets a default value for `apns-expiration` of 30 days and a default value for `apns-priority` of 10 if not explicitly set.
-    pub payload: Option<HashMap<String, String>>,
+    
+    pub payload: Option<HashMap<String, json::Value>>,
 }
 
 impl client::Part for ApnsConfig {}
@@ -310,12 +354,15 @@ impl client::Part for ApnsConfig {}
 /// 
 /// This type is not used in any activity, and only used as *part* of another schema.
 /// 
+#[serde_with::serde_as(crate = "::client::serde_with")]
 #[derive(Default, Clone, Debug, Serialize, Deserialize)]
 pub struct ApnsFcmOptions {
     /// Label associated with the message's analytics data.
     #[serde(rename="analyticsLabel")]
+    
     pub analytics_label: Option<String>,
     /// Contains the URL of an image that is going to be displayed in a notification. If present, it will override google.firebase.fcm.v1.Notification.image.
+    
     pub image: Option<String>,
 }
 
@@ -326,15 +373,20 @@ impl client::Part for ApnsFcmOptions {}
 /// 
 /// This type is not used in any activity, and only used as *part* of another schema.
 /// 
+#[serde_with::serde_as(crate = "::client::serde_with")]
 #[derive(Default, Clone, Debug, Serialize, Deserialize)]
 pub struct Color {
     /// The fraction of this color that should be applied to the pixel. That is, the final pixel color is defined by the equation: `pixel color = alpha * (this color) + (1.0 - alpha) * (background color)` This means that a value of 1.0 corresponds to a solid color, whereas a value of 0.0 corresponds to a completely transparent color. This uses a wrapper message rather than a simple float scalar so that it is possible to distinguish between a default value and the value being unset. If omitted, this color object is rendered as a solid color (as if the alpha value had been explicitly given a value of 1.0).
+    
     pub alpha: Option<f32>,
     /// The amount of blue in the color as a value in the interval [0, 1].
+    
     pub blue: Option<f32>,
     /// The amount of green in the color as a value in the interval [0, 1].
+    
     pub green: Option<f32>,
     /// The amount of red in the color as a value in the interval [0, 1].
+    
     pub red: Option<f32>,
 }
 
@@ -345,10 +397,12 @@ impl client::Part for Color {}
 /// 
 /// This type is not used in any activity, and only used as *part* of another schema.
 /// 
+#[serde_with::serde_as(crate = "::client::serde_with")]
 #[derive(Default, Clone, Debug, Serialize, Deserialize)]
 pub struct FcmOptions {
     /// Label associated with the message's analytics data.
     #[serde(rename="analyticsLabel")]
+    
     pub analytics_label: Option<String>,
 }
 
@@ -359,16 +413,22 @@ impl client::Part for FcmOptions {}
 /// 
 /// This type is not used in any activity, and only used as *part* of another schema.
 /// 
+#[serde_with::serde_as(crate = "::client::serde_with")]
 #[derive(Default, Clone, Debug, Serialize, Deserialize)]
 pub struct LightSettings {
     /// Required. Set `color` of the LED with [google.type.Color](https://github.com/googleapis/googleapis/blob/master/google/type/color.proto).
+    
     pub color: Option<Color>,
     /// Required. Along with `light_on_duration `, define the blink rate of LED flashes. Resolution defined by [proto.Duration](https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Duration)
     #[serde(rename="lightOffDuration")]
-    pub light_off_duration: Option<String>,
+    
+    #[serde_as(as = "Option<::client::serde::duration::Wrapper>")]
+    pub light_off_duration: Option<client::chrono::Duration>,
     /// Required. Along with `light_off_duration`, define the blink rate of LED flashes. Resolution defined by [proto.Duration](https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Duration)
     #[serde(rename="lightOnDuration")]
-    pub light_on_duration: Option<String>,
+    
+    #[serde_as(as = "Option<::client::serde::duration::Wrapper>")]
+    pub light_on_duration: Option<client::chrono::Duration>,
 }
 
 impl client::Part for LightSettings {}
@@ -383,28 +443,39 @@ impl client::Part for LightSettings {}
 /// 
 /// * [messages send projects](ProjectMessageSendCall) (response)
 /// 
+#[serde_with::serde_as(crate = "::client::serde_with")]
 #[derive(Default, Clone, Debug, Serialize, Deserialize)]
 pub struct Message {
     /// Input only. Android specific options for messages sent through [FCM connection server](https://goo.gl/4GLdUl).
+    
     pub android: Option<AndroidConfig>,
     /// Input only. [Apple Push Notification Service](https://goo.gl/MXRTPa) specific options.
+    
     pub apns: Option<ApnsConfig>,
     /// Condition to send a message to, e.g. "'foo' in topics && 'bar' in topics".
+    
     pub condition: Option<String>,
     /// Input only. Arbitrary key/value payload, which must be UTF-8 encoded. The key should not be a reserved word ("from", "message_type", or any word starting with "google" or "gcm"). When sending payloads containing only data fields to iOS devices, only normal priority (`"apns-priority": "5"`) is allowed in [`ApnsConfig`](/docs/reference/fcm/rest/v1/projects.messages#apnsconfig).
+    
     pub data: Option<HashMap<String, String>>,
     /// Input only. Template for FCM SDK feature options to use across all platforms.
     #[serde(rename="fcmOptions")]
+    
     pub fcm_options: Option<FcmOptions>,
     /// Output Only. The identifier of the message sent, in the format of `projects/*/messages/{message_id}`.
+    
     pub name: Option<String>,
     /// Input only. Basic notification template to use across all platforms.
+    
     pub notification: Option<Notification>,
     /// Registration token to send a message to.
+    
     pub token: Option<String>,
     /// Topic name to send a message to, e.g. "weather". Note: "/topics/" prefix should not be provided.
+    
     pub topic: Option<String>,
     /// Input only. [Webpush protocol](https://tools.ietf.org/html/rfc8030) options.
+    
     pub webpush: Option<WebpushConfig>,
 }
 
@@ -415,13 +486,17 @@ impl client::ResponseResult for Message {}
 /// 
 /// This type is not used in any activity, and only used as *part* of another schema.
 /// 
+#[serde_with::serde_as(crate = "::client::serde_with")]
 #[derive(Default, Clone, Debug, Serialize, Deserialize)]
 pub struct Notification {
     /// The notification's body text.
+    
     pub body: Option<String>,
     /// Contains the URL of an image that is going to be downloaded on the device and displayed in a notification. JPEG, PNG, BMP have full support across platforms. Animated GIF and video only work on iOS. WebP and HEIF have varying levels of support across platforms and platform versions. Android has 1MB image size limit. Quota usage and implications/costs for hosting image on Firebase Storage: https://firebase.google.com/pricing
+    
     pub image: Option<String>,
     /// The notification's title.
+    
     pub title: Option<String>,
 }
 
@@ -437,12 +512,15 @@ impl client::Part for Notification {}
 /// 
 /// * [messages send projects](ProjectMessageSendCall) (request)
 /// 
+#[serde_with::serde_as(crate = "::client::serde_with")]
 #[derive(Default, Clone, Debug, Serialize, Deserialize)]
 pub struct SendMessageRequest {
     /// Required. Message to send.
+    
     pub message: Option<Message>,
     /// Flag for testing the request without actually delivering the message.
     #[serde(rename="validateOnly")]
+    
     pub validate_only: Option<bool>,
 }
 
@@ -453,17 +531,22 @@ impl client::RequestValue for SendMessageRequest {}
 /// 
 /// This type is not used in any activity, and only used as *part* of another schema.
 /// 
+#[serde_with::serde_as(crate = "::client::serde_with")]
 #[derive(Default, Clone, Debug, Serialize, Deserialize)]
 pub struct WebpushConfig {
     /// Arbitrary key/value payload. If present, it will override google.firebase.fcm.v1.Message.data.
+    
     pub data: Option<HashMap<String, String>>,
     /// Options for features provided by the FCM SDK for Web.
     #[serde(rename="fcmOptions")]
+    
     pub fcm_options: Option<WebpushFcmOptions>,
     /// HTTP headers defined in webpush protocol. Refer to [Webpush protocol](https://tools.ietf.org/html/rfc8030#section-5) for supported headers, e.g. "TTL": "15".
+    
     pub headers: Option<HashMap<String, String>>,
     /// Web Notification options as a JSON object. Supports Notification instance properties as defined in [Web Notification API](https://developer.mozilla.org/en-US/docs/Web/API/Notification). If present, "title" and "body" fields override [google.firebase.fcm.v1.Notification.title] and [google.firebase.fcm.v1.Notification.body].
-    pub notification: Option<HashMap<String, String>>,
+    
+    pub notification: Option<HashMap<String, json::Value>>,
 }
 
 impl client::Part for WebpushConfig {}
@@ -473,12 +556,15 @@ impl client::Part for WebpushConfig {}
 /// 
 /// This type is not used in any activity, and only used as *part* of another schema.
 /// 
+#[serde_with::serde_as(crate = "::client::serde_with")]
 #[derive(Default, Clone, Debug, Serialize, Deserialize)]
 pub struct WebpushFcmOptions {
     /// Label associated with the message's analytics data.
     #[serde(rename="analyticsLabel")]
+    
     pub analytics_label: Option<String>,
     /// The link to open when the user clicks on the notification. For all URL values, HTTPS is required.
+    
     pub link: Option<String>,
 }
 
@@ -491,7 +577,7 @@ impl client::Part for WebpushFcmOptions {}
 // #################
 
 /// A builder providing access to all methods supported on *project* resources.
-/// It is not used directly, but through the `FirebaseCloudMessaging` hub.
+/// It is not used directly, but through the [`FirebaseCloudMessaging`] hub.
 ///
 /// # Example
 ///
@@ -504,7 +590,7 @@ impl client::Part for WebpushFcmOptions {}
 /// 
 /// # async fn dox() {
 /// use std::default::Default;
-/// use fcm1::{FirebaseCloudMessaging, oauth2, hyper, hyper_rustls};
+/// use fcm1::{FirebaseCloudMessaging, oauth2, hyper, hyper_rustls, chrono, FieldMask};
 /// 
 /// let secret: oauth2::ApplicationSecret = Default::default();
 /// let auth = oauth2::InstalledFlowAuthenticator::builder(
@@ -559,7 +645,7 @@ impl<'a, S> ProjectMethods<'a, S> {
 /// Send a message to specified target (a registration token, topic or condition).
 ///
 /// A builder for the *messages.send* method supported by a *project* resource.
-/// It is not used directly, but through a `ProjectMethods` instance.
+/// It is not used directly, but through a [`ProjectMethods`] instance.
 ///
 /// # Example
 ///
@@ -572,7 +658,7 @@ impl<'a, S> ProjectMethods<'a, S> {
 /// use fcm1::api::SendMessageRequest;
 /// # async fn dox() {
 /// # use std::default::Default;
-/// # use fcm1::{FirebaseCloudMessaging, oauth2, hyper, hyper_rustls};
+/// # use fcm1::{FirebaseCloudMessaging, oauth2, hyper, hyper_rustls, chrono, FieldMask};
 /// 
 /// # let secret: oauth2::ApplicationSecret = Default::default();
 /// # let auth = oauth2::InstalledFlowAuthenticator::builder(
@@ -600,14 +686,14 @@ pub struct ProjectMessageSendCall<'a, S>
     _parent: String,
     _delegate: Option<&'a mut dyn client::Delegate>,
     _additional_params: HashMap<String, String>,
-    _scopes: BTreeMap<String, ()>
+    _scopes: BTreeSet<String>
 }
 
 impl<'a, S> client::CallBuilder for ProjectMessageSendCall<'a, S> {}
 
 impl<'a, S> ProjectMessageSendCall<'a, S>
 where
-    S: tower_service::Service<Uri> + Clone + Send + Sync + 'static,
+    S: tower_service::Service<http::Uri> + Clone + Send + Sync + 'static,
     S::Response: hyper::client::connect::Connection + AsyncRead + AsyncWrite + Send + Unpin + 'static,
     S::Future: Send + Unpin + 'static,
     S::Error: Into<Box<dyn StdError + Send + Sync>>,
@@ -616,64 +702,45 @@ where
 
     /// Perform the operation you have build so far.
     pub async fn doit(mut self) -> client::Result<(hyper::Response<hyper::body::Body>, Message)> {
-        use url::percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
         use std::io::{Read, Seek};
         use hyper::header::{CONTENT_TYPE, CONTENT_LENGTH, AUTHORIZATION, USER_AGENT, LOCATION};
-        use client::ToParts;
+        use client::{ToParts, url::Params};
+        use std::borrow::Cow;
+
         let mut dd = client::DefaultDelegate;
-        let mut dlg: &mut dyn client::Delegate = match self._delegate {
-            Some(d) => d,
-            None => &mut dd
-        };
+        let mut dlg: &mut dyn client::Delegate = self._delegate.unwrap_or(&mut dd);
         dlg.begin(client::MethodInfo { id: "fcm.projects.messages.send",
                                http_method: hyper::Method::POST });
-        let mut params: Vec<(&str, String)> = Vec::with_capacity(4 + self._additional_params.len());
-        params.push(("parent", self._parent.to_string()));
+
         for &field in ["alt", "parent"].iter() {
             if self._additional_params.contains_key(field) {
                 dlg.finished(false);
                 return Err(client::Error::FieldClash(field));
             }
         }
-        for (name, value) in self._additional_params.iter() {
-            params.push((&name, value.clone()));
-        }
 
-        params.push(("alt", "json".to_string()));
+        let mut params = Params::with_capacity(4 + self._additional_params.len());
+        params.push("parent", self._parent);
 
+        params.extend(self._additional_params.iter());
+
+        params.push("alt", "json");
         let mut url = self.hub._base_url.clone() + "v1/{+parent}/messages:send";
-        if self._scopes.len() == 0 {
-            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string(), ());
+        if self._scopes.is_empty() {
+            self._scopes.insert(Scope::CloudPlatform.as_ref().to_string());
         }
 
         for &(find_this, param_name) in [("{+parent}", "parent")].iter() {
-            let mut replace_with = String::new();
-            for &(name, ref value) in params.iter() {
-                if name == param_name {
-                    replace_with = value.to_string();
-                    break;
-                }
-            }
-            if find_this.as_bytes()[1] == '+' as u8 {
-                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET).to_string();
-            }
-            url = url.replace(find_this, &replace_with);
+            url = params.uri_replacement(url, param_name, find_this, true);
         }
         {
-            let mut indices_for_removal: Vec<usize> = Vec::with_capacity(1);
-            for param_name in ["parent"].iter() {
-                if let Some(index) = params.iter().position(|t| &t.0 == param_name) {
-                    indices_for_removal.push(index);
-                }
-            }
-            for &index in indices_for_removal.iter() {
-                params.remove(index);
-            }
+            let to_remove = ["parent"];
+            params.remove_params(&to_remove);
         }
 
-        let url = url::Url::parse_with_params(&url, params).unwrap();
+        let url = params.parse_with_url(&url);
 
-        let mut json_mime_type: mime::Mime = "application/json".parse().unwrap();
+        let mut json_mime_type = mime::APPLICATION_JSON;
         let mut request_value_reader =
             {
                 let mut value = json::value::to_value(&self._request).expect("serde to work");
@@ -687,14 +754,14 @@ where
 
 
         loop {
-            let token = match self.hub.auth.token(&self._scopes.keys().collect::<Vec<_>>()[..]).await {
-                Ok(token) => token.clone(),
-                Err(err) => {
-                    match  dlg.token(&err) {
-                        Some(token) => token,
-                        None => {
+            let token = match self.hub.auth.get_token(&self._scopes.iter().map(String::as_str).collect::<Vec<_>>()[..]).await {
+                Ok(token) => token,
+                Err(e) => {
+                    match dlg.token(e) {
+                        Ok(token) => token,
+                        Err(e) => {
                             dlg.finished(false);
-                            return Err(client::Error::MissingToken(err))
+                            return Err(client::Error::MissingToken(e));
                         }
                     }
                 }
@@ -703,23 +770,29 @@ where
             let mut req_result = {
                 let client = &self.hub.client;
                 dlg.pre_request();
-                let mut req_builder = hyper::Request::builder().method(hyper::Method::POST).uri(url.clone().into_string())
-                        .header(USER_AGENT, self.hub._user_agent.clone())                            .header(AUTHORIZATION, format!("Bearer {}", token.as_str()));
+                let mut req_builder = hyper::Request::builder()
+                    .method(hyper::Method::POST)
+                    .uri(url.as_str())
+                    .header(USER_AGENT, self.hub._user_agent.clone());
+
+                if let Some(token) = token.as_ref() {
+                    req_builder = req_builder.header(AUTHORIZATION, format!("Bearer {}", token));
+                }
 
 
                         let request = req_builder
-                        .header(CONTENT_TYPE, format!("{}", json_mime_type.to_string()))
+                        .header(CONTENT_TYPE, json_mime_type.to_string())
                         .header(CONTENT_LENGTH, request_size as u64)
                         .body(hyper::body::Body::from(request_value_reader.get_ref().clone()));
 
                 client.request(request.unwrap()).await
-                
+
             };
 
             match req_result {
                 Err(err) => {
                     if let client::Retry::After(d) = dlg.http_error(&err) {
-                        sleep(d);
+                        sleep(d).await;
                         continue;
                     }
                     dlg.finished(false);
@@ -735,7 +808,7 @@ where
                         let server_response = json::from_str::<serde_json::Value>(&res_body_string).ok();
 
                         if let client::Retry::After(d) = dlg.http_failure(&restored_response, server_response.clone()) {
-                            sleep(d);
+                            sleep(d).await;
                             continue;
                         }
 
@@ -788,7 +861,8 @@ where
     /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
     /// while executing the actual API request.
     /// 
-    /// It should be used to handle progress information, and to implement a certain level of resilience.
+    /// ````text
+    ///                   It should be used to handle progress information, and to implement a certain level of resilience.````
     ///
     /// Sets the *delegate* property to the given value.
     pub fn delegate(mut self, new_value: &'a mut dyn client::Delegate) -> ProjectMessageSendCall<'a, S> {
@@ -824,25 +898,36 @@ where
 
     /// Identifies the authorization scope for the method you are building.
     ///
-    /// Use this method to actively specify which scope should be used, instead the default `Scope` variant
-    /// `Scope::CloudPlatform`.
+    /// Use this method to actively specify which scope should be used, instead of the default [`Scope`] variant
+    /// [`Scope::CloudPlatform`].
     ///
     /// The `scope` will be added to a set of scopes. This is important as one can maintain access
     /// tokens for more than one scope.
-    /// If `None` is specified, then all scopes will be removed and no default scope will be used either.
-    /// In that case, you have to specify your API-key using the `key` parameter (see the `param()`
-    /// function for details).
     ///
     /// Usually there is more than one suitable scope to authorize an operation, some of which may
     /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
     /// sufficient, a read-write scope will do as well.
-    pub fn add_scope<T, St>(mut self, scope: T) -> ProjectMessageSendCall<'a, S>
-                                                        where T: Into<Option<St>>,
-                                                              St: AsRef<str> {
-        match scope.into() {
-          Some(scope) => self._scopes.insert(scope.as_ref().to_string(), ()),
-          None => None,
-        };
+    pub fn add_scope<St>(mut self, scope: St) -> ProjectMessageSendCall<'a, S>
+                                                        where St: AsRef<str> {
+        self._scopes.insert(String::from(scope.as_ref()));
+        self
+    }
+    /// Identifies the authorization scope(s) for the method you are building.
+    ///
+    /// See [`Self::add_scope()`] for details.
+    pub fn add_scopes<I, St>(mut self, scopes: I) -> ProjectMessageSendCall<'a, S>
+                                                        where I: IntoIterator<Item = St>,
+                                                         St: AsRef<str> {
+        self._scopes
+            .extend(scopes.into_iter().map(|s| String::from(s.as_ref())));
+        self
+    }
+
+    /// Removes all scopes, and no default scope will be used either.
+    /// In this case, you have to specify your API-key using the `key` parameter (see [`Self::param()`]
+    /// for details).
+    pub fn clear_scopes(mut self) -> ProjectMessageSendCall<'a, S> {
+        self._scopes.clear();
         self
     }
 }

--- a/gen/fcm1/src/lib.rs
+++ b/gen/fcm1/src/lib.rs
@@ -2,7 +2,7 @@
 // This file was generated automatically from 'src/generator/templates/api/lib.rs.mako'
 // DO NOT EDIT !
 
-//! This documentation was generated from *Firebase Cloud Messaging* crate version *4.0.1+20220228*, where *20220228* is the exact revision of the *fcm:v1* schema built by the [mako](http://www.makotemplates.org/) code generator *v4.0.1*.
+//! This documentation was generated from *Firebase Cloud Messaging* crate version *5.0.2-beta-1+20220228*, where *20220228* is the exact revision of the *fcm:v1* schema built by the [mako](http://www.makotemplates.org/) code generator *v5.0.2-beta-1*.
 //! 
 //! Everything else about the *Firebase Cloud Messaging* *v1* API can be found at the
 //! [official documentation site](https://firebase.google.com/docs/cloud-messaging).
@@ -78,7 +78,7 @@
 //! use fcm1::{Result, Error};
 //! # async fn dox() {
 //! use std::default::Default;
-//! use fcm1::{FirebaseCloudMessaging, oauth2, hyper, hyper_rustls};
+//! use fcm1::{FirebaseCloudMessaging, oauth2, hyper, hyper_rustls, chrono, FieldMask};
 //! 
 //! // Get an ApplicationSecret instance by some means. It contains the `client_id` and 
 //! // `client_secret`, among other things.
@@ -187,22 +187,17 @@
 // This file was generated automatically from 'src/generator/templates/api/lib.rs.mako'
 // DO NOT EDIT !
 
-#[macro_use]
-extern crate serde_derive;
-
 // Re-export the hyper and hyper_rustls crate, they are required to build the hub
-pub extern crate hyper;
-pub extern crate hyper_rustls;
-extern crate serde;
-extern crate serde_json;
-// Re-export the yup_oauth2 crate, that is required to call some methods of the hub and the client
-pub extern crate yup_oauth2 as oauth2;
-extern crate mime;
-extern crate url;
-
+pub use hyper;
+pub use hyper_rustls;
+pub extern crate google_apis_common as client;
+pub use client::chrono;
 pub mod api;
-pub mod client;
 
 // Re-export the hub type and some basic client structs
 pub use api::FirebaseCloudMessaging;
-pub use client::{Result, Error, Delegate};
+pub use client::{Result, Error, Delegate, FieldMask};
+
+// Re-export the yup_oauth2 crate, that is required to call some methods of the hub and the client
+#[cfg(feature = "yup-oauth2")]
+pub use client::oauth2;

--- a/src/generator/lib/__tests__/util_test.py
+++ b/src/generator/lib/__tests__/util_test.py
@@ -104,7 +104,7 @@ class UtilsTest(unittest.TestCase):
         property_name = 'details'
         property_value = schemas[class_name]['properties'][property_name]
         rust_type = to_rust_type(schemas, class_name, property_name, property_value, allow_optionals=True)
-        self.assertEqual(rust_type, 'Option<Vec<HashMap<String, String>>>')
+        self.assertEqual(rust_type, 'Option<Vec<HashMap<String, json::Value>>>')
 
 
 def main():

--- a/src/generator/lib/types.py
+++ b/src/generator/lib/types.py
@@ -30,7 +30,7 @@ RUST_TYPE_MAP = {
     'double': Base("f64"),
     'float': Base("f32"),
     'int32': Base("i32"),
-    'any': Base("String"),  # TODO: Figure out how to handle it. It's 'interface' in Go ...
+    'any': Base("json::Value"),
     'int64': Base("i64"),
     'uint64': Base("u64"),
     'array': Vec(None),


### PR DESCRIPTION
Resolves #403 #336

This PR:
- changes `any` JSON Schema type mapping to `json::Value`
- regenerates `fcm1` crate