### PR TITLE
fix(homegraph1): Un-blacklist by adding 'async' to reserved words

### DIFF
--- a/etc/api/shared.yaml
+++ b/etc/api/shared.yaml
@@ -1,5 +1,7 @@
 api:
   credentials: '{"installed":{"auth_uri":"https://accounts.google.com/o/oauth2/auth","client_secret":"hCsslbCUyfehWMmbkG8vTYxG","token_uri":"https://accounts.google.com/o/oauth2/token","client_email":"","redirect_uris":["urn:ietf:wg:oauth:2.0:oob","oob"],"client_x509_cert_url":"","client_id":"620010449518-9ngf7o4dhs0dka470npqvor6dc5lqb9b.apps.googleusercontent.com","auth_provider_x509_cert_url":"https://www.googleapis.com/oauth2/v1/certs"}}'
+  # exclude APIs which currently don't build correctly. State the reason for the exclusion as well
+  # to allow looking at it at a later point.
   blacklist:
     # recursive type
     - analyticsadmin
@@ -15,8 +17,6 @@ api:
     - trafficdirector
     # Assertion error during generation
     - admin
-    # exclude APIs which currently don't build correctly. State the reason for the exclusion as well
-    # to allow looking at it at a later point.
     # in beta, there is not a single method !
     - dataflow
     # It doesn't generate due to a recursive data structure, that we currently don't handle it seems
@@ -24,8 +24,6 @@ api:
     - civicinfo
     # It seems functions are containing illegal characters, like `@context`
     - kgsearch
-    # Has a struct field called 'async', which is now reserved
-    - homegraph
     - gkehub
     - firebaserules
     - servicemanagement

--- a/gen/homegraph1/Cargo.toml
+++ b/gen/homegraph1/Cargo.toml
@@ -1,0 +1,47 @@
+# DO NOT EDIT !
+# This file was generated automatically from 'src/generator/templates/Cargo.toml.mako'
+# DO NOT EDIT !
+[package]
+
+name = "google-homegraph1"
+version = "7.0.0+20240621"
+authors = ["Sebastian Thiel <byronimo@gmail.com>"]
+description = "A complete library to interact with Home Graph Service (protocol v1)"
+repository = "https://github.com/Byron/google-apis-rs/tree/main/gen/homegraph1"
+homepage = "https://developers.home.google.com/cloud-to-cloud/get-started"
+documentation = "https://docs.rs/google-homegraph1/7.0.0+20240621"
+license = "MIT"
+keywords = ["homegraph", "google", "protocol", "web", "api"]
+autobins = false
+edition = "2021"
+
+
+[dependencies]
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
+hyper = "1"
+hyper-rustls = { version = "0.27", default-features = false, features = ["http2", "rustls-native-certs", "native-tokio"] }
+hyper-util = "0.1"
+mime = "0.3"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1.0.130"
+serde_with = "3"
+tokio = "1"
+url = "2"
+utoipa = { version = "4", optional = true }
+yup-oauth2 = { version = "12", default-features = false, optional = true }
+
+google-apis-common = { path = "../../google-apis-common", version = "8" }
+
+
+
+[features]
+default = ["yup-oauth2", "ring"]
+utoipa = ["dep:utoipa"]
+
+yup-oauth2 = ["dep:yup-oauth2", "google-apis-common/yup-oauth2"]
+
+yup-oauth2-service-account = ["yup-oauth2", "yup-oauth2/service-account", "google-apis-common/yup-oauth2-service-account"]
+
+aws-lc-rs = ["yup-oauth2?/aws-lc-rs", "google-apis-common/aws-lc-rs", "hyper-rustls/aws-lc-rs"]
+
+ring = ["yup-oauth2?/ring", "google-apis-common/ring", "hyper-rustls/ring"]

--- a/gen/homegraph1/LICENSE.md
+++ b/gen/homegraph1/LICENSE.md
@@ -1,0 +1,30 @@
+<!---
+DO NOT EDIT !
+This file was generated automatically from 'src/generator/templates/LICENSE.md.mako'
+DO NOT EDIT !
+-->
+The MIT License (MIT)
+=====================
+
+Copyright 2015–2024 Sebastian Thiel
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the “Software”), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.

