### PR TITLE
Make field mask inner public

### DIFF
--- a/google-apis-common/src/field_mask.rs
+++ b/google-apis-common/src/field_mask.rs
@@ -32,7 +32,13 @@ fn snakecase(source: &str) -> String {
 
 /// A `FieldMask` as defined in `https://github.com/protocolbuffers/protobuf/blob/ec1a70913e5793a7d0a7b5fbf7e0e4f75409dd41/src/google/protobuf/field_mask.proto#L180`
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub struct FieldMask(pub Vec<String>);
+pub struct FieldMask(Vec<String>);
+
+impl FieldMask {
+    pub fn new<S: AsRef<str>>(values: &[S]) -> Self {
+        return Self(values.iter().map(|s| snakecase(s.as_ref())).collect());
+    }
+}
 
 impl Serialize for FieldMask {
     fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>

--- a/google-apis-common/src/field_mask.rs
+++ b/google-apis-common/src/field_mask.rs
@@ -32,7 +32,7 @@ fn snakecase(source: &str) -> String {
 
 /// A `FieldMask` as defined in `https://github.com/protocolbuffers/protobuf/blob/ec1a70913e5793a7d0a7b5fbf7e0e4f75409dd41/src/google/protobuf/field_mask.proto#L180`
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub struct FieldMask(Vec<String>);
+pub struct FieldMask(pub Vec<String>);
 
 impl Serialize for FieldMask {
     fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>

--- a/google-apis-common/src/field_mask.rs
+++ b/google-apis-common/src/field_mask.rs
@@ -35,6 +35,8 @@ fn snakecase(source: &str) -> String {
 pub struct FieldMask(Vec<String>);
 
 impl FieldMask {
+    /// Create a new `FieldMask` from a list of paths. These are converted to snake
+    /// case if they aren't already.
     pub fn new<S: AsRef<str>>(values: &[S]) -> Self {
         return Self(values.iter().map(|s| snakecase(s.as_ref())).collect());
     }


### PR DESCRIPTION
The inner value was private so it couldn't be constructed directly (without deserializing from a string indirectly).  Creating it directly seems safer than deserializing, especially since I'm unfamiliar with the format.

Was it intended for this to be constructed directly or is there another mechanism for setting these up? I thought the api might do it directly but it doesn't atm afaict.