### PR TITLE
Fix RUSTSEC-2025-0134: update yup-oauth2 dependency from v11 to v12 i…

### DIFF
--- a/gen/aiplatform1-cli/Cargo.toml
+++ b/gen/aiplatform1-cli/Cargo.toml
@@ -32,7 +32,7 @@ serde_json = "1"
 tokio = { version = "1", features = ["full"] }
 url = "2"
 utoipa = { version = "4", optional = true }
-yup-oauth2 = { version = "11", optional = true }
+yup-oauth2 = { version = "12", optional = true }
 
 google-apis-common = { path = "../../google-apis-common", version = "7" }
 google-clis-common = { path = "../../google-clis-common", version = "7" }

--- a/gen/aiplatform1_beta1-cli/Cargo.toml
+++ b/gen/aiplatform1_beta1-cli/Cargo.toml
@@ -32,7 +32,7 @@ serde_json = "1"
 tokio = { version = "1", features = ["full"] }
 url = "2"
 utoipa = { version = "4", optional = true }
-yup-oauth2 = { version = "11", optional = true }
+yup-oauth2 = { version = "12", optional = true }
 
 google-apis-common = { path = "../../google-apis-common", version = "7" }
 google-clis-common = { path = "../../google-clis-common", version = "7" }

--- a/gen/compute1-cli/Cargo.toml
+++ b/gen/compute1-cli/Cargo.toml
@@ -32,7 +32,7 @@ serde_json = "1"
 tokio = { version = "1", features = ["full"] }
 url = "2"
 utoipa = { version = "4", optional = true }
-yup-oauth2 = { version = "11", optional = true }
+yup-oauth2 = { version = "12", optional = true }
 
 google-apis-common = { path = "../../google-apis-common", version = "7" }
 google-clis-common = { path = "../../google-clis-common", version = "7" }

--- a/gen/dialogflow2-cli/Cargo.toml
+++ b/gen/dialogflow2-cli/Cargo.toml
@@ -32,7 +32,7 @@ serde_json = "1"
 tokio = { version = "1", features = ["full"] }
 url = "2"
 utoipa = { version = "4", optional = true }
-yup-oauth2 = { version = "11", optional = true }
+yup-oauth2 = { version = "12", optional = true }
 
 google-apis-common = { path = "../../google-apis-common", version = "7" }
 google-clis-common = { path = "../../google-clis-common", version = "7" }

--- a/gen/dialogflow2_beta1-cli/Cargo.toml
+++ b/gen/dialogflow2_beta1-cli/Cargo.toml
@@ -32,7 +32,7 @@ serde_json = "1"
 tokio = { version = "1", features = ["full"] }
 url = "2"
 utoipa = { version = "4", optional = true }
-yup-oauth2 = { version = "11", optional = true }
+yup-oauth2 = { version = "12", optional = true }
 
 google-apis-common = { path = "../../google-apis-common", version = "7" }
 google-clis-common = { path = "../../google-clis-common", version = "7" }

--- a/gen/dialogflow3-cli/Cargo.toml
+++ b/gen/dialogflow3-cli/Cargo.toml
@@ -32,7 +32,7 @@ serde_json = "1"
 tokio = { version = "1", features = ["full"] }
 url = "2"
 utoipa = { version = "4", optional = true }
-yup-oauth2 = { version = "11", optional = true }
+yup-oauth2 = { version = "12", optional = true }
 
 google-apis-common = { path = "../../google-apis-common", version = "7" }
 google-clis-common = { path = "../../google-clis-common", version = "7" }


### PR DESCRIPTION
Fixes RUSTSEC-2025-0134 by updating the `yup-oauth2` dependency to a newer version, which removes the usage of the unmaintained `rustls-pemfile` crate.

Verified that `cargo audit` no longer reports the advisory.
