### PR TITLE
fix command-line argument parsing of integers

### DIFF
--- a/google-clis-common/src/lib.rs
+++ b/google-clis-common/src/lib.rs
@@ -279,12 +279,12 @@ impl FieldCursor {
                                 Value::Bool(arg_from_str(value, err, field, "boolean"))
                             }
                             JsonType::Int => Value::Number(
-                                json::Number::from_f64(arg_from_str(value, err, field, "int"))
-                                    .expect("valid f64"),
+                                json::Number::from_i128(arg_from_str(value, err, field, "int"))
+                                    .expect("valid i128"),
                             ),
                             JsonType::Uint => Value::Number(
-                                json::Number::from_f64(arg_from_str(value, err, field, "uint"))
-                                    .expect("valid f64"),
+                                json::Number::from_u128(arg_from_str(value, err, field, "uint"))
+                                    .expect("valid u128"),
                             ),
                             JsonType::Float => Value::Number(
                                 json::Number::from_f64(arg_from_str(value, err, field, "float"))

--- a/src/generator/templates/Cargo.toml.mako
+++ b/src/generator/templates/Cargo.toml.mako
@@ -36,7 +36,7 @@ hyper-rustls = { version = "0.27", default-features = false, features = ["http2"
 hyper-util = "0.1"
 mime = "0.3"
 serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde_json = "1.0.130"
 % if not cargo.get('is_executable'):
 serde_with = "3"
 % endif


### PR DESCRIPTION
This requires serde_json >= 1.0.130 (latest: 1.0.140)

It seems that version of serde_json pinned loosely to "1":

```
src/generator/templates/Cargo.toml.mako:serde_json = "1"
```
Thus, a rebuild should work.

Should I also upgrade to `serde_json = "1.0.130"`?

Closes #542 