### PR TITLE
feat(generator): support impl Into<String> in setters

### DIFF
--- a/src/generator/templates/api/api.rs.mako
+++ b/src/generator/templates/api/api.rs.mako
@@ -74,24 +74,24 @@ impl<'a, ${', '.join(HUB_TYPE_PARAMETERS)}> ${hub_type}${ht_params} {
     /// It defaults to `${default_user_agent}`.
     ///
     /// Returns the previously set user-agent.
-    pub fn user_agent(&mut self, agent_name: String) -> String {
-        std::mem::replace(&mut self._user_agent, agent_name)
+    pub fn user_agent(&mut self, agent_name: impl Into<String>) -> String {
+        std::mem::replace(&mut self._user_agent, agent_name.into())
     }
 
     /// Set the base url to use in all requests to the server.
     /// It defaults to `${baseUrl}`.
     ///
     /// Returns the previously set base url.
-    pub fn base_url(&mut self, new_base_url: String) -> String {
-        std::mem::replace(&mut self._base_url, new_base_url)
+    pub fn base_url(&mut self, new_base_url: impl Into<String>) -> String {
+        std::mem::replace(&mut self._base_url, new_base_url.into())
     }
 
     /// Set the root url to use in all requests to the server.
     /// It defaults to `${rootUrl}`.
     ///
     /// Returns the previously set root url.
-    pub fn root_url(&mut self, new_root_url: String) -> String {
-        std::mem::replace(&mut self._root_url, new_root_url)
+    pub fn root_url(&mut self, new_root_url: impl Into<String>) -> String {
+        std::mem::replace(&mut self._root_url, new_root_url.into())
     }
 }
 

--- a/src/generator/templates/api/lib/mbuild.mako
+++ b/src/generator/templates/api/lib/mbuild.mako
@@ -287,6 +287,20 @@ ${self._setter_fn(resource, method, m, p, part_prop, ThisType, c)}\
     ///
     ${part_desc | rust_doc_sanitize(documentationLink), rust_doc_comment, indent_all_but_first_by(1)}
     % endif
+    % if InType == "&str":
+    pub fn ${mangle_ident(setter_fn_name(p))}(mut self, ${value_name}: impl Into<String>) -> ${ThisType} {
+        % if p.get('repeated', False):
+        self.${property(p.name)}.push(${value_name}.into());
+        % else:
+            % if is_required_property(p):
+        self.${property(p.name)} = ${value_name}.into();
+            % else:
+        self.${property(p.name)} = Some(${value_name}.into());
+            % endif
+        % endif
+        self
+    }
+    % else:
     pub fn ${mangle_ident(setter_fn_name(p))}(mut self, ${value_name}: ${InType}) -> ${ThisType} {
         % if p.get('repeated', False):
         self.${property(p.name)}.push(${new_value_copied});
@@ -295,6 +309,7 @@ ${self._setter_fn(resource, method, m, p, part_prop, ThisType, c)}\
         % endif
         self
     }
+    % endif
 </%def>
 
 


### PR DESCRIPTION
*   Updated templates to use `impl Into<String>` for string-based setters.
*   Improves DX by allowing string literals without manual `.to_string()`.
*   Verified with `make youtube3` and `cargo check`.