### PR TITLE
Fix base64 deserialization when using a reader

### DIFF
--- a/google-apis-common/src/serde.rs
+++ b/google-apis-common/src/serde.rs
@@ -139,7 +139,8 @@ pub mod duration {
 pub mod standard_base64 {
     use serde::{Deserialize, Deserializer, Serializer};
     use serde_with::{DeserializeAs, SerializeAs};
-
+    use std::borrow::Cow;
+    
     pub struct Wrapper;
 
     pub fn to_string(bytes: &Vec<u8>) -> String {
@@ -160,8 +161,8 @@ pub mod standard_base64 {
         where
             D: Deserializer<'de>,
         {
-            let s: &str = Deserialize::deserialize(deserializer)?;
-            base64::decode_config(s, base64::STANDARD).map_err(serde::de::Error::custom)
+            let s: Cow<str> = Deserialize::deserialize(deserializer)?;
+            base64::decode_config(s.as_ref(), base64::STANDARD).map_err(serde::de::Error::custom)
         }
     }
 }
@@ -169,6 +170,7 @@ pub mod standard_base64 {
 pub mod urlsafe_base64 {
     use serde::{Deserialize, Deserializer, Serializer};
     use serde_with::{DeserializeAs, SerializeAs};
+    use std::borrow::Cow;
 
     pub struct Wrapper;
 
@@ -190,8 +192,8 @@ pub mod urlsafe_base64 {
         where
             D: Deserializer<'de>,
         {
-            let s: &str = Deserialize::deserialize(deserializer)?;
-            base64::decode_config(s, base64::URL_SAFE).map_err(serde::de::Error::custom)
+            let s: Cow<str> = Deserialize::deserialize(deserializer)?;
+            base64::decode_config(s.as_ref(), base64::URL_SAFE).map_err(serde::de::Error::custom)
         }
     }
 }
@@ -302,7 +304,6 @@ mod test {
     }
 
     #[test]
-    #[should_panic(expected = "expected a borrowed string")]
     fn standard_base64_de_reader_success_cases() {
         let standard: Base64StandardWrapper =
             serde_json::from_reader(r#"{"bytes": "cVhabzk6U21uOkN+MylFWFRJMVFLdEh2MShmVHp9"}"#.as_bytes()).unwrap();
@@ -317,11 +318,10 @@ mod test {
     }
 
     #[test]
-    #[should_panic(expected = "expected a borrowed string")]
     fn urlsafe_base64_de_reader_success_cases() {
-        let url_safe: Base64URLSafeWrapper =
+        let wrapper: Base64URLSafeWrapper =
             serde_json::from_reader(r#"{"bytes": "aGVsbG8gd29ybGQ="}"#.as_bytes()).unwrap();
-        assert_eq!(Some(b"hello world".as_slice()), url_safe.bytes.as_deref());
+        assert_eq!(Some(b"hello world".as_slice()), wrapper.bytes.as_deref());
     }
 
     #[test]

--- a/google-apis-common/src/serde.rs
+++ b/google-apis-common/src/serde.rs
@@ -302,10 +302,26 @@ mod test {
     }
 
     #[test]
+    #[should_panic(expected = "expected a borrowed string")]
+    fn standard_base64_de_reader_success_cases() {
+        let standard: Base64StandardWrapper =
+            serde_json::from_reader(r#"{"bytes": "cVhabzk6U21uOkN+MylFWFRJMVFLdEh2MShmVHp9"}"#.as_bytes()).unwrap();
+        assert_eq!(Some(b"qXZo9:Smn:C~3)EXTI1QKtHv1(fTz}".as_slice()), standard.bytes.as_deref());
+    }
+
+    #[test]
     fn urlsafe_base64_de_success_cases() {
         let wrapper: Base64URLSafeWrapper =
             serde_json::from_str(r#"{"bytes": "aGVsbG8gd29ybGQ="}"#).unwrap();
         assert_eq!(Some(b"hello world".as_slice()), wrapper.bytes.as_deref());
+    }
+
+    #[test]
+    #[should_panic(expected = "expected a borrowed string")]
+    fn urlsafe_base64_de_reader_success_cases() {
+        let url_safe: Base64URLSafeWrapper =
+            serde_json::from_reader(r#"{"bytes": "aGVsbG8gd29ybGQ="}"#.as_bytes()).unwrap();
+        assert_eq!(Some(b"hello world".as_slice()), url_safe.bytes.as_deref());
     }
 
     #[test]


### PR DESCRIPTION
In our use case, we deserialize GCP structs using a file reader (instead from an in-memory string), which yields errors such as this is:

```
Caused by:
    invalid type: string "...", expected a borrowed string at line ... column ...
```

The first commit demonstrates this behavior, and the second fixes it by allow `serde` to choose between a borrowed an owned string using a `Cow`.