### PR TITLE
Tolerant base64 decoding.  Accept url-safe or standard encoding in responses.

### DIFF
--- a/google-apis-common/src/serde.rs
+++ b/google-apis-common/src/serde.rs
@@ -172,7 +172,7 @@ pub mod standard_base64 {
             let s: Cow<str> = Deserialize::deserialize(deserializer)?;
             match base64::prelude::BASE64_STANDARD.decode(s.as_ref()) {
                 Ok(decoded) => Ok(decoded),
-                Err(first_err) => match general_purpose::URL_SAFE.decode(s.as_ref()) {
+                Err(first_err) => match base64::prelude::BASE64_URL_SAFE.decode(s.as_ref()) {
                     Ok(decoded) => Ok(decoded),
                     Err(_) => Err(serde::de::Error::custom(first_err))
                 }
@@ -208,9 +208,9 @@ pub mod urlsafe_base64 {
             D: Deserializer<'de>,
         {
             let s: Cow<str> = Deserialize::deserialize(deserializer)?;
-            match base64::prelude::URL_SAFE.decode(s.as_ref()) {
+            match base64::prelude::BASE64_URL_SAFE.decode(s.as_ref()) {
                 Ok(decoded) => Ok(decoded),
-                Err(first_err) => match general_purpose::URL_STANDARD.decode(s.as_ref()) {
+                Err(first_err) => match base64::prelude::BASE64_STANDARD.decode(s.as_ref()) {
                     Ok(decoded) => Ok(decoded),
                     Err(_) => Err(serde::de::Error::custom(first_err))
                 }

--- a/google-apis-common/src/serde.rs
+++ b/google-apis-common/src/serde.rs
@@ -170,7 +170,13 @@ pub mod standard_base64 {
             D: Deserializer<'de>,
         {
             let s: Cow<str> = Deserialize::deserialize(deserializer)?;
-            base64::prelude::BASE64_STANDARD.decode(s.as_ref()).map_err(serde::de::Error::custom)
+            match base64::prelude::BASE64_STANDARD.decode(s.as_ref()) {
+                Ok(decoded) => Ok(decoded),
+                Err(first_err) => match general_purpose::URL_SAFE.decode(s.as_ref()) {
+                    Ok(decoded) => Ok(decoded),
+                    Err(_) => Err(serde::de::Error::custom(first_err))
+                }
+            }
         }
     }
 }
@@ -202,7 +208,13 @@ pub mod urlsafe_base64 {
             D: Deserializer<'de>,
         {
             let s: Cow<str> = Deserialize::deserialize(deserializer)?;
-            base64::prelude::BASE64_URL_SAFE.decode(s.as_ref()).map_err(serde::de::Error::custom)
+            match base64::prelude::URL_SAFE.decode(s.as_ref()) {
+                Ok(decoded) => Ok(decoded),
+                Err(first_err) => match general_purpose::URL_STANDARD.decode(s.as_ref()) {
+                    Ok(decoded) => Ok(decoded),
+                    Err(_) => Err(serde::de::Error::custom(first_err))
+                }
+            }
         }
     }
 }

--- a/google-apis-common/src/serde.rs
+++ b/google-apis-common/src/serde.rs
@@ -356,11 +356,25 @@ mod test {
     }
 
     #[test]
+    fn urlsafe_base64_de_standard_success_cases() {
+        let wrapper: Base64URLSafeWrapper =  // Expect URL-safe base64 accepts standard encoding
+            serde_json::from_reader(r#"{"bytes": "REE/P0V+Nz4oIWtH"}"#.as_bytes()).unwrap();
+        assert_eq!(Some(b"DA??E~7>(!kG".as_slice()), wrapper.bytes.as_deref());
+    }
+
+    #[test]
     fn urlsafe_base64_de_failure_cases() {
         assert!(
-            serde_json::from_str::<Base64URLSafeWrapper>(r#"{"bytes": "aGVsbG8gd29ybG+Q"}"#)
+            serde_json::from_str::<Base64URLSafeWrapper>(r#"{"bytes": "aGVsbG8gd29ybG&Q"}"#)
                 .is_err()
         );
+    }
+
+    #[test]
+    fn standard_base64_de_urlsafe_success_cases() {
+        let wrapper: Base64URLSafeWrapper =  // Expect standard base64 accepts url-safe encoding
+            serde_json::from_reader(r#"{"bytes": "REE_P0V-Nz4oIWtH"}"#.as_bytes()).unwrap();
+        assert_eq!(Some(b"DA??E~7>(!kG".as_slice()), wrapper.bytes.as_deref());
     }
 
     #[test]


### PR DESCRIPTION
Attempts to decode `bytes` fields in response JSON using both `standard` and `url_safe` encodings.  The expected encoding's desierializer is tried first.  On error the second is attempted.  If the second fails, the original error from the first is returned.

Fixes https://github.com/Byron/google-apis-rs/issues/502

Likely fixes other bugs too but I haven't tested
