### PR TITLE
Add cloudcommerceprocurement API

### DIFF
--- a/apis.json
+++ b/apis.json
@@ -4,6 +4,21 @@
   "items": [
     {
       "kind": "discovery#directoryItem",
+      "id": "cloudcommerceprocurement:v1",
+      "name": "cloudcommerceprocurement",
+      "version": "v1",
+      "title": "Cloud Commerce Partner Procurement API",
+      "description": "Partner API for the Cloud Commerce Procurement Service.",
+      "discoveryRestUrl": "https://cloudcommerceprocurement.googleapis.com/$discovery/rest?version=v1",
+      "icons": {
+        "x16": "http://www.google.com/images/icons/product/search-16.gif",
+        "x32": "http://www.google.com/images/icons/product/search-32.gif"
+      },
+      "documentationLink": "https://cloud.google.com/marketplace/docs/partners/commerce-procurement-api/reference/rest/",
+      "preferred": true
+    },
+    {
+      "kind": "discovery#directoryItem",
       "id": "aiplatform:v1",
       "name": "aiplatform",
       "version": "v1",

--- a/etc/api/api-list.yaml
+++ b/etc/api/api-list.yaml
@@ -126,6 +126,8 @@ api:
     - v1
     cloudchannel:
     - v1
+    cloudcommerceprocurement:
+    - v1
     clouddebugger:
     - v2
     clouddeploy:

--- a/etc/api/cloudcommerceprocurement/v1/cloudcommerceprocurement-api.json
+++ b/etc/api/cloudcommerceprocurement/v1/cloudcommerceprocurement-api.json
@@ -1,0 +1,930 @@
+{
+    "baseUrl": "https://cloudcommerceprocurement.googleapis.com/",
+    "fullyEncodeReservedExpansion": true,
+    "ownerName": "Google",
+    "protocol": "rest",
+    "batchPath": "batch",
+    "rootUrl": "https://cloudcommerceprocurement.googleapis.com/",
+    "documentationLink": "https://cloud.google.com/marketplace/docs/partners/",
+    "resources": {
+        "providers": {
+            "resources": {
+                "entitlements": {
+                    "methods": {
+                        "suspend": {
+                            "flatPath": "v1/providers/{providersId}/entitlements/{entitlementsId}:suspend",
+                            "scopes": [
+                                "https://www.googleapis.com/auth/cloud-platform"
+                            ],
+                            "request": {
+                                "$ref": "SuspendEntitlementRequest"
+                            },
+                            "response": {
+                                "$ref": "Empty"
+                            },
+                            "description": "Requests suspension of an active Entitlement. This is not yet supported.",
+                            "id": "cloudcommerceprocurement.providers.entitlements.suspend",
+                            "httpMethod": "POST",
+                            "path": "v1/{+name}:suspend",
+                            "parameters": {
+                                "name": {
+                                    "type": "string",
+                                    "pattern": "^providers/[^/]+/entitlements/[^/]+$",
+                                    "location": "path",
+                                    "required": true,
+                                    "description": "Required. The name of the entitlement to suspend."
+                                }
+                            },
+                            "parameterOrder": [
+                                "name"
+                            ]
+                        },
+                        "rejectPlanChange": {
+                            "parameterOrder": [
+                                "name"
+                            ],
+                            "request": {
+                                "$ref": "RejectEntitlementPlanChangeRequest"
+                            },
+                            "response": {
+                                "$ref": "Empty"
+                            },
+                            "parameters": {
+                                "name": {
+                                    "type": "string",
+                                    "description": "Required. The resource name of the entitlement.",
+                                    "location": "path",
+                                    "required": true,
+                                    "pattern": "^providers/[^/]+/entitlements/[^/]+$"
+                                }
+                            },
+                            "httpMethod": "POST",
+                            "description": "Rejects an entitlement plan change that is in the EntitlementState.ENTITLEMENT_PENDING_PLAN_CHANGE_APPROVAL state. This method is invoked by the provider to reject the plan change on the entitlement resource.",
+                            "id": "cloudcommerceprocurement.providers.entitlements.rejectPlanChange",
+                            "scopes": [
+                                "https://www.googleapis.com/auth/cloud-platform"
+                            ],
+                            "path": "v1/{+name}:rejectPlanChange",
+                            "flatPath": "v1/providers/{providersId}/entitlements/{entitlementsId}:rejectPlanChange"
+                        },
+                        "get": {
+                            "flatPath": "v1/providers/{providersId}/entitlements/{entitlementsId}",
+                            "scopes": [
+                                "https://www.googleapis.com/auth/cloud-platform"
+                            ],
+                            "response": {
+                                "$ref": "Entitlement"
+                            },
+                            "path": "v1/{+name}",
+                            "httpMethod": "GET",
+                            "id": "cloudcommerceprocurement.providers.entitlements.get",
+                            "parameters": {
+                                "name": {
+                                    "description": "Required. The name of the entitlement to retrieve.",
+                                    "type": "string",
+                                    "pattern": "^providers/[^/]+/entitlements/[^/]+$",
+                                    "required": true,
+                                    "location": "path"
+                                }
+                            },
+                            "description": "Gets a requested Entitlement resource.",
+                            "parameterOrder": [
+                                "name"
+                            ]
+                        },
+                        "approve": {
+                            "parameters": {
+                                "name": {
+                                    "required": true,
+                                    "pattern": "^providers/[^/]+/entitlements/[^/]+$",
+                                    "type": "string",
+                                    "location": "path",
+                                    "description": "Required. The resource name of the entitlement, with the format `providers/{providerId}/entitlements/{entitlementId}`."
+                                }
+                            },
+                            "path": "v1/{+name}:approve",
+                            "httpMethod": "POST",
+                            "request": {
+                                "$ref": "ApproveEntitlementRequest"
+                            },
+                            "flatPath": "v1/providers/{providersId}/entitlements/{entitlementsId}:approve",
+                            "response": {
+                                "$ref": "Empty"
+                            },
+                            "id": "cloudcommerceprocurement.providers.entitlements.approve",
+                            "parameterOrder": [
+                                "name"
+                            ],
+                            "scopes": [
+                                "https://www.googleapis.com/auth/cloud-platform"
+                            ],
+                            "description": "Approves an entitlement that is in the EntitlementState.ENTITLEMENT_ACTIVATION_REQUESTED state. This method is invoked by the provider to approve the creation of the entitlement resource."
+                        },
+                        "list": {
+                            "path": "v1/{+parent}/entitlements",
+                            "scopes": [
+                                "https://www.googleapis.com/auth/cloud-platform"
+                            ],
+                            "parameters": {
+                                "pageToken": {
+                                    "description": "The token for fetching the next page.",
+                                    "location": "query",
+                                    "type": "string"
+                                },
+                                "filter": {
+                                    "description": "The filter that can be used to limit the list request. The filter is a query string that can match a selected set of attributes with string values. For example `account=E-1234-5678-ABCD-EFGH`, `state=pending_cancellation`, and `plan!=foo-plan`. Supported query attributes are * `account` * `customer_billing_account` with value in the format of: `billingAccounts/{id}` * `product_external_name` * `quote_external_name` * `offer` * `new_pending_offer` * `plan` * `newPendingPlan` or `new_pending_plan` * `state` * `consumers.project` * `change_history.new_offer` Note that the consumers and change_history.new_offer match works on repeated structures, so equality (`consumers.project=projects/123456789`) is not supported. Set membership can be expressed with the `:` operator. For example, `consumers.project:projects/123456789` finds entitlements with at least one consumer with project field equal to `projects/123456789`. `change_history.new_offer` retrieves all entitlements that were once associated or are currently active with the offer. Also note that the state name match is case-insensitive and query can omit the prefix \"ENTITLEMENT_\". For example, `state=active` is equivalent to `state=ENTITLEMENT_ACTIVE`. If the query contains some special characters other than letters, underscore, or digits, the phrase must be quoted with double quotes. For example, `product=\"providerId:productId\"`, where the product name needs to be quoted because it contains special character colon. Queries can be combined with `AND`, `OR`, and `NOT` to form more complex queries. They can also be grouped to force a desired evaluation order. For example, `state=active AND (account=E-1234 OR account=5678) AND NOT (product=foo-product)`. Connective `AND` can be omitted between two predicates. For example `account=E-1234 state=active` is equivalent to `account=E-1234 AND state=active`.",
+                                    "location": "query",
+                                    "type": "string"
+                                },
+                                "pageSize": {
+                                    "type": "integer",
+                                    "location": "query",
+                                    "description": "The maximum number of entries that are requested. The default page size is 200.",
+                                    "format": "int32"
+                                },
+                                "parent": {
+                                    "pattern": "^providers/[^/]+$",
+                                    "required": true,
+                                    "description": "Required. The parent resource name.",
+                                    "type": "string",
+                                    "location": "path"
+                                }
+                            },
+                            "flatPath": "v1/providers/{providersId}/entitlements",
+                            "response": {
+                                "$ref": "ListEntitlementsResponse"
+                            },
+                            "description": "Lists Entitlements for which the provider has read access.",
+                            "parameterOrder": [
+                                "parent"
+                            ],
+                            "id": "cloudcommerceprocurement.providers.entitlements.list",
+                            "httpMethod": "GET"
+                        },
+                        "approvePlanChange": {
+                            "scopes": [
+                                "https://www.googleapis.com/auth/cloud-platform"
+                            ],
+                            "description": "Approves an entitlement plan change that is in the EntitlementState.ENTITLEMENT_PENDING_PLAN_CHANGE_APPROVAL state. This method is invoked by the provider to approve the plan change on the entitlement resource.",
+                            "path": "v1/{+name}:approvePlanChange",
+                            "parameters": {
+                                "name": {
+                                    "pattern": "^providers/[^/]+/entitlements/[^/]+$",
+                                    "type": "string",
+                                    "location": "path",
+                                    "description": "Required. The resource name of the entitlement.",
+                                    "required": true
+                                }
+                            },
+                            "id": "cloudcommerceprocurement.providers.entitlements.approvePlanChange",
+                            "httpMethod": "POST",
+                            "flatPath": "v1/providers/{providersId}/entitlements/{entitlementsId}:approvePlanChange",
+                            "parameterOrder": [
+                                "name"
+                            ],
+                            "request": {
+                                "$ref": "ApproveEntitlementPlanChangeRequest"
+                            },
+                            "response": {
+                                "$ref": "Empty"
+                            }
+                        },
+                        "patch": {
+                            "id": "cloudcommerceprocurement.providers.entitlements.patch",
+                            "request": {
+                                "$ref": "Entitlement"
+                            },
+                            "httpMethod": "PATCH",
+                            "description": "Updates an existing Entitlement.",
+                            "parameters": {
+                                "name": {
+                                    "pattern": "^providers/[^/]+/entitlements/[^/]+$",
+                                    "required": true,
+                                    "type": "string",
+                                    "location": "path",
+                                    "description": "Required. The name of the entitlement to update."
+                                },
+                                "updateMask": {
+                                    "location": "query",
+                                    "format": "google-fieldmask",
+                                    "description": "The update mask that applies to the resource. See the [FieldMask definition] (https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#fieldmask) for more details.",
+                                    "type": "string"
+                                }
+                            },
+                            "path": "v1/{+name}",
+                            "flatPath": "v1/providers/{providersId}/entitlements/{entitlementsId}",
+                            "scopes": [
+                                "https://www.googleapis.com/auth/cloud-platform"
+                            ],
+                            "parameterOrder": [
+                                "name"
+                            ],
+                            "response": {
+                                "$ref": "Entitlement"
+                            }
+                        },
+                        "reject": {
+                            "flatPath": "v1/providers/{providersId}/entitlements/{entitlementsId}:reject",
+                            "response": {
+                                "$ref": "Empty"
+                            },
+                            "description": "Rejects an entitlement that is in the EntitlementState.ENTITLEMENT_ACTIVATION_REQUESTED state. This method is invoked by the provider to reject the creation of the entitlement resource.",
+                            "parameters": {
+                                "name": {
+                                    "description": "Required. The resource name of the entitlement.",
+                                    "pattern": "^providers/[^/]+/entitlements/[^/]+$",
+                                    "location": "path",
+                                    "required": true,
+                                    "type": "string"
+                                }
+                            },
+                            "path": "v1/{+name}:reject",
+                            "parameterOrder": [
+                                "name"
+                            ],
+                            "id": "cloudcommerceprocurement.providers.entitlements.reject",
+                            "scopes": [
+                                "https://www.googleapis.com/auth/cloud-platform"
+                            ],
+                            "httpMethod": "POST",
+                            "request": {
+                                "$ref": "RejectEntitlementRequest"
+                            }
+                        }
+                    }
+                },
+                "accounts": {
+                    "methods": {
+                        "approve": {
+                            "description": "Grants an approval on an Account.",
+                            "request": {
+                                "$ref": "ApproveAccountRequest"
+                            },
+                            "flatPath": "v1/providers/{providersId}/accounts/{accountsId}:approve",
+                            "parameters": {
+                                "name": {
+                                    "description": "Required. The resource name of the account, with the format `providers/{providerId}/accounts/{accountId}`.",
+                                    "required": true,
+                                    "type": "string",
+                                    "pattern": "^providers/[^/]+/accounts/[^/]+$",
+                                    "location": "path"
+                                }
+                            },
+                            "id": "cloudcommerceprocurement.providers.accounts.approve",
+                            "scopes": [
+                                "https://www.googleapis.com/auth/cloud-platform"
+                            ],
+                            "httpMethod": "POST",
+                            "response": {
+                                "$ref": "Empty"
+                            },
+                            "path": "v1/{+name}:approve",
+                            "parameterOrder": [
+                                "name"
+                            ]
+                        },
+                        "reject": {
+                            "httpMethod": "POST",
+                            "flatPath": "v1/providers/{providersId}/accounts/{accountsId}:reject",
+                            "id": "cloudcommerceprocurement.providers.accounts.reject",
+                            "response": {
+                                "$ref": "Empty"
+                            },
+                            "path": "v1/{+name}:reject",
+                            "parameterOrder": [
+                                "name"
+                            ],
+                            "request": {
+                                "$ref": "RejectAccountRequest"
+                            },
+                            "scopes": [
+                                "https://www.googleapis.com/auth/cloud-platform"
+                            ],
+                            "parameters": {
+                                "name": {
+                                    "required": true,
+                                    "pattern": "^providers/[^/]+/accounts/[^/]+$",
+                                    "description": "Required. The resource name of the account.",
+                                    "type": "string",
+                                    "location": "path"
+                                }
+                            },
+                            "description": "Rejects an approval on an Account."
+                        },
+                        "reset": {
+                            "httpMethod": "POST",
+                            "description": "Resets an Account and cancels all associated Entitlements. Partner can only reset accounts they own rather than customer accounts.",
+                            "path": "v1/{+name}:reset",
+                            "scopes": [
+                                "https://www.googleapis.com/auth/cloud-platform"
+                            ],
+                            "parameters": {
+                                "name": {
+                                    "pattern": "^providers/[^/]+/accounts/[^/]+$",
+                                    "required": true,
+                                    "description": "Required. The resource name of the account.",
+                                    "type": "string",
+                                    "location": "path"
+                                }
+                            },
+                            "parameterOrder": [
+                                "name"
+                            ],
+                            "flatPath": "v1/providers/{providersId}/accounts/{accountsId}:reset",
+                            "id": "cloudcommerceprocurement.providers.accounts.reset",
+                            "request": {
+                                "$ref": "ResetAccountRequest"
+                            },
+                            "response": {
+                                "$ref": "Empty"
+                            }
+                        },
+                        "get": {
+                            "path": "v1/{+name}",
+                            "parameterOrder": [
+                                "name"
+                            ],
+                            "description": "Gets a requested Account resource.",
+                            "id": "cloudcommerceprocurement.providers.accounts.get",
+                            "response": {
+                                "$ref": "Account"
+                            },
+                            "parameters": {
+                                "name": {
+                                    "description": "Required. The name of the account to retrieve.",
+                                    "pattern": "^providers/[^/]+/accounts/[^/]+$",
+                                    "required": true,
+                                    "type": "string",
+                                    "location": "path"
+                                }
+                            },
+                            "httpMethod": "GET",
+                            "scopes": [
+                                "https://www.googleapis.com/auth/cloud-platform"
+                            ],
+                            "flatPath": "v1/providers/{providersId}/accounts/{accountsId}"
+                        },
+                        "list": {
+                            "flatPath": "v1/providers/{providersId}/accounts",
+                            "id": "cloudcommerceprocurement.providers.accounts.list",
+                            "description": "Lists Accounts that the provider has access to.",
+                            "path": "v1/{+parent}/accounts",
+                            "parameterOrder": [
+                                "parent"
+                            ],
+                            "parameters": {
+                                "pageSize": {
+                                    "type": "integer",
+                                    "location": "query",
+                                    "description": "The maximum number of entries that are requested. The default page size is 25 and the maximum page size is 200.",
+                                    "format": "int32"
+                                },
+                                "pageToken": {
+                                    "description": "The token for fetching the next page.",
+                                    "type": "string",
+                                    "location": "query"
+                                },
+                                "parent": {
+                                    "type": "string",
+                                    "required": true,
+                                    "pattern": "^providers/[^/]+$",
+                                    "description": "Required. The parent resource name.",
+                                    "location": "path"
+                                }
+                            },
+                            "response": {
+                                "$ref": "ListAccountsResponse"
+                            },
+                            "scopes": [
+                                "https://www.googleapis.com/auth/cloud-platform"
+                            ],
+                            "httpMethod": "GET"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "canonicalName": "Cloud Commerce Partner Procurement Service",
+    "basePath": "",
+    "description": "Partner API for the Cloud Commerce Procurement Service.",
+    "version": "v1",
+    "version_module": true,
+    "title": "Cloud Commerce Partner Procurement API",
+    "mtlsRootUrl": "https://cloudcommerceprocurement.mtls.googleapis.com/",
+    "servicePath": "",
+    "kind": "discovery#restDescription",
+    "schemas": {
+        "ResetAccountRequest": {
+            "properties": {},
+            "description": "Request message for PartnerProcurementService.ResetAccount.",
+            "type": "object",
+            "id": "ResetAccountRequest"
+        },
+        "RejectEntitlementPlanChangeRequest": {
+            "properties": {
+                "reason": {
+                    "description": "Free form text string explaining the rejection reason. Max allowed length: 256 bytes. Longer strings will be truncated.",
+                    "type": "string"
+                },
+                "pendingPlanName": {
+                    "description": "Required. Name of the pending plan that is being rejected.",
+                    "type": "string"
+                }
+            },
+            "description": "Request message for PartnerProcurementService.RejectEntitlementPlanChange.",
+            "type": "object",
+            "id": "RejectEntitlementPlanChangeRequest"
+        },
+        "RejectAccountRequest": {
+            "description": "Request message for PartnerProcurementService.RejectAccount.",
+            "type": "object",
+            "id": "RejectAccountRequest",
+            "properties": {
+                "reason": {
+                    "type": "string",
+                    "description": "Free form text string explaining the rejection reason. Max allowed length: 256 bytes. Longer strings will be truncated."
+                },
+                "approvalName": {
+                    "description": "The name of the approval being rejected. If absent and there is only one approval possible, that approval will be rejected. If absent and there are many approvals possible, the request will fail with a 400 Bad Request. Optional.",
+                    "type": "string"
+                }
+            }
+        },
+        "ListAccountsResponse": {
+            "type": "object",
+            "properties": {
+                "nextPageToken": {
+                    "type": "string",
+                    "description": "The token for fetching the next page."
+                },
+                "accounts": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "Account"
+                    },
+                    "description": "The list of accounts in this response."
+                }
+            },
+            "id": "ListAccountsResponse",
+            "description": "Response message for [PartnerProcurementService.ListAccounts[]."
+        },
+        "ListEntitlementsResponse": {
+            "id": "ListEntitlementsResponse",
+            "description": "Response message for PartnerProcurementService.ListEntitlements.",
+            "type": "object",
+            "properties": {
+                "entitlements": {
+                    "description": "The list of entitlements in this response.",
+                    "items": {
+                        "$ref": "Entitlement"
+                    },
+                    "type": "array"
+                },
+                "nextPageToken": {
+                    "type": "string",
+                    "description": "The token for fetching the next page."
+                }
+            }
+        },
+        "Entitlement": {
+            "properties": {
+                "usageReportingId": {
+                    "description": "Output only. The consumerId to use when reporting usage through the Service Control API. See the consumerId field at [Reporting Metrics](https://cloud.google.com/service-control/reporting-metrics) for more details. This field is present only if the product has usage-based billing configured.",
+                    "type": "string"
+                },
+                "newPendingOffer": {
+                    "description": "Output only. The name of the offer the entitlement is switching to upon a pending plan change. Only exists if the pending plan change is moving to an offer. This field isn't populated for entitlements which aren't active yet. Format: 'projects/{project}/services/{service}/privateOffers/{offer-id}' OR 'projects/{project}/services/{service}/standardOffers/{offer-id}', depending on whether the offer is private or public. The {service} in the name is the listing service of the offer. It could be either the product service that the offer is referencing, or a generic private offer parent service. We recommend that you don't build your integration to rely on the meaning of this {service} part.",
+                    "type": "string",
+                    "readOnly": true
+                },
+                "productExternalName": {
+                    "readOnly": true,
+                    "type": "string",
+                    "description": "Output only. The identifier of the product that was procured."
+                },
+                "quoteExternalName": {
+                    "description": "Output only. The identifier of the quote that was used to procure. Empty if the order is not purchased using a quote.",
+                    "type": "string",
+                    "readOnly": true
+                },
+                "messageToUser": {
+                    "type": "string",
+                    "description": "Provider-supplied message that is displayed to the end user. Currently this is used to communicate progress and ETA for provisioning. This field can be updated only when a user is waiting for an action from the provider, i.e. entitlement state is EntitlementState.ENTITLEMENT_ACTIVATION_REQUESTED or EntitlementState.ENTITLEMENT_PENDING_PLAN_CHANGE_APPROVAL. This field is cleared automatically when the entitlement state changes."
+                },
+                "subscriptionEndTime": {
+                    "format": "google-datetime",
+                    "readOnly": true,
+                    "description": "Output only. End time for the subscription corresponding to this entitlement.",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "Output only. The resource name of the entitlement. Entitlement names have the form `providers/{provider_id}/entitlements/{entitlement_id}`.",
+                    "type": "string"
+                },
+                "product": {
+                    "description": "Output only. The identifier of the entity that was purchased. This may actually represent a product, quote, or offer. We strongly recommend that you use the following more explicit fields: productExternalName, quoteExternalName, or offer.",
+                    "type": "string",
+                    "deprecated": true
+                },
+                "createTime": {
+                    "format": "google-datetime",
+                    "description": "Output only. The creation timestamp.",
+                    "type": "string"
+                },
+                "newOfferStartTime": {
+                    "readOnly": true,
+                    "description": "Output only. The timestamp when the new offer becomes effective. This field is populated even if the entitlement isn't active yet. If there's no upcoming offer, the field is empty.",
+                    "format": "google-datetime",
+                    "type": "string"
+                },
+                "newOfferEndTime": {
+                    "type": "string",
+                    "format": "google-datetime",
+                    "description": "Output only. The end time of the new offer. If the offer was created with a term instead of a specified end date, this field is empty. This field is populated even if the entitlement isn't active yet. If there's no upcoming offer, the field is be empty.",
+                    "readOnly": true
+                },
+                "newPendingPlan": {
+                    "type": "string",
+                    "description": "Output only. The identifier of the pending new plan. Required if the product has plans and the entitlement has a pending plan change."
+                },
+                "offerDuration": {
+                    "type": "string",
+                    "readOnly": true,
+                    "description": "Output only. The offer duration of the current offer in ISO 8601 duration format. Field is empty if entitlement was not made using an offer. If the offer was created with a specified end date instead of a duration, this field is empty."
+                },
+                "newPendingOfferDuration": {
+                    "description": "Output only. The duration of the new offer, in ISO 8601 duration format. This field isn't populated for entitlements which aren't active yet, only for pending offer changes. If the offer was created with a specified end date instead of a duration, this field is empty.",
+                    "readOnly": true,
+                    "type": "string"
+                },
+                "state": {
+                    "enum": [
+                        "ENTITLEMENT_STATE_UNSPECIFIED",
+                        "ENTITLEMENT_ACTIVATION_REQUESTED",
+                        "ENTITLEMENT_ACTIVE",
+                        "ENTITLEMENT_PENDING_CANCELLATION",
+                        "ENTITLEMENT_CANCELLED",
+                        "ENTITLEMENT_PENDING_PLAN_CHANGE",
+                        "ENTITLEMENT_PENDING_PLAN_CHANGE_APPROVAL",
+                        "ENTITLEMENT_SUSPENDED"
+                    ],
+                    "type": "string",
+                    "enumDescriptions": [
+                        "Default state of the entitlement. It's only set to this value when the entitlement is first created and has not been initialized.",
+                        "Indicates that the entitlement is being created and the backend has sent a notification to the provider for the activation approval. If the provider approves, then the entitlement will transition to the EntitlementState.ENTITLEMENT_ACTIVE state. Otherwise, the entitlement will be removed. Plan changes are not allowed in this state. Instead the entitlement is cancelled and re-created with a new plan name.",
+                        "Indicates that the entitlement is active. The procured item is now usable and any associated billing events will start occurring. Entitlements in this state WILL renew. The analogous state for an unexpired but non-renewing entitlement is ENTITLEMENT_PENDING_CANCELLATION. In this state, the customer can decide to cancel the entitlement, which would change the state to EntitlementState.ENTITLEMENT_PENDING_CANCELLATION, and then EntitlementState.ENTITLEMENT_CANCELLED. The user can also request a change of plan, which will transition the state to EntitlementState.ENTITLEMENT_PENDING_PLAN_CHANGE, and then back to EntitlementState.ENTITLEMENT_ACTIVE.",
+                        "Indicates that the entitlement will expire at the end of its term. This could mean the customer has elected not to renew this entitlement or the customer elected to cancel an entitlement that only expires at term end. The entitlement typically stays in this state if the entitlement/plan allows use of the underlying resource until the end of the current billing cycle. Once the billing cycle completes, the resource will transition to EntitlementState.ENTITLEMENT_CANCELLED state. The resource cannot be modified during this state.",
+                        "Indicates that the entitlement was cancelled. The entitlement can now be deleted.",
+                        "Indicates that the entitlement is currently active, but there is a pending plan change that is requested by the customer. The entitlement typically stays in this state, if the entitlement/plan requires the completion of the current billing cycle before the plan can be changed. Once the billing cycle completes, the resource will transition to EntitlementState.ENTITLEMENT_ACTIVE, with its plan changed.",
+                        "Indicates that the entitlement is currently active, but there is a plan change request pending provider approval. If the provider approves the plan change, then the entitlement will transition either to EntitlementState.ENTITLEMENT_ACTIVE or EntitlementState.ENTITLEMENT_PENDING_PLAN_CHANGE depending on whether current plan requires that the billing cycle completes. If the provider rejects the plan change, then the pending plan change request is removed and the entitlement stays in EntitlementState.ENTITLEMENT_ACTIVE state with the old plan.",
+                        "Indicates that the entitlement is suspended either by Google or provider request. This can be triggered for various external reasons (e.g. expiration of credit card on the billing account, violation of terms-of-service of the provider etc.). As such, any remediating action needs to be taken externally, before the entitlement can be activated. This is not yet supported."
+                    ],
+                    "description": "Output only. The state of the entitlement."
+                },
+                "consumers": {
+                    "description": "Output only. The resources using this entitlement, if applicable.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "Consumer"
+                    }
+                },
+                "orderId": {
+                    "readOnly": true,
+                    "type": "string",
+                    "description": "Output only. The order ID of this entitlement, without any `orders/` resource name prefix."
+                },
+                "provider": {
+                    "type": "string",
+                    "description": "Output only. The identifier of the service provider that this entitlement was created against. Each service provider is assigned a unique provider value when they onboard with Cloud Commerce platform."
+                },
+                "updateTime": {
+                    "type": "string",
+                    "description": "Output only. The last update timestamp.",
+                    "format": "google-datetime"
+                },
+                "offer": {
+                    "type": "string",
+                    "readOnly": true,
+                    "description": "Output only. The name of the offer that was procured. Field is empty if order was not made using an offer. Format: 'projects/{project}/services/{service}/privateOffers/{offer-id}' OR 'projects/{project}/services/{service}/standardOffers/{offer-id}', depending on whether the offer is private or public. The {service} in the name is the listing service of the offer. It could be either the product service that the offer is referencing, or a generic private offer parent service. We recommend that you don't build your integration to rely on the meaning of this {service} part."
+                },
+                "offerEndTime": {
+                    "type": "string",
+                    "format": "google-datetime",
+                    "readOnly": true,
+                    "description": "Output only. End time for the Offer association corresponding to this entitlement. The field is only populated if the entitlement is currently associated with an Offer."
+                },
+                "account": {
+                    "description": "Output only. The resource name of the account that this entitlement is based on, if any.",
+                    "type": "string"
+                },
+                "plan": {
+                    "description": "Output only. The identifier of the plan that was procured. Required if the product has plans.",
+                    "type": "string"
+                },
+                "cancellationReason": {
+                    "type": "string",
+                    "description": "Output only. The reason the entitlement was cancelled. If this entitlement wasn't cancelled, this field is empty. Possible values include \"unknown\", \"expired\", \"user-cancelled\", \"account-closed\", \"billing-disabled\" (if the customer has manually disabled billing to their resources), \"user-aborted\", and \"migrated\" (if the entitlement has migrated across products). Values of this field are subject to change, and we recommend that you don't build your technical integration to rely on these fields.",
+                    "readOnly": true
+                },
+                "entitlementBenefitIds": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "description": "Output only. The entitlement benefit IDs associated with the purchase.",
+                    "readOnly": true
+                },
+                "inputProperties": {
+                    "description": "Output only. The custom properties that were collected from the user to create this entitlement.",
+                    "deprecated": true,
+                    "type": "object",
+                    "additionalProperties": {
+                        "description": "Properties of the object.",
+                        "type": "any"
+                    }
+                }
+            },
+            "id": "Entitlement",
+            "type": "object",
+            "description": "Represents a procured product of a customer."
+        },
+        "ApproveAccountRequest": {
+            "description": "Request message for PartnerProcurementService.ApproveAccount.",
+            "type": "object",
+            "id": "ApproveAccountRequest",
+            "properties": {
+                "approvalName": {
+                    "description": "The name of the approval being approved. If absent and there is only one approval possible, that approval will be granted. If absent and there are many approvals possible, the request will fail with a 400 Bad Request. Optional.",
+                    "type": "string"
+                },
+                "reason": {
+                    "description": "Free form text string explaining the approval reason. Optional. Max allowed length: 256 bytes. Longer strings will be truncated.",
+                    "type": "string"
+                },
+                "properties": {
+                    "description": "Set of properties that should be associated with the account. Optional.",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "Empty": {
+            "description": "A generic empty message that you can re-use to avoid defining duplicated empty messages in your APIs. A typical example is to use it as the request or the response type of an API method. For instance: service Foo { rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty); }",
+            "properties": {},
+            "type": "object",
+            "id": "Empty"
+        },
+        "SuspendEntitlementRequest": {
+            "id": "SuspendEntitlementRequest",
+            "properties": {
+                "reason": {
+                    "description": "A free-form reason string, explaining the reason for suspension request.",
+                    "type": "string"
+                }
+            },
+            "description": "Request message for ParterProcurementService.SuspendEntitlement. This is not yet supported.",
+            "type": "object"
+        },
+        "RejectEntitlementRequest": {
+            "properties": {
+                "reason": {
+                    "description": "Free form text string explaining the rejection reason. Max allowed length: 256 bytes. Longer strings will be truncated.",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "description": "Request message for PartnerProcurementService.RejectEntitlement.",
+            "id": "RejectEntitlementRequest"
+        },
+        "Consumer": {
+            "properties": {
+                "project": {
+                    "type": "string",
+                    "description": "A project name with format `projects/`."
+                }
+            },
+            "type": "object",
+            "description": "A resource using (consuming) this entitlement.",
+            "id": "Consumer"
+        },
+        "Account": {
+            "type": "object",
+            "properties": {
+                "provider": {
+                    "type": "string",
+                    "description": "Output only. The identifier of the service provider that this account was created against. Each service provider is assigned a unique provider value when they onboard with Cloud Commerce platform."
+                },
+                "approvals": {
+                    "items": {
+                        "$ref": "Approval"
+                    },
+                    "type": "array",
+                    "description": "Output only. The approvals for this account. These approvals are used to track actions that are permitted or have been completed by a customer within the context of the provider. This might include a sign up flow or a provisioning step, for example, that the provider can admit to having happened."
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Output only. The resource name of the account. Account names have the form `accounts/{account_id}`."
+                },
+                "createTime": {
+                    "format": "google-datetime",
+                    "description": "Output only. The creation timestamp.",
+                    "type": "string"
+                },
+                "state": {
+                    "description": "Output only. The state of the account. This is used to decide whether the customer is in good standing with the provider and is able to make purchases. An account might not be able to make a purchase if the billing account is suspended, for example.",
+                    "enum": [
+                        "ACCOUNT_STATE_UNSPECIFIED",
+                        "ACCOUNT_ACTIVATION_REQUESTED",
+                        "ACCOUNT_ACTIVE"
+                    ],
+                    "type": "string",
+                    "enumDescriptions": [
+                        "Default state of the account. It's only set to this value when the account is first created and has not been initialized.",
+                        "The customer has requested the creation of the account resource, and the provider notification message is dispatched. This state has been deprecated, as accounts now immediately transition to AccountState.ACCOUNT_ACTIVE.",
+                        "The account is active and ready for use. The next possible states are: - Account getting deleted: After the user invokes delete from another API."
+                    ]
+                },
+                "updateTime": {
+                    "description": "Output only. The last update timestamp.",
+                    "type": "string",
+                    "format": "google-datetime"
+                },
+                "inputProperties": {
+                    "additionalProperties": {
+                        "description": "Properties of the object.",
+                        "type": "any"
+                    },
+                    "description": "Output only. The custom properties that were collected from the user to create this account.",
+                    "deprecated": true,
+                    "type": "object"
+                }
+            },
+            "id": "Account",
+            "description": "Represents an account that was established by the customer on the service provider's system."
+        },
+        "Approval": {
+            "type": "object",
+            "description": "An approval for some action on an account.",
+            "properties": {
+                "state": {
+                    "type": "string",
+                    "description": "Output only. The state of the approval.",
+                    "enumDescriptions": [
+                        "Sentinel value; do not use.",
+                        "The approval is pending response from the provider. The approval state can transition to Account.Approval.State.APPROVED or Account.Approval.State.REJECTED.",
+                        "The approval has been granted by the provider.",
+                        "The approval has been rejected by the provider. A provider may choose to approve a previously rejected approval, so is it possible to transition to Account.Approval.State.APPROVED."
+                    ],
+                    "enum": [
+                        "STATE_UNSPECIFIED",
+                        "PENDING",
+                        "APPROVED",
+                        "REJECTED"
+                    ]
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Output only. The name of the approval."
+                },
+                "reason": {
+                    "type": "string",
+                    "description": "Output only. An explanation for the state of the approval."
+                },
+                "updateTime": {
+                    "format": "google-datetime",
+                    "type": "string",
+                    "description": "Optional. The last update timestamp of the approval."
+                }
+            },
+            "id": "Approval"
+        },
+        "ApproveEntitlementRequest": {
+            "properties": {
+                "entitlementMigrated": {
+                    "type": "string",
+                    "description": "Optional. The resource name of the entitlement that was migrated, with the format `providers/{provider_id}/entitlements/{entitlement_id}`. Should only be sent when resources have been migrated from entitlement_migrated to the new entitlement. Optional."
+                },
+                "properties": {
+                    "deprecated": true,
+                    "type": "object",
+                    "description": "Set of properties that should be associated with the entitlement. Optional.",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                }
+            },
+            "type": "object",
+            "description": "Request message for [PartnerProcurementService.ApproveEntitlement[].",
+            "id": "ApproveEntitlementRequest"
+        },
+        "ApproveEntitlementPlanChangeRequest": {
+            "id": "ApproveEntitlementPlanChangeRequest",
+            "type": "object",
+            "properties": {
+                "pendingPlanName": {
+                    "description": "Required. Name of the pending plan that's being approved.",
+                    "type": "string"
+                }
+            },
+            "description": "Request message for [PartnerProcurementService.ApproveEntitlementPlanChange[]."
+        }
+    },
+    "revision": "20240804",
+    "ownerDomain": "google.com",
+    "icons": {
+        "x16": "http://www.google.com/images/icons/product/search-16.gif",
+        "x32": "http://www.google.com/images/icons/product/search-32.gif"
+    },
+    "name": "cloudcommerceprocurement",
+    "id": "cloudcommerceprocurement:v1",
+    "discoveryVersion": "v1",
+    "auth": {
+        "oauth2": {
+            "scopes": {
+                "https://www.googleapis.com/auth/cloud-platform": {
+                    "description": "See, edit, configure, and delete your Google Cloud data and see the email address for your Google Account."
+                }
+            }
+        }
+    },
+    "parameters": {
+        "quotaUser": {
+            "description": "Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.",
+            "type": "string",
+            "location": "query"
+        },
+        "access_token": {
+            "location": "query",
+            "type": "string",
+            "description": "OAuth access token."
+        },
+        "callback": {
+            "type": "string",
+            "location": "query",
+            "description": "JSONP"
+        },
+        "uploadType": {
+            "description": "Legacy upload protocol for media (e.g. \"media\", \"multipart\").",
+            "location": "query",
+            "type": "string"
+        },
+        "oauth_token": {
+            "location": "query",
+            "type": "string",
+            "description": "OAuth 2.0 token for the current user."
+        },
+        "key": {
+            "location": "query",
+            "description": "API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.",
+            "type": "string"
+        },
+        "prettyPrint": {
+            "type": "boolean",
+            "location": "query",
+            "default": "true",
+            "description": "Returns response with indentations and line breaks."
+        },
+        "upload_protocol": {
+            "type": "string",
+            "description": "Upload protocol for media (e.g. \"raw\", \"multipart\").",
+            "location": "query"
+        },
+        "alt": {
+            "type": "string",
+            "default": "json",
+            "enumDescriptions": [
+                "Responses with Content-Type of application/json",
+                "Media download with context-dependent Content-Type",
+                "Responses with Content-Type of application/x-protobuf"
+            ],
+            "description": "Data format for response.",
+            "enum": [
+                "json",
+                "media",
+                "proto"
+            ],
+            "location": "query"
+        },
+        "fields": {
+            "location": "query",
+            "description": "Selector specifying which fields to include in a partial response.",
+            "type": "string"
+        },
+        "$.xgafv": {
+            "enumDescriptions": [
+                "v1 error format",
+                "v2 error format"
+            ],
+            "location": "query",
+            "type": "string",
+            "description": "V1 error format.",
+            "enum": [
+                "1",
+                "2"
+            ]
+        }
+    }
+}


### PR DESCRIPTION
Adds:
- cloudcommerceprocurement v1

I tried to do the same thing as https://github.com/Byron/google-apis-rs/pull/515 did.

I was able to use this crate successfully in my own project (private repo unfortunately).