### PR TITLE
update dependencies

### DIFF
--- a/google-apis-common/Cargo.toml
+++ b/google-apis-common/Cargo.toml
@@ -18,15 +18,16 @@ doctest = false
 [dependencies]
 mime = "^ 0.3"
 serde = { version = "^ 1.0", features = ["derive"] }
-serde_with = "2.0.1"
+serde_with = "3.0"
 serde_json = "^ 1.0"
 
-base64 = "0.13.0"
+base64 = "0.22"
 chrono = { version = "0.4.35", default-features = false, features = ["clock", "serde"] }
-url = "= 1.7"
+url = "2.0"
+percent-encoding = "2.0"
 
 yup-oauth2 = { version = "9", optional = true }
-itertools = "^ 0.10"
+itertools = "^ 0.12"
 hyper = { version = "^ 0.14", features = ["client", "http2"] }
 http = "^0.2"
 tokio = { version = "^1.0", features = ["time"] }

--- a/google-apis-common/Cargo.toml
+++ b/google-apis-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "google-apis-common"
-version = "6.0.3"
+version = "6.0.4"
 authors = ["Sebastian Thiel <byronimo@gmail.com>"]
 repository = "https://github.com/Byron/google-apis-rs"
 homepage = "https://github.com/Byron/google-apis-rs/google-apis-common"

--- a/google-apis-common/src/serde.rs
+++ b/google-apis-common/src/serde.rs
@@ -144,6 +144,7 @@ pub mod duration {
 }
 
 pub mod standard_base64 {
+    use base64::Engine as _;
     use serde::{Deserialize, Deserializer, Serializer};
     use serde_with::{DeserializeAs, SerializeAs};
     use std::borrow::Cow;
@@ -151,7 +152,7 @@ pub mod standard_base64 {
     pub struct Wrapper;
 
     pub fn to_string(bytes: &Vec<u8>) -> String {
-        base64::encode_config(bytes, base64::STANDARD)
+        base64::prelude::BASE64_STANDARD.encode(bytes)
     }
 
     impl SerializeAs<Vec<u8>> for Wrapper {
@@ -169,12 +170,13 @@ pub mod standard_base64 {
             D: Deserializer<'de>,
         {
             let s: Cow<str> = Deserialize::deserialize(deserializer)?;
-            base64::decode_config(s.as_ref(), base64::STANDARD).map_err(serde::de::Error::custom)
+            base64::prelude::BASE64_STANDARD.decode(s.as_ref()).map_err(serde::de::Error::custom)
         }
     }
 }
 
 pub mod urlsafe_base64 {
+    use base64::Engine as _;
     use serde::{Deserialize, Deserializer, Serializer};
     use serde_with::{DeserializeAs, SerializeAs};
     use std::borrow::Cow;
@@ -182,7 +184,7 @@ pub mod urlsafe_base64 {
     pub struct Wrapper;
 
     pub fn to_string(bytes: &Vec<u8>) -> String {
-        base64::encode_config(bytes, base64::URL_SAFE)
+        base64::prelude::BASE64_URL_SAFE.encode(bytes)
     }
 
     impl SerializeAs<Vec<u8>> for Wrapper {
@@ -200,7 +202,7 @@ pub mod urlsafe_base64 {
             D: Deserializer<'de>,
         {
             let s: Cow<str> = Deserialize::deserialize(deserializer)?;
-            base64::decode_config(s.as_ref(), base64::URL_SAFE).map_err(serde::de::Error::custom)
+            base64::prelude::BASE64_URL_SAFE.decode(s.as_ref()).map_err(serde::de::Error::custom)
         }
     }
 }
@@ -212,6 +214,7 @@ pub fn datetime_to_string(datetime: &chrono::DateTime<chrono::offset::Utc>) -> S
 #[cfg(test)]
 mod test {
     use super::{duration, standard_base64, urlsafe_base64};
+    use base64::Engine as _;
     use serde::{Deserialize, Serialize};
     use serde_with::{serde_as, DisplayFromStr};
 

--- a/google-apis-common/src/url.rs
+++ b/google-apis-common/src/url.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use ::url::percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
+use ::percent_encoding::{percent_encode, AsciiSet, CONTROLS};
 use ::url::Url;
 
 pub struct Params<'a> {
@@ -40,6 +40,7 @@ impl<'a> Params<'a> {
         from: &str,
         url_encode: bool,
     ) -> String {
+        const DEFAULT_ENCODE_SET: &AsciiSet = &CONTROLS.add(b' ').add(b'"').add(b'#').add(b'<').add(b'>').add(b'`').add(b'?').add(b'{').add(b'}');
         if url_encode {
             let mut replace_with: Cow<str> = self.get(param).unwrap_or_default().into();
             if from.as_bytes()[1] == b'+' {


### PR DESCRIPTION
base64 0.22, serde_with 3, url 2

url v2 no longer exports percent_encoding, add percent-encoding v2 as explicit dependency

percent-encoding v2 no longer includes predefined encoding sets

No changes necessary for serde_with or itertools