### PR TITLE
Avoid processing incoming bodies unnecessarily

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,15 +7,22 @@ on:
     branches: [main]
 
 jobs:
-  meta-check:
-    name: Check the generative code
+  common-check:
+    name: Check the common code
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: make meta-check
+      - run: make common-check
 
-  check:
-    name: Check the generated code
+  common-test:
+    name: Test the common code
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: make common-test
+
+  api-check:
+    name: Check the generated APIs
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -24,21 +31,11 @@ jobs:
           make gen-all-api
           make cargo-api ARGS=check
           make cargo-api ARGS='check --no-default-features'
-
-          make gen-all-cli
-          make cargo-cli ARGS=check
         env:
           CI: true
 
-  meta-test:
-    name: Test the generative code
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - run: make meta-test
-
-  test:
-    name: Test the generated code
+  api-test:
+    name: Test the generated APIs
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -49,8 +46,8 @@ jobs:
         env:
           CI: true
 
-  document:
-    name: Document the generated code
+  api-document:
+    name: Document the generated APIs
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -62,3 +59,17 @@ jobs:
         env:
           CI: true
           RUSTDOCFLAGS: -A warnings
+
+  cli-check:
+    name: Check the generated CLIs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
+      - run: |
+          make gen-all-api
+          make gen-all-cli
+          make cargo-cli ARGS=check
+          make cargo-cli ARGS='check --no-default-features'
+        env:
+          CI: true

--- a/Makefile
+++ b/Makefile
@@ -93,20 +93,20 @@ license: LICENSE.md
 
 regen-apis: | clean-all-api clean-all-cli gen-all-api gen-all-cli license
 
-meta-test: meta-test-python meta-test-rust
+common-test: common-test-python common-test-rust
 
-meta-test-python: $(PYTHON_BIN)
+common-test-python: $(PYTHON_BIN)
 	PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 $(PYTEST) src
 
-meta-test-rust:
+common-test-rust:
 	cargo test
 
-meta-check: meta-check-python meta-check-rust
+common-check: common-check-python common-check-rust
 
-meta-check-python: $(PYTHON_BIN)
+common-check-python: $(PYTHON_BIN)
 	$(VENV_DIR)/bin/pre-commit run --all-files --show-diff-on-failure
 
-meta-check-rust:
+common-check-rust:
 	cargo clippy -- -D warnings
 
 typecheck: $(PYTHON_BIN)

--- a/google-apis-common/Cargo.toml
+++ b/google-apis-common/Cargo.toml
@@ -19,7 +19,7 @@ chrono = { version = "0.4", default-features = false, features = ["clock", "serd
 http = "1"
 http-body-util = "0.1"
 hyper = { version = "1", features = ["client", "http2"] }
-hyper-util = "0.1"
+hyper-util = { version = "0.1", features = ["client-legacy", "http2"] }
 itertools = "0.13"
 mime = "0.3"
 percent-encoding = "2"

--- a/src/generator/templates/Cargo.toml.mako
+++ b/src/generator/templates/Cargo.toml.mako
@@ -32,7 +32,7 @@ clap = "2"
 http-body-util = "0.1"
 % endif
 hyper = "1"
-hyper-rustls = "0.27"
+hyper-rustls = { version = "0.27", default-features = false }
 hyper-util = "0.1"
 mime = "0.3"
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
Previously, I defined the body to be `Full<Bytes>`, which meant that the response would have to be fully received inside the API functions. However, that seems wasteful if one wants to do some streaming processing of the incoming data. This PR switches over to `http_body_util::combinators::BoxBody`, which is what is [recommended](https://hyper.rs/guides/1/upgrading/) in cases of having to accommodate different response types.