### PR TITLE
Make UserDraftCreateCall::doit public

### DIFF
--- a/gen/gmail1/src/api.rs
+++ b/gen/gmail1/src/api.rs
@@ -3384,7 +3384,7 @@ where
 
 
     /// Perform the operation you have build so far.
-    async fn doit<RS>(mut self, mut reader: RS, reader_mime_type: mime::Mime, protocol: client::UploadProtocol) -> client::Result<(hyper::Response<hyper::body::Body>, Draft)>
+    pub async fn doit<RS>(mut self, mut reader: RS, reader_mime_type: mime::Mime, protocol: client::UploadProtocol) -> client::Result<(hyper::Response<hyper::body::Body>, Draft)>
 		where RS: client::ReadSeek {
         use std::io::{Read, Seek};
         use hyper::header::{CONTENT_TYPE, CONTENT_LENGTH, AUTHORIZATION, USER_AGENT, LOCATION};


### PR DESCRIPTION
UserDraftCreateCall::doit is currently private which prevents performing the operation