### PR TITLE
docs: fix generated rustdoc links

### DIFF
--- a/gen/sheets4/README.md
+++ b/gen/sheets4/README.md
@@ -11,10 +11,10 @@ Everything else about the *Sheets* *v4* API can be found at the
 [official documentation site](https://developers.google.com/workspace/sheets/).
 # Features
 
-Handle the following *Resources* with ease from the central [hub](https://docs.rs/google-sheets4/7.0.0+20251215/google_sheets4/Sheets) ...
+Handle the following *Resources* with ease from the central [hub](https://docs.rs/google-sheets4/7.0.0+20251215/google_sheets4/api/struct.Sheets.html) ...
 
-* [spreadsheets](https://docs.rs/google-sheets4/7.0.0+20251215/google_sheets4/api::Spreadsheet)
- * [*batch update*](https://docs.rs/google-sheets4/7.0.0+20251215/google_sheets4/api::SpreadsheetBatchUpdateCall), [*create*](https://docs.rs/google-sheets4/7.0.0+20251215/google_sheets4/api::SpreadsheetCreateCall), [*developer metadata get*](https://docs.rs/google-sheets4/7.0.0+20251215/google_sheets4/api::SpreadsheetDeveloperMetadataGetCall), [*developer metadata search*](https://docs.rs/google-sheets4/7.0.0+20251215/google_sheets4/api::SpreadsheetDeveloperMetadataSearchCall), [*get*](https://docs.rs/google-sheets4/7.0.0+20251215/google_sheets4/api::SpreadsheetGetCall), [*get by data filter*](https://docs.rs/google-sheets4/7.0.0+20251215/google_sheets4/api::SpreadsheetGetByDataFilterCall), [*sheets copy to*](https://docs.rs/google-sheets4/7.0.0+20251215/google_sheets4/api::SpreadsheetSheetCopyToCall), [*values append*](https://docs.rs/google-sheets4/7.0.0+20251215/google_sheets4/api::SpreadsheetValueAppendCall), [*values batch clear*](https://docs.rs/google-sheets4/7.0.0+20251215/google_sheets4/api::SpreadsheetValueBatchClearCall), [*values batch clear by data filter*](https://docs.rs/google-sheets4/7.0.0+20251215/google_sheets4/api::SpreadsheetValueBatchClearByDataFilterCall), [*values batch get*](https://docs.rs/google-sheets4/7.0.0+20251215/google_sheets4/api::SpreadsheetValueBatchGetCall), [*values batch get by data filter*](https://docs.rs/google-sheets4/7.0.0+20251215/google_sheets4/api::SpreadsheetValueBatchGetByDataFilterCall), [*values batch update*](https://docs.rs/google-sheets4/7.0.0+20251215/google_sheets4/api::SpreadsheetValueBatchUpdateCall), [*values batch update by data filter*](https://docs.rs/google-sheets4/7.0.0+20251215/google_sheets4/api::SpreadsheetValueBatchUpdateByDataFilterCall), [*values clear*](https://docs.rs/google-sheets4/7.0.0+20251215/google_sheets4/api::SpreadsheetValueClearCall), [*values get*](https://docs.rs/google-sheets4/7.0.0+20251215/google_sheets4/api::SpreadsheetValueGetCall) and [*values update*](https://docs.rs/google-sheets4/7.0.0+20251215/google_sheets4/api::SpreadsheetValueUpdateCall)
+* [spreadsheets](https://docs.rs/google-sheets4/7.0.0+20251215/google_sheets4/api/struct.Spreadsheet.html)
+ * [*batch update*](https://docs.rs/google-sheets4/7.0.0+20251215/google_sheets4/api/struct.SpreadsheetBatchUpdateCall.html), [*create*](https://docs.rs/google-sheets4/7.0.0+20251215/google_sheets4/api/struct.SpreadsheetCreateCall.html), [*developer metadata get*](https://docs.rs/google-sheets4/7.0.0+20251215/google_sheets4/api/struct.SpreadsheetDeveloperMetadataGetCall.html), [*developer metadata search*](https://docs.rs/google-sheets4/7.0.0+20251215/google_sheets4/api/struct.SpreadsheetDeveloperMetadataSearchCall.html), [*get*](https://docs.rs/google-sheets4/7.0.0+20251215/google_sheets4/api/struct.SpreadsheetGetCall.html), [*get by data filter*](https://docs.rs/google-sheets4/7.0.0+20251215/google_sheets4/api/struct.SpreadsheetGetByDataFilterCall.html), [*sheets copy to*](https://docs.rs/google-sheets4/7.0.0+20251215/google_sheets4/api/struct.SpreadsheetSheetCopyToCall.html), [*values append*](https://docs.rs/google-sheets4/7.0.0+20251215/google_sheets4/api/struct.SpreadsheetValueAppendCall.html), [*values batch clear*](https://docs.rs/google-sheets4/7.0.0+20251215/google_sheets4/api/struct.SpreadsheetValueBatchClearCall.html), [*values batch clear by data filter*](https://docs.rs/google-sheets4/7.0.0+20251215/google_sheets4/api/struct.SpreadsheetValueBatchClearByDataFilterCall.html), [*values batch get*](https://docs.rs/google-sheets4/7.0.0+20251215/google_sheets4/api/struct.SpreadsheetValueBatchGetCall.html), [*values batch get by data filter*](https://docs.rs/google-sheets4/7.0.0+20251215/google_sheets4/api/struct.SpreadsheetValueBatchGetByDataFilterCall.html), [*values batch update*](https://docs.rs/google-sheets4/7.0.0+20251215/google_sheets4/api/struct.SpreadsheetValueBatchUpdateCall.html), [*values batch update by data filter*](https://docs.rs/google-sheets4/7.0.0+20251215/google_sheets4/api/struct.SpreadsheetValueBatchUpdateByDataFilterCall.html), [*values clear*](https://docs.rs/google-sheets4/7.0.0+20251215/google_sheets4/api/struct.SpreadsheetValueClearCall.html), [*values get*](https://docs.rs/google-sheets4/7.0.0+20251215/google_sheets4/api/struct.SpreadsheetValueGetCall.html) and [*values update*](https://docs.rs/google-sheets4/7.0.0+20251215/google_sheets4/api/struct.SpreadsheetValueUpdateCall.html)
 
 
 
@@ -23,17 +23,17 @@ Handle the following *Resources* with ease from the central [hub](https://docs.r
 
 The API is structured into the following primary items:
 
-* **[Hub](https://docs.rs/google-sheets4/7.0.0+20251215/google_sheets4/Sheets)**
+* **[Hub](https://docs.rs/google-sheets4/7.0.0+20251215/google_sheets4/api/struct.Sheets.html)**
     * a central object to maintain state and allow accessing all *Activities*
-    * creates [*Method Builders*](https://docs.rs/google-sheets4/7.0.0+20251215/google_sheets4/common::MethodsBuilder) which in turn
-      allow access to individual [*Call Builders*](https://docs.rs/google-sheets4/7.0.0+20251215/google_sheets4/common::CallBuilder)
-* **[Resources](https://docs.rs/google-sheets4/7.0.0+20251215/google_sheets4/common::Resource)**
+    * creates [*Method Builders*](https://docs.rs/google-apis-common/latest/google_apis_common/trait.MethodsBuilder.html) which in turn
+      allow access to individual [*Call Builders*](https://docs.rs/google-apis-common/latest/google_apis_common/trait.CallBuilder.html)
+* **[Resources](https://docs.rs/google-apis-common/latest/google_apis_common/trait.Resource.html)**
     * primary types that you can apply *Activities* to
     * a collection of properties and *Parts*
-    * **[Parts](https://docs.rs/google-sheets4/7.0.0+20251215/google_sheets4/common::Part)**
+    * **[Parts](https://docs.rs/google-apis-common/latest/google_apis_common/trait.Part.html)**
         * a collection of properties
         * never directly used in *Activities*
-* **[Activities](https://docs.rs/google-sheets4/7.0.0+20251215/google_sheets4/common::CallBuilder)**
+* **[Activities](https://docs.rs/google-apis-common/latest/google_apis_common/trait.CallBuilder.html)**
     * operations to apply to *Resources*
 
 All *structures* are marked with applicable traits to further categorize them and ease browsing.
@@ -167,17 +167,17 @@ match result {
 ```
 ## Handling Errors
 
-All errors produced by the system are provided either as [Result](https://docs.rs/google-sheets4/7.0.0+20251215/google_sheets4/common::Result) enumeration as return value of
+All errors produced by the system are provided either as [Result](https://docs.rs/google-sheets4/7.0.0+20251215/google_sheets4/type.Result.html) enumeration as return value of
 the doit() methods, or handed as possibly intermediate results to either the
-[Hub Delegate](https://docs.rs/google-sheets4/7.0.0+20251215/google_sheets4/common::Delegate), or the [Authenticator Delegate](https://docs.rs/yup-oauth2/*/yup_oauth2/trait.AuthenticatorDelegate.html).
+[Hub Delegate](https://docs.rs/google-sheets4/7.0.0+20251215/google_sheets4/trait.Delegate.html), or the [Authenticator Delegate](https://docs.rs/yup-oauth2/*/yup_oauth2/trait.AuthenticatorDelegate.html).
 
 When delegates handle errors or intermediate values, they may have a chance to instruct the system to retry. This
 makes the system potentially resilient to all kinds of errors.
 
 ## Uploads and Downloads
-If a method supports downloads, the response body, which is part of the [Result](https://docs.rs/google-sheets4/7.0.0+20251215/google_sheets4/common::Result), should be
+If a method supports downloads, the response body, which is part of the [Result](https://docs.rs/google-sheets4/7.0.0+20251215/google_sheets4/type.Result.html), should be
 read by you to obtain the media.
-If such a method also supports a [Response Result](https://docs.rs/google-sheets4/7.0.0+20251215/google_sheets4/common::ResponseResult), it will return that by default.
+If such a method also supports a [Response Result](https://docs.rs/google-apis-common/latest/google_apis_common/trait.ResponseResult.html), it will return that by default.
 You can see it as meta-data for the actual media. To trigger a media download, you will have to set up the builder by making
 this call: `.param("alt", "media")`.
 
@@ -187,29 +187,29 @@ Methods supporting uploads can do so using up to 2 different protocols:
 
 ## Customization and Callbacks
 
-You may alter the way an `doit()` method is called by providing a [delegate](https://docs.rs/google-sheets4/7.0.0+20251215/google_sheets4/common::Delegate) to the
-[Method Builder](https://docs.rs/google-sheets4/7.0.0+20251215/google_sheets4/common::CallBuilder) before making the final `doit()` call.
+You may alter the way an `doit()` method is called by providing a [delegate](https://docs.rs/google-sheets4/7.0.0+20251215/google_sheets4/trait.Delegate.html) to the
+[Method Builder](https://docs.rs/google-apis-common/latest/google_apis_common/trait.CallBuilder.html) before making the final `doit()` call.
 Respective methods will be called to provide progress information, as well as determine whether the system should
 retry on failure.
 
-The [delegate trait](https://docs.rs/google-sheets4/7.0.0+20251215/google_sheets4/common::Delegate) is default-implemented, allowing you to customize it with minimal effort.
+The [delegate trait](https://docs.rs/google-sheets4/7.0.0+20251215/google_sheets4/trait.Delegate.html) is default-implemented, allowing you to customize it with minimal effort.
 
 ## Optional Parts in Server-Requests
 
-All structures provided by this library are made to be [encodable](https://docs.rs/google-sheets4/7.0.0+20251215/google_sheets4/common::RequestValue) and
-[decodable](https://docs.rs/google-sheets4/7.0.0+20251215/google_sheets4/common::ResponseResult) via *json*. Optionals are used to indicate that partial requests are responses
+All structures provided by this library are made to be [encodable](https://docs.rs/google-apis-common/latest/google_apis_common/trait.RequestValue.html) and
+[decodable](https://docs.rs/google-apis-common/latest/google_apis_common/trait.ResponseResult.html) via *json*. Optionals are used to indicate that partial requests are responses
 are valid.
-Most optionals are are considered [Parts](https://docs.rs/google-sheets4/7.0.0+20251215/google_sheets4/common::Part) which are identifiable by name, which will be sent to
+Most optionals are are considered [Parts](https://docs.rs/google-apis-common/latest/google_apis_common/trait.Part.html) which are identifiable by name, which will be sent to
 the server to indicate either the set parts of the request or the desired parts in the response.
 
 ## Builder Arguments
 
-Using [method builders](https://docs.rs/google-sheets4/7.0.0+20251215/google_sheets4/common::CallBuilder), you are able to prepare an action call by repeatedly calling it's methods.
+Using [method builders](https://docs.rs/google-apis-common/latest/google_apis_common/trait.CallBuilder.html), you are able to prepare an action call by repeatedly calling it's methods.
 These will always take a single argument, for which the following statements are true.
 
 * [PODs][wiki-pod] are handed by copy
 * strings are passed as `&str`
-* [request values](https://docs.rs/google-sheets4/7.0.0+20251215/google_sheets4/common::RequestValue) are moved
+* [request values](https://docs.rs/google-apis-common/latest/google_apis_common/trait.RequestValue.html) are moved
 
 Arguments will always be copied or cloned into the builder, to make them independent of their original life times.
 

--- a/gen/sheets4/src/lib.rs
+++ b/gen/sheets4/src/lib.rs
@@ -9,7 +9,7 @@
 //! The original source code is [on github](https://github.com/Byron/google-apis-rs/tree/main/gen/sheets4).
 //! # Features
 //!
-//! Handle the following *Resources* with ease from the central [hub](Sheets) ...
+//! Handle the following *Resources* with ease from the central [hub](api::Sheets) ...
 //!
 //! * [spreadsheets](api::Spreadsheet)
 //!  * [*batch update*](api::SpreadsheetBatchUpdateCall), [*create*](api::SpreadsheetCreateCall), [*developer metadata get*](api::SpreadsheetDeveloperMetadataGetCall), [*developer metadata search*](api::SpreadsheetDeveloperMetadataSearchCall), [*get*](api::SpreadsheetGetCall), [*get by data filter*](api::SpreadsheetGetByDataFilterCall), [*sheets copy to*](api::SpreadsheetSheetCopyToCall), [*values append*](api::SpreadsheetValueAppendCall), [*values batch clear*](api::SpreadsheetValueBatchClearCall), [*values batch clear by data filter*](api::SpreadsheetValueBatchClearByDataFilterCall), [*values batch get*](api::SpreadsheetValueBatchGetCall), [*values batch get by data filter*](api::SpreadsheetValueBatchGetByDataFilterCall), [*values batch update*](api::SpreadsheetValueBatchUpdateCall), [*values batch update by data filter*](api::SpreadsheetValueBatchUpdateByDataFilterCall), [*values clear*](api::SpreadsheetValueClearCall), [*values get*](api::SpreadsheetValueGetCall) and [*values update*](api::SpreadsheetValueUpdateCall)
@@ -23,7 +23,7 @@
 //!
 //! The API is structured into the following primary items:
 //!
-//! * **[Hub](Sheets)**
+//! * **[Hub](api::Sheets)**
 //!     * a central object to maintain state and allow accessing all *Activities*
 //!     * creates [*Method Builders*](common::MethodsBuilder) which in turn
 //!       allow access to individual [*Call Builders*](common::CallBuilder)

--- a/src/generator/templates/api/lib/lib.mako
+++ b/src/generator/templates/api/lib/lib.mako
@@ -51,7 +51,7 @@
 <%
     # fr == fattest resource, the fatter, the more important, right ?
     fr = find_fattest_resource(c)
-    hub_url = hub_type(c.schemas, util.canonical_name())
+    hub_url = "api::%s" % hub_type(c.schemas, util.canonical_name())
     call_builder_url = CALL_BUILDER_MARKERT_TRAIT
     delegate_url = DELEGATE_TYPE
     request_trait_url = REQUEST_MARKER_TRAIT
@@ -59,6 +59,28 @@
     part_trait_url = PART_MARKER_TRAIT
 
     doc_base_url = util.doc_base_url() + '/' + to_extern_crate_name(util.crate_name()) + '/'
+    common_doc_base_url = 'https://docs.rs/google-apis-common/latest/google_apis_common/'
+    crate_common_items = {
+        'common::Delegate': 'trait.Delegate.html',
+        'common::Result': 'type.Result.html',
+    }
+    google_apis_common_items = {
+        'common::CallBuilder': 'trait.CallBuilder.html',
+        'common::MethodsBuilder': 'trait.MethodsBuilder.html',
+        'common::Part': 'trait.Part.html',
+        'common::RequestValue': 'trait.RequestValue.html',
+        'common::Resource': 'trait.Resource.html',
+        'common::ResponseResult': 'trait.ResponseResult.html',
+    }
+
+    def rustdoc_readme_url(url):
+        if url.startswith('api::'):
+            return 'api/struct.%s.html' % url.split('::', 1)[1]
+        if url in crate_common_items:
+            return crate_common_items[url]
+        if url in google_apis_common_items:
+            return common_doc_base_url + google_apis_common_items[url]
+        return url
 
     def link(name, url):
         lf = '[%s](%s)'
@@ -67,6 +89,9 @@
         for scheme in ('http', 'https'):
             if url.startswith(scheme + '://'):
                 return lf % (name, url)
+        url = rustdoc_readme_url(url)
+        if url.startswith('http://') or url.startswith('https://'):
+            return lf % (name, url)
         return lf % (name, doc_base_url + url)
 
 


### PR DESCRIPTION
Closes #297.

## Summary
- update generated README Rustdoc links from `api::Type` to current docs.rs paths like `api/struct.Type.html`
- link common marker traits to `google-apis-common/latest` documentation
- refresh `gen/sheets4/README.md` so the reported Sheets API links resolve now

## Verification
- `git diff --check`
- `PYTHONPATH=src uv run --with mako --with inflect python - <<'PY' ... Template(filename='src/generator/templates/api/lib/lib.mako') ... PY`
- checked 28 unique docs.rs links in `gen/sheets4/README.md`; all updated google-sheets4/google-apis-common links returned HTTP 200

Note: an existing `yup-oauth2/*/trait.AuthenticatorDelegate.html` link still 404s because current yup-oauth2 no longer exposes that trait; this PR stays focused on the generated Rustdoc links reported for the Sheets API README.