### PR TITLE
Made doit() method for ObjectInsertCall public

### DIFF
--- a/gen/storage1/src/api.rs
+++ b/gen/storage1/src/api.rs
@@ -22890,7 +22890,7 @@ where
 
 
     /// Perform the operation you have build so far.
-    async fn doit<RS>(mut self, mut reader: RS, reader_mime_type: mime::Mime, protocol: client::UploadProtocol) -> client::Result<(hyper::Response<hyper::body::Body>, Object)>
+    pub async fn doit<RS>(mut self, mut reader: RS, reader_mime_type: mime::Mime, protocol: client::UploadProtocol) -> client::Result<(hyper::Response<hyper::body::Body>, Object)>
 		where RS: client::ReadSeek {
         use std::io::{Read, Seek};
         use hyper::header::{CONTENT_TYPE, CONTENT_LENGTH, AUTHORIZATION, USER_AGENT, LOCATION};


### PR DESCRIPTION
Readme for google_storage1 says that .objects().insert() method could be invoked like this 
```rust
let r = hub.objects().insert(...).doit().await
```
but it is impossible since doit() is private