### PR TITLE
fix: percent-encode URL path parameters

### DIFF
--- a/google-apis-common/src/url.rs
+++ b/google-apis-common/src/url.rs
@@ -44,33 +44,31 @@ impl<'a> Params<'a> {
         url: String,
         param: &str,
         from: &str,
-        url_encode: bool,
+        _url_encode: bool,
     ) -> String {
-        const DEFAULT_ENCODE_SET: &AsciiSet = &CONTROLS
-            .add(b' ')
-            .add(b'"')
-            .add(b'#')
-            .add(b'<')
-            .add(b'>')
-            .add(b'`')
-            .add(b'?')
-            .add(b'{')
-            .add(b'}');
-        if url_encode {
-            let mut replace_with: Cow<str> = self.get(param).unwrap_or_default().into();
-            if from.as_bytes()[1] == b'+' {
-                replace_with = percent_encode(replace_with.as_bytes(), DEFAULT_ENCODE_SET)
-                    .to_string()
-                    .into();
-            }
-            url.replace(from, &replace_with)
-        } else {
-            let replace_with = self
-                .get(param)
-                .expect("to find substitution value in params");
+        let replace_with = self.get(param).unwrap_or_default();
+        let is_plus = from.starts_with("{+");
 
-            url.replace(from, replace_with)
-        }
+        let replace_with = if is_plus {
+            const PLUS_ENCODE_SET: &AsciiSet = &CONTROLS
+                .add(b' ')
+                .add(b'"')
+                .add(b'<')
+                .add(b'>')
+                .add(b'`')
+                .add(b'{')
+                .add(b'}');
+            percent_encode(replace_with.as_bytes(), PLUS_ENCODE_SET).to_string()
+        } else {
+            const NORMAL_ENCODE_SET: &AsciiSet = &percent_encoding::NON_ALPHANUMERIC
+                .remove(b'-')
+                .remove(b'_')
+                .remove(b'.')
+                .remove(b'~');
+            percent_encode(replace_with.as_bytes(), NORMAL_ENCODE_SET).to_string()
+        };
+
+        url.replace(from, &replace_with)
     }
 
     /// Removes parameters

--- a/src/generator/templates/api/lib/mbuild.mako
+++ b/src/generator/templates/api/lib/mbuild.mako
@@ -683,7 +683,7 @@ else {
         % if replacements:
         #[allow(clippy::single_element_loop)]
         for &(find_this, param_name) in [${', '.join('("%s", "%s")' % r for r in replacements)}].iter() {
-            url = params.uri_replacement(url, param_name, find_this, ${"true" if URL_ENCODE in special_cases else "false"});
+            url = params.uri_replacement(url, param_name, find_this, true);
         }
         ## Remove all used parameters
         {


### PR DESCRIPTION
Fixes #560

Path params like `range="#sheet1"` weren't being percent-encoded, causing 404s. Fixed `uri_replacement` to auto-detect `{+var}` vs `{var}` and encode accordingly.

params.push("range", "#sheet1");
// before: /values/#sheet1 → 404
// after:  /values/%23sheet1 ✓