### PR TITLE
Bump yup-oauth2 to v10

### DIFF
--- a/google-apis-common/Cargo.toml
+++ b/google-apis-common/Cargo.toml
@@ -26,7 +26,7 @@ chrono = { version = "0.4.35", default-features = false, features = ["clock", "s
 url = "2.0"
 percent-encoding = "2.0"
 
-yup-oauth2 = { version = "9", optional = true }
+yup-oauth2 = { version = "10", optional = true }
 itertools = "^ 0.12"
 hyper = { version = "^ 0.14", features = ["client", "http2"] }
 http = "^0.2"

--- a/google-clis-common/Cargo.toml
+++ b/google-clis-common/Cargo.toml
@@ -17,7 +17,7 @@ doctest = false
 
 [dependencies]
 mime = "^ 0.3"
-yup-oauth2 = "9"
+yup-oauth2 = "10"
 serde = "1"
 serde_json = "1"
 strsim = "0.10.0"


### PR DESCRIPTION
Version 10 of [yup-oauth2](https://github.com/dermesser/yup-oauth2) was released recently, this PR bumps the version here as well.