### PR TITLE
Detect fields using base64 URL encoding

### DIFF
--- a/src/generator/lib/rust_type.py
+++ b/src/generator/lib/rust_type.py
@@ -32,14 +32,23 @@ class RustType:
                     self.members[i] = Base("_")
         return changed
 
-    def serde_as(self) -> Tuple["RustType", bool]:
+    def serde_as(self, description) -> Tuple["RustType", bool]:
         copied = deepcopy(self)
-        from_to = {
-            Vec(Base("u8")): Base("::client::serde::standard_base64::Wrapper"),
-            Base("client::chrono::Duration"): Base("::client::serde::duration::Wrapper"),
-            Base("i64"): Base("::client::serde_with::DisplayFromStr"),
-            Base("u64"): Base("::client::serde_with::DisplayFromStr"),
-        }
+
+        if "base64url" in description or "URL-safe Base64" in description:
+            from_to = {
+                Vec(Base("u8")): Base("::client::serde::urlsafe_base64::Wrapper"),
+                Base("client::chrono::Duration"): Base("::client::serde::duration::Wrapper"),
+                Base("i64"): Base("::client::serde_with::DisplayFromStr"),
+                Base("u64"): Base("::client::serde_with::DisplayFromStr"),
+            }
+        else:
+            from_to = {
+                Vec(Base("u8")): Base("::client::serde::standard_base64::Wrapper"),
+                Base("client::chrono::Duration"): Base("::client::serde::duration::Wrapper"),
+                Base("i64"): Base("::client::serde_with::DisplayFromStr"),
+                Base("u64"): Base("::client::serde_with::DisplayFromStr"),
+            }
 
         changed = copied.serde_replace_inner_ty(from_to)
 

--- a/src/generator/lib/util.py
+++ b/src/generator/lib/util.py
@@ -410,7 +410,7 @@ def to_serde_type(
         allow_optionals=True,
         _is_recursive=False
 ) -> Tuple[RustType, bool]:
-    return to_rust_type_inner(schemas, schema_name, property_name, t, allow_optionals, _is_recursive).serde_as()
+    return to_rust_type_inner(schemas, schema_name, property_name, t, allow_optionals, _is_recursive).serde_as(t.get('description', 'no description'))
 
 
 def to_rust_type_inner(


### PR DESCRIPTION
Some fields are encoded as base64 URL instead of Base64 Standard. This tries to catch fields requiring URL encoding by searching the description for specific words.

I'm not happy with the current implementation but I'm not too familiar with Python. Any suggestions on how to avoid the `description` parameter on `serde_as`?

This resulted into the following diff:

```diff
diff --git a/gen/drive2/src/api.rs b/gen/drive2/src/api.rs
index 7f30911f30..cb2689d1ff 100644
--- a/gen/drive2/src/api.rs
+++ b/gen/drive2/src/api.rs
@@ -3019,7 +3019,7 @@ impl client::Part for FileShortcutDetails {}
 pub struct FileThumbnail {
     /// The URL-safe Base64 encoded bytes of the thumbnail image. It should conform to RFC 4648 section 5.
     
-    #[serde_as(as = "Option<::client::serde::standard_base64::Wrapper>")]
+    #[serde_as(as = "Option<::client::serde::urlsafe_base64::Wrapper>")]
     pub image: Option<Vec<u8>>,
     /// The MIME type of the thumbnail.
     #[serde(rename="mimeType")]
diff --git a/gen/drive3/src/api.rs b/gen/drive3/src/api.rs
index 0ec40ea3d6..33887e2bc2 100644
--- a/gen/drive3/src/api.rs
+++ b/gen/drive3/src/api.rs
@@ -2231,7 +2231,7 @@ impl client::Part for FileContentHints {}
 pub struct FileContentHintsThumbnail {
     /// The thumbnail data encoded with URL-safe Base64 (RFC 4648 section 5).
     
-    #[serde_as(as = "Option<::client::serde::standard_base64::Wrapper>")]
+    #[serde_as(as = "Option<::client::serde::urlsafe_base64::Wrapper>")]
     pub image: Option<Vec<u8>>,
     /// The MIME type of the thumbnail.
     #[serde(rename="mimeType")]
diff --git a/gen/firebaseappcheck1_beta/src/api.rs b/gen/firebaseappcheck1_beta/src/api.rs
index 93ba4c06c6..9d43f7c238 100644
--- a/gen/firebaseappcheck1_beta/src/api.rs
+++ b/gen/firebaseappcheck1_beta/src/api.rs
@@ -590,7 +590,7 @@ pub struct GoogleFirebaseAppcheckV1betaExchangeAppAttestAttestationRequest {
     /// Required. The App Attest statement returned by the client-side App Attest API. This is a base64url encoded CBOR object in the JSON response.
     #[serde(rename="attestationStatement")]
     
-    #[serde_as(as = "Option<::client::serde::standard_base64::Wrapper>")]
+    #[serde_as(as = "Option<::client::serde::urlsafe_base64::Wrapper>")]
     pub attestation_statement: Option<Vec<u8>>,
     /// Required. A one-time challenge returned by an immediately prior call to GenerateAppAttestChallenge.
     
diff --git a/gen/gmail1/src/api.rs b/gen/gmail1/src/api.rs
index f8ed7e083f..ffb6b3a33f 100644
--- a/gen/gmail1/src/api.rs
+++ b/gen/gmail1/src/api.rs
@@ -1181,7 +1181,7 @@ pub struct Message {
     pub payload: Option<MessagePart>,
     /// The entire email message in an RFC 2822 formatted and base64url encoded string. Returned in `messages.get` and `drafts.get` responses when the `format=RAW` parameter is supplied.
     
-    #[serde_as(as = "Option<::client::serde::standard_base64::Wrapper>")]
+    #[serde_as(as = "Option<::client::serde::urlsafe_base64::Wrapper>")]
     pub raw: Option<Vec<u8>>,
     /// Estimated size in bytes of the message.
     #[serde(rename="sizeEstimate")]
@@ -1249,7 +1249,7 @@ pub struct MessagePartBody {
     pub attachment_id: Option<String>,
     /// The body data of a MIME message part as a base64url encoded string. May be empty for MIME container types that have no message body or when the body data is sent as a separate attachment. An attachment ID is present if the body data is contained in a separate attachment.
     
-    #[serde_as(as = "Option<::client::serde::standard_base64::Wrapper>")]
+    #[serde_as(as = "Option<::client::serde::urlsafe_base64::Wrapper>")]
     pub data: Option<Vec<u8>>,
     /// Number of bytes for the message part data (encoding notwithstanding).
     
```

Fixes #496