### PR TITLE
Match version of hyper-rustls used by yup-oauth2 8.2.0

### DIFF
--- a/google-apis-common/Cargo.toml
+++ b/google-apis-common/Cargo.toml
@@ -25,7 +25,7 @@ base64 = "0.13.0"
 chrono = { version = "0.4.22", default-features = false, features = ["clock", "serde"] }
 url = "= 1.7"
 
-yup-oauth2 = { version = "^ 8.0", optional = true }
+yup-oauth2 = { version = "^ 8.2", optional = true }
 itertools = "^ 0.10"
 hyper = { version = "^ 0.14", features = ["client", "http2"] }
 http = "^0.2"

--- a/src/generator/templates/Cargo.toml.mako
+++ b/src/generator/templates/Cargo.toml.mako
@@ -27,7 +27,7 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "^ 1.0"
-hyper-rustls = "0.23.0"
+hyper-rustls = "0.24.0"
 ## Must match the one hyper uses, otherwise there are duplicate similarly named `Mime` structs
 mime = "^ 0.3.0"
 serde = { version = "^ 1.0", features = ["derive"] }


### PR DESCRIPTION
I ran cargo update in my crate and I noticed I was getting compile errors due to the versions of `hyper-rustls` used by the generated API crates don't match the version of `hyper-rustls` used by the `yup-oauth2` crate version `8.2`