--- a/gen/homegraph1/README.md
+++ b/gen/homegraph1/README.md
@@ -1,0 +1,217 @@
+<!---
+DO NOT EDIT !
+This file was generated automatically from 'src/generator/templates/api/README.md.mako'
+DO NOT EDIT !
+-->
+The `google-homegraph1` library allows access to all features of the *Google Home Graph Service* service.
+
+This documentation was generated from *Home Graph Service* crate version *7.0.0+20240621*, where *20240621* is the exact revision of the *homegraph:v1* schema built by the [mako](http://www.makotemplates.org/) code generator *v7.0.0*.
+
+Everything else about the *Home Graph Service* *v1* API can be found at the
+[official documentation site](https://developers.home.google.com/cloud-to-cloud/get-started).
+# Features
+
+Handle the following *Resources* with ease from the central [hub](https://docs.rs/google-homegraph1/7.0.0+20240621/google_homegraph1/HomeGraphService) ...
+
+* agent users
+ * [*delete*](https://docs.rs/google-homegraph1/7.0.0+20240621/google_homegraph1/api::AgentUserDeleteCall)
+* [devices](https://docs.rs/google-homegraph1/7.0.0+20240621/google_homegraph1/api::Device)
+ * [*query*](https://docs.rs/google-homegraph1/7.0.0+20240621/google_homegraph1/api::DeviceQueryCall), [*report state and notification*](https://docs.rs/google-homegraph1/7.0.0+20240621/google_homegraph1/api::DeviceReportStateAndNotificationCall), [*request sync*](https://docs.rs/google-homegraph1/7.0.0+20240621/google_homegraph1/api::DeviceRequestSyncCall) and [*sync*](https://docs.rs/google-homegraph1/7.0.0+20240621/google_homegraph1/api::DeviceSyncCall)
+
+
+
+
+# Structure of this Library
+
+The API is structured into the following primary items:
+
+* **[Hub](https://docs.rs/google-homegraph1/7.0.0+20240621/google_homegraph1/HomeGraphService)**
+    * a central object to maintain state and allow accessing all *Activities*
+    * creates [*Method Builders*](https://docs.rs/google-homegraph1/7.0.0+20240621/google_homegraph1/common::MethodsBuilder) which in turn
+      allow access to individual [*Call Builders*](https://docs.rs/google-homegraph1/7.0.0+20240621/google_homegraph1/common::CallBuilder)
+* **[Resources](https://docs.rs/google-homegraph1/7.0.0+20240621/google_homegraph1/common::Resource)**
+    * primary types that you can apply *Activities* to
+    * a collection of properties and *Parts*
+    * **[Parts](https://docs.rs/google-homegraph1/7.0.0+20240621/google_homegraph1/common::Part)**
+        * a collection of properties
+        * never directly used in *Activities*
+* **[Activities](https://docs.rs/google-homegraph1/7.0.0+20240621/google_homegraph1/common::CallBuilder)**
+    * operations to apply to *Resources*
+
+All *structures* are marked with applicable traits to further categorize them and ease browsing.
+
+Generally speaking, you can invoke *Activities* like this:
+
+```Rust,ignore
+let r = hub.resource().activity(...).doit().await
+```
+
+Or specifically ...
+
+```ignore
+let r = hub.devices().query(...).doit().await
+let r = hub.devices().report_state_and_notification(...).doit().await
+let r = hub.devices().request_sync(...).doit().await
+let r = hub.devices().sync(...).doit().await
+```
+
+The `resource()` and `activity(...)` calls create [builders][builder-pattern]. The second one dealing with `Activities`
+supports various methods to configure the impending operation (not shown here). It is made such that all required arguments have to be
+specified right away (i.e. `(...)`), whereas all optional ones can be [build up][builder-pattern] as desired.
+The `doit()` method performs the actual communication with the server and returns the respective result.
+
+# Usage
+
+## Setting up your Project
+
+To use this library, you would put the following lines into your `Cargo.toml` file:
+
+```toml
+[dependencies]
+google-homegraph1 = "*"
+serde = "1"
+serde_json = "1"
+```
+
+## A complete example
+
+```Rust
+extern crate hyper;
+extern crate hyper_rustls;
+extern crate google_homegraph1 as homegraph1;
+use homegraph1::api::QueryRequest;
+use homegraph1::{Result, Error};
+use homegraph1::{HomeGraphService, FieldMask, hyper_rustls, hyper_util, yup_oauth2};
+
+// Get an ApplicationSecret instance by some means. It contains the `client_id` and
+// `client_secret`, among other things.
+let secret: yup_oauth2::ApplicationSecret = Default::default();
+// Instantiate the authenticator. It will choose a suitable authentication flow for you,
+// unless you replace  `None` with the desired Flow.
+// Provide your own `AuthenticatorDelegate` to adjust the way it operates and get feedback about
+// what's going on. You probably want to bring in your own `TokenStorage` to persist tokens and
+// retrieve them from storage.
+let connector = hyper_rustls::HttpsConnectorBuilder::new()
+    .with_native_roots()
+    .unwrap()
+    .https_only()
+    .enable_http2()
+    .build();
+
+let executor = hyper_util::rt::TokioExecutor::new();
+let auth = yup_oauth2::InstalledFlowAuthenticator::with_client(
+    secret,
+    yup_oauth2::InstalledFlowReturnMethod::HTTPRedirect,
+    yup_oauth2::client::CustomHyperClientBuilder::from(
+        hyper_util::client::legacy::Client::builder(executor).build(connector),
+    ),
+).build().await.unwrap();
+
+let client = hyper_util::client::legacy::Client::builder(
+    hyper_util::rt::TokioExecutor::new()
+)
+.build(
+    hyper_rustls::HttpsConnectorBuilder::new()
+        .with_native_roots()
+        .unwrap()
+        .https_or_http()
+        .enable_http2()
+        .build()
+);
+let mut hub = HomeGraphService::new(client, auth);
+// As the method needs a request, you would usually fill it with the desired information
+// into the respective structure. Some of the parts shown here might not be applicable !
+// Values shown here are possibly random and not representative !
+let mut req = QueryRequest::default();
+
+// You can configure optional parameters by calling the respective setters at will, and
+// execute the final call using `doit()`.
+// Values shown here are possibly random and not representative !
+let result = hub.devices().query(req)
+             .doit().await;
+
+match result {
+    Err(e) => match e {
+        // The Error enum provides details about what exactly happened.
+        // You can also just use its `Debug`, `Display` or `Error` traits
+         Error::HttpError(_)
+        |Error::Io(_)
+        |Error::MissingAPIKey
+        |Error::MissingToken(_)
+        |Error::Cancelled
+        |Error::UploadSizeLimitExceeded(_, _)
+        |Error::Failure(_)
+        |Error::BadRequest(_)
+        |Error::FieldClash(_)
+        |Error::JsonDecodeError(_, _) => println!("{}", e),
+    },
+    Ok(res) => println!("Success: {:?}", res),
+}
+
+```
+## Handling Errors
+
+All errors produced by the system are provided either as [Result](https://docs.rs/google-homegraph1/7.0.0+20240621/google_homegraph1/common::Result) enumeration as return value of
+the doit() methods, or handed as possibly intermediate results to either the
+[Hub Delegate](https://docs.rs/google-homegraph1/7.0.0+20240621/google_homegraph1/common::Delegate), or the [Authenticator Delegate](https://docs.rs/yup-oauth2/*/yup_oauth2/trait.AuthenticatorDelegate.html).
+
+When delegates handle errors or intermediate values, they may have a chance to instruct the system to retry. This
+makes the system potentially resilient to all kinds of errors.
+
+## Uploads and Downloads
+If a method supports downloads, the response body, which is part of the [Result](https://docs.rs/google-homegraph1/7.0.0+20240621/google_homegraph1/common::Result), should be
+read by you to obtain the media.
+If such a method also supports a [Response Result](https://docs.rs/google-homegraph1/7.0.0+20240621/google_homegraph1/common::ResponseResult), it will return that by default.
+You can see it as meta-data for the actual media. To trigger a media download, you will have to set up the builder by making
+this call: `.param("alt", "media")`.
+
+Methods supporting uploads can do so using up to 2 different protocols:
+*simple* and *resumable*. The distinctiveness of each is represented by customized
+`doit(...)` methods, which are then named `upload(...)` and `upload_resumable(...)` respectively.
+
+## Customization and Callbacks
+
+You may alter the way an `doit()` method is called by providing a [delegate](https://docs.rs/google-homegraph1/7.0.0+20240621/google_homegraph1/common::Delegate) to the
+[Method Builder](https://docs.rs/google-homegraph1/7.0.0+20240621/google_homegraph1/common::CallBuilder) before making the final `doit()` call.
+Respective methods will be called to provide progress information, as well as determine whether the system should
+retry on failure.
+
+The [delegate trait](https://docs.rs/google-homegraph1/7.0.0+20240621/google_homegraph1/common::Delegate) is default-implemented, allowing you to customize it with minimal effort.
+
+## Optional Parts in Server-Requests
+
+All structures provided by this library are made to be [encodable](https://docs.rs/google-homegraph1/7.0.0+20240621/google_homegraph1/common::RequestValue) and
+[decodable](https://docs.rs/google-homegraph1/7.0.0+20240621/google_homegraph1/common::ResponseResult) via *json*. Optionals are used to indicate that partial requests are responses
+are valid.
+Most optionals are are considered [Parts](https://docs.rs/google-homegraph1/7.0.0+20240621/google_homegraph1/common::Part) which are identifiable by name, which will be sent to
+the server to indicate either the set parts of the request or the desired parts in the response.
+
+## Builder Arguments
+
+Using [method builders](https://docs.rs/google-homegraph1/7.0.0+20240621/google_homegraph1/common::CallBuilder), you are able to prepare an action call by repeatedly calling it's methods.
+These will always take a single argument, for which the following statements are true.
+
+* [PODs][wiki-pod] are handed by copy
+* strings are passed as `&str`
+* [request values](https://docs.rs/google-homegraph1/7.0.0+20240621/google_homegraph1/common::RequestValue) are moved
+
+Arguments will always be copied or cloned into the builder, to make them independent of their original life times.
+
+[wiki-pod]: http://en.wikipedia.org/wiki/Plain_old_data_structure
+[builder-pattern]: http://en.wikipedia.org/wiki/Builder_pattern
+[google-go-api]: https://github.com/google/google-api-go-client
+
+## Cargo Features
+
+* `utoipa` - Add support for [utoipa](https://crates.io/crates/utoipa) and derive `utoipa::ToSchema` on all
+the types. You'll have to import and register the required types in `#[openapi(schemas(...))]`, otherwise the
+generated `openapi` spec would be invalid.
+
+
+# License
+The **homegraph1** library was generated by Sebastian Thiel, and is placed
+under the *MIT* license.
+You can read the full text at the repository's [license file][repo-license].
+
+[repo-license]: https://github.com/Byron/google-apis-rsblob/main/LICENSE.md
+

--- a/gen/homegraph1/src/api.rs
+++ b/gen/homegraph1/src/api.rs
@@ -1,0 +1,2358 @@
+#![allow(clippy::ptr_arg)]
+
+use std::collections::{BTreeSet, HashMap};
+
+use tokio::time::sleep;
+
+// ##############
+// UTILITIES ###
+// ############
+
+/// Identifies the an OAuth2 authorization scope.
+/// A scope is needed when requesting an
+/// [authorization token](https://developers.google.com/youtube/v3/guides/authentication).
+#[derive(PartialEq, Eq, Ord, PartialOrd, Hash, Debug, Clone, Copy)]
+pub enum Scope {
+    /// Private Service: https://www.googleapis.com/auth/homegraph
+    Full,
+}
+
+impl AsRef<str> for Scope {
+    fn as_ref(&self) -> &str {
+        match *self {
+            Scope::Full => "https://www.googleapis.com/auth/homegraph",
+        }
+    }
+}
+
+#[allow(clippy::derivable_impls)]
+impl Default for Scope {
+    fn default() -> Scope {
+        Scope::Full
+    }
+}
+
+// ########
+// HUB ###
+// ######
+
+/// Central instance to access all HomeGraphService related resource activities
+///
+/// # Examples
+///
+/// Instantiate a new hub
+///
+/// ```test_harness,no_run
+/// extern crate hyper;
+/// extern crate hyper_rustls;
+/// extern crate google_homegraph1 as homegraph1;
+/// use homegraph1::api::QueryRequest;
+/// use homegraph1::{Result, Error};
+/// # async fn dox() {
+/// use homegraph1::{HomeGraphService, FieldMask, hyper_rustls, hyper_util, yup_oauth2};
+///
+/// // Get an ApplicationSecret instance by some means. It contains the `client_id` and
+/// // `client_secret`, among other things.
+/// let secret: yup_oauth2::ApplicationSecret = Default::default();
+/// // Instantiate the authenticator. It will choose a suitable authentication flow for you,
+/// // unless you replace  `None` with the desired Flow.
+/// // Provide your own `AuthenticatorDelegate` to adjust the way it operates and get feedback about
+/// // what's going on. You probably want to bring in your own `TokenStorage` to persist tokens and
+/// // retrieve them from storage.
+/// let connector = hyper_rustls::HttpsConnectorBuilder::new()
+///     .with_native_roots()
+///     .unwrap()
+///     .https_only()
+///     .enable_http2()
+///     .build();
+///
+/// let executor = hyper_util::rt::TokioExecutor::new();
+/// let auth = yup_oauth2::InstalledFlowAuthenticator::with_client(
+///     secret,
+///     yup_oauth2::InstalledFlowReturnMethod::HTTPRedirect,
+///     yup_oauth2::client::CustomHyperClientBuilder::from(
+///         hyper_util::client::legacy::Client::builder(executor).build(connector),
+///     ),
+/// ).build().await.unwrap();
+///
+/// let client = hyper_util::client::legacy::Client::builder(
+///     hyper_util::rt::TokioExecutor::new()
+/// )
+/// .build(
+///     hyper_rustls::HttpsConnectorBuilder::new()
+///         .with_native_roots()
+///         .unwrap()
+///         .https_or_http()
+///         .enable_http2()
+///         .build()
+/// );
+/// let mut hub = HomeGraphService::new(client, auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = QueryRequest::default();
+///
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.devices().query(req)
+///              .doit().await;
+///
+/// match result {
+///     Err(e) => match e {
+///         // The Error enum provides details about what exactly happened.
+///         // You can also just use its `Debug`, `Display` or `Error` traits
+///          Error::HttpError(_)
+///         |Error::Io(_)
+///         |Error::MissingAPIKey
+///         |Error::MissingToken(_)
+///         |Error::Cancelled
+///         |Error::UploadSizeLimitExceeded(_, _)
+///         |Error::Failure(_)
+///         |Error::BadRequest(_)
+///         |Error::FieldClash(_)
+///         |Error::JsonDecodeError(_, _) => println!("{}", e),
+///     },
+///     Ok(res) => println!("Success: {:?}", res),
+/// }
+/// # }
+/// ```
+#[derive(Clone)]
+pub struct HomeGraphService<C> {
+    pub client: common::Client<C>,
+    pub auth: Box<dyn common::GetToken>,
+    _user_agent: String,
+    _base_url: String,
+    _root_url: String,
+}
+
+impl<C> common::Hub for HomeGraphService<C> {}
+
+impl<'a, C> HomeGraphService<C> {
+    pub fn new<A: 'static + common::GetToken>(
+        client: common::Client<C>,
+        auth: A,
+    ) -> HomeGraphService<C> {
+        HomeGraphService {
+            client,
+            auth: Box::new(auth),
+            _user_agent: "google-api-rust-client/7.0.0".to_string(),
+            _base_url: "https://homegraph.googleapis.com/".to_string(),
+            _root_url: "https://homegraph.googleapis.com/".to_string(),
+        }
+    }
+
+    pub fn agent_users(&'a self) -> AgentUserMethods<'a, C> {
+        AgentUserMethods { hub: self }
+    }
+    pub fn devices(&'a self) -> DeviceMethods<'a, C> {
+        DeviceMethods { hub: self }
+    }
+
+    /// Set the user-agent header field to use in all requests to the server.
+    /// It defaults to `google-api-rust-client/7.0.0`.
+    ///
+    /// Returns the previously set user-agent.
+    pub fn user_agent(&mut self, agent_name: String) -> String {
+        std::mem::replace(&mut self._user_agent, agent_name)
+    }
+
+    /// Set the base url to use in all requests to the server.
+    /// It defaults to `https://homegraph.googleapis.com/`.
+    ///
+    /// Returns the previously set base url.
+    pub fn base_url(&mut self, new_base_url: String) -> String {
+        std::mem::replace(&mut self._base_url, new_base_url)
+    }
+
+    /// Set the root url to use in all requests to the server.
+    /// It defaults to `https://homegraph.googleapis.com/`.
+    ///
+    /// Returns the previously set root url.
+    pub fn root_url(&mut self, new_root_url: String) -> String {
+        std::mem::replace(&mut self._root_url, new_root_url)
+    }
+}
+
+// ############
+// SCHEMAS ###
+// ##########
+/// Third-party device ID for one device.
+///
+/// This type is not used in any activity, and only used as *part* of another schema.
+///
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[serde_with::serde_as]
+#[derive(Default, Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct AgentDeviceId {
+    /// Third-party device ID.
+    pub id: Option<String>,
+}
+
+impl common::Part for AgentDeviceId {}
+
+/// Alternate third-party device ID.
+///
+/// This type is not used in any activity, and only used as *part* of another schema.
+///
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[serde_with::serde_as]
+#[derive(Default, Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct AgentOtherDeviceId {
+    /// Project ID for your smart home Action.
+    #[serde(rename = "agentId")]
+    pub agent_id: Option<String>,
+    /// Unique third-party device ID.
+    #[serde(rename = "deviceId")]
+    pub device_id: Option<String>,
+}
+
+impl common::Part for AgentOtherDeviceId {}
+
+/// Third-party device definition.
+///
+/// # Activities
+///
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in.
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+///
+/// * [query devices](DeviceQueryCall) (none)
+/// * [report state and notification devices](DeviceReportStateAndNotificationCall) (none)
+/// * [request sync devices](DeviceRequestSyncCall) (none)
+/// * [sync devices](DeviceSyncCall) (none)
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[serde_with::serde_as]
+#[derive(Default, Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct Device {
+    /// Attributes for the traits supported by the device.
+    pub attributes: Option<HashMap<String, serde_json::Value>>,
+    /// Custom device attributes stored in Home Graph and provided to your smart home Action in each [QUERY](https://developers.home.google.com/cloud-to-cloud/intents/query) and [EXECUTE](https://developers.home.google.com/cloud-to-cloud/intents/execute) intent. Data in this object has a few constraints: No sensitive information, including but not limited to Personally Identifiable Information.
+    #[serde(rename = "customData")]
+    pub custom_data: Option<HashMap<String, serde_json::Value>>,
+    /// Device manufacturer, model, hardware version, and software version.
+    #[serde(rename = "deviceInfo")]
+    pub device_info: Option<DeviceInfo>,
+    /// Third-party device ID.
+    pub id: Option<String>,
+    /// Names given to this device by your smart home Action.
+    pub name: Option<DeviceNames>,
+    /// Indicates whether your smart home Action will report notifications to Google for this device via ReportStateAndNotification. If your smart home Action enables users to control device notifications, you should update this field and call RequestSyncDevices.
+    #[serde(rename = "notificationSupportedByAgent")]
+    pub notification_supported_by_agent: Option<bool>,
+    /// Alternate IDs associated with this device. This is used to identify cloud synced devices enabled for [local fulfillment](https://developers.home.google.com/local-home/overview).
+    #[serde(rename = "otherDeviceIds")]
+    pub other_device_ids: Option<Vec<AgentOtherDeviceId>>,
+    /// Suggested name for the room where this device is installed. Google attempts to use this value during user setup.
+    #[serde(rename = "roomHint")]
+    pub room_hint: Option<String>,
+    /// Suggested name for the structure where this device is installed. Google attempts to use this value during user setup.
+    #[serde(rename = "structureHint")]
+    pub structure_hint: Option<String>,
+    /// Traits supported by the device. See [device traits](https://developers.home.google.com/cloud-to-cloud/traits).
+    pub traits: Option<Vec<String>>,
+    /// Hardware type of the device. See [device types](https://developers.home.google.com/cloud-to-cloud/guides).
+    #[serde(rename = "type")]
+    pub type_: Option<String>,
+    /// Indicates whether your smart home Action will report state of this device to Google via ReportStateAndNotification.
+    #[serde(rename = "willReportState")]
+    pub will_report_state: Option<bool>,
+}
+
+impl common::Resource for Device {}
+
+/// Device information.
+///
+/// This type is not used in any activity, and only used as *part* of another schema.
+///
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[serde_with::serde_as]
+#[derive(Default, Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct DeviceInfo {
+    /// Device hardware version.
+    #[serde(rename = "hwVersion")]
+    pub hw_version: Option<String>,
+    /// Device manufacturer.
+    pub manufacturer: Option<String>,
+    /// Device model.
+    pub model: Option<String>,
+    /// Device software version.
+    #[serde(rename = "swVersion")]
+    pub sw_version: Option<String>,
+}
+
+impl common::Part for DeviceInfo {}
+
+/// Identifiers used to describe the device.
+///
+/// This type is not used in any activity, and only used as *part* of another schema.
+///
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[serde_with::serde_as]
+#[derive(Default, Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct DeviceNames {
+    /// List of names provided by the manufacturer rather than the user, such as serial numbers, SKUs, etc.
+    #[serde(rename = "defaultNames")]
+    pub default_names: Option<Vec<String>>,
+    /// Primary name of the device, generally provided by the user.
+    pub name: Option<String>,
+    /// Additional names provided by the user for the device.
+    pub nicknames: Option<Vec<String>>,
+}
+
+impl common::Part for DeviceNames {}
+
+/// A generic empty message that you can re-use to avoid defining duplicated empty messages in your APIs. A typical example is to use it as the request or the response type of an API method. For instance: service Foo { rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty); }
+///
+/// # Activities
+///
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in.
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+///
+/// * [delete agent users](AgentUserDeleteCall) (response)
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[serde_with::serde_as]
+#[derive(Default, Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct Empty {
+    _never_set: Option<bool>,
+}
+
+impl common::ResponseResult for Empty {}
+
+/// Request type for the [`Query`](#google.home.graph.v1.HomeGraphApiService.Query) call.
+///
+/// # Activities
+///
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in.
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+///
+/// * [query devices](DeviceQueryCall) (request)
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[serde_with::serde_as]
+#[derive(Default, Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct QueryRequest {
+    /// Required. Third-party user ID.
+    #[serde(rename = "agentUserId")]
+    pub agent_user_id: Option<String>,
+    /// Required. Inputs containing third-party device IDs for which to get the device states.
+    pub inputs: Option<Vec<QueryRequestInput>>,
+    /// Request ID used for debugging.
+    #[serde(rename = "requestId")]
+    pub request_id: Option<String>,
+}
+
+impl common::RequestValue for QueryRequest {}
+
+/// Device ID inputs to QueryRequest.
+///
+/// This type is not used in any activity, and only used as *part* of another schema.
+///
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[serde_with::serde_as]
+#[derive(Default, Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct QueryRequestInput {
+    /// Payload containing third-party device IDs.
+    pub payload: Option<QueryRequestPayload>,
+}
+
+impl common::Part for QueryRequestInput {}
+
+/// Payload containing device IDs.
+///
+/// This type is not used in any activity, and only used as *part* of another schema.
+///
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[serde_with::serde_as]
+#[derive(Default, Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct QueryRequestPayload {
+    /// Third-party device IDs for which to get the device states.
+    pub devices: Option<Vec<AgentDeviceId>>,
+}
+
+impl common::Part for QueryRequestPayload {}
+
+/// Response type for the [`Query`](#google.home.graph.v1.HomeGraphApiService.Query) call. This should follow the same format as the Google smart home `action.devices.QUERY` [response](https://developers.home.google.com/cloud-to-cloud/intents/query). Example: `json { "requestId": "ff36a3cc-ec34-11e6-b1a0-64510650abcf", "payload": { "devices": { "123": { "on": true, "online": true }, "456": { "on": true, "online": true, "brightness": 80, "color": { "name": "cerulean", "spectrumRGB": 31655 } } } } } `
+///
+/// # Activities
+///
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in.
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+///
+/// * [query devices](DeviceQueryCall) (response)
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[serde_with::serde_as]
+#[derive(Default, Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct QueryResponse {
+    /// Device states for the devices given in the request.
+    pub payload: Option<QueryResponsePayload>,
+    /// Request ID used for debugging. Copied from the request.
+    #[serde(rename = "requestId")]
+    pub request_id: Option<String>,
+}
+
+impl common::ResponseResult for QueryResponse {}
+
+/// Payload containing device states information.
+///
+/// This type is not used in any activity, and only used as *part* of another schema.
+///
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[serde_with::serde_as]
+#[derive(Default, Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct QueryResponsePayload {
+    /// States of the devices. Map of third-party device ID to struct of device states.
+    pub devices: Option<HashMap<String, HashMap<String, serde_json::Value>>>,
+}
+
+impl common::Part for QueryResponsePayload {}
+
+/// The states and notifications specific to a device.
+///
+/// This type is not used in any activity, and only used as *part* of another schema.
+///
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[serde_with::serde_as]
+#[derive(Default, Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct ReportStateAndNotificationDevice {
+    /// Notifications metadata for devices. See the **Device NOTIFICATIONS** section of the individual trait [reference guides](https://developers.home.google.com/cloud-to-cloud/traits).
+    pub notifications: Option<HashMap<String, serde_json::Value>>,
+    /// States of devices to update. See the **Device STATES** section of the individual trait [reference guides](https://developers.home.google.com/cloud-to-cloud/traits).
+    pub states: Option<HashMap<String, serde_json::Value>>,
+}
+
+impl common::Part for ReportStateAndNotificationDevice {}
+
+/// Request type for the [`ReportStateAndNotification`](#google.home.graph.v1.HomeGraphApiService.ReportStateAndNotification) call. It may include states, notifications, or both. States and notifications are defined per `device_id` (for example, “123” and “456” in the following example). Example: `json { "requestId": "ff36a3cc-ec34-11e6-b1a0-64510650abcf", "agentUserId": "1234", "payload": { "devices": { "states": { "123": { "on": true }, "456": { "on": true, "brightness": 10 } }, } } } `
+///
+/// # Activities
+///
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in.
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+///
+/// * [report state and notification devices](DeviceReportStateAndNotificationCall) (request)
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[serde_with::serde_as]
+#[derive(Default, Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct ReportStateAndNotificationRequest {
+    /// Required. Third-party user ID.
+    #[serde(rename = "agentUserId")]
+    pub agent_user_id: Option<String>,
+    /// Unique identifier per event (for example, a doorbell press).
+    #[serde(rename = "eventId")]
+    pub event_id: Option<String>,
+    /// Deprecated.
+    #[serde(rename = "followUpToken")]
+    pub follow_up_token: Option<String>,
+    /// Required. State of devices to update and notification metadata for devices.
+    pub payload: Option<StateAndNotificationPayload>,
+    /// Request ID used for debugging.
+    #[serde(rename = "requestId")]
+    pub request_id: Option<String>,
+}
+
+impl common::RequestValue for ReportStateAndNotificationRequest {}
+
+/// Response type for the [`ReportStateAndNotification`](#google.home.graph.v1.HomeGraphApiService.ReportStateAndNotification) call.
+///
+/// # Activities
+///
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in.
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+///
+/// * [report state and notification devices](DeviceReportStateAndNotificationCall) (response)
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[serde_with::serde_as]
+#[derive(Default, Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct ReportStateAndNotificationResponse {
+    /// Request ID copied from ReportStateAndNotificationRequest.
+    #[serde(rename = "requestId")]
+    pub request_id: Option<String>,
+}
+
+impl common::ResponseResult for ReportStateAndNotificationResponse {}
+
+/// Request type for the [`RequestSyncDevices`](#google.home.graph.v1.HomeGraphApiService.RequestSyncDevices) call.
+///
+/// # Activities
+///
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in.
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+///
+/// * [request sync devices](DeviceRequestSyncCall) (request)
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[serde_with::serde_as]
+#[derive(Default, Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct RequestSyncDevicesRequest {
+    /// Required. Third-party user ID.
+    #[serde(rename = "agentUserId")]
+    pub agent_user_id: Option<String>,
+    /// Optional. If set, the request will be added to a queue and a response will be returned immediately. This enables concurrent requests for the given `agent_user_id`, but the caller will not receive any error responses.
+    #[serde(rename = "async")]
+    pub async_: Option<bool>,
+}
+
+impl common::RequestValue for RequestSyncDevicesRequest {}
+
+/// Response type for the [`RequestSyncDevices`](#google.home.graph.v1.HomeGraphApiService.RequestSyncDevices) call. Intentionally empty upon success. An HTTP response code is returned with more details upon failure.
+///
+/// # Activities
+///
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in.
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+///
+/// * [request sync devices](DeviceRequestSyncCall) (response)
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[serde_with::serde_as]
+#[derive(Default, Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct RequestSyncDevicesResponse {
+    _never_set: Option<bool>,
+}
+
+impl common::ResponseResult for RequestSyncDevicesResponse {}
+
+/// Payload containing the state and notification information for devices.
+///
+/// This type is not used in any activity, and only used as *part* of another schema.
+///
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[serde_with::serde_as]
+#[derive(Default, Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct StateAndNotificationPayload {
+    /// The devices for updating state and sending notifications.
+    pub devices: Option<ReportStateAndNotificationDevice>,
+}
+
+impl common::Part for StateAndNotificationPayload {}
+
+/// Request type for the [`Sync`](#google.home.graph.v1.HomeGraphApiService.Sync) call.
+///
+/// # Activities
+///
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in.
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+///
+/// * [sync devices](DeviceSyncCall) (request)
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[serde_with::serde_as]
+#[derive(Default, Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct SyncRequest {
+    /// Required. Third-party user ID.
+    #[serde(rename = "agentUserId")]
+    pub agent_user_id: Option<String>,
+    /// Request ID used for debugging.
+    #[serde(rename = "requestId")]
+    pub request_id: Option<String>,
+}
+
+impl common::RequestValue for SyncRequest {}
+
+/// Response type for the [`Sync`](#google.home.graph.v1.HomeGraphApiService.Sync) call. This should follow the same format as the Google smart home `action.devices.SYNC` [response](https://developers.home.google.com/cloud-to-cloud/intents/sync). Example: `json { "requestId": "ff36a3cc-ec34-11e6-b1a0-64510650abcf", "payload": { "agentUserId": "1836.15267389", "devices": [{ "id": "123", "type": "action.devices.types.OUTLET", "traits": [ "action.devices.traits.OnOff" ], "name": { "defaultNames": ["My Outlet 1234"], "name": "Night light", "nicknames": ["wall plug"] }, "willReportState": false, "deviceInfo": { "manufacturer": "lights-out-inc", "model": "hs1234", "hwVersion": "3.2", "swVersion": "11.4" }, "customData": { "fooValue": 74, "barValue": true, "bazValue": "foo" } }] } } `
+///
+/// # Activities
+///
+/// This type is used in activities, which are methods you may call on this type or where this type is involved in.
+/// The list links the activity name, along with information about where it is used (one of *request* and *response*).
+///
+/// * [sync devices](DeviceSyncCall) (response)
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[serde_with::serde_as]
+#[derive(Default, Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct SyncResponse {
+    /// Devices associated with the third-party user.
+    pub payload: Option<SyncResponsePayload>,
+    /// Request ID used for debugging. Copied from the request.
+    #[serde(rename = "requestId")]
+    pub request_id: Option<String>,
+}
+
+impl common::ResponseResult for SyncResponse {}
+
+/// Payload containing device information.
+///
+/// This type is not used in any activity, and only used as *part* of another schema.
+///
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[serde_with::serde_as]
+#[derive(Default, Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct SyncResponsePayload {
+    /// Third-party user ID
+    #[serde(rename = "agentUserId")]
+    pub agent_user_id: Option<String>,
+    /// Devices associated with the third-party user.
+    pub devices: Option<Vec<Device>>,
+}
+
+impl common::Part for SyncResponsePayload {}
+
+// ###################
+// MethodBuilders ###
+// #################
+
+/// A builder providing access to all methods supported on *agentUser* resources.
+/// It is not used directly, but through the [`HomeGraphService`] hub.
+///
+/// # Example
+///
+/// Instantiate a resource builder
+///
+/// ```test_harness,no_run
+/// extern crate hyper;
+/// extern crate hyper_rustls;
+/// extern crate google_homegraph1 as homegraph1;
+///
+/// # async fn dox() {
+/// use homegraph1::{HomeGraphService, FieldMask, hyper_rustls, hyper_util, yup_oauth2};
+///
+/// let secret: yup_oauth2::ApplicationSecret = Default::default();
+/// let connector = hyper_rustls::HttpsConnectorBuilder::new()
+///     .with_native_roots()
+///     .unwrap()
+///     .https_only()
+///     .enable_http2()
+///     .build();
+///
+/// let executor = hyper_util::rt::TokioExecutor::new();
+/// let auth = yup_oauth2::InstalledFlowAuthenticator::with_client(
+///     secret,
+///     yup_oauth2::InstalledFlowReturnMethod::HTTPRedirect,
+///     yup_oauth2::client::CustomHyperClientBuilder::from(
+///         hyper_util::client::legacy::Client::builder(executor).build(connector),
+///     ),
+/// ).build().await.unwrap();
+///
+/// let client = hyper_util::client::legacy::Client::builder(
+///     hyper_util::rt::TokioExecutor::new()
+/// )
+/// .build(
+///     hyper_rustls::HttpsConnectorBuilder::new()
+///         .with_native_roots()
+///         .unwrap()
+///         .https_or_http()
+///         .enable_http2()
+///         .build()
+/// );
+/// let mut hub = HomeGraphService::new(client, auth);
+/// // Usually you wouldn't bind this to a variable, but keep calling *CallBuilders*
+/// // like `delete(...)`
+/// // to build up your call.
+/// let rb = hub.agent_users();
+/// # }
+/// ```
+pub struct AgentUserMethods<'a, C>
+where
+    C: 'a,
+{
+    hub: &'a HomeGraphService<C>,
+}
+
+impl<'a, C> common::MethodsBuilder for AgentUserMethods<'a, C> {}
+
+impl<'a, C> AgentUserMethods<'a, C> {
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Unlinks the given third-party user from your smart home Action. All data related to this user will be deleted. For more details on how users link their accounts, see [fulfillment and authentication](https://developers.home.google.com/cloud-to-cloud/primer/fulfillment). The third-party user's identity is passed in via the `agent_user_id` (see DeleteAgentUserRequest). This request must be authorized using service account credentials from your Actions console project.
+    ///
+    /// # Arguments
+    ///
+    /// * `agentUserId` - Required. Third-party user ID.
+    pub fn delete(&self, agent_user_id: &str) -> AgentUserDeleteCall<'a, C> {
+        AgentUserDeleteCall {
+            hub: self.hub,
+            _agent_user_id: agent_user_id.to_string(),
+            _request_id: Default::default(),
+            _delegate: Default::default(),
+            _additional_params: Default::default(),
+            _scopes: Default::default(),
+        }
+    }
+}
+
+/// A builder providing access to all methods supported on *device* resources.
+/// It is not used directly, but through the [`HomeGraphService`] hub.
+///
+/// # Example
+///
+/// Instantiate a resource builder
+///
+/// ```test_harness,no_run
+/// extern crate hyper;
+/// extern crate hyper_rustls;
+/// extern crate google_homegraph1 as homegraph1;
+///
+/// # async fn dox() {
+/// use homegraph1::{HomeGraphService, FieldMask, hyper_rustls, hyper_util, yup_oauth2};
+///
+/// let secret: yup_oauth2::ApplicationSecret = Default::default();
+/// let connector = hyper_rustls::HttpsConnectorBuilder::new()
+///     .with_native_roots()
+///     .unwrap()
+///     .https_only()
+///     .enable_http2()
+///     .build();
+///
+/// let executor = hyper_util::rt::TokioExecutor::new();
+/// let auth = yup_oauth2::InstalledFlowAuthenticator::with_client(
+///     secret,
+///     yup_oauth2::InstalledFlowReturnMethod::HTTPRedirect,
+///     yup_oauth2::client::CustomHyperClientBuilder::from(
+///         hyper_util::client::legacy::Client::builder(executor).build(connector),
+///     ),
+/// ).build().await.unwrap();
+///
+/// let client = hyper_util::client::legacy::Client::builder(
+///     hyper_util::rt::TokioExecutor::new()
+/// )
+/// .build(
+///     hyper_rustls::HttpsConnectorBuilder::new()
+///         .with_native_roots()
+///         .unwrap()
+///         .https_or_http()
+///         .enable_http2()
+///         .build()
+/// );
+/// let mut hub = HomeGraphService::new(client, auth);
+/// // Usually you wouldn't bind this to a variable, but keep calling *CallBuilders*
+/// // like `query(...)`, `report_state_and_notification(...)`, `request_sync(...)` and `sync(...)`
+/// // to build up your call.
+/// let rb = hub.devices();
+/// # }
+/// ```
+pub struct DeviceMethods<'a, C>
+where
+    C: 'a,
+{
+    hub: &'a HomeGraphService<C>,
+}
+
+impl<'a, C> common::MethodsBuilder for DeviceMethods<'a, C> {}
+
+impl<'a, C> DeviceMethods<'a, C> {
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Gets the current states in Home Graph for the given set of the third-party user's devices. The third-party user's identity is passed in via the `agent_user_id` (see QueryRequest). This request must be authorized using service account credentials from your Actions console project.
+    ///
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    pub fn query(&self, request: QueryRequest) -> DeviceQueryCall<'a, C> {
+        DeviceQueryCall {
+            hub: self.hub,
+            _request: request,
+            _delegate: Default::default(),
+            _additional_params: Default::default(),
+            _scopes: Default::default(),
+        }
+    }
+
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Reports device state and optionally sends device notifications. Called by your smart home Action when the state of a third-party device changes or you need to send a notification about the device. See [Implement Report State](https://developers.home.google.com/cloud-to-cloud/integration/report-state) for more information. This method updates the device state according to its declared [traits](https://developers.home.google.com/cloud-to-cloud/primer/device-types-and-traits). Publishing a new state value outside of these traits will result in an `INVALID_ARGUMENT` error response. The third-party user's identity is passed in via the `agent_user_id` (see ReportStateAndNotificationRequest). This request must be authorized using service account credentials from your Actions console project.
+    ///
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    pub fn report_state_and_notification(
+        &self,
+        request: ReportStateAndNotificationRequest,
+    ) -> DeviceReportStateAndNotificationCall<'a, C> {
+        DeviceReportStateAndNotificationCall {
+            hub: self.hub,
+            _request: request,
+            _delegate: Default::default(),
+            _additional_params: Default::default(),
+            _scopes: Default::default(),
+        }
+    }
+
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Requests Google to send an `action.devices.SYNC` [intent](https://developers.home.google.com/cloud-to-cloud/intents/sync) to your smart home Action to update device metadata for the given user. The third-party user's identity is passed via the `agent_user_id` (see RequestSyncDevicesRequest). This request must be authorized using service account credentials from your Actions console project.
+    ///
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    pub fn request_sync(&self, request: RequestSyncDevicesRequest) -> DeviceRequestSyncCall<'a, C> {
+        DeviceRequestSyncCall {
+            hub: self.hub,
+            _request: request,
+            _delegate: Default::default(),
+            _additional_params: Default::default(),
+            _scopes: Default::default(),
+        }
+    }
+
+    /// Create a builder to help you perform the following task:
+    ///
+    /// Gets all the devices associated with the given third-party user. The third-party user's identity is passed in via the `agent_user_id` (see SyncRequest). This request must be authorized using service account credentials from your Actions console project.
+    ///
+    /// # Arguments
+    ///
+    /// * `request` - No description provided.
+    pub fn sync(&self, request: SyncRequest) -> DeviceSyncCall<'a, C> {
+        DeviceSyncCall {
+            hub: self.hub,
+            _request: request,
+            _delegate: Default::default(),
+            _additional_params: Default::default(),
+            _scopes: Default::default(),
+        }
+    }
+}
+
+// ###################
+// CallBuilders   ###
+// #################
+
+/// Unlinks the given third-party user from your smart home Action. All data related to this user will be deleted. For more details on how users link their accounts, see [fulfillment and authentication](https://developers.home.google.com/cloud-to-cloud/primer/fulfillment). The third-party user's identity is passed in via the `agent_user_id` (see DeleteAgentUserRequest). This request must be authorized using service account credentials from your Actions console project.
+///
+/// A builder for the *delete* method supported by a *agentUser* resource.
+/// It is not used directly, but through a [`AgentUserMethods`] instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate google_homegraph1 as homegraph1;
+/// # async fn dox() {
+/// # use homegraph1::{HomeGraphService, FieldMask, hyper_rustls, hyper_util, yup_oauth2};
+///
+/// # let secret: yup_oauth2::ApplicationSecret = Default::default();
+/// # let connector = hyper_rustls::HttpsConnectorBuilder::new()
+/// #     .with_native_roots()
+/// #     .unwrap()
+/// #     .https_only()
+/// #     .enable_http2()
+/// #     .build();
+///
+/// # let executor = hyper_util::rt::TokioExecutor::new();
+/// # let auth = yup_oauth2::InstalledFlowAuthenticator::with_client(
+/// #     secret,
+/// #     yup_oauth2::InstalledFlowReturnMethod::HTTPRedirect,
+/// #     yup_oauth2::client::CustomHyperClientBuilder::from(
+/// #         hyper_util::client::legacy::Client::builder(executor).build(connector),
+/// #     ),
+/// # ).build().await.unwrap();
+///
+/// # let client = hyper_util::client::legacy::Client::builder(
+/// #     hyper_util::rt::TokioExecutor::new()
+/// # )
+/// # .build(
+/// #     hyper_rustls::HttpsConnectorBuilder::new()
+/// #         .with_native_roots()
+/// #         .unwrap()
+/// #         .https_or_http()
+/// #         .enable_http2()
+/// #         .build()
+/// # );
+/// # let mut hub = HomeGraphService::new(client, auth);
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.agent_users().delete("agentUserId")
+///              .request_id("magna")
+///              .doit().await;
+/// # }
+/// ```
+pub struct AgentUserDeleteCall<'a, C>
+where
+    C: 'a,
+{
+    hub: &'a HomeGraphService<C>,
+    _agent_user_id: String,
+    _request_id: Option<String>,
+    _delegate: Option<&'a mut dyn common::Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeSet<String>,
+}
+
+impl<'a, C> common::CallBuilder for AgentUserDeleteCall<'a, C> {}
+
+impl<'a, C> AgentUserDeleteCall<'a, C>
+where
+    C: common::Connector,
+{
+    /// Perform the operation you have build so far.
+    pub async fn doit(mut self) -> common::Result<(common::Response, Empty)> {
+        use std::borrow::Cow;
+        use std::io::{Read, Seek};
+
+        use common::{url::Params, ToParts};
+        use hyper::header::{AUTHORIZATION, CONTENT_LENGTH, CONTENT_TYPE, LOCATION, USER_AGENT};
+
+        let mut dd = common::DefaultDelegate;
+        let mut dlg: &mut dyn common::Delegate = self._delegate.unwrap_or(&mut dd);
+        dlg.begin(common::MethodInfo {
+            id: "homegraph.agentUsers.delete",
+            http_method: hyper::Method::DELETE,
+        });
+
+        for &field in ["alt", "agentUserId", "requestId"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(common::Error::FieldClash(field));
+            }
+        }
+
+        let mut params = Params::with_capacity(4 + self._additional_params.len());
+        params.push("agentUserId", self._agent_user_id);
+        if let Some(value) = self._request_id.as_ref() {
+            params.push("requestId", value);
+        }
+
+        params.extend(self._additional_params.iter());
+
+        params.push("alt", "json");
+        let mut url = self.hub._base_url.clone() + "v1/{+agentUserId}";
+        if self._scopes.is_empty() {
+            self._scopes.insert(Scope::Full.as_ref().to_string());
+        }
+
+        #[allow(clippy::single_element_loop)]
+        for &(find_this, param_name) in [("{+agentUserId}", "agentUserId")].iter() {
+            url = params.uri_replacement(url, param_name, find_this, true);
+        }
+        {
+            let to_remove = ["agentUserId"];
+            params.remove_params(&to_remove);
+        }
+
+        let url = params.parse_with_url(&url);
+
+        loop {
+            let token = match self
+                .hub
+                .auth
+                .get_token(&self._scopes.iter().map(String::as_str).collect::<Vec<_>>()[..])
+                .await
+            {
+                Ok(token) => token,
+                Err(e) => match dlg.token(e) {
+                    Ok(token) => token,
+                    Err(e) => {
+                        dlg.finished(false);
+                        return Err(common::Error::MissingToken(e));
+                    }
+                },
+            };
+            let mut req_result = {
+                let client = &self.hub.client;
+                dlg.pre_request();
+                let mut req_builder = hyper::Request::builder()
+                    .method(hyper::Method::DELETE)
+                    .uri(url.as_str())
+                    .header(USER_AGENT, self.hub._user_agent.clone());
+
+                if let Some(token) = token.as_ref() {
+                    req_builder = req_builder.header(AUTHORIZATION, format!("Bearer {}", token));
+                }
+
+                let request = req_builder
+                    .header(CONTENT_LENGTH, 0_u64)
+                    .body(common::to_body::<String>(None));
+
+                client.request(request.unwrap()).await
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let common::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d).await;
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(common::Error::HttpError(err));
+                }
+                Ok(res) => {
+                    let (mut parts, body) = res.into_parts();
+                    let mut body = common::Body::new(body);
+                    if !parts.status.is_success() {
+                        let bytes = common::to_bytes(body).await.unwrap_or_default();
+                        let error = serde_json::from_str(&common::to_string(&bytes));
+                        let response = common::to_response(parts, bytes.into());
+
+                        if let common::Retry::After(d) =
+                            dlg.http_failure(&response, error.as_ref().ok())
+                        {
+                            sleep(d).await;
+                            continue;
+                        }
+
+                        dlg.finished(false);
+
+                        return Err(match error {
+                            Ok(value) => common::Error::BadRequest(value),
+                            _ => common::Error::Failure(response),
+                        });
+                    }
+                    let response = {
+                        let bytes = common::to_bytes(body).await.unwrap_or_default();
+                        let encoded = common::to_string(&bytes);
+                        match serde_json::from_str(&encoded) {
+                            Ok(decoded) => (common::to_response(parts, bytes.into()), decoded),
+                            Err(error) => {
+                                dlg.response_json_decode_error(&encoded, &error);
+                                return Err(common::Error::JsonDecodeError(
+                                    encoded.to_string(),
+                                    error,
+                                ));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(response);
+                }
+            }
+        }
+    }
+
+    /// Required. Third-party user ID.
+    ///
+    /// Sets the *agent user id* path property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn agent_user_id(mut self, new_value: &str) -> AgentUserDeleteCall<'a, C> {
+        self._agent_user_id = new_value.to_string();
+        self
+    }
+    /// Request ID used for debugging.
+    ///
+    /// Sets the *request id* query property to the given value.
+    pub fn request_id(mut self, new_value: &str) -> AgentUserDeleteCall<'a, C> {
+        self._request_id = Some(new_value.to_string());
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    ///
+    /// ````text
+    ///                   It should be used to handle progress information, and to implement a certain level of resilience.
+    /// ````
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(
+        mut self,
+        new_value: &'a mut dyn common::Delegate,
+    ) -> AgentUserDeleteCall<'a, C> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known parameters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *$.xgafv* (query-string) - V1 error format.
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *callback* (query-string) - JSONP
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    pub fn param<T>(mut self, name: T, value: T) -> AgentUserDeleteCall<'a, C>
+    where
+        T: AsRef<str>,
+    {
+        self._additional_params
+            .insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead of the default [`Scope`] variant
+    /// [`Scope::Full`].
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<St>(mut self, scope: St) -> AgentUserDeleteCall<'a, C>
+    where
+        St: AsRef<str>,
+    {
+        self._scopes.insert(String::from(scope.as_ref()));
+        self
+    }
+    /// Identifies the authorization scope(s) for the method you are building.
+    ///
+    /// See [`Self::add_scope()`] for details.
+    pub fn add_scopes<I, St>(mut self, scopes: I) -> AgentUserDeleteCall<'a, C>
+    where
+        I: IntoIterator<Item = St>,
+        St: AsRef<str>,
+    {
+        self._scopes
+            .extend(scopes.into_iter().map(|s| String::from(s.as_ref())));
+        self
+    }
+
+    /// Removes all scopes, and no default scope will be used either.
+    /// In this case, you have to specify your API-key using the `key` parameter (see [`Self::param()`]
+    /// for details).
+    pub fn clear_scopes(mut self) -> AgentUserDeleteCall<'a, C> {
+        self._scopes.clear();
+        self
+    }
+}
+
+/// Gets the current states in Home Graph for the given set of the third-party user's devices. The third-party user's identity is passed in via the `agent_user_id` (see QueryRequest). This request must be authorized using service account credentials from your Actions console project.
+///
+/// A builder for the *query* method supported by a *device* resource.
+/// It is not used directly, but through a [`DeviceMethods`] instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate google_homegraph1 as homegraph1;
+/// use homegraph1::api::QueryRequest;
+/// # async fn dox() {
+/// # use homegraph1::{HomeGraphService, FieldMask, hyper_rustls, hyper_util, yup_oauth2};
+///
+/// # let secret: yup_oauth2::ApplicationSecret = Default::default();
+/// # let connector = hyper_rustls::HttpsConnectorBuilder::new()
+/// #     .with_native_roots()
+/// #     .unwrap()
+/// #     .https_only()
+/// #     .enable_http2()
+/// #     .build();
+///
+/// # let executor = hyper_util::rt::TokioExecutor::new();
+/// # let auth = yup_oauth2::InstalledFlowAuthenticator::with_client(
+/// #     secret,
+/// #     yup_oauth2::InstalledFlowReturnMethod::HTTPRedirect,
+/// #     yup_oauth2::client::CustomHyperClientBuilder::from(
+/// #         hyper_util::client::legacy::Client::builder(executor).build(connector),
+/// #     ),
+/// # ).build().await.unwrap();
+///
+/// # let client = hyper_util::client::legacy::Client::builder(
+/// #     hyper_util::rt::TokioExecutor::new()
+/// # )
+/// # .build(
+/// #     hyper_rustls::HttpsConnectorBuilder::new()
+/// #         .with_native_roots()
+/// #         .unwrap()
+/// #         .https_or_http()
+/// #         .enable_http2()
+/// #         .build()
+/// # );
+/// # let mut hub = HomeGraphService::new(client, auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = QueryRequest::default();
+///
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.devices().query(req)
+///              .doit().await;
+/// # }
+/// ```
+pub struct DeviceQueryCall<'a, C>
+where
+    C: 'a,
+{
+    hub: &'a HomeGraphService<C>,
+    _request: QueryRequest,
+    _delegate: Option<&'a mut dyn common::Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeSet<String>,
+}
+
+impl<'a, C> common::CallBuilder for DeviceQueryCall<'a, C> {}
+
+impl<'a, C> DeviceQueryCall<'a, C>
+where
+    C: common::Connector,
+{
+    /// Perform the operation you have build so far.
+    pub async fn doit(mut self) -> common::Result<(common::Response, QueryResponse)> {
+        use std::borrow::Cow;
+        use std::io::{Read, Seek};
+
+        use common::{url::Params, ToParts};
+        use hyper::header::{AUTHORIZATION, CONTENT_LENGTH, CONTENT_TYPE, LOCATION, USER_AGENT};
+
+        let mut dd = common::DefaultDelegate;
+        let mut dlg: &mut dyn common::Delegate = self._delegate.unwrap_or(&mut dd);
+        dlg.begin(common::MethodInfo {
+            id: "homegraph.devices.query",
+            http_method: hyper::Method::POST,
+        });
+
+        for &field in ["alt"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(common::Error::FieldClash(field));
+            }
+        }
+
+        let mut params = Params::with_capacity(3 + self._additional_params.len());
+
+        params.extend(self._additional_params.iter());
+
+        params.push("alt", "json");
+        let mut url = self.hub._base_url.clone() + "v1/devices:query";
+        if self._scopes.is_empty() {
+            self._scopes.insert(Scope::Full.as_ref().to_string());
+        }
+
+        let url = params.parse_with_url(&url);
+
+        let mut json_mime_type = mime::APPLICATION_JSON;
+        let mut request_value_reader = {
+            let mut value = serde_json::value::to_value(&self._request).expect("serde to work");
+            common::remove_json_null_values(&mut value);
+            let mut dst = std::io::Cursor::new(Vec::with_capacity(128));
+            serde_json::to_writer(&mut dst, &value).unwrap();
+            dst
+        };
+        let request_size = request_value_reader
+            .seek(std::io::SeekFrom::End(0))
+            .unwrap();
+        request_value_reader
+            .seek(std::io::SeekFrom::Start(0))
+            .unwrap();
+
+        loop {
+            let token = match self
+                .hub
+                .auth
+                .get_token(&self._scopes.iter().map(String::as_str).collect::<Vec<_>>()[..])
+                .await
+            {
+                Ok(token) => token,
+                Err(e) => match dlg.token(e) {
+                    Ok(token) => token,
+                    Err(e) => {
+                        dlg.finished(false);
+                        return Err(common::Error::MissingToken(e));
+                    }
+                },
+            };
+            request_value_reader
+                .seek(std::io::SeekFrom::Start(0))
+                .unwrap();
+            let mut req_result = {
+                let client = &self.hub.client;
+                dlg.pre_request();
+                let mut req_builder = hyper::Request::builder()
+                    .method(hyper::Method::POST)
+                    .uri(url.as_str())
+                    .header(USER_AGENT, self.hub._user_agent.clone());
+
+                if let Some(token) = token.as_ref() {
+                    req_builder = req_builder.header(AUTHORIZATION, format!("Bearer {}", token));
+                }
+
+                let request = req_builder
+                    .header(CONTENT_TYPE, json_mime_type.to_string())
+                    .header(CONTENT_LENGTH, request_size as u64)
+                    .body(common::to_body(
+                        request_value_reader.get_ref().clone().into(),
+                    ));
+
+                client.request(request.unwrap()).await
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let common::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d).await;
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(common::Error::HttpError(err));
+                }
+                Ok(res) => {
+                    let (mut parts, body) = res.into_parts();
+                    let mut body = common::Body::new(body);
+                    if !parts.status.is_success() {
+                        let bytes = common::to_bytes(body).await.unwrap_or_default();
+                        let error = serde_json::from_str(&common::to_string(&bytes));
+                        let response = common::to_response(parts, bytes.into());
+
+                        if let common::Retry::After(d) =
+                            dlg.http_failure(&response, error.as_ref().ok())
+                        {
+                            sleep(d).await;
+                            continue;
+                        }
+
+                        dlg.finished(false);
+
+                        return Err(match error {
+                            Ok(value) => common::Error::BadRequest(value),
+                            _ => common::Error::Failure(response),
+                        });
+                    }
+                    let response = {
+                        let bytes = common::to_bytes(body).await.unwrap_or_default();
+                        let encoded = common::to_string(&bytes);
+                        match serde_json::from_str(&encoded) {
+                            Ok(decoded) => (common::to_response(parts, bytes.into()), decoded),
+                            Err(error) => {
+                                dlg.response_json_decode_error(&encoded, &error);
+                                return Err(common::Error::JsonDecodeError(
+                                    encoded.to_string(),
+                                    error,
+                                ));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(response);
+                }
+            }
+        }
+    }
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: QueryRequest) -> DeviceQueryCall<'a, C> {
+        self._request = new_value;
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    ///
+    /// ````text
+    ///                   It should be used to handle progress information, and to implement a certain level of resilience.
+    /// ````
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut dyn common::Delegate) -> DeviceQueryCall<'a, C> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known parameters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *$.xgafv* (query-string) - V1 error format.
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *callback* (query-string) - JSONP
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    pub fn param<T>(mut self, name: T, value: T) -> DeviceQueryCall<'a, C>
+    where
+        T: AsRef<str>,
+    {
+        self._additional_params
+            .insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead of the default [`Scope`] variant
+    /// [`Scope::Full`].
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<St>(mut self, scope: St) -> DeviceQueryCall<'a, C>
+    where
+        St: AsRef<str>,
+    {
+        self._scopes.insert(String::from(scope.as_ref()));
+        self
+    }
+    /// Identifies the authorization scope(s) for the method you are building.
+    ///
+    /// See [`Self::add_scope()`] for details.
+    pub fn add_scopes<I, St>(mut self, scopes: I) -> DeviceQueryCall<'a, C>
+    where
+        I: IntoIterator<Item = St>,
+        St: AsRef<str>,
+    {
+        self._scopes
+            .extend(scopes.into_iter().map(|s| String::from(s.as_ref())));
+        self
+    }
+
+    /// Removes all scopes, and no default scope will be used either.
+    /// In this case, you have to specify your API-key using the `key` parameter (see [`Self::param()`]
+    /// for details).
+    pub fn clear_scopes(mut self) -> DeviceQueryCall<'a, C> {
+        self._scopes.clear();
+        self
+    }
+}
+
+/// Reports device state and optionally sends device notifications. Called by your smart home Action when the state of a third-party device changes or you need to send a notification about the device. See [Implement Report State](https://developers.home.google.com/cloud-to-cloud/integration/report-state) for more information. This method updates the device state according to its declared [traits](https://developers.home.google.com/cloud-to-cloud/primer/device-types-and-traits). Publishing a new state value outside of these traits will result in an `INVALID_ARGUMENT` error response. The third-party user's identity is passed in via the `agent_user_id` (see ReportStateAndNotificationRequest). This request must be authorized using service account credentials from your Actions console project.
+///
+/// A builder for the *reportStateAndNotification* method supported by a *device* resource.
+/// It is not used directly, but through a [`DeviceMethods`] instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate google_homegraph1 as homegraph1;
+/// use homegraph1::api::ReportStateAndNotificationRequest;
+/// # async fn dox() {
+/// # use homegraph1::{HomeGraphService, FieldMask, hyper_rustls, hyper_util, yup_oauth2};
+///
+/// # let secret: yup_oauth2::ApplicationSecret = Default::default();
+/// # let connector = hyper_rustls::HttpsConnectorBuilder::new()
+/// #     .with_native_roots()
+/// #     .unwrap()
+/// #     .https_only()
+/// #     .enable_http2()
+/// #     .build();
+///
+/// # let executor = hyper_util::rt::TokioExecutor::new();
+/// # let auth = yup_oauth2::InstalledFlowAuthenticator::with_client(
+/// #     secret,
+/// #     yup_oauth2::InstalledFlowReturnMethod::HTTPRedirect,
+/// #     yup_oauth2::client::CustomHyperClientBuilder::from(
+/// #         hyper_util::client::legacy::Client::builder(executor).build(connector),
+/// #     ),
+/// # ).build().await.unwrap();
+///
+/// # let client = hyper_util::client::legacy::Client::builder(
+/// #     hyper_util::rt::TokioExecutor::new()
+/// # )
+/// # .build(
+/// #     hyper_rustls::HttpsConnectorBuilder::new()
+/// #         .with_native_roots()
+/// #         .unwrap()
+/// #         .https_or_http()
+/// #         .enable_http2()
+/// #         .build()
+/// # );
+/// # let mut hub = HomeGraphService::new(client, auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = ReportStateAndNotificationRequest::default();
+///
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.devices().report_state_and_notification(req)
+///              .doit().await;
+/// # }
+/// ```
+pub struct DeviceReportStateAndNotificationCall<'a, C>
+where
+    C: 'a,
+{
+    hub: &'a HomeGraphService<C>,
+    _request: ReportStateAndNotificationRequest,
+    _delegate: Option<&'a mut dyn common::Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeSet<String>,
+}
+
+impl<'a, C> common::CallBuilder for DeviceReportStateAndNotificationCall<'a, C> {}
+
+impl<'a, C> DeviceReportStateAndNotificationCall<'a, C>
+where
+    C: common::Connector,
+{
+    /// Perform the operation you have build so far.
+    pub async fn doit(
+        mut self,
+    ) -> common::Result<(common::Response, ReportStateAndNotificationResponse)> {
+        use std::borrow::Cow;
+        use std::io::{Read, Seek};
+
+        use common::{url::Params, ToParts};
+        use hyper::header::{AUTHORIZATION, CONTENT_LENGTH, CONTENT_TYPE, LOCATION, USER_AGENT};
+
+        let mut dd = common::DefaultDelegate;
+        let mut dlg: &mut dyn common::Delegate = self._delegate.unwrap_or(&mut dd);
+        dlg.begin(common::MethodInfo {
+            id: "homegraph.devices.reportStateAndNotification",
+            http_method: hyper::Method::POST,
+        });
+
+        for &field in ["alt"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(common::Error::FieldClash(field));
+            }
+        }
+
+        let mut params = Params::with_capacity(3 + self._additional_params.len());
+
+        params.extend(self._additional_params.iter());
+
+        params.push("alt", "json");
+        let mut url = self.hub._base_url.clone() + "v1/devices:reportStateAndNotification";
+        if self._scopes.is_empty() {
+            self._scopes.insert(Scope::Full.as_ref().to_string());
+        }
+
+        let url = params.parse_with_url(&url);
+
+        let mut json_mime_type = mime::APPLICATION_JSON;
+        let mut request_value_reader = {
+            let mut value = serde_json::value::to_value(&self._request).expect("serde to work");
+            common::remove_json_null_values(&mut value);
+            let mut dst = std::io::Cursor::new(Vec::with_capacity(128));
+            serde_json::to_writer(&mut dst, &value).unwrap();
+            dst
+        };
+        let request_size = request_value_reader
+            .seek(std::io::SeekFrom::End(0))
+            .unwrap();
+        request_value_reader
+            .seek(std::io::SeekFrom::Start(0))
+            .unwrap();
+
+        loop {
+            let token = match self
+                .hub
+                .auth
+                .get_token(&self._scopes.iter().map(String::as_str).collect::<Vec<_>>()[..])
+                .await
+            {
+                Ok(token) => token,
+                Err(e) => match dlg.token(e) {
+                    Ok(token) => token,
+                    Err(e) => {
+                        dlg.finished(false);
+                        return Err(common::Error::MissingToken(e));
+                    }
+                },
+            };
+            request_value_reader
+                .seek(std::io::SeekFrom::Start(0))
+                .unwrap();
+            let mut req_result = {
+                let client = &self.hub.client;
+                dlg.pre_request();
+                let mut req_builder = hyper::Request::builder()
+                    .method(hyper::Method::POST)
+                    .uri(url.as_str())
+                    .header(USER_AGENT, self.hub._user_agent.clone());
+
+                if let Some(token) = token.as_ref() {
+                    req_builder = req_builder.header(AUTHORIZATION, format!("Bearer {}", token));
+                }
+
+                let request = req_builder
+                    .header(CONTENT_TYPE, json_mime_type.to_string())
+                    .header(CONTENT_LENGTH, request_size as u64)
+                    .body(common::to_body(
+                        request_value_reader.get_ref().clone().into(),
+                    ));
+
+                client.request(request.unwrap()).await
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let common::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d).await;
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(common::Error::HttpError(err));
+                }
+                Ok(res) => {
+                    let (mut parts, body) = res.into_parts();
+                    let mut body = common::Body::new(body);
+                    if !parts.status.is_success() {
+                        let bytes = common::to_bytes(body).await.unwrap_or_default();
+                        let error = serde_json::from_str(&common::to_string(&bytes));
+                        let response = common::to_response(parts, bytes.into());
+
+                        if let common::Retry::After(d) =
+                            dlg.http_failure(&response, error.as_ref().ok())
+                        {
+                            sleep(d).await;
+                            continue;
+                        }
+
+                        dlg.finished(false);
+
+                        return Err(match error {
+                            Ok(value) => common::Error::BadRequest(value),
+                            _ => common::Error::Failure(response),
+                        });
+                    }
+                    let response = {
+                        let bytes = common::to_bytes(body).await.unwrap_or_default();
+                        let encoded = common::to_string(&bytes);
+                        match serde_json::from_str(&encoded) {
+                            Ok(decoded) => (common::to_response(parts, bytes.into()), decoded),
+                            Err(error) => {
+                                dlg.response_json_decode_error(&encoded, &error);
+                                return Err(common::Error::JsonDecodeError(
+                                    encoded.to_string(),
+                                    error,
+                                ));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(response);
+                }
+            }
+        }
+    }
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(
+        mut self,
+        new_value: ReportStateAndNotificationRequest,
+    ) -> DeviceReportStateAndNotificationCall<'a, C> {
+        self._request = new_value;
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    ///
+    /// ````text
+    ///                   It should be used to handle progress information, and to implement a certain level of resilience.
+    /// ````
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(
+        mut self,
+        new_value: &'a mut dyn common::Delegate,
+    ) -> DeviceReportStateAndNotificationCall<'a, C> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known parameters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *$.xgafv* (query-string) - V1 error format.
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *callback* (query-string) - JSONP
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    pub fn param<T>(mut self, name: T, value: T) -> DeviceReportStateAndNotificationCall<'a, C>
+    where
+        T: AsRef<str>,
+    {
+        self._additional_params
+            .insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead of the default [`Scope`] variant
+    /// [`Scope::Full`].
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<St>(mut self, scope: St) -> DeviceReportStateAndNotificationCall<'a, C>
+    where
+        St: AsRef<str>,
+    {
+        self._scopes.insert(String::from(scope.as_ref()));
+        self
+    }
+    /// Identifies the authorization scope(s) for the method you are building.
+    ///
+    /// See [`Self::add_scope()`] for details.
+    pub fn add_scopes<I, St>(mut self, scopes: I) -> DeviceReportStateAndNotificationCall<'a, C>
+    where
+        I: IntoIterator<Item = St>,
+        St: AsRef<str>,
+    {
+        self._scopes
+            .extend(scopes.into_iter().map(|s| String::from(s.as_ref())));
+        self
+    }
+
+    /// Removes all scopes, and no default scope will be used either.
+    /// In this case, you have to specify your API-key using the `key` parameter (see [`Self::param()`]
+    /// for details).
+    pub fn clear_scopes(mut self) -> DeviceReportStateAndNotificationCall<'a, C> {
+        self._scopes.clear();
+        self
+    }
+}
+
+/// Requests Google to send an `action.devices.SYNC` [intent](https://developers.home.google.com/cloud-to-cloud/intents/sync) to your smart home Action to update device metadata for the given user. The third-party user's identity is passed via the `agent_user_id` (see RequestSyncDevicesRequest). This request must be authorized using service account credentials from your Actions console project.
+///
+/// A builder for the *requestSync* method supported by a *device* resource.
+/// It is not used directly, but through a [`DeviceMethods`] instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate google_homegraph1 as homegraph1;
+/// use homegraph1::api::RequestSyncDevicesRequest;
+/// # async fn dox() {
+/// # use homegraph1::{HomeGraphService, FieldMask, hyper_rustls, hyper_util, yup_oauth2};
+///
+/// # let secret: yup_oauth2::ApplicationSecret = Default::default();
+/// # let connector = hyper_rustls::HttpsConnectorBuilder::new()
+/// #     .with_native_roots()
+/// #     .unwrap()
+/// #     .https_only()
+/// #     .enable_http2()
+/// #     .build();
+///
+/// # let executor = hyper_util::rt::TokioExecutor::new();
+/// # let auth = yup_oauth2::InstalledFlowAuthenticator::with_client(
+/// #     secret,
+/// #     yup_oauth2::InstalledFlowReturnMethod::HTTPRedirect,
+/// #     yup_oauth2::client::CustomHyperClientBuilder::from(
+/// #         hyper_util::client::legacy::Client::builder(executor).build(connector),
+/// #     ),
+/// # ).build().await.unwrap();
+///
+/// # let client = hyper_util::client::legacy::Client::builder(
+/// #     hyper_util::rt::TokioExecutor::new()
+/// # )
+/// # .build(
+/// #     hyper_rustls::HttpsConnectorBuilder::new()
+/// #         .with_native_roots()
+/// #         .unwrap()
+/// #         .https_or_http()
+/// #         .enable_http2()
+/// #         .build()
+/// # );
+/// # let mut hub = HomeGraphService::new(client, auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = RequestSyncDevicesRequest::default();
+///
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.devices().request_sync(req)
+///              .doit().await;
+/// # }
+/// ```
+pub struct DeviceRequestSyncCall<'a, C>
+where
+    C: 'a,
+{
+    hub: &'a HomeGraphService<C>,
+    _request: RequestSyncDevicesRequest,
+    _delegate: Option<&'a mut dyn common::Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeSet<String>,
+}
+
+impl<'a, C> common::CallBuilder for DeviceRequestSyncCall<'a, C> {}
+
+impl<'a, C> DeviceRequestSyncCall<'a, C>
+where
+    C: common::Connector,
+{
+    /// Perform the operation you have build so far.
+    pub async fn doit(mut self) -> common::Result<(common::Response, RequestSyncDevicesResponse)> {
+        use std::borrow::Cow;
+        use std::io::{Read, Seek};
+
+        use common::{url::Params, ToParts};
+        use hyper::header::{AUTHORIZATION, CONTENT_LENGTH, CONTENT_TYPE, LOCATION, USER_AGENT};
+
+        let mut dd = common::DefaultDelegate;
+        let mut dlg: &mut dyn common::Delegate = self._delegate.unwrap_or(&mut dd);
+        dlg.begin(common::MethodInfo {
+            id: "homegraph.devices.requestSync",
+            http_method: hyper::Method::POST,
+        });
+
+        for &field in ["alt"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(common::Error::FieldClash(field));
+            }
+        }
+
+        let mut params = Params::with_capacity(3 + self._additional_params.len());
+
+        params.extend(self._additional_params.iter());
+
+        params.push("alt", "json");
+        let mut url = self.hub._base_url.clone() + "v1/devices:requestSync";
+        if self._scopes.is_empty() {
+            self._scopes.insert(Scope::Full.as_ref().to_string());
+        }
+
+        let url = params.parse_with_url(&url);
+
+        let mut json_mime_type = mime::APPLICATION_JSON;
+        let mut request_value_reader = {
+            let mut value = serde_json::value::to_value(&self._request).expect("serde to work");
+            common::remove_json_null_values(&mut value);
+            let mut dst = std::io::Cursor::new(Vec::with_capacity(128));
+            serde_json::to_writer(&mut dst, &value).unwrap();
+            dst
+        };
+        let request_size = request_value_reader
+            .seek(std::io::SeekFrom::End(0))
+            .unwrap();
+        request_value_reader
+            .seek(std::io::SeekFrom::Start(0))
+            .unwrap();
+
+        loop {
+            let token = match self
+                .hub
+                .auth
+                .get_token(&self._scopes.iter().map(String::as_str).collect::<Vec<_>>()[..])
+                .await
+            {
+                Ok(token) => token,
+                Err(e) => match dlg.token(e) {
+                    Ok(token) => token,
+                    Err(e) => {
+                        dlg.finished(false);
+                        return Err(common::Error::MissingToken(e));
+                    }
+                },
+            };
+            request_value_reader
+                .seek(std::io::SeekFrom::Start(0))
+                .unwrap();
+            let mut req_result = {
+                let client = &self.hub.client;
+                dlg.pre_request();
+                let mut req_builder = hyper::Request::builder()
+                    .method(hyper::Method::POST)
+                    .uri(url.as_str())
+                    .header(USER_AGENT, self.hub._user_agent.clone());
+
+                if let Some(token) = token.as_ref() {
+                    req_builder = req_builder.header(AUTHORIZATION, format!("Bearer {}", token));
+                }
+
+                let request = req_builder
+                    .header(CONTENT_TYPE, json_mime_type.to_string())
+                    .header(CONTENT_LENGTH, request_size as u64)
+                    .body(common::to_body(
+                        request_value_reader.get_ref().clone().into(),
+                    ));
+
+                client.request(request.unwrap()).await
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let common::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d).await;
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(common::Error::HttpError(err));
+                }
+                Ok(res) => {
+                    let (mut parts, body) = res.into_parts();
+                    let mut body = common::Body::new(body);
+                    if !parts.status.is_success() {
+                        let bytes = common::to_bytes(body).await.unwrap_or_default();
+                        let error = serde_json::from_str(&common::to_string(&bytes));
+                        let response = common::to_response(parts, bytes.into());
+
+                        if let common::Retry::After(d) =
+                            dlg.http_failure(&response, error.as_ref().ok())
+                        {
+                            sleep(d).await;
+                            continue;
+                        }
+
+                        dlg.finished(false);
+
+                        return Err(match error {
+                            Ok(value) => common::Error::BadRequest(value),
+                            _ => common::Error::Failure(response),
+                        });
+                    }
+                    let response = {
+                        let bytes = common::to_bytes(body).await.unwrap_or_default();
+                        let encoded = common::to_string(&bytes);
+                        match serde_json::from_str(&encoded) {
+                            Ok(decoded) => (common::to_response(parts, bytes.into()), decoded),
+                            Err(error) => {
+                                dlg.response_json_decode_error(&encoded, &error);
+                                return Err(common::Error::JsonDecodeError(
+                                    encoded.to_string(),
+                                    error,
+                                ));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(response);
+                }
+            }
+        }
+    }
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: RequestSyncDevicesRequest) -> DeviceRequestSyncCall<'a, C> {
+        self._request = new_value;
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    ///
+    /// ````text
+    ///                   It should be used to handle progress information, and to implement a certain level of resilience.
+    /// ````
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(
+        mut self,
+        new_value: &'a mut dyn common::Delegate,
+    ) -> DeviceRequestSyncCall<'a, C> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known parameters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *$.xgafv* (query-string) - V1 error format.
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *callback* (query-string) - JSONP
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    pub fn param<T>(mut self, name: T, value: T) -> DeviceRequestSyncCall<'a, C>
+    where
+        T: AsRef<str>,
+    {
+        self._additional_params
+            .insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead of the default [`Scope`] variant
+    /// [`Scope::Full`].
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<St>(mut self, scope: St) -> DeviceRequestSyncCall<'a, C>
+    where
+        St: AsRef<str>,
+    {
+        self._scopes.insert(String::from(scope.as_ref()));
+        self
+    }
+    /// Identifies the authorization scope(s) for the method you are building.
+    ///
+    /// See [`Self::add_scope()`] for details.
+    pub fn add_scopes<I, St>(mut self, scopes: I) -> DeviceRequestSyncCall<'a, C>
+    where
+        I: IntoIterator<Item = St>,
+        St: AsRef<str>,
+    {
+        self._scopes
+            .extend(scopes.into_iter().map(|s| String::from(s.as_ref())));
+        self
+    }
+
+    /// Removes all scopes, and no default scope will be used either.
+    /// In this case, you have to specify your API-key using the `key` parameter (see [`Self::param()`]
+    /// for details).
+    pub fn clear_scopes(mut self) -> DeviceRequestSyncCall<'a, C> {
+        self._scopes.clear();
+        self
+    }
+}
+
+/// Gets all the devices associated with the given third-party user. The third-party user's identity is passed in via the `agent_user_id` (see SyncRequest). This request must be authorized using service account credentials from your Actions console project.
+///
+/// A builder for the *sync* method supported by a *device* resource.
+/// It is not used directly, but through a [`DeviceMethods`] instance.
+///
+/// # Example
+///
+/// Instantiate a resource method builder
+///
+/// ```test_harness,no_run
+/// # extern crate hyper;
+/// # extern crate hyper_rustls;
+/// # extern crate google_homegraph1 as homegraph1;
+/// use homegraph1::api::SyncRequest;
+/// # async fn dox() {
+/// # use homegraph1::{HomeGraphService, FieldMask, hyper_rustls, hyper_util, yup_oauth2};
+///
+/// # let secret: yup_oauth2::ApplicationSecret = Default::default();
+/// # let connector = hyper_rustls::HttpsConnectorBuilder::new()
+/// #     .with_native_roots()
+/// #     .unwrap()
+/// #     .https_only()
+/// #     .enable_http2()
+/// #     .build();
+///
+/// # let executor = hyper_util::rt::TokioExecutor::new();
+/// # let auth = yup_oauth2::InstalledFlowAuthenticator::with_client(
+/// #     secret,
+/// #     yup_oauth2::InstalledFlowReturnMethod::HTTPRedirect,
+/// #     yup_oauth2::client::CustomHyperClientBuilder::from(
+/// #         hyper_util::client::legacy::Client::builder(executor).build(connector),
+/// #     ),
+/// # ).build().await.unwrap();
+///
+/// # let client = hyper_util::client::legacy::Client::builder(
+/// #     hyper_util::rt::TokioExecutor::new()
+/// # )
+/// # .build(
+/// #     hyper_rustls::HttpsConnectorBuilder::new()
+/// #         .with_native_roots()
+/// #         .unwrap()
+/// #         .https_or_http()
+/// #         .enable_http2()
+/// #         .build()
+/// # );
+/// # let mut hub = HomeGraphService::new(client, auth);
+/// // As the method needs a request, you would usually fill it with the desired information
+/// // into the respective structure. Some of the parts shown here might not be applicable !
+/// // Values shown here are possibly random and not representative !
+/// let mut req = SyncRequest::default();
+///
+/// // You can configure optional parameters by calling the respective setters at will, and
+/// // execute the final call using `doit()`.
+/// // Values shown here are possibly random and not representative !
+/// let result = hub.devices().sync(req)
+///              .doit().await;
+/// # }
+/// ```
+pub struct DeviceSyncCall<'a, C>
+where
+    C: 'a,
+{
+    hub: &'a HomeGraphService<C>,
+    _request: SyncRequest,
+    _delegate: Option<&'a mut dyn common::Delegate>,
+    _additional_params: HashMap<String, String>,
+    _scopes: BTreeSet<String>,
+}
+
+impl<'a, C> common::CallBuilder for DeviceSyncCall<'a, C> {}
+
+impl<'a, C> DeviceSyncCall<'a, C>
+where
+    C: common::Connector,
+{
+    /// Perform the operation you have build so far.
+    pub async fn doit(mut self) -> common::Result<(common::Response, SyncResponse)> {
+        use std::borrow::Cow;
+        use std::io::{Read, Seek};
+
+        use common::{url::Params, ToParts};
+        use hyper::header::{AUTHORIZATION, CONTENT_LENGTH, CONTENT_TYPE, LOCATION, USER_AGENT};
+
+        let mut dd = common::DefaultDelegate;
+        let mut dlg: &mut dyn common::Delegate = self._delegate.unwrap_or(&mut dd);
+        dlg.begin(common::MethodInfo {
+            id: "homegraph.devices.sync",
+            http_method: hyper::Method::POST,
+        });
+
+        for &field in ["alt"].iter() {
+            if self._additional_params.contains_key(field) {
+                dlg.finished(false);
+                return Err(common::Error::FieldClash(field));
+            }
+        }
+
+        let mut params = Params::with_capacity(3 + self._additional_params.len());
+
+        params.extend(self._additional_params.iter());
+
+        params.push("alt", "json");
+        let mut url = self.hub._base_url.clone() + "v1/devices:sync";
+        if self._scopes.is_empty() {
+            self._scopes.insert(Scope::Full.as_ref().to_string());
+        }
+
+        let url = params.parse_with_url(&url);
+
+        let mut json_mime_type = mime::APPLICATION_JSON;
+        let mut request_value_reader = {
+            let mut value = serde_json::value::to_value(&self._request).expect("serde to work");
+            common::remove_json_null_values(&mut value);
+            let mut dst = std::io::Cursor::new(Vec::with_capacity(128));
+            serde_json::to_writer(&mut dst, &value).unwrap();
+            dst
+        };
+        let request_size = request_value_reader
+            .seek(std::io::SeekFrom::End(0))
+            .unwrap();
+        request_value_reader
+            .seek(std::io::SeekFrom::Start(0))
+            .unwrap();
+
+        loop {
+            let token = match self
+                .hub
+                .auth
+                .get_token(&self._scopes.iter().map(String::as_str).collect::<Vec<_>>()[..])
+                .await
+            {
+                Ok(token) => token,
+                Err(e) => match dlg.token(e) {
+                    Ok(token) => token,
+                    Err(e) => {
+                        dlg.finished(false);
+                        return Err(common::Error::MissingToken(e));
+                    }
+                },
+            };
+            request_value_reader
+                .seek(std::io::SeekFrom::Start(0))
+                .unwrap();
+            let mut req_result = {
+                let client = &self.hub.client;
+                dlg.pre_request();
+                let mut req_builder = hyper::Request::builder()
+                    .method(hyper::Method::POST)
+                    .uri(url.as_str())
+                    .header(USER_AGENT, self.hub._user_agent.clone());
+
+                if let Some(token) = token.as_ref() {
+                    req_builder = req_builder.header(AUTHORIZATION, format!("Bearer {}", token));
+                }
+
+                let request = req_builder
+                    .header(CONTENT_TYPE, json_mime_type.to_string())
+                    .header(CONTENT_LENGTH, request_size as u64)
+                    .body(common::to_body(
+                        request_value_reader.get_ref().clone().into(),
+                    ));
+
+                client.request(request.unwrap()).await
+            };
+
+            match req_result {
+                Err(err) => {
+                    if let common::Retry::After(d) = dlg.http_error(&err) {
+                        sleep(d).await;
+                        continue;
+                    }
+                    dlg.finished(false);
+                    return Err(common::Error::HttpError(err));
+                }
+                Ok(res) => {
+                    let (mut parts, body) = res.into_parts();
+                    let mut body = common::Body::new(body);
+                    if !parts.status.is_success() {
+                        let bytes = common::to_bytes(body).await.unwrap_or_default();
+                        let error = serde_json::from_str(&common::to_string(&bytes));
+                        let response = common::to_response(parts, bytes.into());
+
+                        if let common::Retry::After(d) =
+                            dlg.http_failure(&response, error.as_ref().ok())
+                        {
+                            sleep(d).await;
+                            continue;
+                        }
+
+                        dlg.finished(false);
+
+                        return Err(match error {
+                            Ok(value) => common::Error::BadRequest(value),
+                            _ => common::Error::Failure(response),
+                        });
+                    }
+                    let response = {
+                        let bytes = common::to_bytes(body).await.unwrap_or_default();
+                        let encoded = common::to_string(&bytes);
+                        match serde_json::from_str(&encoded) {
+                            Ok(decoded) => (common::to_response(parts, bytes.into()), decoded),
+                            Err(error) => {
+                                dlg.response_json_decode_error(&encoded, &error);
+                                return Err(common::Error::JsonDecodeError(
+                                    encoded.to_string(),
+                                    error,
+                                ));
+                            }
+                        }
+                    };
+
+                    dlg.finished(true);
+                    return Ok(response);
+                }
+            }
+        }
+    }
+
+    ///
+    /// Sets the *request* property to the given value.
+    ///
+    /// Even though the property as already been set when instantiating this call,
+    /// we provide this method for API completeness.
+    pub fn request(mut self, new_value: SyncRequest) -> DeviceSyncCall<'a, C> {
+        self._request = new_value;
+        self
+    }
+    /// The delegate implementation is consulted whenever there is an intermediate result, or if something goes wrong
+    /// while executing the actual API request.
+    ///
+    /// ````text
+    ///                   It should be used to handle progress information, and to implement a certain level of resilience.
+    /// ````
+    ///
+    /// Sets the *delegate* property to the given value.
+    pub fn delegate(mut self, new_value: &'a mut dyn common::Delegate) -> DeviceSyncCall<'a, C> {
+        self._delegate = Some(new_value);
+        self
+    }
+
+    /// Set any additional parameter of the query string used in the request.
+    /// It should be used to set parameters which are not yet available through their own
+    /// setters.
+    ///
+    /// Please note that this method must not be used to set any of the known parameters
+    /// which have their own setter method. If done anyway, the request will fail.
+    ///
+    /// # Additional Parameters
+    ///
+    /// * *$.xgafv* (query-string) - V1 error format.
+    /// * *access_token* (query-string) - OAuth access token.
+    /// * *alt* (query-string) - Data format for response.
+    /// * *callback* (query-string) - JSONP
+    /// * *fields* (query-string) - Selector specifying which fields to include in a partial response.
+    /// * *key* (query-string) - API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.
+    /// * *oauth_token* (query-string) - OAuth 2.0 token for the current user.
+    /// * *prettyPrint* (query-boolean) - Returns response with indentations and line breaks.
+    /// * *quotaUser* (query-string) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
+    /// * *uploadType* (query-string) - Legacy upload protocol for media (e.g. "media", "multipart").
+    /// * *upload_protocol* (query-string) - Upload protocol for media (e.g. "raw", "multipart").
+    pub fn param<T>(mut self, name: T, value: T) -> DeviceSyncCall<'a, C>
+    where
+        T: AsRef<str>,
+    {
+        self._additional_params
+            .insert(name.as_ref().to_string(), value.as_ref().to_string());
+        self
+    }
+
+    /// Identifies the authorization scope for the method you are building.
+    ///
+    /// Use this method to actively specify which scope should be used, instead of the default [`Scope`] variant
+    /// [`Scope::Full`].
+    ///
+    /// The `scope` will be added to a set of scopes. This is important as one can maintain access
+    /// tokens for more than one scope.
+    ///
+    /// Usually there is more than one suitable scope to authorize an operation, some of which may
+    /// encompass more rights than others. For example, for listing resources, a *read-only* scope will be
+    /// sufficient, a read-write scope will do as well.
+    pub fn add_scope<St>(mut self, scope: St) -> DeviceSyncCall<'a, C>
+    where
+        St: AsRef<str>,
+    {
+        self._scopes.insert(String::from(scope.as_ref()));
+        self
+    }
+    /// Identifies the authorization scope(s) for the method you are building.
+    ///
+    /// See [`Self::add_scope()`] for details.
+    pub fn add_scopes<I, St>(mut self, scopes: I) -> DeviceSyncCall<'a, C>
+    where
+        I: IntoIterator<Item = St>,
+        St: AsRef<str>,
+    {
+        self._scopes
+            .extend(scopes.into_iter().map(|s| String::from(s.as_ref())));
+        self
+    }
+
+    /// Removes all scopes, and no default scope will be used either.
+    /// In this case, you have to specify your API-key using the `key` parameter (see [`Self::param()`]
+    /// for details).
+    pub fn clear_scopes(mut self) -> DeviceSyncCall<'a, C> {
+        self._scopes.clear();
+        self
+    }
+}

