### PR TITLE
Fix clippy complaining about "direct implementation of `ToString`"

### DIFF
--- a/google-clis-common/src/lib.rs
+++ b/google-clis-common/src/lib.rs
@@ -11,9 +11,9 @@ use std::io;
 use std::io::{stdout, Write};
 use std::path::Path;
 use std::str::FromStr;
-use std::string::ToString;
 
 use std::default::Default;
+use std::fmt::Display;
 
 const FIELD_SEP: char = '.';
 
@@ -125,9 +125,9 @@ impl AsRef<str> for CallType {
 #[derive(Clone, Default)]
 pub struct FieldCursor(Vec<String>);
 
-impl ToString for FieldCursor {
-    fn to_string(&self) -> String {
-        self.0.join(".")
+impl Display for FieldCursor {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0.join("."))
     }
 }
 


### PR DESCRIPTION
The clippy action currently fails due to a direct implementation fo ToString instead of Display

The error message is:
```
error: direct implementation of `ToString`
   --> google-clis-common/src/lib.rs:128:1
    |
    | / impl ToString for FieldCursor {
    | |     fn to_string(&self) -> String {
    | |         self.0.join(".")
    | |     }
    | | }
    | |_^
    |
    = help: prefer implementing `Display` instead
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#to_string_trait_impl
    = note: `-D clippy::to-string-trait-impl` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::to_string_trait_impl)]`
```