### PR TITLE
Derive utoipa::ToSchema by default for generating openapi specs by other libraries

### DIFF
--- a/src/generator/lib/util.py
+++ b/src/generator/lib/util.py
@@ -1199,7 +1199,7 @@ def unique(
     original: str,
     desired: str,
     attempts: int = 0,
-    assigned: dict[str, str] = {},
+    assigned: Dict[str, str] = {},
 ) -> str:
     if original in assigned:
         return assigned[original]

--- a/src/generator/templates/Cargo.toml.mako
+++ b/src/generator/templates/Cargo.toml.mako
@@ -31,7 +31,7 @@ hyper-rustls = "0.25.0"
 ## Must match the one hyper uses, otherwise there are duplicate similarly named `Mime` structs
 mime = "^ 0.3.0"
 serde = { version = "^ 1.0", features = ["derive"] }
-utoipa = { version = "4.2", features = ["axum_extras", "actix_extras", "uuid", "chrono", "url"] }
+utoipa = { version = "^4.2", features = ["axum_extras", "uuid", "chrono", "url"] }
 serde_json = "^ 1.0"
 itertools = "0.13"
 % if cargo.get('is_executable', False):

--- a/src/generator/templates/Cargo.toml.mako
+++ b/src/generator/templates/Cargo.toml.mako
@@ -31,7 +31,7 @@ hyper-rustls = "0.25.0"
 ## Must match the one hyper uses, otherwise there are duplicate similarly named `Mime` structs
 mime = "^ 0.3.0"
 serde = { version = "^ 1.0", features = ["derive"] }
-utoipa = { version = "^4.2", features = ["axum_extras", "uuid", "chrono", "url"] }
+utoipa = { version = "^4.2", optional = true }
 serde_json = "^ 1.0"
 itertools = "0.13"
 % if cargo.get('is_executable', False):
@@ -62,4 +62,5 @@ version = "${util.crate_version()}"
 [features]
 yup-oauth2 = ["google-apis-common/yup-oauth2"]
 default = ["yup-oauth2"]
+utoipa = ["dep:utoipa", "utoipa/url"]
 % endif

--- a/src/generator/templates/Cargo.toml.mako
+++ b/src/generator/templates/Cargo.toml.mako
@@ -31,6 +31,7 @@ hyper-rustls = "0.25.0"
 ## Must match the one hyper uses, otherwise there are duplicate similarly named `Mime` structs
 mime = "^ 0.3.0"
 serde = { version = "^ 1.0", features = ["derive"] }
+utoipa = { version = "4.2", features = ["axum_extras", "actix_extras", "uuid", "chrono", "url"] }
 serde_json = "^ 1.0"
 itertools = "0.13"
 % if cargo.get('is_executable', False):

--- a/src/generator/templates/Cargo.toml.mako
+++ b/src/generator/templates/Cargo.toml.mako
@@ -62,5 +62,5 @@ version = "${util.crate_version()}"
 [features]
 yup-oauth2 = ["google-apis-common/yup-oauth2"]
 default = ["yup-oauth2"]
-utoipa = ["dep:utoipa", "utoipa/url"]
+utoipa = ["dep:utoipa"]
 % endif

--- a/src/generator/templates/api/api.rs.mako
+++ b/src/generator/templates/api/api.rs.mako
@@ -30,6 +30,7 @@ use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::time::sleep;
 use tower_service;
 use serde::{Serialize, Deserialize};
+use utoipa::ToSchema;
 
 use crate::{client, client::GetToken, client::serde_with};
 

--- a/src/generator/templates/api/api.rs.mako
+++ b/src/generator/templates/api/api.rs.mako
@@ -30,7 +30,6 @@ use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::time::sleep;
 use tower_service;
 use serde::{Serialize, Deserialize};
-use utoipa::ToSchema;
 
 use crate::{client, client::GetToken, client::serde_with};
 

--- a/src/generator/templates/api/lib/lib.mako
+++ b/src/generator/templates/api/lib/lib.mako
@@ -235,6 +235,13 @@ Arguments will always be copied or cloned into the builder, to make them indepen
 [wiki-pod]: http://en.wikipedia.org/wiki/Plain_old_data_structure
 [builder-pattern]: http://en.wikipedia.org/wiki/Builder_pattern
 [google-go-api]: https://github.com/google/google-api-go-client
+
+${'##'} Cargo Features
+
+* `utoipa` - Add support for [utoipa](https://crates.io/crates/utoipa) and derive `utoipa::ToSchema` on all
+the types. You'll have to import and register the required types in `#[openapi(schemas(...))]`, otherwise the
+generated `openapi` spec would be invalid.
+
 </%def>
 
 ## Sets up a hub ready for use. You must wrap it into a test function for it to work
@@ -307,6 +314,7 @@ ${self.test_hub(hub_type(c.schemas, util.canonical_name()))}
 </%block>
 % endif
 </%def>
+
 
 ###############################################################################################
 ###############################################################################################

--- a/src/generator/templates/api/lib/schema.mako
+++ b/src/generator/templates/api/lib/schema.mako
@@ -65,7 +65,7 @@ ${struct} { _never_set: Option<bool> }
     # We always need Serialization support, as others might want to serialize the response, even though we will 
     # only deserialize it.
     # And since we don't know what others want to do, we implement Deserialize as well by default ... 
-    traits = ['Clone', 'Debug', 'Serialize', 'Deserialize']
+    traits = ['Clone', 'Debug', 'Serialize', 'Deserialize', 'ToSchema']
 
     # default only works for structs, and 'variant' will be an enum
     if 'variant' not in s:

--- a/src/generator/templates/api/lib/schema.mako
+++ b/src/generator/templates/api/lib/schema.mako
@@ -65,7 +65,7 @@ ${struct} { _never_set: Option<bool> }
     # We always need Serialization support, as others might want to serialize the response, even though we will 
     # only deserialize it.
     # And since we don't know what others want to do, we implement Deserialize as well by default ... 
-    traits = ['Clone', 'Debug', 'Serialize', 'Deserialize', 'ToSchema']
+    traits = ['Clone', 'Debug', 'Serialize', 'Deserialize']
 
     # default only works for structs, and 'variant' will be an enum
     if 'variant' not in s:
@@ -83,6 +83,7 @@ ${struct} { _never_set: Option<bool> }
 <%block filter="rust_doc_sanitize(documentationLink), rust_doc_comment">\
 ${doc(s, c)}\
 </%block>
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde_with::serde_as(crate = "::client::serde_with")]
 #[derive(${', '.join(traits)})]
 % if s.type == 'object':


### PR DESCRIPTION
I needed this feature because our consuming API needs to generate docs for the frontend client but could not because of Rust's orphan rule.

This is PR is incomplete, I think it would be better to put this feature in a feature flag because everyone would not need it.

Please validate that this feature is a good idea.