--- a/gen/homegraph1/src/lib.rs
+++ b/gen/homegraph1/src/lib.rs
@@ -1,0 +1,235 @@
+// DO NOT EDIT !
+// This file was generated automatically from 'src/generator/templates/api/lib.rs.mako'
+// DO NOT EDIT !
+
+//! This documentation was generated from *Home Graph Service* crate version *7.0.0+20240621*, where *20240621* is the exact revision of the *homegraph:v1* schema built by the [mako](http://www.makotemplates.org/) code generator *v7.0.0*.
+//!
+//! Everything else about the *Home Graph Service* *v1* API can be found at the
+//! [official documentation site](https://developers.home.google.com/cloud-to-cloud/get-started).
+//! The original source code is [on github](https://github.com/Byron/google-apis-rs/tree/main/gen/homegraph1).
+//! # Features
+//!
+//! Handle the following *Resources* with ease from the central [hub](HomeGraphService) ...
+//!
+//! * agent users
+//!  * [*delete*](api::AgentUserDeleteCall)
+//! * [devices](api::Device)
+//!  * [*query*](api::DeviceQueryCall), [*report state and notification*](api::DeviceReportStateAndNotificationCall), [*request sync*](api::DeviceRequestSyncCall) and [*sync*](api::DeviceSyncCall)
+//!
+//!
+//!
+//!
+//! Not what you are looking for ? Find all other Google APIs in their Rust [documentation index](http://byron.github.io/google-apis-rs).
+//!
+//! # Structure of this Library
+//!
+//! The API is structured into the following primary items:
+//!
+//! * **[Hub](HomeGraphService)**
+//!     * a central object to maintain state and allow accessing all *Activities*
+//!     * creates [*Method Builders*](common::MethodsBuilder) which in turn
+//!       allow access to individual [*Call Builders*](common::CallBuilder)
+//! * **[Resources](common::Resource)**
+//!     * primary types that you can apply *Activities* to
+//!     * a collection of properties and *Parts*
+//!     * **[Parts](common::Part)**
+//!         * a collection of properties
+//!         * never directly used in *Activities*
+//! * **[Activities](common::CallBuilder)**
+//!     * operations to apply to *Resources*
+//!
+//! All *structures* are marked with applicable traits to further categorize them and ease browsing.
+//!
+//! Generally speaking, you can invoke *Activities* like this:
+//!
+//! ```Rust,ignore
+//! let r = hub.resource().activity(...).doit().await
+//! ```
+//!
+//! Or specifically ...
+//!
+//! ```ignore
+//! let r = hub.devices().query(...).doit().await
+//! let r = hub.devices().report_state_and_notification(...).doit().await
+//! let r = hub.devices().request_sync(...).doit().await
+//! let r = hub.devices().sync(...).doit().await
+//! ```
+//!
+//! The `resource()` and `activity(...)` calls create [builders][builder-pattern]. The second one dealing with `Activities`
+//! supports various methods to configure the impending operation (not shown here). It is made such that all required arguments have to be
+//! specified right away (i.e. `(...)`), whereas all optional ones can be [build up][builder-pattern] as desired.
+//! The `doit()` method performs the actual communication with the server and returns the respective result.
+//!
+//! # Usage
+//!
+//! ## Setting up your Project
+//!
+//! To use this library, you would put the following lines into your `Cargo.toml` file:
+//!
+//! ```toml
+//! [dependencies]
+//! google-homegraph1 = "*"
+//! serde = "1"
+//! serde_json = "1"
+//! ```
+//!
+//! ## A complete example
+//!
+//! ```test_harness,no_run
+//! extern crate hyper;
+//! extern crate hyper_rustls;
+//! extern crate google_homegraph1 as homegraph1;
+//! use homegraph1::api::QueryRequest;
+//! use homegraph1::{Result, Error};
+//! # async fn dox() {
+//! use homegraph1::{HomeGraphService, FieldMask, hyper_rustls, hyper_util, yup_oauth2};
+//!
+//! // Get an ApplicationSecret instance by some means. It contains the `client_id` and
+//! // `client_secret`, among other things.
+//! let secret: yup_oauth2::ApplicationSecret = Default::default();
+//! // Instantiate the authenticator. It will choose a suitable authentication flow for you,
+//! // unless you replace  `None` with the desired Flow.
+//! // Provide your own `AuthenticatorDelegate` to adjust the way it operates and get feedback about
+//! // what's going on. You probably want to bring in your own `TokenStorage` to persist tokens and
+//! // retrieve them from storage.
+//! let connector = hyper_rustls::HttpsConnectorBuilder::new()
+//!     .with_native_roots()
+//!     .unwrap()
+//!     .https_only()
+//!     .enable_http2()
+//!     .build();
+//!
+//! let executor = hyper_util::rt::TokioExecutor::new();
+//! let auth = yup_oauth2::InstalledFlowAuthenticator::with_client(
+//!     secret,
+//!     yup_oauth2::InstalledFlowReturnMethod::HTTPRedirect,
+//!     yup_oauth2::client::CustomHyperClientBuilder::from(
+//!         hyper_util::client::legacy::Client::builder(executor).build(connector),
+//!     ),
+//! ).build().await.unwrap();
+//!
+//! let client = hyper_util::client::legacy::Client::builder(
+//!     hyper_util::rt::TokioExecutor::new()
+//! )
+//! .build(
+//!     hyper_rustls::HttpsConnectorBuilder::new()
+//!         .with_native_roots()
+//!         .unwrap()
+//!         .https_or_http()
+//!         .enable_http2()
+//!         .build()
+//! );
+//! let mut hub = HomeGraphService::new(client, auth);
+//! // As the method needs a request, you would usually fill it with the desired information
+//! // into the respective structure. Some of the parts shown here might not be applicable !
+//! // Values shown here are possibly random and not representative !
+//! let mut req = QueryRequest::default();
+//!
+//! // You can configure optional parameters by calling the respective setters at will, and
+//! // execute the final call using `doit()`.
+//! // Values shown here are possibly random and not representative !
+//! let result = hub.devices().query(req)
+//!              .doit().await;
+//!
+//! match result {
+//!     Err(e) => match e {
+//!         // The Error enum provides details about what exactly happened.
+//!         // You can also just use its `Debug`, `Display` or `Error` traits
+//!          Error::HttpError(_)
+//!         |Error::Io(_)
+//!         |Error::MissingAPIKey
+//!         |Error::MissingToken(_)
+//!         |Error::Cancelled
+//!         |Error::UploadSizeLimitExceeded(_, _)
+//!         |Error::Failure(_)
+//!         |Error::BadRequest(_)
+//!         |Error::FieldClash(_)
+//!         |Error::JsonDecodeError(_, _) => println!("{}", e),
+//!     },
+//!     Ok(res) => println!("Success: {:?}", res),
+//! }
+//! # }
+//! ```
+//! ## Handling Errors
+//!
+//! All errors produced by the system are provided either as [Result](common::Result) enumeration as return value of
+//! the doit() methods, or handed as possibly intermediate results to either the
+//! [Hub Delegate](common::Delegate), or the [Authenticator Delegate](https://docs.rs/yup-oauth2/*/yup_oauth2/trait.AuthenticatorDelegate.html).
+//!
+//! When delegates handle errors or intermediate values, they may have a chance to instruct the system to retry. This
+//! makes the system potentially resilient to all kinds of errors.
+//!
+//! ## Uploads and Downloads
+//! If a method supports downloads, the response body, which is part of the [Result](common::Result), should be
+//! read by you to obtain the media.
+//! If such a method also supports a [Response Result](common::ResponseResult), it will return that by default.
+//! You can see it as meta-data for the actual media. To trigger a media download, you will have to set up the builder by making
+//! this call: `.param("alt", "media")`.
+//!
+//! Methods supporting uploads can do so using up to 2 different protocols:
+//! *simple* and *resumable*. The distinctiveness of each is represented by customized
+//! `doit(...)` methods, which are then named `upload(...)` and `upload_resumable(...)` respectively.
+//!
+//! ## Customization and Callbacks
+//!
+//! You may alter the way an `doit()` method is called by providing a [delegate](common::Delegate) to the
+//! [Method Builder](common::CallBuilder) before making the final `doit()` call.
+//! Respective methods will be called to provide progress information, as well as determine whether the system should
+//! retry on failure.
+//!
+//! The [delegate trait](common::Delegate) is default-implemented, allowing you to customize it with minimal effort.
+//!
+//! ## Optional Parts in Server-Requests
+//!
+//! All structures provided by this library are made to be [encodable](common::RequestValue) and
+//! [decodable](common::ResponseResult) via *json*. Optionals are used to indicate that partial requests are responses
+//! are valid.
+//! Most optionals are are considered [Parts](common::Part) which are identifiable by name, which will be sent to
+//! the server to indicate either the set parts of the request or the desired parts in the response.
+//!
+//! ## Builder Arguments
+//!
+//! Using [method builders](common::CallBuilder), you are able to prepare an action call by repeatedly calling it's methods.
+//! These will always take a single argument, for which the following statements are true.
+//!
+//! * [PODs][wiki-pod] are handed by copy
+//! * strings are passed as `&str`
+//! * [request values](common::RequestValue) are moved
+//!
+//! Arguments will always be copied or cloned into the builder, to make them independent of their original life times.
+//!
+//! [wiki-pod]: http://en.wikipedia.org/wiki/Plain_old_data_structure
+//! [builder-pattern]: http://en.wikipedia.org/wiki/Builder_pattern
+//! [google-go-api]: https://github.com/google/google-api-go-client
+//!
+//! ## Cargo Features
+//!
+//! * `utoipa` - Add support for [utoipa](https://crates.io/crates/utoipa) and derive `utoipa::ToSchema` on all
+//! the types. You'll have to import and register the required types in `#[openapi(schemas(...))]`, otherwise the
+//! generated `openapi` spec would be invalid.
+//!
+//!
+//!
+
+// Unused attributes happen thanks to defined, but unused structures We don't
+// warn about this, as depending on the API, some data structures or facilities
+// are never used. Instead of pre-determining this, we just disable the lint.
+// It's manually tuned to not have any unused imports in fully featured APIs.
+// Same with unused_mut.
+#![allow(unused_imports, unused_mut, dead_code)]
+
+// DO NOT EDIT !
+// This file was generated automatically from 'src/generator/templates/api/lib.rs.mako'
+// DO NOT EDIT !
+
+pub extern crate hyper;
+pub extern crate hyper_rustls;
+pub extern crate hyper_util;
+#[cfg(feature = "yup-oauth2")]
+pub extern crate yup_oauth2;
+
+pub extern crate google_apis_common as common;
+pub use common::{Delegate, Error, FieldMask, Result};
+
+pub mod api;
+pub use api::HomeGraphService;

--- a/src/generator/lib/util.py
+++ b/src/generator/lib/util.py
@@ -31,6 +31,7 @@ RESERVED_WORDS = set(
     (
         "abstract",
         "alignof",
+        "async",
         "as",
         "become",
         "box",


### PR DESCRIPTION
I'm not sure why the solution to `async` being a keyword was blacklisting instead of adding `async` to the long list of reserved keywords. So this PR removes homegraph1 from the blacklist and adds the gen back.

I would welcome guidance on what to do to "release" a new version of the crate, in this PR or as a follow-up.

Also: fixes the comment about the blacklist in `shared.yaml`, which somehow moved to a random item within.